### PR TITLE
Harden user update validation guards

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
@@ -147,6 +147,93 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void UpdateUserValidatesUsernameBeforeAuthorizationLookupAndSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateUserAsync",
+                "public async Task<bool> ChangeUserPasswordAsync");
+
+            Assert.Contains("if (user is null)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(user));", method, StringComparison.Ordinal);
+            Assert.Contains("if (user.UserID < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("user.UserName = (user.UserName ?? string.Empty).Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentException(\"Username cannot be empty.\", nameof(user.UserName));", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("if (user is null)", StringComparison.Ordinal) < method.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Null update users should fail before authorization work.");
+            Assert.True(
+                method.IndexOf("if (user.UserID < 1)", StringComparison.Ordinal) < method.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Invalid update user IDs should fail before authorization work.");
+            Assert.True(
+                method.IndexOf("user.UserName = (user.UserName ?? string.Empty).Trim();", StringComparison.Ordinal) < method.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Update usernames should be normalized before authorization, lookup, and SQL work.");
+            Assert.True(
+                method.IndexOf("throw new ArgumentException(\"Username cannot be empty.\", nameof(user.UserName));", StringComparison.Ordinal) < method.IndexOf("GetUserByIDAsync", StringComparison.Ordinal),
+                "Blank update usernames should fail before target-user lookup.");
+            Assert.True(
+                method.IndexOf("throw new ArgumentException(\"Username cannot be empty.\", nameof(user.UserName));", StringComparison.Ordinal) < method.IndexOf("const string sql = @\"", StringComparison.Ordinal),
+                "Blank update usernames should fail before update SQL is prepared.");
+        }
+
+        [Fact]
+        public void UpdateUserValidatesRawReplacementPasswordsBeforeHashingAndSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateUserAsync",
+                "public async Task<bool> ChangeUserPasswordAsync");
+
+            Assert.Contains("var password = user.PasswordHash.Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("if (!PasswordValidator.IsValid(password, out var error))", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentException(error, nameof(user.PasswordHash));", method, StringComparison.Ordinal);
+            Assert.Contains("var result = await SecurityHelper.HashPasswordAsync(password).ConfigureAwait(false);", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("var existing = await GetUserByIDAsync", StringComparison.Ordinal) < method.IndexOf("if (!PasswordValidator.IsValid(password, out var error))", StringComparison.Ordinal),
+                "Missing update users should fail before validating or hashing replacement passwords.");
+            Assert.True(
+                method.IndexOf("if (!PasswordValidator.IsValid(password, out var error))", StringComparison.Ordinal) < method.IndexOf("SecurityHelper.HashPasswordAsync(password)", StringComparison.Ordinal),
+                "Invalid replacement passwords should fail before hashing work.");
+            Assert.True(
+                method.IndexOf("if (!PasswordValidator.IsValid(password, out var error))", StringComparison.Ordinal) < method.IndexOf("const string sql = @\"", StringComparison.Ordinal),
+                "Invalid replacement passwords should fail before update SQL is prepared.");
+            Assert.True(
+                method.IndexOf("if (!PasswordValidator.IsValid(password, out var error))", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                "Invalid replacement passwords should fail before opening an update database connection.");
+        }
+
+        [Fact]
+        public void UpdateUserGuardsStaleAndDuplicateWritesBeforeInMemoryPasswordMutation()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateUserAsync",
+                "public async Task<bool> ChangeUserPasswordAsync");
+
+            Assert.Contains("int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);", method, StringComparison.Ordinal);
+            Assert.Contains("EnsureUserWriteSucceeded(rows, user.UserID);", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (rows == 0)\n                throw new KeyNotFoundException", method, StringComparison.Ordinal);
+            Assert.Contains("catch (SqliteException ex) when (ex.SqliteErrorCode == SQLitePCL.raw.SQLITE_CONSTRAINT &&", method, StringComparison.Ordinal);
+            Assert.Contains("ex.Message.Contains(\"Users.UserName\", StringComparison.OrdinalIgnoreCase)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException(\"A user with the same username already exists.\", ex);", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);", StringComparison.Ordinal) < method.IndexOf("EnsureUserWriteSucceeded(rows, user.UserID);", StringComparison.Ordinal),
+                "User updates should capture affected rows before checking the update result.");
+            Assert.True(
+                method.IndexOf("EnsureUserWriteSucceeded(rows, user.UserID);", StringComparison.Ordinal) < method.IndexOf("user.PasswordHash = hashed;", StringComparison.Ordinal),
+                "Stale user updates should fail before the in-memory user is finalized.");
+            Assert.True(
+                method.IndexOf("throw new InvalidOperationException(\"A user with the same username already exists.\", ex);", StringComparison.Ordinal) < method.IndexOf("user.PasswordHash = hashed;", StringComparison.Ordinal),
+                "Duplicate usernames should fail before the in-memory user is finalized.");
+        }
+
+        [Fact]
         public void ChangePasswordRejectsInvalidUserIdsBeforeAuthorizationPasswordAndSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-user-update-validation-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-user-update-validation-guards.md
