### PR TITLE
Harden user create validation guards

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
@@ -81,6 +81,42 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void AddUserValidatesInputsBeforeLookupPasswordHashingAndSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task AddUserAsync",
+                "public async Task UpdateUserAsync");
+
+            Assert.Contains("if (user is null)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(user));", method, StringComparison.Ordinal);
+            Assert.Contains("user.UserName = (user.UserName ?? string.Empty).Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentException(\"Username cannot be empty.\", nameof(user.UserName));", method, StringComparison.Ordinal);
+            Assert.Contains("var password = (user.PasswordHash ?? string.Empty).Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentException(\"Password cannot be empty.\", nameof(user.PasswordHash));", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("if (user is null)", StringComparison.Ordinal) < method.IndexOf("var existingUsers = await GetAllUsersAsync", StringComparison.Ordinal),
+                "Null users should fail before loading existing users.");
+            Assert.True(
+                method.IndexOf("user.UserName = (user.UserName ?? string.Empty).Trim();", StringComparison.Ordinal) < method.IndexOf("var existingUsers = await GetAllUsersAsync", StringComparison.Ordinal),
+                "Usernames should be normalized before existing-user lookup and insert work.");
+            Assert.True(
+                method.IndexOf("throw new ArgumentException(\"Username cannot be empty.\", nameof(user.UserName));", StringComparison.Ordinal) < method.IndexOf("var existingUsers = await GetAllUsersAsync", StringComparison.Ordinal),
+                "Blank usernames should fail before existing-user lookup and authorization work.");
+            Assert.True(
+                method.IndexOf("var password = (user.PasswordHash ?? string.Empty).Trim();", StringComparison.Ordinal) < method.IndexOf("const string sql = @\"", StringComparison.Ordinal),
+                "Password validation should happen before insert SQL is prepared.");
+            Assert.True(
+                method.IndexOf("PasswordValidator.IsValid", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                "Invalid user passwords should fail before opening a database connection.");
+            Assert.True(
+                method.IndexOf("PasswordValidator.IsValid", StringComparison.Ordinal) < method.IndexOf("SecurityHelper.HashPasswordAsync", StringComparison.Ordinal),
+                "Invalid user passwords should fail before password hashing work.");
+        }
+
+        [Fact]
         public void AddUserChecksInsertedRowsBeforeAssigningNewUserId()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-user-create-validation-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-user-create-validation-guards.md
@@ -1,0 +1,20 @@
+# User Create Validation Guards
+
+Date: 2026-06-30
+
+## Completed
+
+- Hardened `UserService.AddUserAsync` so null user models fail immediately before existing-user lookup, authorization, SQL, or hashing work.
+- Normalized new-account usernames by trimming them before lookup and insert parameter binding.
+- Added an explicit blank-username failure before existing-user lookup and authorization work.
+- Moved create-password validation ahead of insert SQL preparation, SQLite connection creation, and password hashing.
+- Extended `UserServiceEntryPointContractTests` so the admin user creation workflow keeps the validation, normalization, password validation, and existing insert-result guard ordering.
+
+## Why It Matters
+
+Admin user creation is a core setup and account-management workflow. Failing invalid inputs before database and hashing work prevents avoidable null-reference crashes, avoids storing usernames with accidental surrounding whitespace, and keeps user-facing validation errors close to the source of the bad input.
+
+## Validation
+
+- Source-contract coverage was updated to pin the validation order for `AddUserAsync`.
+- Local build/test/full validation could not be run in the scheduled Linux environment because direct checkout is blocked and the required Windows/.NET/PowerShell tooling is unavailable here.

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-user-create-validation-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-user-create-validation-guards.md
@@ -7,12 +7,12 @@ Date: 2026-06-30
 - Hardened `UserService.AddUserAsync` so null user models fail immediately before existing-user lookup, authorization, SQL, or hashing work.
 - Normalized new-account usernames by trimming them before lookup and insert parameter binding.
 - Added an explicit blank-username failure before existing-user lookup and authorization work.
-- Moved create-password validation ahead of insert SQL preparation, SQLite connection creation, and password hashing.
+- Moved create-password validation ahead of insert SQL preparation, create-connection work, and password hashing while preserving the existing first-user/admin authorization flow.
 - Extended `UserServiceEntryPointContractTests` so the admin user creation workflow keeps the validation, normalization, password validation, and existing insert-result guard ordering.
 
 ## Why It Matters
 
