### PR TITLE
Harden kit create persistence guards

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceWriteGuardContractTests.cs
@@ -7,6 +7,38 @@ namespace InventoryManagementApp.Tests
     public class KitServiceWriteGuardContractTests
     {
         [Fact]
+        public void KitCreateChecksInsertedRowsBeforeReturningId()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+            var createMethod = ExtractMethod(
+                source,
+                "public async Task<int> CreateKitAsync",
+                "public async Task<bool> UpdateKitAsync");
+
+            AssertCreateGuard(
+                createMethod,
+                "EnsureKitCreateSucceeded(insertedRows);",
+                "Unable to create kit.");
+            Assert.Contains("private static void EnsureKitCreateSucceeded(int affectedRows)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitItemCreateChecksInsertedRowsBeforeReturningId()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+            var createMethod = ExtractMethod(
+                source,
+                "public async Task<int> AddKitItemAsync",
+                "public async Task<bool> UpdateKitItemAsync");
+
+            AssertCreateGuard(
+                createMethod,
+                "EnsureKitItemCreateSucceeded(insertedRows);",
+                "Unable to add kit item.");
+            Assert.Contains("private static void EnsureKitItemCreateSucceeded(int affectedRows)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void KitWritesThrowWhenNoRowsAreAffected()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
@@ -48,6 +80,34 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("private static void EnsureKitItemWriteSucceeded(int affectedRows)", source, StringComparison.Ordinal);
             Assert.Contains("throw new InvalidOperationException(\"Kit item not found.\");", source, StringComparison.Ordinal);
+        }
+
+        private static void AssertCreateGuard(
+            string createMethod,
+            string guardSnippet,
+            string failureMessage)
+        {
+            Assert.Contains("var insertedRows = cmd.ExecuteNonQuery();", createMethod, StringComparison.Ordinal);
+            Assert.Contains(guardSnippet, createMethod, StringComparison.Ordinal);
+            Assert.Contains("using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn);", createMethod, StringComparison.Ordinal);
+            Assert.Contains("if (id < 1)", createMethod, StringComparison.Ordinal);
+            Assert.Contains($"throw new InvalidOperationException(\"{failureMessage}\");", createMethod, StringComparison.Ordinal);
+            Assert.Contains("return id;", createMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("cmd.ExecuteScalar()", createMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("SELECT last_insert_rowid();\";", createMethod, StringComparison.Ordinal);
+
+            Assert.True(
+                createMethod.IndexOf("var insertedRows = cmd.ExecuteNonQuery();", StringComparison.Ordinal) <
+                createMethod.IndexOf(guardSnippet, StringComparison.Ordinal),
+                "Expected create methods to inspect affected rows immediately after executing the insert.");
+            Assert.True(
+                createMethod.IndexOf(guardSnippet, StringComparison.Ordinal) <
+                createMethod.IndexOf("using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn);", StringComparison.Ordinal),
+                "Expected failed creates to stop before reading the inserted id.");
+            Assert.True(
+                createMethod.IndexOf("if (id < 1)", StringComparison.Ordinal) <
+                createMethod.IndexOf("return id;", StringComparison.Ordinal),
+                "Expected create methods to reject invalid inserted ids before reporting success.");
         }
 
         private static void AssertWriteGuard(

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-kit-create-write-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-kit-create-write-guards.md
@@ -1,0 +1,15 @@
+# Kit Create Write Guards
+
+## What changed
+- Split kit creation into an explicit insert followed by a same-connection `last_insert_rowid()` lookup.
+- Split kit-item creation into the same explicit insert plus guarded id lookup pattern.
+- Added affected-row checks so zero-row kit creates throw `Unable to create kit.` and zero-row kit-item creates throw `Unable to add kit item.` before any inserted id is read or returned.
+- Extended kit write-guard source-contract coverage so both create paths keep the insert guard before id lookup and reject invalid inserted ids.
+
+## Why it matters
+Kit updates, deletes, kit-item updates, and kit-item removals already check affected rows before reporting success. The create paths still used combined insert/id scalar commands, which could hide a non-inserting command behind an id lookup. Guarding both workflows keeps kit persistence aligned with the recently hardened reservation, maintenance, and calibration create paths.
+
+## Validation
+- Connector readback should confirm `CreateKitAsync` and `AddKitItemAsync` store `insertedRows`, call create-specific guards, read `last_insert_rowid()` only after the guard, and reject ids below 1.
+- Connector readback should confirm `KitServiceWriteGuardContractTests` covers both create guards and keeps the existing update/delete write guards intact.
+- Local .NET tests, WPF runtime checks, and full Windows validation could not be run from the scheduled Linux environment.

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -144,8 +144,7 @@ namespace InventoryManagementApp.Services.Kits
                     INSERT INTO Kits 
                     (KitNumber, Name, Description, Category, IsActive, CreatedByUserID, CreatedAt, UpdatedAt)
                     VALUES 
-                    (@KitNumber, @Name, @Description, @Category, @IsActive, @CreatedByUserID, @CreatedAt, @UpdatedAt);
-                    SELECT last_insert_rowid();";
+                    (@KitNumber, @Name, @Description, @Category, @IsActive, @CreatedByUserID, @CreatedAt, @UpdatedAt)";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@KitNumber", kit.KitNumber.Trim());
                 cmd.Parameters.AddWithValue("@Name", kit.Name.Trim());
@@ -155,7 +154,13 @@ namespace InventoryManagementApp.Services.Kits
                 cmd.Parameters.AddWithValue("@CreatedByUserID", _userContext.CurrentUser?.UserID ?? 0);
                 cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
                 cmd.Parameters.AddWithValue("@UpdatedAt", DateTime.Now);
-                var id = Convert.ToInt32(cmd.ExecuteScalar());
+                var insertedRows = cmd.ExecuteNonQuery();
+                EnsureKitCreateSucceeded(insertedRows);
+
+                using var idCmd = new SqliteCommand("SELECT last_insert_rowid();", conn);
+                var id = Convert.ToInt32(idCmd.ExecuteScalar());
+                if (id < 1)
+                    throw new InvalidOperationException("Unable to create kit.");
                 return id;
             });
         }
