### PR TITLE
Guard customer import batch duplicates

### DIFF
--- a/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
@@ -132,6 +132,40 @@ namespace InventoryManagementApp.Tests
                 "Customer creation should reject invalid inserted ids before returning success.");
         }
 
+        [Fact]
+        public void CustomerImportsTrackDuplicateCustomersWithinEachImportBatch()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var csvImportMethod = ExtractMethod(
+                source,
+                "async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync",
+                "async Task ExportCustomersToCsvInternalAsync");
+            var genericImportMethod = ExtractMethod(
+                source,
+                "public async Task<int> ImportCustomersAsync",
+                "public async Task ExportCustomersAsync");
+
+            Assert.Contains("var importedCustomerKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("if (!TryReserveImportedCustomer(importedCustomerKeys, c))", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("Row {row}: Duplicate customer in import file", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("var importedCustomerKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);", genericImportMethod, StringComparison.Ordinal);
+            Assert.Contains("if (!TryReserveImportedCustomer(importedCustomerKeys, customerModel))", genericImportMethod, StringComparison.Ordinal);
+            Assert.Contains("static bool TryReserveImportedCustomer(HashSet<string> importedCustomerKeys, CustomerModel customer)", source, StringComparison.Ordinal);
+            Assert.Contains("static IEnumerable<string> BuildCustomerDuplicateKeys(CustomerModel customer)", source, StringComparison.Ordinal);
+            Assert.Contains("yield return $\"{contact}|phone:{phone}\";", source, StringComparison.Ordinal);
+            Assert.Contains("yield return $\"{contact}|mobile:{mobile}\";", source, StringComparison.Ordinal);
+
+            Assert.True(
+                csvImportMethod.IndexOf("if (await CustomerExistsAsync(c.Contact, c.Phone, c.Mobile, cancellationToken))", StringComparison.Ordinal) < csvImportMethod.IndexOf("if (!TryReserveImportedCustomer(importedCustomerKeys, c))", StringComparison.Ordinal),
+                "CSV import should preserve the database duplicate check before reserving a customer identity for the current file.");
+            Assert.True(
+                csvImportMethod.IndexOf("if (!TryReserveImportedCustomer(importedCustomerKeys, c))", StringComparison.Ordinal) < csvImportMethod.IndexOf("await InsertCustomerAsync(conn, tran, c, cancellationToken);", StringComparison.Ordinal),
+                "CSV import should reject duplicate rows from the same file before inserting into the transaction.");
+            Assert.True(
+                genericImportMethod.IndexOf("if (!TryReserveImportedCustomer(importedCustomerKeys, customerModel))", StringComparison.Ordinal) < genericImportMethod.IndexOf("await InsertCustomerAsync(conn, null, customerModel, cancellationToken);", StringComparison.Ordinal),
+                "Generic customer import should reject duplicate rows from the same import batch before inserting.");
+        }
+
         private static void AssertCancellationGuardBeforeSqlAndConnection(string source, string startMarker, string endMarker)
         {
             var method = ExtractMethod(source, startMarker, endMarker);

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-customer-import-batch-duplicate-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-customer-import-batch-duplicate-guards.md
@@ -1,0 +1,22 @@
+# Customer Import Batch Duplicate Guard Hardening - 2026-06-30
+
+## Completed
+
+- Hardened CSV customer imports so each file tracks customer identities already accepted during the current import batch.
+- Hardened the generic customer import entry point with the same in-memory duplicate tracking before insert work.
+- Added shared duplicate-key helpers that mirror the existing customer duplicate rule by contact plus phone and contact plus mobile, using trimmed case-insensitive keys for import-batch comparisons.
+- Added source-contract coverage so both import entry points keep the batch duplicate guard before insert calls and preserve the existing database duplicate check.
+
+## Why This Matters
+
+CSV customer imports insert rows inside a transaction while the existing duplicate check reads through a separate database connection. That means a later duplicate row from the same file may not see an earlier uncommitted insert and could be imported as a duplicate customer. The new batch-level guard closes that data-quality gap without changing the existing persisted-customer duplicate lookup.
+
+## Validation
+
+- GitHub connector readback/compare was used because direct checkout is blocked in this scheduled environment.
+- Local `dotnet` tests, WPF runtime checks, screenshots, PowerShell validation, and full Windows validation could not be run here.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Consider behavior-level import tests for duplicate-row handling when a full checkout and test runtime are available.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -319,6 +319,7 @@ namespace InventoryManagementApp.Services.Customers
             cancellationToken.ThrowIfCancellationRequested();
 
             var result = new CustomerImportResult();
+            var importedCustomerKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             using var conn = _dbService.CreateConnection();
             using var tran = conn.BeginTransaction();
             try
@@ -340,6 +341,14 @@ namespace InventoryManagementApp.Services.Customers
                     if (await CustomerExistsAsync(c.Contact, c.Phone, c.Mobile, cancellationToken))
                     {
                         var msg = $"Row {row}: Duplicate customer";
+                        result.SkippedRows.Add(msg);
+                        _logger.LogInformation("{Message}", msg);
+                        continue;
+                    }
+
+                    if (!TryReserveImportedCustomer(importedCustomerKeys, c))
+                    {
+                        var msg = $"Row {row}: Duplicate customer in import file";
                         result.SkippedRows.Add(msg);
                         _logger.LogInformation("{Message}", msg);
                         continue;
@@ -455,6 +464,33 @@ namespace InventoryManagementApp.Services.Customers
                 throw new KeyNotFoundException($"Customer {customerID} not found.");
         }
 
+        static bool TryReserveImportedCustomer(HashSet<string> importedCustomerKeys, CustomerModel customer)
+        {
+            var duplicateKeys = BuildCustomerDuplicateKeys(customer).ToList();
+            if (duplicateKeys.Any(importedCustomerKeys.Contains))
+                return false;
+
+            foreach (var key in duplicateKeys)
+                importedCustomerKeys.Add(key);
+
+            return true;
+        }
+
+        static IEnumerable<string> BuildCustomerDuplicateKeys(CustomerModel customer)
+        {
+            var contact = (customer.Contact ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(contact))
+                yield break;
+
+            var phone = (customer.Phone ?? string.Empty).Trim();
+            if (!string.IsNullOrWhiteSpace(phone))
+                yield return $"{contact}|phone:{phone}";
+
+            var mobile = (customer.Mobile ?? string.Empty).Trim();
+            if (!string.IsNullOrWhiteSpace(mobile))
+                yield return $"{contact}|mobile:{mobile}";
+        }
+
         static string? GetSkipReason(CustomerModel c)
         {
             var reasons = new List<string>();
@@ -484,6 +520,7 @@ namespace InventoryManagementApp.Services.Customers
             cancellationToken.ThrowIfCancellationRequested();
             
             int importedCount = 0;
+            var importedCustomerKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             using var conn = _dbService.CreateConnection();
             
             foreach (var customer in customers)
@@ -506,6 +543,9 @@ namespace InventoryManagementApp.Services.Customers
 
                 bool exists = await CustomerExistsAsync(customerModel.Contact, customerModel.Phone, customerModel.Mobile, cancellationToken);
                 if (exists)
+                    continue;
+
+                if (!TryReserveImportedCustomer(importedCustomerKeys, customerModel))
                     continue;
 
                 await InsertCustomerAsync(conn, null, customerModel, cancellationToken);


### PR DESCRIPTION
## What changed
- Added per-import in-memory duplicate tracking to CSV customer imports so rows already accepted in the same file cannot be inserted again before the transaction commits.
- Added the same batch duplicate guard to the generic customer import entry point.
- Added shared duplicate-key helpers that mirror the existing duplicate identity shape: contact plus phone and contact plus mobile, using trimmed case-insensitive import-batch keys.
- Extended `CustomerServiceEntryPointContractTests` to pin duplicate guard placement before insert work while preserving the existing persisted-customer duplicate check.
- Added a progress note for the completed customer import data-quality slice.

## Why this was the highest-value next step
Full Windows/.NET validation remains the top repo need, but this scheduled environment still cannot run it. Recent merged work hardened customer creation persistence; connector readback then showed customer imports still rely on a database duplicate lookup from a separate connection while CSV inserts happen inside an uncommitted transaction. That makes same-file duplicate customer rows a concrete data-quality risk in a core import workflow.

## Why this is real progress
This is a focused workflow slice across both customer import entry points, shared service logic, source-contract coverage, and progress notes. It closes an import-batch validation gap rather than making another isolated guard or cosmetic edit.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, and limited to `CustomerService`, `CustomerServiceEntryPointContractTests`, and one progress note.
- Connector readback confirmed CSV imports create an `importedCustomerKeys` set, preserve the existing `CustomerExistsAsync` check, reject `TryReserveImportedCustomer` failures with a skipped-row message, and guard before transactional insert work.
- Connector readback confirmed generic imports use the same `importedCustomerKeys` set and reject duplicate batch rows before `InsertCustomerAsync`.
- Connector readback confirmed duplicate-key helpers build contact-plus-phone and contact-plus-mobile keys with trimmed values and case-insensitive storage.
- Connector readback confirmed source-contract coverage for both import entry points and helper key shapes.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local .NET tests, PowerShell validation runner, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Add behavior-level customer import duplicate tests when a full checkout and test runtime are available.