### PR TITLE
Guard QA screenshot ignores from root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -378,4 +378,6 @@ Thumbs.db
 *.pdf
 
 # QA automation artifacts
+.qa-screenshots/*
+!.qa-screenshots/.gitignore
 

--- a/InventoryManagementApp.Tests/RepositoryHygieneContractTests.cs
+++ b/InventoryManagementApp.Tests/RepositoryHygieneContractTests.cs
@@ -9,12 +9,18 @@ namespace InventoryManagementApp.Tests
         [Fact]
         public void QaScreenshotArtifactsStayIgnoredByDefault()
         {
-            var ignoreFile = ReadRepoFile(".qa-screenshots", ".gitignore");
+            var rootIgnoreFile = ReadRepoFile(".gitignore");
+            var screenshotIgnoreFile = ReadRepoFile(".qa-screenshots", ".gitignore");
 
-            Assert.Contains("*", ignoreFile, StringComparison.Ordinal);
-            Assert.Contains("!.gitignore", ignoreFile, StringComparison.Ordinal);
-            Assert.DoesNotContain("!latest", ignoreFile, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("!*.png", ignoreFile, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(".qa-screenshots/*", rootIgnoreFile, StringComparison.Ordinal);
+            Assert.Contains("!.qa-screenshots/.gitignore", rootIgnoreFile, StringComparison.Ordinal);
+            Assert.DoesNotContain("!.qa-screenshots/latest", rootIgnoreFile, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("!.qa-screenshots/*.png", rootIgnoreFile, StringComparison.OrdinalIgnoreCase);
+
+            Assert.Contains("*", screenshotIgnoreFile, StringComparison.Ordinal);
+            Assert.Contains("!.gitignore", screenshotIgnoreFile, StringComparison.Ordinal);
+            Assert.DoesNotContain("!latest", screenshotIgnoreFile, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("!*.png", screenshotIgnoreFile, StringComparison.OrdinalIgnoreCase);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-root-qa-screenshot-ignore.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-root-qa-screenshot-ignore.md
@@ -1,0 +1,16 @@
+# Root QA Screenshot Ignore Guard
+
+## What changed
+- Added root `.gitignore` rules for `.qa-screenshots/*` while preserving the nested `.qa-screenshots/.gitignore` file.
+- Extended `RepositoryHygieneContractTests` so the root ignore rule and nested ignore file both keep generated QA screenshots ignored by default.
+
+## Why it matters
+Recent layout QA work produced generated `.qa-screenshots/latest` artifacts. The nested ignore file protects new output created inside the screenshot folder, but the root ignore section was still empty. Keeping the root rule explicit makes the repository hygiene contract easier to see and harder to regress during future QA automation updates.
+
+## Validation
+- Connector readback should confirm `.gitignore` now contains `.qa-screenshots/*` and `!.qa-screenshots/.gitignore`.
+- Connector readback should confirm `RepositoryHygieneContractTests` checks both root and nested ignore behavior while rejecting exceptions for `latest` or `*.png` screenshots.
+- This is repository hygiene only and does not change runtime UI layout. It supports the existing screenshot workflow across the 1366x768 through 3840x2160 validation target range by keeping generated evidence local unless intentionally force-added.
+
+## Follow-up
+- If a full repository checkout is available later, inspect whether old generated `.qa-screenshots/latest` files are already tracked and remove them in a separate cleanup PR if safe.


### PR DESCRIPTION
## Summary

- Add root `.gitignore` rules so `.qa-screenshots/*` output stays ignored while preserving `.qa-screenshots/.gitignore`.
- Extend `RepositoryHygieneContractTests` to cover both the root ignore rule and nested screenshot-folder ignore file.
- Add a progress note documenting the repository hygiene follow-up.

## Why This Was The Highest-Value Next Step

Recent layout QA and repository hygiene work showed generated `.qa-screenshots/latest` artifacts are a real churn risk. PR #1398 added a nested ignore file, but the root `.gitignore` still had an empty `QA automation artifacts` section. Making the root rule explicit gives future screenshot automation a visible top-level guard and keeps the existing nested guard from becoming the only line of defense.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `.gitignore`, `RepositoryHygieneContractTests.cs`, and one progress note.
- GitHub connector readback confirmed `.gitignore` now contains `.qa-screenshots/*` and `!.qa-screenshots/.gitignore`.
- GitHub connector readback confirmed `RepositoryHygieneContractTests` checks both root and nested ignore behavior and rejects explicit exceptions for `latest` or `*.png` screenshot artifacts.
- Layout impact: this is repository hygiene only and does not change runtime UI. It supports the existing layout QA workflow across the required 1366x768 through 3840x2160 target range by keeping generated screenshot evidence local unless intentionally force-added.
- GitHub connector status readback found no attached commit statuses on the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation and live WPF screenshots were not run.
- The repository default branch reports as `master`; this run mentioned `main`, but GitHub metadata and recent history show `master` is active.

## Follow-up

- If a full checkout is available later, inspect whether old generated `.qa-screenshots/latest` files are already tracked and remove them in a separate cleanup PR if safe.