### PR TITLE
Harden settings write guards

### DIFF
--- a/InventoryManagementApp.Tests/SettingsServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceWriteGuardContractTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class SettingsServiceWriteGuardContractTests
+    {
+        [Fact]
+        public void SaveSettingNormalizesKeysAndGuardsUpsertRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "SettingsService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task SaveSettingAsync",
+                "        /// <summary>\n        /// Retrieves a setting value from the database.");
+
+            Assert.Contains("var normalizedKey = key.Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Key\", normalizedKey)", method, StringComparison.Ordinal);
+            Assert.Contains("var affectedRows = await SqliteHelper.ExecuteNonQueryAsync", method, StringComparison.Ordinal);
+            Assert.Contains("EnsureSettingsWriteSucceeded(affectedRows, normalizedKey);", method, StringComparison.Ordinal);
+            Assert.Contains("Failed to save setting '{normalizedKey}'.", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("await SqliteHelper.ExecuteNonQueryAsync(conn, UpsertSql, p, cancellationToken).ConfigureAwait(false);", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("var normalizedKey = key.Trim();", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Key\", normalizedKey)", StringComparison.Ordinal),
+                "Single setting writes should bind the normalized key.");
+            Assert.True(
+                method.IndexOf("var affectedRows = await SqliteHelper.ExecuteNonQueryAsync", StringComparison.Ordinal) < method.IndexOf("EnsureSettingsWriteSucceeded(affectedRows, normalizedKey);", StringComparison.Ordinal),
+                "Single setting writes should capture affected rows before checking the upsert result.");
+        }
+
+        [Fact]
+        public void BatchSettingsNormalizeAndValidateKeysBeforeOpeningTransaction()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "SettingsService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateSettingsAsync",
+                "public async Task DeleteSettingAsync");
+
+            Assert.Contains("var normalizedSettings = new List<KeyValuePair<string, string>>(settings.Count);", method, StringComparison.Ordinal);
+            Assert.Contains("var normalizedKeys = new HashSet<string>(StringComparer.Ordinal);", method, StringComparison.Ordinal);
+            Assert.Contains("var normalizedKey = kv.Key.Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentException(\"Duplicate setting keys are not allowed.\", nameof(settings));", method, StringComparison.Ordinal);
+            Assert.Contains("normalizedSettings.Add(new KeyValuePair<string, string>(normalizedKey, kv.Value));", method, StringComparison.Ordinal);
+            Assert.Contains("foreach (var kv in normalizedSettings)", method, StringComparison.Ordinal);
+            Assert.Contains("EnsureSettingsWriteSucceeded(affectedRows, kv.Key);", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("var normalizedSettings = new List<KeyValuePair<string, string>>(settings.Count);", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                "Batch settings should normalize and validate keys before opening a database connection.");
+            Assert.True(
+                method.IndexOf("throw new ArgumentException(\"Duplicate setting keys are not allowed.\", nameof(settings));", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                "Duplicate normalized keys should fail before transaction work begins.");
+            Assert.True(
+                method.IndexOf("var affectedRows = await SqliteHelper.ExecuteNonQueryAsync", StringComparison.Ordinal) < method.IndexOf("EnsureSettingsWriteSucceeded(affectedRows, kv.Key);", StringComparison.Ordinal),
+                "Batch setting writes should check each upsert result before committing.");
+            Assert.True(
+                method.IndexOf("EnsureSettingsWriteSucceeded(affectedRows, kv.Key);", StringComparison.Ordinal) < method.IndexOf("tx.Commit();", StringComparison.Ordinal),
+                "Batch setting writes should fail the transaction before commit when an upsert writes no rows.");
+        }
+
+        [Fact]
+        public void DeleteSettingRejectsBlankKeysBeforeConnectionWorkAndBindsNormalizedKeys()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "SettingsService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task DeleteSettingAsync",
+                "static void EnsureSettingsWriteSucceeded");
+
+            Assert.Contains("if (string.IsNullOrWhiteSpace(key))", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentException(\"Key cannot be null or empty.\", nameof(key));", method, StringComparison.Ordinal);
+            Assert.Contains("var normalizedKey = key.Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Key\", normalizedKey)", method, StringComparison.Ordinal);
+            Assert.Contains("No setting found for key {Key}", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(key))", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                "Invalid delete keys should fail before opening a database connection.");
+            Assert.True(
+                method.IndexOf("var normalizedKey = key.Trim();", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Key\", normalizedKey)", StringComparison.Ordinal),
+                "Setting delete should bind the normalized key.");
+        }
+
+        [Fact]
+        public void SettingsWriteGuardThrowsWhenNoRowsAreWritten()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "SettingsService.cs");
+
+            Assert.Contains("static void EnsureSettingsWriteSucceeded(int affectedRows, string key)", source, StringComparison.Ordinal);
+            Assert.Contains("if (affectedRows < 1)", source, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException($\"Failed to save setting '{key}'.\");", source, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-settings-write-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-settings-write-guards.md
@@ -1,0 +1,22 @@
+# Settings Write Guard Hardening - 2026-06-30
+
+## Completed
+
+- Hardened `SettingsService.SaveSettingAsync` so setting keys are trimmed before persistence and the upsert affected-row count is checked before the save can report success.
+- Hardened `SettingsService.UpdateSettingsAsync` so batch setting updates normalize keys, reject blank or duplicate normalized keys before transaction work, and guard every upsert result before committing.
+- Hardened `SettingsService.DeleteSettingAsync` so blank delete keys fail before database work and persisted key lookups use the same trimmed key shape.
+- Added `SettingsServiceWriteGuardContractTests` to pin key normalization, duplicate-key validation, affected-row checks, transaction ordering, and the shared settings write guard.
+
+## Why This Matters
+
+Settings persistence backs app-wide workflows such as theme selection, item terminology, detail visibility, item card sizing, password iteration configuration, and auto-logout timing. These writes previously executed an upsert without confirming SQLite reported a row write, and batch updates could persist whitespace-padded keys that later reads would not match. The new guards keep failed or malformed settings writes from quietly looking successful.
+
+## Validation
+
+- GitHub connector readback/compare was used because direct checkout is blocked in this scheduled environment.
+- Local `dotnet` tests, WPF runtime checks, screenshots, PowerShell validation, and full Windows validation could not be run here.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Continue prioritizing concrete persistence and validation gaps only where current repo evidence shows remaining risk.

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -64,30 +64,33 @@ namespace InventoryManagementApp.Services.Settings
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentException("Key cannot be null or empty.", nameof(key));
 
+            var normalizedKey = key.Trim();
+
             try
             {
                 var p = new[]
                 {
-                    new SqliteParameter("@Key", key),
+                    new SqliteParameter("@Key", normalizedKey),
                     new SqliteParameter("@Value", value)
                 };
                 using var conn = _dbService.CreateConnection();
-                await SqliteHelper.ExecuteNonQueryAsync(conn, UpsertSql, p, cancellationToken).ConfigureAwait(false);
+                var affectedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, UpsertSql, p, cancellationToken).ConfigureAwait(false);
+                EnsureSettingsWriteSucceeded(affectedRows, normalizedKey);
             }
             catch (OperationCanceledException ex)
             {
-                _logger.LogWarning(ex, "Saving setting {Key} canceled or timed out", key);
+                _logger.LogWarning(ex, "Saving setting {Key} canceled or timed out", normalizedKey);
                 throw;
             }
             catch (SqliteException ex) when (ex.SqliteErrorCode == SQLitePCL.raw.SQLITE_BUSY)
             {
-                _logger.LogWarning(ex, "Saving setting {Key} timed out", key);
+                _logger.LogWarning(ex, "Saving setting {Key} timed out", normalizedKey);
                 throw;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to save setting {Key}", key);
-                throw new InvalidOperationException($"Failed to save setting '{key}'.", ex);
+                _logger.LogError(ex, "Failed to save setting {Key}", normalizedKey);
+                throw new InvalidOperationException($"Failed to save setting '{normalizedKey}'.", ex);
             }
         }
 
