### PR TITLE
Harden item and category create id writes

### DIFF
--- a/InventoryManagementApp.Tests/CategoriesServiceTests.cs
+++ b/InventoryManagementApp.Tests/CategoriesServiceTests.cs
@@ -82,6 +82,36 @@ public class CategoriesServiceTests
     }
 
     [Fact]
+    public void EnsureCategoryAsyncChecksInsertRowsBeforeReadingCreatedId()
+    {
+        var source = ReadRepoFile("InventoryManagementApp", "Services", "Categories", "CategoriesService.cs");
+        var method = ExtractMethod(
+            source,
+            "public async Task<int> EnsureCategoryAsync(string name, CancellationToken ct = default)",
+            "public async Task LinkCategoryToInventoryAsync");
+
+        Assert.Contains("var insertedRows = await conn.ExecuteAsync(", method, StringComparison.Ordinal);
+        Assert.Contains("if (insertedRows == 0)", method, StringComparison.Ordinal);
+        Assert.Contains("throw new InvalidOperationException(\"Unable to create category.\");", method, StringComparison.Ordinal);
+        Assert.Contains("SELECT last_insert_rowid();", method, StringComparison.Ordinal);
+        Assert.Contains("if (id < 1)", method, StringComparison.Ordinal);
+        Assert.DoesNotContain("INSERT INTO Categories(Name) VALUES(@n); SELECT last_insert_rowid();", method, StringComparison.Ordinal);
+
+        Assert.True(
+            method.IndexOf("var insertedRows = await conn.ExecuteAsync(", StringComparison.Ordinal) <
+            method.IndexOf("if (insertedRows == 0)", StringComparison.Ordinal),
+            "Category creation should inspect the insert affected-row count immediately after insert execution.");
+        Assert.True(
+            method.IndexOf("if (insertedRows == 0)", StringComparison.Ordinal) <
+            method.IndexOf("SELECT last_insert_rowid();", StringComparison.Ordinal),
+            "Category creation should not read a generated id until the insert is known to have affected a row.");
+        Assert.True(
+            method.IndexOf("if (id < 1)", StringComparison.Ordinal) <
+            method.IndexOf("tx.Commit();", StringComparison.Ordinal),
+            "Category creation should fail invalid generated ids before committing.");
+    }
+
+    [Fact]
     public void CategoryServiceHonorsCancellationBeforeConnectionWork()
     {
         var source = ReadRepoFile("InventoryManagementApp", "Services", "Categories", "CategoriesService.cs");
@@ -97,7 +127,7 @@ public class CategoriesServiceTests
         AssertCancellationGuardBeforeConnection(
             source,
             "public async Task LinkCategoryToInventoryAsync(int categoryId, int inventoryId, CancellationToken ct = default)",
-            "public async Task<List<CategoryDto>> GetCategoriesForInventoryAsync");
+            "public async Task EnsureInventoryAsync");
         AssertCancellationGuardBeforeConnection(
             source,
             "public async Task<List<CategoryDto>> GetCategoriesForInventoryAsync(int inventoryId, CancellationToken ct = default)",

--- a/InventoryManagementApp.Tests/ItemRepositoryWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryWriteGuardContractTests.cs
@@ -25,6 +25,31 @@ namespace InventoryManagementApp.Tests
                 saveChangesMethod.IndexOf("if (rows == 0)", StringComparison.Ordinal),
                 "Expected bulk item saves to inspect affected rows after executing each update.");
 