@@ -239,14 +244,19 @@ namespace InventoryManagementApp.Services.Kits
                     INSERT INTO KitItems 
                     (KitID, ItemID, Quantity, IsOptional)
                     VALUES 
-                    (@KitID, @ItemID, @Quantity, @IsOptional);
-                    SELECT last_insert_rowid();";
+                    (@KitID, @ItemID, @Quantity, @IsOptional)";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@KitID", kitItem.KitID);
                 cmd.Parameters.AddWithValue("@ItemID", kitItem.ItemID);
                 cmd.Parameters.AddWithValue("@Quantity", kitItem.Quantity);
                 cmd.Parameters.AddWithValue("@IsOptional", kitItem.IsOptional ? 1 : 0);
-                var id = Convert.ToInt32(cmd.ExecuteScalar());
+                var insertedRows = cmd.ExecuteNonQuery();
+                EnsureKitItemCreateSucceeded(insertedRows);
+
+                using var idCmd = new SqliteCommand("SELECT last_insert_rowid();", conn);
+                var id = Convert.ToInt32(idCmd.ExecuteScalar());
+                if (id < 1)
+                    throw new InvalidOperationException("Unable to add kit item.");
                 return id;
             });
         }
@@ -389,10 +399,22 @@ namespace InventoryManagementApp.Services.Kits
                 throw new InvalidOperationException("Kit item not found.");
         }
 
+        private static void EnsureKitCreateSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
+                throw new InvalidOperationException("Unable to create kit.");
+        }
+
         private static void EnsureKitWriteSucceeded(int affectedRows)
         {
             if (affectedRows == 0)
                 throw new InvalidOperationException("Kit not found.");
+        }
+
+        private static void EnsureKitItemCreateSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
+                throw new InvalidOperationException("Unable to add kit item.");
         }
 
         private static void EnsureKitItemWriteSucceeded(int affectedRows)


### PR DESCRIPTION
## What changed
- Split `CreateKitAsync` into an explicit insert followed by a same-connection `last_insert_rowid()` lookup.
- Split `AddKitItemAsync` into the same explicit insert plus guarded id lookup pattern.
- Added create-specific affected-row guards and invalid-id rejection before either create path reports success.
- Extended `KitServiceWriteGuardContractTests` to cover the new create guard ordering while preserving the existing update/delete guard contracts.
- Added a progress note for the completed kit persistence hardening slice.

## Why this was the highest-value next step
Recent merged work hardened reservation, maintenance, calibration, rental, and activity-log persistence paths. Repo evidence showed kit and kit-item creation still used combined insert/id scalar commands, so this was the next adjacent data-integrity risk in an existing core workflow.

## Why this is real progress
This completes a vertical kit-management persistence slice across service behavior, source-contract coverage, and project notes. It closes both kit create paths rather than making a tiny isolated guard change.

## Validation
- GitHub connector compare confirms the branch is current with `master` and limited to `KitService`, its write-guard contract tests, and one progress note.
- Connector readback confirms both create paths now store `insertedRows`, call workflow-specific create guards, read `last_insert_rowid()` only after the guard, reject ids below 1, and return the id afterward.
- Connector readback confirms `KitServiceWriteGuardContractTests` covers both create guard paths and keeps the existing update/delete write-guard coverage.
- Connector status/workflow readback found no attached commit statuses or workflow runs for the branch head at PR creation time.

## Could not be checked
- Local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local .NET tests, PowerShell validation runner, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue reviewing remaining create paths for the same explicit insert/id guard pattern where repo evidence shows a gap.