@@ -178,24 +181,33 @@ namespace InventoryManagementApp.Services.Settings
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
 
+            var normalizedSettings = new List<KeyValuePair<string, string>>(settings.Count);
+            var normalizedKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (var kv in settings)
             {
                 if (string.IsNullOrWhiteSpace(kv.Key))
                     throw new ArgumentException("Key cannot be null or empty.", nameof(settings));
+
+                var normalizedKey = kv.Key.Trim();
+                if (!normalizedKeys.Add(normalizedKey))
+                    throw new ArgumentException("Duplicate setting keys are not allowed.", nameof(settings));
+
+                normalizedSettings.Add(new KeyValuePair<string, string>(normalizedKey, kv.Value));
             }
 
             using var conn = _dbService.CreateConnection();
             using var tx = conn.BeginTransaction();
             try
             {
-                foreach (var kv in settings)
+                foreach (var kv in normalizedSettings)
                 {
                     var p = new[]
                     {
                         new SqliteParameter("@Key", kv.Key),
                         new SqliteParameter("@Value", kv.Value)
                     };
-                    await SqliteHelper.ExecuteNonQueryAsync(conn, tx, UpsertSql, p, cancellationToken).ConfigureAwait(false);
+                    var affectedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, tx, UpsertSql, p, cancellationToken).ConfigureAwait(false);
+                    EnsureSettingsWriteSucceeded(affectedRows, kv.Key);
                 }
                 tx.Commit();
             }