+            var insertMethod = ExtractMethod(
+                source,
+                "public async Task<int> InsertAsync(Item item, CancellationToken ct)",
+                "public async Task UpdateAsync(Item item, CancellationToken ct)");
+            AssertContainsAll(
+                insertMethod,
+                "var insertedRows = await conn.ExecuteAsync(new CommandDefinition(sql, new",
+                "if (insertedRows == 0)",
+                "throw new InvalidOperationException(\"Failed to create item.\");",
+                "SELECT last_insert_rowid();",
+                "if (id < 1)");
+            Assert.DoesNotContain("SELECT last_insert_rowid();\";", insertMethod, StringComparison.Ordinal);
+            Assert.True(
+                insertMethod.IndexOf("var insertedRows = await conn.ExecuteAsync", StringComparison.Ordinal) <
+                insertMethod.IndexOf("if (insertedRows == 0)", StringComparison.Ordinal),
+                "Expected item inserts to inspect affected rows after executing the insert.");
+            Assert.True(
+                insertMethod.IndexOf("if (insertedRows == 0)", StringComparison.Ordinal) <
+                insertMethod.IndexOf("SELECT last_insert_rowid();", StringComparison.Ordinal),
+                "Expected item inserts to read the generated id only after the insert affected a row.");
+            Assert.True(
+                insertMethod.IndexOf("if (id < 1)", StringComparison.Ordinal) <
+                insertMethod.IndexOf("return (int)id;", StringComparison.Ordinal),
+                "Expected item inserts to reject invalid generated ids before returning success.");
+
             var updateMethod = ExtractMethod(
                 source,
                 "public async Task UpdateAsync(Item item, CancellationToken ct)",

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -101,10 +101,9 @@ public sealed class ItemRepository : IItemRepository
         ct.ThrowIfCancellationRequested();
 
         const string sql = @"INSERT INTO Items (ItemNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, IsPowered, IsIncomplete, MissingComponentsNotes, IssuesNotes, CheckoutCount)
-                             VALUES (@ItemNumber,@Name,@Location,@Brand,@PartNumber,@Supplier,@PurchasedDate,@Notes,@Keywords,@QuantityOnHand,@RentedQuantity,@IsRentalItem,@Price,@ImagePath,0,@IsPowered,0,'','',0);
-                             SELECT last_insert_rowid();";
+                             VALUES (@ItemNumber,@Name,@Location,@Brand,@PartNumber,@Supplier,@PurchasedDate,@Notes,@Keywords,@QuantityOnHand,@RentedQuantity,@IsRentalItem,@Price,@ImagePath,0,@IsPowered,0,'','',0);";
         await using var conn = (DbConnection)_factory.Create();
-        var id = await conn.ExecuteScalarAsync<long>(new CommandDefinition(sql, new
+        var insertedRows = await conn.ExecuteAsync(new CommandDefinition(sql, new
         {
             item.ItemNumber,
             Name = item.Name,
@@ -122,6 +121,13 @@ public sealed class ItemRepository : IItemRepository
             item.ImagePath,
             IsPowered = item.IsPowered ? 1 : 0
         }, cancellationToken: ct));
+        if (insertedRows == 0)
+            throw new InvalidOperationException("Failed to create item.");
+
+        var id = await conn.ExecuteScalarAsync<long>(new CommandDefinition("SELECT last_insert_rowid();", cancellationToken: ct));
+        if (id < 1)
+            throw new InvalidOperationException("Failed to create item.");
+
         return (int)id;
     }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-item-category-create-write-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-item-category-create-write-guards.md
@@ -1,0 +1,24 @@
+# Item And Category Create Write Guards
+
+Date: 2026-06-30
+
+## Completed
+
+- Hardened `ItemRepository.InsertAsync` so item creation executes the insert first, checks the affected-row count, then reads `last_insert_rowid()` only after the insert is known to have succeeded.
+- Added an invalid generated-id guard for item creation so the repository fails with `Failed to create item.` instead of returning a nonpositive id.
+- Hardened `CategoriesService.EnsureCategoryAsync` with the same create flow inside its transaction: find existing category, execute insert, check affected rows, read the generated id, reject invalid ids, then commit.
+- Extended source-contract coverage for item and category creation so the old combined insert-plus-id scalar pattern is not reintroduced.
+
+## Why This Was Next
+
+Recent scheduled work has been closing persistence gaps where create workflows trusted `last_insert_rowid()` without first proving that an insert affected a row. Search/readback showed the remaining inventory item and category create paths still used that fragile combined pattern. These paths are core to inventory setup, imports, item maintenance, and category linking, so hardening them together completes a useful reliability slice across shared inventory persistence.
+
+## Validation
+
+- GitHub connector readback was used to inspect the current `master` service and test files before the change.
+- Source-contract tests were updated to pin the affected-row guard, generated-id lookup ordering, invalid-id rejection, and absence of the old combined scalar create pattern.
+
+## Not Run
+
+- Local .NET restore/build/test and `pwsh -File scripts/run-full-validation.ps1` were not run in this scheduled Linux environment because direct checkout is blocked by `CONNECT tunnel failed, response 403` and the local Windows/.NET validation toolchain is unavailable here.
+- WPF runtime, screenshot, print, and layout checks were not applicable to this persistence-only change.

--- a/InventoryManagementApp/Services/Categories/CategoriesService.cs
+++ b/InventoryManagementApp/Services/Categories/CategoriesService.cs
@@ -78,9 +78,19 @@ CREATE TABLE IF NOT EXISTS InventoryCategories (
                     tx.Commit();
                     return (int)id;
                 }
-                id = await conn.ExecuteScalarAsync<long>(
-                    "INSERT INTO Categories(Name) VALUES(@n); SELECT last_insert_rowid();",
+
+                var insertedRows = await conn.ExecuteAsync(
+                    "INSERT INTO Categories(Name) VALUES(@n);",
                     new { n = name }, tx);
+                if (insertedRows == 0)
+                    throw new InvalidOperationException("Unable to create category.");
+
+                id = await conn.ExecuteScalarAsync<long>(
+                    "SELECT last_insert_rowid();",
+                    transaction: tx);
+                if (id < 1)
+                    throw new InvalidOperationException("Unable to create category.");
+
                 tx.Commit();
                 return (int)id;
             }
@@ -96,7 +106,6 @@ CREATE TABLE IF NOT EXISTS InventoryCategories (
         /// </summary>
         /// <param name="categoryId">The category ID.</param>
         /// <param name="inventoryId">The inventory ID.</param>
-        /// <param name="ct">Cancellation token for the operation.</param>
         /// <exception cref="InvalidOperationException">Thrown if inventory not found.</exception>
         /// <exception cref="KeyNotFoundException">Thrown if category not found.</exception>
         public async Task LinkCategoryToInventoryAsync(int categoryId, int inventoryId, CancellationToken ct = default)


### PR DESCRIPTION
## What changed

- Hardened `ItemRepository.InsertAsync` so item creation executes the insert, checks the affected-row count, then reads `last_insert_rowid()` only after the insert is known to have succeeded.
- Added an invalid generated-id guard for item creation with the existing item create failure wording.
- Hardened `CategoriesService.EnsureCategoryAsync` with the same insert row-count and generated-id validation inside the category create transaction.
- Extended source-contract coverage for both create paths and added a progress note for the reliability slice.

## Why this was the highest-value next step

Recent repository work has been closing create-path persistence gaps where services trusted `last_insert_rowid()` without proving an insert affected a row. Connector search/readback showed item creation and category creation still had that fragile combined insert/id pattern. These paths are core inventory setup workflows and support downstream import, item maintenance, and category-linking behavior.

## Why this is real progress

This is a focused vertical reliability slice across two core inventory create paths plus tests and project notes. It removes the same persistence risk from item and category creation instead of making a one-off guard in a single file.

## Validation

- GitHub connector readback confirmed the branch is 5 focused files, ahead of `master` with no unrelated changes.
- Connector readback confirmed `ItemRepository.InsertAsync` now checks `insertedRows`, reads `last_insert_rowid()` afterward, and rejects ids below 1.
- Connector readback confirmed `CategoriesService.EnsureCategoryAsync` now checks insert rows, reads the generated id afterward within the transaction, rejects invalid ids, then commits.
- Connector status/workflow readback found no attached statuses or workflow runs for the branch head at PR creation time.

## Could not be checked

- Local `pwsh -File scripts/run-full-validation.ps1`, restore/build/test, and WPF runtime checks could not be run in this scheduled Linux environment because direct checkout is blocked by `CONNECT tunnel failed, response 403` and `dotnet`, `pwsh`, and `gh` are unavailable.

## Known follow-up work

- Run the checked-in full validation script in a Windows/.NET-capable checkout.
- Continue replacing fragile source-text contracts with behavior-focused tests where practical.