-Admin user creation is a core setup and account-management workflow. Failing invalid inputs before database and hashing work prevents avoidable null-reference crashes, avoids storing usernames with accidental surrounding whitespace, and keeps user-facing validation errors close to the source of the bad input.
+Admin user creation is a core setup and account-management workflow. Failing invalid account models and usernames before database work prevents avoidable null-reference crashes, trimming avoids storing usernames with accidental surrounding whitespace, and validating create passwords before insert preparation keeps user-facing validation errors close to the source of the bad input.
 
 ## Validation
 

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -278,6 +278,13 @@ namespace InventoryManagementApp.Services.Users
 
         public async Task AddUserAsync(User user)
         {
+            if (user is null)
+                throw new ArgumentNullException(nameof(user));
+
+            user.UserName = (user.UserName ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(user.UserName))
+                throw new ArgumentException("Username cannot be empty.", nameof(user.UserName));
+
             var existingUsers = await GetAllUsersAsync(CancellationToken.None);
             if (existingUsers.Count == 0)
             {
@@ -287,6 +294,13 @@ namespace InventoryManagementApp.Services.Users
             {
                 _auth.EnsurePermission(User.PermissionManageUsers);
             }
+
+            var password = (user.PasswordHash ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(password))
+                throw new ArgumentException("Password cannot be empty.", nameof(user.PasswordHash));
+            if (!PasswordValidator.IsValid(password, out var error))
+                throw new ArgumentException(error, nameof(user.PasswordHash));
+
             const string sql = @"
                 INSERT INTO Users
                   (UserName, PasswordHash, PasswordSalt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired, Permissions)
@@ -295,12 +309,6 @@ namespace InventoryManagementApp.Services.Users
 
             using var conn = _dbService.CreateConnection();
             using var cmd = new SqliteCommand(sql, conn);
-
-            var password = (user.PasswordHash ?? string.Empty).Trim();
-            if (string.IsNullOrWhiteSpace(password))
-                throw new ArgumentException("Password cannot be empty.", nameof(user.PasswordHash));
-            if (!PasswordValidator.IsValid(password, out var error))
-                throw new ArgumentException(error, nameof(user.PasswordHash));
 
             var result = await SecurityHelper.HashPasswordAsync(password).ConfigureAwait(false);
             string hashed = result.hash;


### PR DESCRIPTION
## What changed
- Added an immediate null guard to `UserService.AddUserAsync` before existing-user lookup, authorization, SQL, or hashing work.
- Normalized new-account usernames by trimming them before lookup and insert parameter binding.
- Added an explicit blank-username failure before lookup/authorization work.
- Moved create-password validation ahead of insert SQL preparation, create-connection work, and password hashing while preserving the existing first-user/admin authorization flow.
- Extended `UserServiceEntryPointContractTests` to pin validation, normalization, password validation, and existing insert-result guard ordering.
- Added a progress note for the completed admin user creation validation slice.

## Why this was the highest-value next step
Full Windows/.NET validation remains the top repo need, but this scheduled environment still cannot run it. The freshest merged work hardened user creation persistence in PR #1409; direct readback then showed `AddUserAsync` still accepted invalid account input too far into the workflow. Tightening that same admin account creation path is the next adjacent data-validation risk in a core setup and user-management workflow.

## Why this is real progress
This is a complete admin user creation validation slice across service behavior, source-contract coverage, and project notes. It prevents avoidable null-reference crashes, avoids persisting usernames with accidental surrounding whitespace, and keeps invalid password handling before insert preparation/hashing rather than making a cosmetic one-line edit.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, four commits ahead, and limited to `UserService`, `UserServiceEntryPointContractTests`, and one progress note.
- Connector readback confirmed `AddUserAsync` now guards null users, trims usernames, rejects blank usernames before existing-user lookup, validates the create password before insert SQL/connection/hash work, and preserves the guarded insert/id lookup from PR #1409.
- Connector readback confirmed the source-contract test pins null, username, password-validation, and insert-result guard ordering.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local .NET tests, PowerShell validation runner, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue reviewing admin user-management validation paths only where current repo evidence shows concrete gaps.