### PR TITLE
Normalize activity log read fields

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogReadNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogReadNormalizationContractTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ActivityLogReadNormalizationContractTests
+    {
+        [Fact]
+        public void MapLogNormalizesLegacyAuditFieldsWhenReading()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "ActivityLog MapLog",
+                "            return log;");
+
+            Assert.Contains("UserName = (r[\"UserName\"]?.ToString() ?? string.Empty).Trim(),", method, StringComparison.Ordinal);
+            Assert.Contains("Action   = (r[\"Action\"]?.ToString() ?? string.Empty).Trim(),", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("UserName = r[\"UserName\"]?.ToString() ?? string.Empty,", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("Action   = r[\"Action\"]?.ToString() ?? string.Empty,", method, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-read-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-read-normalization.md
@@ -1,0 +1,13 @@
+# Activity Log Read Normalization
+
+## Summary
+- Trimmed Activity Log user names and actions when rows are mapped back from SQLite.
+- Added source-contract coverage so legacy padded audit rows are normalized on read, matching the current write-side normalization.
+
+## Why
+Recent Activity Log hardening normalized new audit entries before persistence. Legacy rows or rows created before that change could still carry padded user names/actions into reports, filters, and history views, creating duplicate-looking audit values. Normalizing in `MapLog` keeps the visible audit trail consistent without changing the stored historical row text.
+
+## Validation
+- Connector readback was used because direct clone/raw access is blocked in this scheduled Linux environment.
+- Local `dotnet` restore/build/test, PowerShell validation, WPF runtime checks, screenshots, and banned-word checks were unavailable here.
+- This is not a UI layout change; it affects the Activity Log read model used by existing grids, reports, and history views across the supported screen sizes without changing control sizing.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using Microsoft.Data.Sqlite;
@@ -210,8 +210,8 @@ namespace InventoryManagementApp.Services.Users
             var log = new ActivityLog
             {
                 LogID = Convert.ToInt32(r["LogID"]),
-                UserName = r["UserName"]?.ToString() ?? string.Empty,
-                Action   = r["Action"]?.ToString() ?? string.Empty,
+                UserName = (r["UserName"]?.ToString() ?? string.Empty).Trim(),
+                Action   = (r["Action"]?.ToString() ?? string.Empty).Trim(),
                 Timestamp = timestamp
             };
 


### PR DESCRIPTION
## Summary

- Trim Activity Log user names and actions when rows are mapped back from SQLite.
- Add focused source-contract coverage so legacy padded audit rows are normalized on read.
- Add a progress note documenting the read-model follow-up.

## Why This Was The Highest-Value Next Step

Recent Activity Log work normalized new audit entries before persistence, but repository readback showed `MapLog` still returned stored `UserName` and `Action` values raw. That means legacy padded audit rows could still appear as duplicate-looking names/actions in Activity Logs, reports, filters, and item checkout history even after new writes were fixed. This is a focused reliability/data-quality fix outside the Admin Settings theme loop and does not extend visual polish work.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ActivityLogService.cs`, one new source-contract test, and one progress note.
- GitHub connector readback confirmed `MapLog` now trims mapped `UserName` and `Action` values.
- GitHub connector readback confirmed `ActivityLogReadNormalizationContractTests` requires the trimmed mappings and rejects the old raw mappings.
- Layout impact: this is not a UI layout change. It affects the read model behind existing Activity Log grids, reports, and checkout-history views without changing control sizing, so the supported 1366x768 through 3840x2160 layout assumptions are unchanged.
- GitHub connector status readback found no attached commit statuses on the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation and live WPF screenshots were not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.

## Follow-up

- Run the full Windows/.NET validation and WPF smoke checks when a Windows-capable environment is available.