### PR TITLE
Fit item edit dialog to laptop baseline

### DIFF
--- a/InventoryManagementApp.Tests/Views/ItemEditWindowLayoutContractTests.cs
+++ b/InventoryManagementApp.Tests/Views/ItemEditWindowLayoutContractTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Views
+{
+    public class ItemEditWindowLayoutContractTests
+    {
+        [Fact]
+        public void ItemEditWindowFitsOldLaptopHeightAndKeepsFormBodyScrollable()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ItemEditWindow.xaml");
+
+            Assert.Equal(720, ReadWindowDimension(xaml, "Height"));
+            Assert.Equal(620, ReadWindowDimension(xaml, "MinHeight"));
+            Assert.True(ReadWindowDimension(xaml, "MinHeight") <= 720, "Item edit minimum height should leave room for window chrome on a 1366x768 laptop baseline.");
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<RowDefinition Height=\"*\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinHeight=\"780\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Height=\"840\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static int ReadWindowDimension(string xaml, string attribute)
+        {
+            var match = Regex.Match(xaml, $"\\b{attribute}=\\\"(?<value>\\d+)\\\"");
+            Assert.True(match.Success, $"Expected ItemEditWindow.xaml to declare {attribute}.");
+            return int.Parse(match.Groups["value"].Value);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePath)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null)
+            {
+                var candidate = Path.Combine(directory.FullName, Path.Combine(relativePath));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                directory = directory.Parent;
+            }
+
+            throw new FileNotFoundException("Could not locate repository file.", Path.Combine(relativePath));
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-item-edit-window-small-screen-fit.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-item-edit-window-small-screen-fit.md
@@ -1,0 +1,15 @@
+# Item Edit Window Small-Screen Fit
+
+- Date: 2026-06-29
+- Area: Item editing workflow, WPF layout, source-contract coverage
+
+## Completed
+
+- Reduced `ItemEditWindow` shell height from 840 to 720 and minimum height from 780 to 620 so the dialog can fit the 1366x768 laptop baseline.
+- Preserved the existing scrollable form body so dense item identity, availability, notes, and missing-component fields remain reachable at smaller heights.
+- Added source-contract coverage that keeps the item editor within the small-screen height budget and verifies the body remains scrollable.
+
+## Validation
+
+- XAML inspection confirms the window no longer requires a height above the 1366x768 baseline and still uses a star-sized body row with `ScrollViewer` vertical scrolling.
+- Local WPF screenshots and .NET test execution still require a Windows/.NET-capable environment.

--- a/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
@@ -6,9 +6,9 @@
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}"
         Width="840"
-        Height="840"
+        Height="720"
         MinWidth="760"
-        MinHeight="780"
+        MinHeight="620"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="16">


### PR DESCRIPTION
## Summary

- Reduce `ItemEditWindow` default height from 840 to 720 and minimum height from 780 to 620.
- Preserve the existing scrollable form body so item identity, availability, notes, and missing-component fields remain reachable at smaller heights.
- Add source-contract coverage that keeps the dialog within the 1366x768 laptop baseline height budget and verifies the form body remains scrollable.

## Why This Was The Highest-Value Next Step

Recent repo activity has heavily hardened service contracts. Current instructions call for stepping back from repeated theme/report expansion and looking for concrete layout risks. `ItemEditWindow` was still declaring `MinHeight="780"`, which exceeds the 1366x768 practical baseline before Windows chrome or DPI scaling, making a core inventory editing workflow vulnerable to off-screen controls on old laptops.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ItemEditWindow.xaml`, one focused layout contract test, and one progress note.
- GitHub connector readback confirmed `ItemEditWindow` now declares `Height="720"` and `MinHeight="620"` while keeping the star-sized content row and `ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto"`.
- Source-contract coverage now checks the item editor height/min-height budget, rejects the previous 840/780 sizing, and verifies the form body remains scrollable.
- Layout assumption: at the 1366x768 practical minimum, the dialog shell now leaves room for window chrome while dense fields remain reachable through the existing internal vertical scroll; at larger viewports up through 3840x2160, the fixed dialog remains a contained edit form rather than stretching awkwardly across the display.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation and live WPF screenshots were not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.

## Follow-up

- Run the full Windows/.NET validation and a live WPF visual check when a Windows-capable environment is available, especially at 1366x768 with 125%, 150%, and 200% scaling.