### PR TITLE
Align item edit responsive sizing

### DIFF
--- a/InventoryManagementApp.Tests/Views/ItemEditWindowLayoutContractTests.cs
+++ b/InventoryManagementApp.Tests/Views/ItemEditWindowLayoutContractTests.cs
@@ -11,12 +11,15 @@ namespace InventoryManagementApp.Tests.Views
         public void ItemEditWindowFitsOldLaptopHeightAndKeepsFormBodyScrollable()
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ItemEditWindow.xaml");
+            var codeBehind = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ItemEditWindow.xaml.cs");
 
             Assert.Equal(720, ReadWindowDimension(xaml, "Height"));
             Assert.Equal(620, ReadWindowDimension(xaml, "MinHeight"));
             Assert.True(ReadWindowDimension(xaml, "MinHeight") <= 720, "Item edit minimum height should leave room for window chrome on a 1366x768 laptop baseline.");
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<RowDefinition Height=\"*\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("UseResponsiveDefaultSize(840, 720)", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("UseResponsiveDefaultSize(980, 880)", codeBehind, StringComparison.Ordinal);
             Assert.DoesNotContain("MinHeight=\"780\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Height=\"840\"", xaml, StringComparison.Ordinal);
         }

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-item-edit-window-responsive-size-alignment.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-item-edit-window-responsive-size-alignment.md
@@ -1,0 +1,16 @@
+# Item Edit Window Responsive Size Alignment
+
+## Completed
+
+- Aligned `ItemEditWindow` code-behind responsive default sizing with the XAML dialog budget by changing `UseResponsiveDefaultSize(980, 880)` to `UseResponsiveDefaultSize(840, 720)`.
+- Extended `ItemEditWindowLayoutContractTests` so the old runtime sizing cannot silently override the 1366x768-friendly shell height from the XAML-only layout fix.
+
+## Why
+
+The previous layout pass lowered the XAML height and minimum height, but the constructor still requested a taller responsive default size. Keeping these values aligned protects the core item editing workflow on older laptops and scaled displays.
+
+## Validation
+
+- Source readback confirms the XAML dialog still declares `Height="720"`, `MinHeight="620"`, a star-sized body row, and an internal vertical `ScrollViewer`.
+- Source-contract coverage now checks the constructor uses `UseResponsiveDefaultSize(840, 720)` and rejects the previous `UseResponsiveDefaultSize(980, 880)` value.
+- Local WPF screenshots, Windows DPI checks, and `dotnet test` were not run in the scheduled Linux environment.

--- a/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml.cs
@@ -15,7 +15,7 @@ namespace InventoryManagementApp.Views.Windows
         public ItemEditWindow(ItemModel item, Action onSave, Action onCancel, IFileDialogService fileDialogService)
         {
             InitializeComponent();
-            this.UseResponsiveDefaultSize(980, 880);
+            this.UseResponsiveDefaultSize(840, 720);
             _fileDialogService = fileDialogService;
             DataContext = new ItemEditViewModel(item, onSave, onCancel, _fileDialogService);
             this.DisposeDataContextOnUnload();


### PR DESCRIPTION
## Summary

- Align `ItemEditWindow` runtime responsive default sizing with its XAML shell budget by changing `UseResponsiveDefaultSize(980, 880)` to `UseResponsiveDefaultSize(840, 720)`.
- Extend `ItemEditWindowLayoutContractTests` so the XAML height/min-height and code-behind responsive default stay in sync.
- Add a progress note documenting the layout follow-up.

## Why This Was The Highest-Value Next Step

The previous scheduled pass lowered `ItemEditWindow.xaml` to fit the 1366x768 laptop baseline, but repository readback showed the constructor still requested an 880px responsive default height. That could reintroduce the same off-screen item-editing risk at runtime, especially on older laptops and scaled displays. This is a focused reliability/layout fix outside the repeated Admin Settings theme loop.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ItemEditWindow.xaml.cs`, `ItemEditWindowLayoutContractTests.cs`, and one progress note.
- GitHub connector readback confirmed `ItemEditWindow.xaml.cs` now calls `UseResponsiveDefaultSize(840, 720)`.
- GitHub connector readback confirmed the source-contract test checks the XAML `Height="720"`, `MinHeight="620"`, star-sized body row, internal vertical `ScrollViewer`, and the code-behind `UseResponsiveDefaultSize(840, 720)` call while rejecting the previous `UseResponsiveDefaultSize(980, 880)` value.
- Layout assumption: at the 1366x768 practical minimum, the runtime default now matches the smaller dialog shell and keeps dense form content reachable through the existing scrollable body; on large displays up through 3840x2160, the dialog remains a contained edit workflow instead of expanding into a sprawling form.
- GitHub connector status readback found no attached commit statuses on the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation and live WPF screenshots were not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.

## Follow-up

- Run the full Windows/.NET validation and live WPF DPI checks when a Windows-capable environment is available, especially at 1366x768 with 125%, 150%, and 200% scaling.