### PR TITLE
Cap recent activity log reads

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -140,6 +140,32 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void RecentLogsCapsRequestedCountsBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync",
+                "public virtual async Task<Result<List<ActivityLog>>> GetCheckoutHistoryForItemAsync");
+
+            Assert.Contains("const int MaxRecentLogCount = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("if (count > MaxRecentLogCount)", method, StringComparison.Ordinal);
+            Assert.Contains("return new Result<List<ActivityLog>>(null, false, $\"Count cannot exceed {MaxRecentLogCount}.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (count < 1)", StringComparison.Ordinal) < method.IndexOf("if (count > MaxRecentLogCount)", StringComparison.Ordinal),
+                "The positive-count guard should still run before the maximum-count guard.");
+            Assert.True(
+                method.IndexOf("if (count > MaxRecentLogCount)", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
+                "Oversized recent-log requests should be rejected before SQL text is prepared.");
+            Assert.True(
+                method.IndexOf("if (count > MaxRecentLogCount)", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Count\", count)", StringComparison.Ordinal),
+                "Oversized recent-log requests should be rejected before parameters are prepared.");
+            Assert.True(
+                method.IndexOf("if (count > MaxRecentLogCount)", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
+                "Oversized recent-log requests should be rejected before opening a database connection.");
+        }
+
+        [Fact]
         public void RecentLogsStillOrdersByTimestampAndAppliesTheRequestedLimit()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-recent-count-cap.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-recent-count-cap.md
@@ -1,0 +1,14 @@
+# Activity Log Recent Count Cap
+
+## Summary
+- Added a maximum recent-log query count of 500 to `ActivityLogService.GetRecentLogsAsync`.
+- Oversized recent-log requests now fail before SQL text, parameters, or a database connection are created.
+- Extended Activity Log source-contract coverage so the positive-count guard, maximum-count guard, and requested SQL limit stay ordered intentionally.
+
+## Why
+Recent Activity Log work hardened audit writes and read normalization. The matching read path still accepted any positive recent-log count, which could let a bad caller request an oversized audit result and make Activity Log grids or reports sluggish. Capping the count keeps the audit workflow bounded without changing the default 50-row behavior.
+
+## Validation
+- Connector readback and compare were used because direct clone/raw access is blocked in this scheduled Linux environment.
+- Local `dotnet` restore/build/test, PowerShell validation, WPF runtime checks, screenshots, and banned-word checks were unavailable here.
+- This is not a UI layout change; it bounds the data read behind existing Activity Log surfaces without changing control sizing or screen-density assumptions.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -15,6 +15,8 @@ namespace InventoryManagementApp.Services.Users
 {
     public class ActivityLogService
     {
+        const int MaxRecentLogCount = 500;
+
         readonly DatabaseService _dbService;
         readonly ILogger<ActivityLogService> _logger;
 
@@ -80,6 +82,9 @@ namespace InventoryManagementApp.Services.Users
 
                 if (count < 1)
                     return new Result<List<ActivityLog>>(null, false, "Count must be positive.");
+
+                if (count > MaxRecentLogCount)
+                    return new Result<List<ActivityLog>>(null, false, $"Count cannot exceed {MaxRecentLogCount}.");
 
                 const string sql = @"
                     SELECT * FROM ActivityLogs


### PR DESCRIPTION
## Summary

- Add a 500-row maximum to `ActivityLogService.GetRecentLogsAsync`.
- Reject oversized recent-log requests before SQL text, parameters, or database connection work starts.
- Extend Activity Log source-contract coverage so the positive-count guard, maximum-count guard, and requested SQL limit stay ordered intentionally.

## Why This Was The Highest-Value Next Step

Recent scheduled work hardened Activity Log writes and read normalization, and repository readback showed the remaining recent-log read path accepted any positive count. A bad caller could request an oversized audit result and make Activity Log grids or report generation sluggish. This is a focused reliability/usability fix for an existing workflow, avoids more Admin Settings theme expansion, and leaves the default 50-row behavior unchanged.

## Validation

- GitHub connector compare confirmed the refreshed branch is current with `master`, three commits ahead, and changes only `ActivityLogService.cs`, `ActivityLogCheckoutHistoryContractTests.cs`, and one progress note.
- GitHub connector readback confirmed `MaxRecentLogCount = 500`, the oversized-count guard, and the failure result are in `GetRecentLogsAsync` before SQL text, parameter creation, and database connection work.
- GitHub connector readback confirmed the source-contract test pins the cap and guard ordering while preserving the `ORDER BY Timestamp DESC` and `LIMIT @Count` query contract.
- Layout impact: this is not a UI layout change. It bounds the data read behind existing Activity Log grids/reports without changing control sizing or visual behavior across the required 1366x768 through 3840x2160 target range.
- GitHub connector status readback found no attached commit statuses on the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation and live WPF screenshots were not run.
- The repository default branch reports as `master`; this run mentioned `main`, but GitHub metadata and current history show `master` is active.

## Follow-up

- Run full Windows/.NET validation when a Windows-capable environment is available.