@@ -222,30 +234,41 @@ namespace InventoryManagementApp.Services.Settings
         public async Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
         {
             _auth.EnsurePermission(User.PermissionSettings);
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentException("Key cannot be null or empty.", nameof(key));
+
+            var normalizedKey = key.Trim();
+
             try
             {
                 const string sql = "DELETE FROM Settings WHERE Key = @Key";
-                var p = new[] { new SqliteParameter("@Key", key) };
+                var p = new[] { new SqliteParameter("@Key", normalizedKey) };
                 using var conn = _dbService.CreateConnection();
                 var affected = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
                 if (affected == 0)
-                    _logger.LogWarning("No setting found for key {Key}", key);
+                    _logger.LogWarning("No setting found for key {Key}", normalizedKey);
             }
             catch (OperationCanceledException ex)
             {
-                _logger.LogWarning(ex, "Deleting setting {Key} canceled or timed out", key);
+                _logger.LogWarning(ex, "Deleting setting {Key} canceled or timed out", normalizedKey);
                 throw;
             }
             catch (SqliteException ex) when (ex.SqliteErrorCode == SQLitePCL.raw.SQLITE_BUSY)
             {
-                _logger.LogWarning(ex, "Deleting setting {Key} timed out", key);
+                _logger.LogWarning(ex, "Deleting setting {Key} timed out", normalizedKey);
                 throw;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to delete setting {Key}", key);
-                throw new InvalidOperationException($"Failed to delete setting '{key}'.", ex);
+                _logger.LogError(ex, "Failed to delete setting {Key}", normalizedKey);
+                throw new InvalidOperationException($"Failed to delete setting '{normalizedKey}'.", ex);
             }
+        }
+
+        static void EnsureSettingsWriteSucceeded(int affectedRows, string key)
+        {
+            if (affectedRows < 1)
+                throw new InvalidOperationException($"Failed to save setting '{key}'.");
         }
 
         const string PasswordIterationsKey = "PasswordIterations";


### PR DESCRIPTION
## What changed
- Trim setting keys before single-setting saves and deletes bind them to SQLite.
- Check single-setting upsert affected-row counts before save workflows can report success.
- Normalize batch setting keys before transaction work, reject blank or duplicate normalized keys, and guard every batch upsert before commit.
- Add source-contract coverage for key normalization, duplicate-key validation, affected-row checks, transaction ordering, delete validation, and the shared settings write guard.
- Add a progress note for the completed settings persistence hardening slice.

## Why this was the highest-value next step
Full Windows/.NET validation remains the top repo need, but this scheduled environment still cannot run it. Recent merged work has been closing concrete persistence gaps in core services. Connector readback showed `SettingsService` still executed settings upserts without confirming SQLite reported a write and allowed whitespace-padded batch keys into persistence. Settings back theme, item terminology, visibility, card sizing, password iteration, and auto-logout workflows, making this the next concrete data-integrity improvement.

## Why this is real progress
This is a focused settings workflow slice across service behavior, batch validation, source-contract coverage, and progress notes. It closes a shared persistence path used by several app-wide settings rather than making an isolated guard or formatting edit.

## Validation
- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and limited to `SettingsService`, one new source-contract test, and one progress note.
- Connector readback confirmed `SaveSettingAsync` trims keys, binds `normalizedKey`, captures `affectedRows`, and calls `EnsureSettingsWriteSucceeded`.
- Connector readback confirmed `UpdateSettingsAsync` builds normalized settings before opening a connection, rejects duplicate normalized keys before transaction work, checks every upsert result, and guards before `tx.Commit()`.
- Connector readback confirmed `DeleteSettingAsync` rejects blank keys before database work and binds the trimmed key.
- Connector readback confirmed `SettingsServiceWriteGuardContractTests` covers the source-contract expectations.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local .NET tests, PowerShell validation runner, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue reviewing settings and persistence workflows only where current repo evidence shows concrete validation or write-result gaps.