### PR TITLE
Harden user password change write guard

### DIFF
--- a/InventoryManagementApp.Tests/UserPasswordChangeWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/UserPasswordChangeWriteGuardContractTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserPasswordChangeWriteGuardContractTests
+    {
+        [Fact]
+        public void ChangePasswordGuardsStaleWritesBeforeReportingSuccess()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<bool> ChangeUserPasswordAsync",
+                "async Task<bool> DeleteUserInternalAsync");
+
+            Assert.Contains("var existing = await GetUserByIDAsync(userID, CancellationToken.None);", method, StringComparison.Ordinal);
+            Assert.Contains("if (existing is null)", method, StringComparison.Ordinal);
+            Assert.Contains("return false;", method, StringComparison.Ordinal);
+            Assert.Contains("int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);", method, StringComparison.Ordinal);
+            Assert.Contains("EnsureUserWriteSucceeded(rows, userID);", method, StringComparison.Ordinal);
+            Assert.Contains("return true;", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("return rows > 0;", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("Password update affected 0 rows", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("if (existing is null)", StringComparison.Ordinal) < method.IndexOf("PasswordValidator.IsValid", StringComparison.Ordinal),
+                "Missing password-change users should keep the friendly false result before validation and hashing work.");
+            Assert.True(
+                method.IndexOf("int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);", StringComparison.Ordinal) < method.IndexOf("EnsureUserWriteSucceeded(rows, userID);", StringComparison.Ordinal),
+                "Password changes should capture affected rows before checking the update result.");
+            Assert.True(
+                method.IndexOf("EnsureUserWriteSucceeded(rows, userID);", StringComparison.Ordinal) < method.IndexOf("return true;", StringComparison.Ordinal),
+                "Stale password-change writes should fail before the workflow reports success.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-user-password-change-write-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-user-password-change-write-guard.md
@@ -1,0 +1,20 @@
+# User Password Change Write Guard
+
+Date: 2026-06-30
+
+## Completed
+
+- Hardened `UserService.ChangeUserPasswordAsync` so password changes that pass the initial user lookup must also pass the shared affected-row write guard before returning success.
+- Preserved the existing friendly `false` result when the target user is missing before password validation, hashing, SQL preparation, or update work begins.
+- Removed the softer zero-row log-and-false path after the update attempt, aligning password changes with the rest of user-management stale-write handling.
+- Added source-contract coverage in `UserPasswordChangeWriteGuardContractTests` to keep the missing-user precheck, affected-row guard, and success ordering in place.
+
+## Validation
+
+- GitHub connector write/readback was used because direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
+- Local `pwsh -File scripts/run-full-validation.ps1`, restore/build/test, WPF runtime checks, screenshots, and full Windows validation were not available in this Linux scheduled environment.
+
+## Follow-up
+
+- Run the checked-in full validation script from a Windows/.NET-capable checkout.
+- Continue reviewing adjacent user-management workflows only where current repo evidence shows concrete validation or persistence gaps.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -473,9 +473,8 @@ namespace InventoryManagementApp.Services.Users
             };
             using var conn = _dbService.CreateConnection();
             int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
-            if (rows == 0)
-                _logger.LogWarning("Password update affected 0 rows for UserID {UserID}", userID);
-            return rows > 0;
+            EnsureUserWriteSucceeded(rows, userID);
+            return true;
         }
 
         async Task<bool> DeleteUserInternalAsync(int userID)


### PR DESCRIPTION
## What changed
- Hardened `UserService.ChangeUserPasswordAsync` so password changes that pass the initial user lookup must also pass the shared affected-row write guard before returning success.
- Preserved the existing friendly `false` result when the target user is missing before password validation, hashing, SQL preparation, or update work begins.
- Removed the softer zero-row log-and-false path after the update attempt, aligning password changes with the rest of user-management stale-write handling.
- Added focused source-contract coverage and a progress note for the completed user-management reliability slice.

## Why this was the highest-value next step
Full Windows/.NET validation remains the top repo need, but this scheduled environment still cannot run it. Recent merged work has hardened user creation and update workflows; connector readback showed the adjacent password-change workflow still returned `rows > 0` after a prechecked user could disappear before the update. That made password-change stale-write handling the next concrete data-integrity gap in the same core admin/user-management workflow.

## Why this is real progress
This is a focused workflow slice across service behavior, source-contract coverage, and project notes. It finishes the stale-write behavior for user password changes rather than making a one-line guard or unrelated cleanup.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, and limited to `UserService`, one new source-contract test, and one progress note.
- Connector readback confirmed `ChangeUserPasswordAsync` still returns `false` for a missing user before validation/hash/SQL/update work.
- Connector readback confirmed password update rows are captured, passed to `EnsureUserWriteSucceeded(rows, userID)`, and only then returns `true`.
- Connector readback confirmed the new contract test pins the missing-user precheck, affected-row guard, removal of the old `return rows > 0` path, and success ordering.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local `pwsh -File scripts/run-full-validation.ps1`, restore/build/test, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue reviewing adjacent user-management workflows only where current repo evidence shows concrete validation or persistence gaps.