@@ -1,0 +1,18 @@
+# User Update Validation Guards - 2026-06-30
+
+## Completed
+
+- Hardened `UserService.UpdateUserAsync` so updated usernames are trimmed and blank usernames fail before authorization, target-user lookup, SQL preparation, or database update work.
+- Applied the existing password policy to raw replacement passwords passed through user updates before hashing, SQL preparation, or update connection work.
+- Reused the existing user write guard for update affected-row checks and kept stale-row failures before in-memory password hash/salt finalization.
+- Added duplicate-username handling so update constraint failures surface the same operator-friendly message used by user creation.
+- Extended `UserServiceEntryPointContractTests` to pin update username normalization, password validation ordering, stale-write guard behavior, duplicate handling, and in-memory finalization ordering.
+
+## Why It Matters
+
+User creation already rejected invalid account input early, but user updates could still carry blank or whitespace-padded usernames into the persistence path and hash raw replacement passwords without the same password-policy check. This keeps the admin user-management workflow consistent across create, update, and password-change paths.
+
+## Validation
+
+- GitHub connector readback/compare was used for source inspection because direct local checkout is blocked in the scheduled environment.
+- Local .NET tests, PowerShell validation, WPF runtime checks, screenshots, and full Windows validation still need to be run from a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -361,7 +361,34 @@ namespace InventoryManagementApp.Services.Users
             if (user.UserID < 1)
                 throw new ArgumentOutOfRangeException(nameof(user), "User ID must be greater than 0.");
 
+            user.UserName = (user.UserName ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(user.UserName))
+                throw new ArgumentException("Username cannot be empty.", nameof(user.UserName));
+
             _auth.EnsurePermission(User.PermissionManageUsers);
+            var existing = await GetUserByIDAsync(user.UserID, CancellationToken.None);
+            if (existing is null)
+                throw new KeyNotFoundException($"User {user.UserID} not found.");
+
+            string hashed = user.PasswordHash;
+            string salt = user.PasswordSalt;
+
+            if (string.IsNullOrWhiteSpace(user.PasswordHash))
+                hashed = existing.PasswordHash;
+            if (string.IsNullOrWhiteSpace(user.PasswordSalt))
+                salt = existing.PasswordSalt;
+
+            if (!string.IsNullOrWhiteSpace(user.PasswordHash) && string.IsNullOrWhiteSpace(user.PasswordSalt))
+            {
+                var password = user.PasswordHash.Trim();
+                if (!PasswordValidator.IsValid(password, out var error))
+                    throw new ArgumentException(error, nameof(user.PasswordHash));
+
+                var result = await SecurityHelper.HashPasswordAsync(password).ConfigureAwait(false);
+                hashed = result.hash;
+                salt = result.salt;
+            }
+
             const string sql = @"
                 UPDATE Users SET
                   UserName      = @UserName,
