### PR TITLE
Ignore generated QA screenshot artifacts

### DIFF
--- a/.qa-screenshots/.gitignore
+++ b/.qa-screenshots/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/InventoryManagementApp.Tests/RepositoryHygieneContractTests.cs
+++ b/InventoryManagementApp.Tests/RepositoryHygieneContractTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RepositoryHygieneContractTests
+    {
+        [Fact]
+        public void QaScreenshotArtifactsStayIgnoredByDefault()
+        {
+            var ignoreFile = ReadRepoFile(".qa-screenshots", ".gitignore");
+
+            Assert.Contains("*", ignoreFile, StringComparison.Ordinal);
+            Assert.Contains("!.gitignore", ignoreFile, StringComparison.Ordinal);
+            Assert.DoesNotContain("!latest", ignoreFile, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("!*.png", ignoreFile, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-qa-screenshot-artifact-ignore.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-qa-screenshot-artifact-ignore.md
@@ -1,0 +1,16 @@
+# QA Screenshot Artifact Ignore Guard
+
+## What changed
+
+- Added `.qa-screenshots/.gitignore` so generated screenshot output under the QA artifact directory is ignored by default.
+- Added `RepositoryHygieneContractTests` coverage to keep the ignore-all rule and the `.gitignore` exception in place.
+
+## Why
+
+Recent layout QA runs generated large screenshot artifacts directly under `.qa-screenshots/latest`. The root `.gitignore` already reserved a QA automation artifact section, but the generated screenshot directory still needed a local guard so future QA runs do not keep adding visual artifacts to source control by accident.
+
+## Validation notes
+
+- Connector compare/readback should verify this change is limited to the nested ignore file, one source-contract test, and this note.
+- Local .NET tests and live WPF screenshot validation were not run in the scheduled Linux container because direct repository checkout remains blocked and the Windows/WPF toolchain is unavailable here.
+- Layout impact: this is repository hygiene only; it does not change runtime UI layout. The related QA workflow continues to support small-screen and large-screen captures, but future generated images should remain local artifacts unless intentionally force-added.


### PR DESCRIPTION
## Summary

- Add `.qa-screenshots/.gitignore` so generated QA screenshot output stays ignored by default.
- Add `RepositoryHygieneContractTests` coverage to keep the ignore-all rule and `.gitignore` exception in place.
- Add a progress note documenting why this guard was added after the recent layout QA runs.

## Why This Was The Highest-Value Next Step

Recent direct commits on `master` added large `.qa-screenshots/latest` visual artifacts while the root `.gitignore` had an empty `QA automation artifacts` section. That is a repository hygiene and packaging risk: future layout QA runs can keep adding generated PNGs unless the output directory has a local guard. This focused change improves maintainability without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `.qa-screenshots/.gitignore`, `RepositoryHygieneContractTests.cs`, and one progress note.
- GitHub connector readback confirmed `.qa-screenshots/.gitignore` contains `*` and `!.gitignore`.
- GitHub connector readback confirmed `RepositoryHygieneContractTests` requires the ignore-all rule and rejects exceptions for `latest` or `*.png`.
- Layout impact: this is repository hygiene only and does not change runtime UI. It supports the existing small-screen and large-screen QA screenshot workflow by keeping generated output local unless intentionally force-added.
- GitHub connector status readback found no attached statuses on the latest observed `master` head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation and live WPF screenshots were not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and branch search show `master` is the active default branch.

## Follow-up

- Consider a separate cleanup PR to remove already tracked `.qa-screenshots/latest` artifacts once a full file list can be reviewed safely.