### PR TITLE
Guard maintenance and calibration create inserts

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceCalibrationWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceCalibrationWriteGuardContractTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MaintenanceCalibrationWriteGuardContractTests
+    {
+        [Fact]
+        public void MaintenanceCreateChecksInsertedRowsBeforeReturningId()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+            var createMethod = ExtractMethod(
+                source,
+                "public async Task<int> CreateMaintenanceRecordAsync(MaintenanceRecord record)",
+                "public async Task<bool> UpdateMaintenanceRecordAsync");
+
+            AssertCreateGuard(
+                createMethod,
+                "EnsureMaintenanceCreateSucceeded(insertedRows);",
+                "Unable to create maintenance record.");
+        }
+
+        [Fact]
+        public void CalibrationCreateChecksInsertedRowsBeforeReturningId()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+            var createMethod = ExtractMethod(
+                source,
+                "public async Task<int> CreateCalibrationRecordAsync(CalibrationRecord record)",
+                "public async Task<bool> UpdateCalibrationRecordAsync");
+
+            AssertCreateGuard(
+                createMethod,
+                "EnsureCalibrationCreateSucceeded(insertedRows);",
+                "Unable to create calibration record.");
+        }
+
+        [Fact]
+        public void CreateWriteGuardsKeepWorkflowSpecificFailureMessages()
+        {
+            var maintenanceSource = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+            var calibrationSource = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+
+            AssertContainsAll(
+                maintenanceSource,
+                "private static void EnsureMaintenanceCreateSucceeded(int affectedRows)",
+                "throw new InvalidOperationException(\"Unable to create maintenance record.\");");
+            AssertContainsAll(
+                calibrationSource,
+                "private static void EnsureCalibrationCreateSucceeded(int affectedRows)",
+                "throw new InvalidOperationException(\"Unable to create calibration record.\");");
+        }
+
+        private static void AssertCreateGuard(
+            string createMethod,
+            string guardSnippet,
+            string failureMessage)
+        {
+            AssertContainsAll(
+                createMethod,
+                "var insertedRows = cmd.ExecuteNonQuery();",
+                guardSnippet,
+                "using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn);",
+                "if (id < 1)",
+                $"throw new InvalidOperationException(\"{failureMessage}\");",
+                "return id;");
+            Assert.DoesNotContain("SELECT last_insert_rowid();\";", createMethod, StringComparison.Ordinal);
+
+            Assert.True(
+                createMethod.IndexOf("var insertedRows = cmd.ExecuteNonQuery();", StringComparison.Ordinal) <
+                createMethod.IndexOf(guardSnippet, StringComparison.Ordinal),
+                "Expected create methods to inspect affected rows immediately after executing the insert.");
+            Assert.True(
+                createMethod.IndexOf(guardSnippet, StringComparison.Ordinal) <
+                createMethod.IndexOf("using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn);", StringComparison.Ordinal),
+                "Expected failed creates to stop before reading the inserted id.");
+            Assert.True(
+                createMethod.IndexOf("if (id < 1)", StringComparison.Ordinal) <
+                createMethod.IndexOf("return id;", StringComparison.Ordinal),
+                "Expected create methods to reject invalid inserted ids before reporting success.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-maintenance-calibration-create-write-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-maintenance-calibration-create-write-guards.md
@@ -1,0 +1,14 @@
+# Maintenance And Calibration Create Write Guards
+
+## What changed
+- Split maintenance record creation into an explicit insert followed by a same-connection `last_insert_rowid()` lookup.
+- Split calibration record creation into the same explicit insert plus guarded id lookup pattern.
+- Added source-contract coverage so both create paths confirm affected rows before reading an inserted id or reporting success.
+
+## Why it matters
+Maintenance and calibration update/delete paths already fail when a raced write affects no rows. Their create paths still used a combined insert plus id scalar query, which could report success after any non-throwing command without separately proving a row was inserted. Guarding both workflows keeps equipment-care persistence behavior aligned with the rest of the hardened service layer.
+
+## Validation
+- Connector readback should confirm `CreateMaintenanceRecordAsync` and `CreateCalibrationRecordAsync` store `insertedRows`, call their create guards, read `last_insert_rowid()` only after the guard, and reject ids below 1.
+- Connector readback should confirm `MaintenanceCalibrationWriteGuardContractTests` covers both create guards and their workflow-specific failure messages.
+- Local .NET tests, WPF runtime checks, and full Windows validation could not be run from the scheduled Linux environment.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -204,8 +204,7 @@ namespace InventoryManagementApp.Services.Calibration
                      CertificateNumber, Standard, Result, Cost, Notes, UserID, CreatedAt)
                     VALUES 
                     (@ItemID, @CalibrationDate, @NextCalibrationDue, @CalibratedBy, 
-                     @CertificateNumber, @Standard, @Result, @Cost, @Notes, @UserID, @CreatedAt);
-                    SELECT last_insert_rowid();";
+                     @CertificateNumber, @Standard, @Result, @Cost, @Notes, @UserID, @CreatedAt)";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ItemID", record.ItemID);
                 cmd.Parameters.AddWithValue("@CalibrationDate", record.CalibrationDate);
@@ -218,7 +217,14 @@ namespace InventoryManagementApp.Services.Calibration
                 cmd.Parameters.AddWithValue("@Notes", record.Notes);
                 cmd.Parameters.AddWithValue("@UserID", _userContext.CurrentUser?.UserID ?? 0);
                 cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
