### PR TITLE
Guard customer create insert results

### DIFF
--- a/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
@@ -74,7 +74,7 @@ namespace InventoryManagementApp.Tests
             AssertCancellationGuardBeforeSql(
                 source,
                 "static async Task EnsureCustomerRowExistsAsync",
-                "static string? GetSkipReason");
+                "static void EnsureCustomerCreateSucceeded");
         }
 
         [Fact]
@@ -99,6 +99,37 @@ namespace InventoryManagementApp.Tests
                 "public async Task ExportCustomersAsync",
                 "    }\n}",
                 "GetAllCustomersAsync");
+        }
+
+        [Fact]
+        public void CustomerCreatesCheckInsertedRowsBeforeAssigningNewCustomerId()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var method = ExtractMethod(
+                source,
+                "async Task InsertCustomerAsync",
+                "async Task<bool> CustomerExistsAsync");
+            var insertSql = method[..method.IndexOf("var p = new[]", StringComparison.Ordinal)];
+
+            Assert.DoesNotContain("SELECT last_insert_rowid();", insertSql, StringComparison.Ordinal);
+            Assert.Contains("var insertedRows = await cmd.ExecuteNonQueryAsync(cancellationToken);", method, StringComparison.Ordinal);
+            Assert.Contains("EnsureCustomerCreateSucceeded(insertedRows);", method, StringComparison.Ordinal);
+            Assert.Contains("using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn, tran);", method, StringComparison.Ordinal);
+            Assert.Contains("customer.CustomerID = Convert.ToInt32(await idCmd.ExecuteScalarAsync(cancellationToken));", method, StringComparison.Ordinal);
+            Assert.Contains("if (customer.CustomerID < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException(\"Unable to create customer.\");", method, StringComparison.Ordinal);
+            Assert.Contains("static void EnsureCustomerCreateSucceeded(int affectedRows)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("customer.CustomerID = Convert.ToInt32(await cmd.ExecuteScalarAsync", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("var insertedRows = await cmd.ExecuteNonQueryAsync(cancellationToken);", StringComparison.Ordinal) < method.IndexOf("EnsureCustomerCreateSucceeded(insertedRows);", StringComparison.Ordinal),
+                "Customer creation should capture affected rows before checking the insert result.");
+            Assert.True(
+                method.IndexOf("EnsureCustomerCreateSucceeded(insertedRows);", StringComparison.Ordinal) < method.IndexOf("using var idCmd = new SqliteCommand(\"SELECT last_insert_rowid();\", conn, tran);", StringComparison.Ordinal),
+                "Failed customer creates should stop before reading a new customer id.");
+            Assert.True(
+                method.IndexOf("if (customer.CustomerID < 1)", StringComparison.Ordinal) > method.IndexOf("customer.CustomerID = Convert.ToInt32(await idCmd.ExecuteScalarAsync(cancellationToken));", StringComparison.Ordinal),
+                "Customer creation should reject invalid inserted ids before returning success.");
         }
 
         private static void AssertCancellationGuardBeforeSqlAndConnection(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-customer-create-write-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-customer-create-write-guard.md
@@ -1,0 +1,19 @@
+# Customer Create Write Guard
+
+Date: 2026-06-30
+
+## Completed
+
+- Hardened customer creation so `InsertCustomerAsync` now executes the customer insert as an explicit non-query write.
+- Added an affected-row guard before reading `last_insert_rowid()`, preventing a zero-row insert from being treated as a successful customer create.
+- Added invalid inserted-id rejection before the create helper returns to direct add and import workflows.
+- Extended `CustomerServiceEntryPointContractTests` to keep the insert guard, id lookup ordering, invalid-id guard, and old combined scalar pattern under source-contract coverage.
+
+## Why This Matters
+
+Customer creation is reused by direct admin adds, CSV import, and generic importer paths. Updates and deletes already guard stale customer writes; this closes the matching create-side persistence gap so customer workflows do not silently report success without a row being inserted.
+
+## Validation
+
+- GitHub connector readback and compare were used for scope verification in this scheduled environment.
+- Local Windows/.NET validation was not available here because direct checkout is blocked by `CONNECT tunnel failed, response 403`, and `dotnet`, PowerShell/`pwsh`, WPF runtime checks, screenshots, and local banned-word checks could not be run.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -373,8 +373,7 @@ namespace InventoryManagementApp.Services.Customers
 
             const string sql = @"
         INSERT INTO Customers (Company, Email, Contact, Phone, Mobile, Address)
-        VALUES (@Company, @Email, @Contact, @Phone, @Mobile, @Address);
-        SELECT last_insert_rowid();";
+        VALUES (@Company, @Email, @Contact, @Phone, @Mobile, @Address);";
 
             var p = new[]
             {
@@ -390,7 +389,13 @@ namespace InventoryManagementApp.Services.Customers
             {
                 using var cmd = new SqliteCommand(sql, conn, tran);
                 cmd.Parameters.AddRange(p);
-                customer.CustomerID = Convert.ToInt32(await cmd.ExecuteScalarAsync(cancellationToken));
+                var insertedRows = await cmd.ExecuteNonQueryAsync(cancellationToken);
+                EnsureCustomerCreateSucceeded(insertedRows);
+
+                using var idCmd = new SqliteCommand("SELECT last_insert_rowid();", conn, tran);
+                customer.CustomerID = Convert.ToInt32(await idCmd.ExecuteScalarAsync(cancellationToken));
+                if (customer.CustomerID < 1)
+                    throw new InvalidOperationException("Unable to create customer.");
             }
             catch (Exception ex)
             {
@@ -436,6 +441,12 @@ namespace InventoryManagementApp.Services.Customers
 
             if (count == 0)
                 throw new KeyNotFoundException($"Customer {customerID} not found.");
+        }
+
+        static void EnsureCustomerCreateSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
+                throw new InvalidOperationException("Unable to create customer.");
         }
 
         static void EnsureCustomerWriteSucceeded(int affectedRows, int customerID)


### PR DESCRIPTION
## What changed
- Split `CustomerService.InsertCustomerAsync` into an explicit customer insert followed by a same-connection `last_insert_rowid()` lookup.
- Added `EnsureCustomerCreateSucceeded` so zero-row customer inserts fail with `Unable to create customer.` before any inserted id is read.
- Added inserted-id validation before direct add, CSV import, or generic importer workflows can treat the customer create as successful.
- Extended `CustomerServiceEntryPointContractTests` to pin the insert guard, id lookup ordering, invalid-id guard, and absence of the old combined insert/scalar pattern.
- Added a progress note for the completed customer persistence hardening slice.

## Why this was the highest-value next step
Full Windows/.NET validation remains the top repo need, but this scheduled environment still cannot run it. Recent merged work has been closing create/write persistence gaps in core services. Connector readback showed customer creation still used the older combined insert plus `last_insert_rowid()` scalar command, while customer update/delete paths already guard stale writes. Customer creation is reused by direct admin adds and both import paths, making it the next concrete data-integrity gap.

## Why this is real progress
This is a focused workflow slice across service behavior, shared create helper behavior used by imports, source-contract coverage, and progress notes. It closes a core customer persistence path rather than making an isolated formatting or naming edit.

## Validation
- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and limited to `CustomerService`, `CustomerServiceEntryPointContractTests`, and one progress note.
- Connector readback confirmed `InsertCustomerAsync` now runs `ExecuteNonQueryAsync`, calls `EnsureCustomerCreateSucceeded(insertedRows)`, reads `last_insert_rowid()` only afterward, and rejects ids below 1 with `Unable to create customer.`.
- Connector readback confirmed source-contract coverage for affected-row ordering, id lookup ordering, invalid-id rejection, and the old `cmd.ExecuteScalarAsync` assignment pattern.
- Connector status and workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local .NET tests, PowerShell validation runner, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue reviewing remaining create/import helpers only where current repo evidence shows a concrete unguarded persistence path.