### PR TITLE
Guard rental create insert before stock sync

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceWriteGuardContractTests.cs
@@ -11,6 +11,30 @@ namespace InventoryManagementApp.Tests
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
 
+            var rentMethod = ExtractMethod(
+                source,
+                "public async Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate)",
+                "public async Task ReturnItemAsync");
+            AssertContainsAll(
+                rentMethod,
+                "var insertedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, tx,",
+                "INSERT INTO Rentals (ItemID, CustomerID, RentalDate, DueDate, Status)",
+                "if (insertedRows == 0)",
+                "throw new InvalidOperationException(\"Unable to create rental.\");",
+                "await _itemService.UpdateItemQuantitiesAsync(itemID, 1, true, conn, tx);");
+            Assert.True(
+                rentMethod.IndexOf("var insertedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, tx,", StringComparison.Ordinal) <
+                rentMethod.IndexOf("if (insertedRows == 0)", StringComparison.Ordinal),
+                "Expected rental create writes to inspect affected rows after executing the insert.");
+            Assert.True(
+                rentMethod.IndexOf("if (insertedRows == 0)", StringComparison.Ordinal) <
+                rentMethod.IndexOf("await _itemService.UpdateItemQuantitiesAsync(itemID, 1, true, conn, tx);", StringComparison.Ordinal),
+                "Expected failed rental creates to stop before inventory quantity sync.");
+            Assert.True(
+                rentMethod.IndexOf("if (insertedRows == 0)", StringComparison.Ordinal) <
+                rentMethod.IndexOf("await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $\"Rented item {itemID} to customer {customerID}\").ConfigureAwait(false);", StringComparison.Ordinal),
+                "Expected failed rental creates to stop before activity logging can report success.");
+
             var returnMethod = ExtractMethod(
                 source,
                 "public async Task ReturnItemAsync(int rentalID, DateTime returnDate)",

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-rental-create-insert-write-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-rental-create-insert-write-guard.md
@@ -1,0 +1,15 @@
+# Rental Create Insert Write Guard
+
+- Date: 2026-06-29
+- Area: Rentals, inventory quantity synchronization, source-contract coverage
+
+## Completed
+
+- Updated `RentalService.RentItemAsync` to capture the rental insert affected-row count.
+- Added a zero-row guard that throws `Unable to create rental.` before inventory quantity sync can decrement stock.
+- Extended `RentalServiceWriteGuardContractTests` so the rental create path is covered alongside return, extension, and delete write guards.
+
+## Validation
+
+- Source-contract coverage now requires the insert affected-row check to run before inventory sync and success activity logging.
+- Local build/test validation still requires a Windows/.NET-capable environment.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -179,7 +179,7 @@ namespace InventoryManagementApp.Services.Rentals
                 if (avail < 1)
                     throw new InvalidOperationException("Insufficient quantity.");
 
-                await SqliteHelper.ExecuteNonQueryAsync(conn, tx,
+                var insertedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, tx,
                     "INSERT INTO Rentals (ItemID, CustomerID, RentalDate, DueDate, Status) " +
                     "VALUES (@ItemID, @CustomerID, @RentalDate, @DueDate, 'Rented')",
                     new[]
@@ -189,6 +189,8 @@ namespace InventoryManagementApp.Services.Rentals
                         new SqliteParameter("@RentalDate", rentalDate),
                         new SqliteParameter("@DueDate", dueDate)
                     });
+                if (insertedRows == 0)
+                    throw new InvalidOperationException("Unable to create rental.");
 
                 if (_itemService != null)
                     await _itemService.UpdateItemQuantitiesAsync(itemID, 1, true, conn, tx);


### PR DESCRIPTION
## Summary

- Update `RentalService.RentItemAsync` to capture the rental insert affected-row count.
- Fail zero-row rental creates with `Unable to create rental.` before inventory quantity sync can decrement stock.
- Extend `RentalServiceWriteGuardContractTests` so rental create, return, extension, and delete write guards are covered together.

## Why This Matters

Recent rental hardening covered stale return, delete, and extension paths. Rental creation is the matching checkout write path; this keeps an unexpected failed insert from flowing into stock updates or success activity logging.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `RentalService`, `RentalServiceWriteGuardContractTests`, and one progress note.
- GitHub connector readback confirmed `RentItemAsync` now assigns `insertedRows` from the rental insert, throws `Unable to create rental.` when it is zero, and does so before `_itemService.UpdateItemQuantitiesAsync` and success activity logging.
- GitHub connector readback confirmed the source-contract test now requires rental create insert affected-row checking and ordering before inventory sync and activity logging.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.