### PR TITLE
Guard user create insert results

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
@@ -81,6 +81,36 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void AddUserChecksInsertedRowsBeforeAssigningNewUserId()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task AddUserAsync",
+                "public async Task UpdateUserAsync");
+
+            Assert.Contains("var insertedRows = await cmd.ExecuteNonQueryAsync();", method, StringComparison.Ordinal);
+            Assert.Contains("EnsureUserCreateSucceeded(insertedRows);", method, StringComparison.Ordinal);
+            Assert.Contains("using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn);", method, StringComparison.Ordinal);
+            Assert.Contains("user.UserID = Convert.ToInt32(await idCmd.ExecuteScalarAsync());", method, StringComparison.Ordinal);
+            Assert.Contains("if (user.UserID < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException(\"Unable to create user.\");", method, StringComparison.Ordinal);
+            Assert.Contains("static void EnsureUserCreateSucceeded(int rows)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("SELECT last_insert_rowid();\";", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("cmd.ExecuteScalarAsync()", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("var insertedRows = await cmd.ExecuteNonQueryAsync();", StringComparison.Ordinal) < method.IndexOf("EnsureUserCreateSucceeded(insertedRows);", StringComparison.Ordinal),
+                "User creation should capture affected rows before checking the insert result.");
+            Assert.True(
+                method.IndexOf("EnsureUserCreateSucceeded(insertedRows);", StringComparison.Ordinal) < method.IndexOf("using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn);", StringComparison.Ordinal),
+                "Failed user creates should stop before reading a new user id.");
+            Assert.True(
+                method.IndexOf("if (user.UserID < 1)", StringComparison.Ordinal) < method.IndexOf("user.PasswordHash = hashed;", StringComparison.Ordinal),
+                "Invalid user ids should fail before the in-memory user is finalized.");
+        }
+
+        [Fact]
         public void ChangePasswordRejectsInvalidUserIdsBeforeAuthorizationPasswordAndSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-user-create-write-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-user-create-write-guard.md
@@ -1,0 +1,15 @@
+# User Create Write Guard
+
+## What changed
+- Split user creation into an explicit insert followed by a same-connection `last_insert_rowid()` lookup.
+- Added an affected-row check so zero-row user inserts throw `Unable to create user.` before any new user id is read.
+- Added invalid-id rejection before the in-memory user is finalized with password hash, salt, login-failure, and lockout state.
+- Extended user service source-contract coverage so the create guard ordering stays aligned with the rest of the hardened persistence paths.
+
+## Why it matters
+User management is a core admin workflow. Recent work hardened reservation, maintenance, calibration, kit, and activity-log creation paths so a non-throwing insert cannot be mistaken for a successful create. `AddUserAsync` still combined the insert and id lookup in one scalar command, so this closes the matching reliability gap for account creation without changing the visible workflow.
+
+## Validation
+- Connector readback should confirm `AddUserAsync` stores `insertedRows`, calls `EnsureUserCreateSucceeded(insertedRows)`, reads `last_insert_rowid()` only after the guard, and rejects ids below 1 before finalizing the in-memory user.
+- Connector readback should confirm `UserServiceEntryPointContractTests` covers the user create guard, ordering before id lookup, invalid-id rejection, and removal of the combined insert/scalar pattern.
+- Local .NET tests, WPF runtime checks, and full Windows validation could not be run from the scheduled Linux environment.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -257,6 +257,12 @@ namespace InventoryManagementApp.Services.Users
             EnsureUserWriteSucceeded(clearedRows, userID);
         }
 
+        static void EnsureUserCreateSucceeded(int rows)
+        {
+            if (rows == 0)
+                throw new InvalidOperationException("Unable to create user.");
+        }
+
         static void EnsureUserWriteSucceeded(int rows, int userID)
         {
             if (rows == 0)
@@ -285,8 +291,7 @@ namespace InventoryManagementApp.Services.Users
                 INSERT INTO Users
                   (UserName, PasswordHash, PasswordSalt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired, Permissions)
                 VALUES
-                  (@UserName,@PasswordHash,@PasswordSalt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@PasswordExpired,@Permissions);
-                SELECT last_insert_rowid();";
+                  (@UserName,@PasswordHash,@PasswordSalt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@PasswordExpired,@Permissions)";
 
             using var conn = _dbService.CreateConnection();
             using var cmd = new SqliteCommand(sql, conn);
@@ -322,7 +327,13 @@ namespace InventoryManagementApp.Services.Users
             });
             try
             {
-                user.UserID = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+                var insertedRows = await cmd.ExecuteNonQueryAsync();
+                EnsureUserCreateSucceeded(insertedRows);
+
+                using var idCmd = new SqliteCommand("SELECT last_insert_rowid();", conn);
+                user.UserID = Convert.ToInt32(await idCmd.ExecuteScalarAsync());
+                if (user.UserID < 1)
+                    throw new InvalidOperationException("Unable to create user.");
             }
             catch (SqliteException ex) when (ex.SqliteErrorCode == SQLitePCL.raw.SQLITE_CONSTRAINT &&
                                              ex.Message.Contains("Users.UserName", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## What changed
- Split `AddUserAsync` into an explicit insert followed by a same-connection `last_insert_rowid()` lookup.
- Added `EnsureUserCreateSucceeded` so zero-row user inserts throw `Unable to create user.` before any new id is read.
- Added invalid-id rejection before the in-memory user is finalized with password hash, salt, login-failure, and lockout state.
- Extended `UserServiceEntryPointContractTests` to guard create ordering and reject the old combined insert/scalar pattern.
- Added a progress note for the completed user-management persistence hardening slice.

## Why this was the highest-value next step
Full Windows/.NET validation remains the top repo need, but this scheduled Linux environment still cannot run it. The freshest merged work hardened reservation, maintenance, calibration, kit, kit-item, and activity-log create/write paths. Connector readback showed user creation still combined insert and id lookup in one scalar command, making it the next clear core workflow data-integrity gap.

## Why this is real progress
This is a complete admin user-management persistence slice across service behavior, source-contract coverage, and project notes. It is focused, but it closes the remaining create guard pattern in a core workflow rather than making a small isolated polish edit.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, and limited to `UserService`, `UserServiceEntryPointContractTests`, and one progress note.
- Connector readback confirmed `AddUserAsync` now stores `insertedRows`, calls `EnsureUserCreateSucceeded(insertedRows)`, reads `last_insert_rowid()` only after the guard, rejects ids below 1, and finalizes the in-memory user afterward.
- Connector readback confirmed `UserServiceEntryPointContractTests` covers the user create guard, ordering before id lookup, invalid-id rejection before in-memory finalization, and absence of the old combined `SELECT last_insert_rowid();` scalar pattern.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local .NET tests, PowerShell validation runner, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue reviewing any remaining create/write paths for explicit affected-row handling only where repo evidence shows a concrete gap.