@@ -377,25 +404,6 @@ namespace InventoryManagementApp.Services.Users
                   IsActive      = @IsActive,
                   Permissions   = @Permissions
                 WHERE UserID = @UserID";
-
-            var existing = await GetUserByIDAsync(user.UserID, CancellationToken.None);
-            if (existing is null)
-                throw new KeyNotFoundException($"User {user.UserID} not found.");
-
-            string hashed = user.PasswordHash;
-            string salt = user.PasswordSalt;
-
-            if (string.IsNullOrWhiteSpace(user.PasswordHash))
-                hashed = existing.PasswordHash;
-            if (string.IsNullOrWhiteSpace(user.PasswordSalt))
-                salt = existing.PasswordSalt;
-
-            if (!string.IsNullOrWhiteSpace(user.PasswordHash) && string.IsNullOrWhiteSpace(user.PasswordSalt))
-            {
-                var result = await SecurityHelper.HashPasswordAsync(user.PasswordHash).ConfigureAwait(false);
-                hashed = result.hash;
-                salt = result.salt;
-            }
 
             var p = new[]
             {
@@ -414,10 +422,17 @@ namespace InventoryManagementApp.Services.Users
                 new SqliteParameter("@Permissions", (object)user.Permissions ?? DBNull.Value)
             };
 
-            using var conn = _dbService.CreateConnection();
-            int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
-            if (rows == 0)
-                throw new KeyNotFoundException($"User {user.UserID} not found.");
+            try
+            {
+                using var conn = _dbService.CreateConnection();
+                int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+                EnsureUserWriteSucceeded(rows, user.UserID);
+            }
+            catch (SqliteException ex) when (ex.SqliteErrorCode == SQLitePCL.raw.SQLITE_CONSTRAINT &&
+                                             ex.Message.Contains("Users.UserName", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("A user with the same username already exists.", ex);
+            }
 
             user.PasswordHash = hashed;
             user.PasswordSalt = salt;


### PR DESCRIPTION
## What changed
- Trim and validate updated usernames in `UserService.UpdateUserAsync` before authorization, lookup, SQL preparation, or database update work.
- Apply the existing password policy to raw replacement passwords passed through user updates before hashing or opening the update connection.
- Reuse the existing user write guard for stale update rows before finalizing the in-memory password hash/salt state.
- Surface duplicate username update constraints with the same operator-friendly message used by user creation.
- Extend `UserServiceEntryPointContractTests` to pin the update validation, stale-write, duplicate-handling, and finalization ordering.
- Add a progress note for the completed user-management validation slice.

## Why this was the highest-value next step
Full Windows/.NET validation remains the top repo need, but this scheduled environment still cannot run it. The freshest merged work hardened user creation validation; connector readback showed the adjacent user update workflow still allowed blank/whitespace-padded usernames into the persistence path and hashed raw replacement passwords without the same password-policy check. That made admin user update validation the next concrete data-integrity gap in the same core workflow.

## Why this is real progress
This completes a focused user-management validation slice across service behavior, source-contract coverage, and progress notes. It aligns create, update, and password-change validation instead of making an isolated cosmetic edit.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, and limited to `UserService`, `UserServiceEntryPointContractTests`, and one progress note.
- Connector readback confirmed `UpdateUserAsync` now trims usernames, rejects blank usernames before authorization/lookup/SQL work, validates raw replacement passwords before hashing/update SQL/connection work, uses `EnsureUserWriteSucceeded(rows, user.UserID)`, maps duplicate username constraints to a friendly `InvalidOperationException`, and finalizes in-memory password fields only after the guarded write.
- Connector readback confirmed source-contract tests cover username normalization, invalid username ordering, raw replacement password validation ordering, stale write guards, duplicate username handling, and finalization ordering.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local .NET tests, PowerShell validation runner, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue reviewing user-management edit flows only where current repo evidence shows concrete validation or persistence gaps.