### PR TITLE
Guard reservation create inserts

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceWriteGuardContractTests.cs
@@ -7,6 +7,39 @@ namespace InventoryManagementApp.Tests
     public class ReservationServiceWriteGuardContractTests
     {
         [Fact]
+        public void ReservationCreateChecksInsertedRowsBeforeReturningId()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+            var createMethod = ExtractMethod(
+                source,
+                "public async Task<int> CreateReservationAsync(Reservation reservation)",
+                "public async Task<bool> UpdateReservationAsync");
+
+            AssertContainsAll(
+                createMethod,
+                "var insertedRows = cmd.ExecuteNonQuery();",
+                "EnsureReservationCreateSucceeded(insertedRows);",
+                "using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn);",
+                "if (id < 1)",
+                "throw new InvalidOperationException(\"Unable to create reservation.\");",
+                "return id;");
+
+            Assert.True(
+                createMethod.IndexOf("var insertedRows = cmd.ExecuteNonQuery();", StringComparison.Ordinal) <
+                createMethod.IndexOf("EnsureReservationCreateSucceeded(insertedRows);", StringComparison.Ordinal),
+                "Expected reservation creates to inspect affected rows after executing the insert.");
+            Assert.True(
+                createMethod.IndexOf("EnsureReservationCreateSucceeded(insertedRows);", StringComparison.Ordinal) <
+                createMethod.IndexOf("using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn);", StringComparison.Ordinal),
+                "Expected failed reservation creates to stop before reading the new reservation id.");
+            Assert.True(
+                createMethod.IndexOf("if (id < 1)", StringComparison.Ordinal) <
+                createMethod.IndexOf("return id;", StringComparison.Ordinal),
+                "Expected reservation creates to reject an invalid inserted id before reporting success.");
+            Assert.DoesNotContain("SELECT last_insert_rowid();\";", createMethod, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ReservationWritesThrowWhenNoRowsAreAffected()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
@@ -47,6 +80,19 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("throw new InvalidOperationException(\"Reservation not found.\");", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ReservationWriteGuardKeepsCreateSpecificFailureMessage()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+
+            AssertContainsAll(
+                source,
+                "private static void EnsureReservationWriteSucceeded(int affectedRows)",
+                "throw new InvalidOperationException(\"Reservation not found.\");",
+                "private static void EnsureReservationCreateSucceeded(int affectedRows)",
+                "throw new InvalidOperationException(\"Unable to create reservation.\");");
+        }
+
         private static void AssertWriteGuard(
             string source,
             string startMarker,
@@ -66,6 +112,14 @@ namespace InventoryManagementApp.Tests
             Assert.True(
                 method.IndexOf(guardSnippet, StringComparison.Ordinal) < method.IndexOf("return true;", StringComparison.Ordinal),
                 $"Expected {startMarker} to fail stale writes before reporting success.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-reservation-create-write-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-reservation-create-write-guard.md
@@ -1,0 +1,14 @@
+# Reservation Create Write Guard
+
+## What changed
+- Split reservation creation into an explicit insert followed by a new-id lookup on the same SQLite connection.
+- Added an affected-row check so a zero-row reservation insert throws `Unable to create reservation.` instead of returning a misleading id.
+- Extended reservation write-guard source-contract coverage so the create path checks inserted rows before reading `last_insert_rowid()` or returning success.
+
+## Why it matters
+Reservation updates, confirmations, cancellations, fulfillment, and deletion already guarded zero-row writes. Creation was the remaining reservation write path that could report success after a non-throwing command without separately proving a row was inserted. This keeps the reservation workflow consistent with the rest of the service and reduces the chance of quiet persistence failures.
+
+## Validation
+- Connector readback should confirm `CreateReservationAsync` stores `insertedRows`, calls `EnsureReservationCreateSucceeded(insertedRows)`, reads `last_insert_rowid()` only after that guard, and rejects ids below 1.
+- Connector readback should confirm `ReservationServiceWriteGuardContractTests` covers the create insert guard and preserves the create-specific failure message.
+- Local .NET tests, WPF runtime checks, and full Windows validation could not be run from the scheduled Linux environment.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -209,8 +209,7 @@ namespace InventoryManagementApp.Services.Reservations
                      Quantity, Status, Notes, CreatedByUserID, CreatedAt)
                     VALUES 
                     (@ItemID, @CustomerID, @ReservationDate, @StartDate, @EndDate, 
-                     @Quantity, @Status, @Notes, @CreatedByUserID, @CreatedAt);
-                    SELECT last_insert_rowid();";
+                     @Quantity, @Status, @Notes, @CreatedByUserID, @CreatedAt)";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ItemID", reservation.ItemID);
                 cmd.Parameters.AddWithValue("@CustomerID", reservation.CustomerID);
@@ -222,7 +221,14 @@ namespace InventoryManagementApp.Services.Reservations
                 cmd.Parameters.AddWithValue("@Notes", ToDbNullableText(reservation.Notes));
                 cmd.Parameters.AddWithValue("@CreatedByUserID", _userContext.CurrentUser?.UserID ?? 0);
                 cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
-                var id = Convert.ToInt32(cmd.ExecuteScalar());
+                var insertedRows = cmd.ExecuteNonQuery();
+                EnsureReservationCreateSucceeded(insertedRows);
+
+                using var idCmd = new SqliteCommand("SELECT last_insert_rowid();", conn);
+                var id = Convert.ToInt32(idCmd.ExecuteScalar());
+                if (id < 1)
+                    throw new InvalidOperationException("Unable to create reservation.");
+
                 return id;
             });
         }
