### PR TITLE
Guard activity log insert results

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -106,6 +106,24 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void LogActionChecksInsertAffectedRowsBeforeReturningSuccess()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result> LogActionAsync",
+                "public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync");
+
+            Assert.Contains("var insertedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);", method, StringComparison.Ordinal);
+            Assert.Contains("if (insertedRows == 0)", method, StringComparison.Ordinal);
+            Assert.Contains("return new Result(false, \"Unable to log activity.\");", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);\n                return new Result(true);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (insertedRows == 0)", StringComparison.Ordinal) < method.IndexOf("return new Result(true);", StringComparison.Ordinal),
+                "Activity logging should verify the insert affected rows before reporting success.");
+        }
+
+        [Fact]
         public void RecentLogsRejectsInvalidCountsBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-insert-write-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-insert-write-guard.md
@@ -1,0 +1,14 @@
+# Activity Log Insert Write Guard
+
+## Summary
+- Captured the affected-row count from `ActivityLogService.LogActionAsync` inserts.
+- Return `Unable to log activity.` when SQLite reports that no activity-log row was inserted.
+- Added source-contract coverage so the write guard stays between the insert call and the success result.
+
+## Why
+Recent Activity Log work hardened blank-input handling and normalized audit fields on write/read. The remaining write-path fragility was that `LogActionAsync` ignored the insert result and returned success after any non-throwing call, even if no row was written. Checking the affected-row count keeps the audit trail from reporting false success on an unexpected no-op insert.
+
+## Validation
+- Connector readback and compare were used because direct clone/raw access is blocked in this scheduled Linux environment.
+- Local `dotnet` restore/build/test, PowerShell validation, WPF runtime checks, screenshots, and banned-word checks were unavailable here.
+- This is not a UI layout change; it affects the Activity Log service write path without changing visual layout, sizing, or screen-density assumptions.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -49,7 +49,10 @@ namespace InventoryManagementApp.Services.Users
                     new SqliteParameter("@Action",   normalizedAction)
                 };
                 using var conn = _dbService.CreateConnection();
-                await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
+                var insertedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
+                if (insertedRows == 0)
+                    return new Result(false, "Unable to log activity.");
+
                 return new Result(true);
             }
             catch (OperationCanceledException ex)


### PR DESCRIPTION
## Summary

- Capture the affected-row count from `ActivityLogService.LogActionAsync` inserts.
- Return `Unable to log activity.` if SQLite reports that no activity-log row was inserted.
- Extend Activity Log source-contract coverage so the insert guard stays before the success result.

## Why This Was The Highest-Value Next Step

Recent Activity Log work hardened blank audit inputs and normalized audit values on write/read. Repository readback showed the matching insert write path still ignored `ExecuteNonQueryAsync` results and returned success after any non-throwing insert call. This is a narrow reliability fix for the app's audit trail and continues the current write-guard hardening direction without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ActivityLogService.cs`, `ActivityLogCheckoutHistoryContractTests.cs`, and one progress note.
- GitHub connector readback confirmed `LogActionAsync` now stores `insertedRows`, returns `Unable to log activity.` when the count is zero, and checks that before `return new Result(true);`.
- GitHub connector readback confirmed the source-contract test requires the affected-row check and rejects the previous fire-and-forget insert followed immediately by success.
- Layout impact: this is not a UI layout change. It affects the Activity Log service write path only, with no control sizing or visual behavior changes across the required 1366x768 through 3840x2160 target range.
- GitHub connector status readback found no attached commit statuses on the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation and live WPF screenshots were not run.
- The repository default branch reports as `master`; this run mentioned `main`, but GitHub metadata and recent history show `master` is active.

## Follow-up

- Run full Windows/.NET validation when a Windows-capable environment is available.