### PR TITLE
Cap checkout history activity log reads

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -212,6 +212,26 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("ORDER BY Timestamp DESC", method, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void CheckoutHistoryCapsAuditReadsAfterOrderingMatches()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result<List<ActivityLog>>> GetCheckoutHistoryForItemAsync",
+                "public virtual async Task<Result> PurgeOldLogsAsync");
+
+            Assert.Contains("const int MaxCheckoutHistoryLogCount = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("ORDER BY Timestamp DESC LIMIT @CheckoutHistoryLimit", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@CheckoutHistoryLimit\", MaxCheckoutHistoryLogCount)", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("ORDER BY Timestamp DESC LIMIT @CheckoutHistoryLimit", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
+                "The checkout-history read cap should be part of the SQL before the database connection opens.");
+            Assert.True(
+                method.IndexOf("new SqliteParameter(\"@CheckoutHistoryLimit\", MaxCheckoutHistoryLogCount)", StringComparison.Ordinal) < method.IndexOf("parameters.ToArray()", StringComparison.Ordinal),
+                "The checkout-history cap parameter should be included in the executed parameter set.");
+        }
+
         private static void AssertCancellationGuardBeforeSqlWork(string source, string startMarker, string endMarker)
         {
             var method = ExtractMethod(source, startMarker, endMarker);

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-checkout-history-log-cap.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-checkout-history-log-cap.md
@@ -1,0 +1,14 @@
+# Checkout History Activity Log Cap
+
+## Completed
+- Added a `MaxCheckoutHistoryLogCount` cap to `ActivityLogService.GetCheckoutHistoryForItemAsync`.
+- Kept item checkout history ordered by newest activity first while limiting the query to the most recent 500 matching activity rows.
+- Extended Activity Log source-contract coverage so the checkout-history limit and SQL parameter stay in place.
+
+## Why
+Item checkout history is shown from Activity Log data and previously read every matching audit row for an item. Recent Activity Log work capped broad recent-log reads; this applies the same bounded-read safeguard to item-specific checkout history so older audit-heavy items do not make detail/history workflows sluggish.
+
+## Validation
+- GitHub connector readback should confirm the query appends `ORDER BY Timestamp DESC LIMIT @CheckoutHistoryLimit` and supplies `MaxCheckoutHistoryLogCount` as the limit parameter.
+- Local .NET/WPF validation was not available in this scheduled Linux environment.
+- Layout impact: this is not a visual layout change. It reduces the maximum rows feeding existing item history displays without changing control sizing or screen behavior across the supported 1366x768 through 3840x2160 range.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -16,6 +16,7 @@ namespace InventoryManagementApp.Services.Users
     public class ActivityLogService
     {
         const int MaxRecentLogCount = 500;
+        const int MaxCheckoutHistoryLogCount = 500;
 
         readonly DatabaseService _dbService;
         readonly ILogger<ActivityLogService> _logger;
@@ -140,7 +141,8 @@ namespace InventoryManagementApp.Services.Users
                     parameters.Add(new SqliteParameter("@ItemNumberPattern", itemNumberPattern));
                 }
 
-                sql += " ORDER BY Timestamp DESC";
+                sql += " ORDER BY Timestamp DESC LIMIT @CheckoutHistoryLimit";
+                parameters.Add(new SqliteParameter("@CheckoutHistoryLimit", MaxCheckoutHistoryLogCount));
 
                 using var conn = _dbService.CreateConnection();
                 var logs = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapLog, parameters.ToArray(), cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

- Add a 500-row cap to `ActivityLogService.GetCheckoutHistoryForItemAsync`.
- Keep item checkout history ordered by newest activity first while limiting the query to the most recent matching audit rows.
- Extend Activity Log source-contract coverage so the checkout-history SQL limit and parameter stay in place.

## Why This Was The Highest-Value Next Step

Recent Activity Log work capped broad recent-log reads and hardened audit writes. Repository readback showed the item-specific checkout-history path still read every matching audit row for an item. That can make item detail/history workflows sluggish for audit-heavy items, so this applies the same bounded-read reliability safeguard without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ActivityLogService.cs`, `ActivityLogCheckoutHistoryContractTests.cs`, and one progress note.
- GitHub connector readback confirmed `MaxCheckoutHistoryLogCount = 500`, `ORDER BY Timestamp DESC LIMIT @CheckoutHistoryLimit`, and the `@CheckoutHistoryLimit` parameter are present in `GetCheckoutHistoryForItemAsync` before database execution.
- GitHub connector readback confirmed the source-contract test requires the checkout-history cap and executed parameter while preserving legacy item-id and item-number activity matching.
- Layout impact: this is not a visual layout change. It bounds the row count behind existing item checkout-history displays without changing control sizing or visual behavior across the required 1366x768 through 3840x2160 target range.
- GitHub connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation and live WPF screenshots were not run.
- The repository default branch reports as `master`; this run mentioned `main`, but GitHub metadata and current history show `master` is active.

## Follow-up

- Run full Windows/.NET validation when a Windows-capable environment is available.