@@ -433,6 +439,12 @@ namespace InventoryManagementApp.Services.Reservations
         {
             if (affectedRows == 0)
                 throw new InvalidOperationException("Reservation not found.");
+        }
+
+        private static void EnsureReservationCreateSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
+                throw new InvalidOperationException("Unable to create reservation.");
         }
 
         private static void EnsureReservationItemExists(SqliteConnection conn, int itemID)


### PR DESCRIPTION
## Summary

- Split reservation creation into an explicit insert followed by a same-connection `last_insert_rowid()` lookup.
- Add an affected-row guard so zero-row reservation inserts throw `Unable to create reservation.` before reading or returning an id.
- Extend reservation write-guard source-contract coverage and add a progress note for the workflow hardening.

## Why This Was The Highest-Value Next Step

Full Windows/.NET validation remains the top repository need, but this scheduled Linux environment still cannot run it. Recent service work hardened write paths across rentals and activity logs, and current repository readback showed reservations already guarded update, confirm, cancel, fulfill, and delete writes. Creation was the remaining reservation write path that could move from a non-throwing command to returning an id without explicitly proving a row was inserted.

## Why The Scope Counts As Real Progress

This completes a coherent reservation persistence reliability slice: service behavior, source-contract coverage, and progress notes all move together. It is intentionally focused, but it improves a core workflow end to end rather than making an isolated naming or formatting change.

## Validation

- GitHub connector readback confirmed `CreateReservationAsync` now stores `insertedRows`, calls `EnsureReservationCreateSucceeded(insertedRows)`, reads `last_insert_rowid()` only after the guard, and rejects ids below 1.
- GitHub connector readback confirmed `ReservationServiceWriteGuardContractTests` covers the create insert guard, guard ordering, id validation, and create-specific failure message.
- GitHub connector readback confirmed the progress note is present.
- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ReservationService.cs`, `ReservationServiceWriteGuardContractTests.cs`, and one progress note.
- GitHub connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## What Could Not Be Checked

- Direct local checkout is blocked in this scheduled container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, and `gh` are unavailable here, so local build/test/full validation, WPF runtime checks, and local banned-word checks were not run.

## Known Follow-up Work

- Run `pwsh -File scripts/run-full-validation.ps1` in a Windows/.NET-capable checkout.
- Continue reviewing persistence paths for any remaining create operations that return success without explicit write confirmation.