-                var id = Convert.ToInt32(cmd.ExecuteScalar());
+                var insertedRows = cmd.ExecuteNonQuery();
+                EnsureCalibrationCreateSucceeded(insertedRows);
+
+                using var idCmd = new SqliteCommand("SELECT last_insert_rowid();", conn);
+                var id = Convert.ToInt32(idCmd.ExecuteScalar());
+                if (id < 1)
+                    throw new InvalidOperationException("Unable to create calibration record.");
+
                 return id;
             });
         }
@@ -307,6 +313,12 @@ namespace InventoryManagementApp.Services.Calibration
                 UserID = reader.IsDBNull(reader.GetOrdinal("UserID")) ? 0 : reader.GetInt32(reader.GetOrdinal("UserID")),
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt"))
             };
+        }
+
+        private static void EnsureCalibrationCreateSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
+                throw new InvalidOperationException("Unable to create calibration record.");
         }
 
         private static void EnsureItemExists(SqliteConnection conn, int itemID)

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -182,8 +182,7 @@ namespace InventoryManagementApp.Services.Maintenance
                      PerformedBy, Cost, Status, Notes, UserID, CreatedAt)
                     VALUES 
                     (@ItemID, @ScheduledDate, @CompletedDate, @MaintenanceType, @Description, 
-                     @PerformedBy, @Cost, @Status, @Notes, @UserID, @CreatedAt);
-                    SELECT last_insert_rowid();";
+                     @PerformedBy, @Cost, @Status, @Notes, @UserID, @CreatedAt)";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ItemID", record.ItemID);
                 cmd.Parameters.AddWithValue("@ScheduledDate", record.ScheduledDate);
@@ -196,7 +195,14 @@ namespace InventoryManagementApp.Services.Maintenance
                 cmd.Parameters.AddWithValue("@Notes", record.Notes);
                 cmd.Parameters.AddWithValue("@UserID", _userContext.CurrentUser?.UserID ?? 0);
                 cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
-                var id = Convert.ToInt32(cmd.ExecuteScalar());
+                var insertedRows = cmd.ExecuteNonQuery();
+                EnsureMaintenanceCreateSucceeded(insertedRows);
+
+                using var idCmd = new SqliteCommand("SELECT last_insert_rowid();", conn);
+                var id = Convert.ToInt32(idCmd.ExecuteScalar());
+                if (id < 1)
+                    throw new InvalidOperationException("Unable to create maintenance record.");
+
                 return id;
             });
         }
@@ -314,6 +320,12 @@ namespace InventoryManagementApp.Services.Maintenance
                 UserID = reader.IsDBNull(reader.GetOrdinal("UserID")) ? 0 : reader.GetInt32(reader.GetOrdinal("UserID")),
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt"))
             };
+        }
+
+        private static void EnsureMaintenanceCreateSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
+                throw new InvalidOperationException("Unable to create maintenance record.");
         }
 
         private static void EnsureItemExists(SqliteConnection conn, int itemID)


### PR DESCRIPTION
## Summary

- Split maintenance record creation into an explicit insert followed by a guarded same-connection `last_insert_rowid()` lookup.
- Split calibration record creation into the same guarded insert/id lookup pattern.
- Add source-contract coverage so both create paths confirm affected rows before reading an inserted id or returning success.
- Add a progress note documenting the workflow hardening and validation limits.

## Why This Was The Highest-Value Next Step

Full Windows/.NET validation remains the top repository need, but this scheduled Linux environment still cannot run it. The freshest merged work hardened reservation creates, and repository readback showed maintenance and calibration create workflows had the same persistence shape: a combined insert plus scalar id read with no explicit affected-row confirmation. These are core equipment-care workflows, and their update/delete paths already fail on zero-row writes, so guarding create completes the same reliability pattern for both services.

## Why The Scope Counts As Real Progress

This is a coherent persistence slice across two related workflows rather than a tiny isolated edit. It updates service behavior, adds source-contract coverage for ordering and workflow-specific failure messages, and records the completed work in progress notes. It improves reliability without broad rewrites, UI churn, or new dependencies.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, four commits ahead, and changes only maintenance/calibration services, one source-contract test, and one progress note.
- GitHub connector readback confirmed `CreateMaintenanceRecordAsync` stores `insertedRows`, calls `EnsureMaintenanceCreateSucceeded(insertedRows)`, reads `last_insert_rowid()` only after the guard, rejects ids below 1, and returns the id afterward.
- GitHub connector readback confirmed `CreateCalibrationRecordAsync` stores `insertedRows`, calls `EnsureCalibrationCreateSucceeded(insertedRows)`, reads `last_insert_rowid()` only after the guard, rejects ids below 1, and returns the id afterward.
- GitHub connector readback confirmed `MaintenanceCalibrationWriteGuardContractTests` covers both create guards, ordering before id lookup, invalid-id rejection, and workflow-specific failure messages.
- GitHub connector readback confirmed the progress note is present.
- GitHub connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## What Could Not Be Checked

- Direct local checkout is blocked in this scheduled container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, and `gh` are unavailable here, so local build/test/full validation, WPF runtime checks, screenshots, and local banned-word checks were not run.

## Known Follow-up Work

- Run `pwsh -File scripts/run-full-validation.ps1` in a Windows/.NET-capable checkout.
- Continue reviewing remaining create workflows for insert-result checks, prioritizing core persistence paths that still combine insert and id lookup without an affected-row guard.