### PR TITLE
Harden customer save validation guards

### DIFF
--- a/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
@@ -42,6 +42,67 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void DirectCustomerSavesNormalizeAndValidateRequiredFieldsBeforeAuthorizationAndWriteWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var addMethod = ExtractMethod(
+                source,
+                "public Task AddCustomerAsync",
+                "public Task UpdateCustomerAsync");
+            var updateMethod = ExtractMethod(
+                source,
+                "public Task UpdateCustomerAsync",
+                "public Task DeleteCustomerAsync");
+
+            Assert.Contains("NormalizeCustomerForSave(customer);", addMethod, StringComparison.Ordinal);
+            Assert.Contains("ValidateCustomerRequiredFields(customer);", addMethod, StringComparison.Ordinal);
+            Assert.Contains("NormalizeCustomerForSave(customer);", updateMethod, StringComparison.Ordinal);
+            Assert.Contains("ValidateCustomerRequiredFields(customer);", updateMethod, StringComparison.Ordinal);
+
+            Assert.True(
+                addMethod.IndexOf("NormalizeCustomerForSave(customer);", StringComparison.Ordinal) < addMethod.IndexOf("ValidateCustomerRequiredFields(customer);", StringComparison.Ordinal),
+                "Direct customer adds should normalize text before required-field validation.");
+            Assert.True(
+                addMethod.IndexOf("ValidateCustomerRequiredFields(customer);", StringComparison.Ordinal) < addMethod.IndexOf("_auth.EnsureAdmin();", StringComparison.Ordinal),
+                "Invalid direct customer adds should fail before authorization or database work.");
+            Assert.True(
+                addMethod.IndexOf("ValidateCustomerRequiredFields(customer);", StringComparison.Ordinal) < addMethod.IndexOf("return AddCustomerInternalAsync", StringComparison.Ordinal),
+                "Invalid direct customer adds should not reach insert work.");
+            Assert.True(
+                updateMethod.IndexOf("if (customer.CustomerID < 1)", StringComparison.Ordinal) < updateMethod.IndexOf("NormalizeCustomerForSave(customer);", StringComparison.Ordinal),
+                "Invalid update customer IDs should still fail before normalizing save fields.");
+            Assert.True(
+                updateMethod.IndexOf("NormalizeCustomerForSave(customer);", StringComparison.Ordinal) < updateMethod.IndexOf("ValidateCustomerRequiredFields(customer);", StringComparison.Ordinal),
+                "Direct customer updates should normalize text before required-field validation.");
+            Assert.True(
+                updateMethod.IndexOf("ValidateCustomerRequiredFields(customer);", StringComparison.Ordinal) < updateMethod.IndexOf("_auth.EnsureAdmin();", StringComparison.Ordinal),
+                "Invalid direct customer updates should fail before authorization or database work.");
+            Assert.True(
+                updateMethod.IndexOf("ValidateCustomerRequiredFields(customer);", StringComparison.Ordinal) < updateMethod.IndexOf("return UpdateCustomerInternalAsync", StringComparison.Ordinal),
+                "Invalid direct customer updates should not reach update write work.");
+        }
+
+        [Fact]
+        public void CustomerValidationReusesImportRequiredFieldRulesAndTrimsPersistedText()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+
+            Assert.Contains("static void NormalizeCustomerForSave(CustomerModel customer)", source, StringComparison.Ordinal);
+            Assert.Contains("customer.Company = (customer.Company ?? string.Empty).Trim();", source, StringComparison.Ordinal);
+            Assert.Contains("customer.Email = (customer.Email ?? string.Empty).Trim();", source, StringComparison.Ordinal);
+            Assert.Contains("customer.Contact = (customer.Contact ?? string.Empty).Trim();", source, StringComparison.Ordinal);
+            Assert.Contains("customer.Phone = (customer.Phone ?? string.Empty).Trim();", source, StringComparison.Ordinal);
+            Assert.Contains("customer.Mobile = (customer.Mobile ?? string.Empty).Trim();", source, StringComparison.Ordinal);
+            Assert.Contains("customer.Address = (customer.Address ?? string.Empty).Trim();", source, StringComparison.Ordinal);
+            Assert.Contains("static void ValidateCustomerRequiredFields(CustomerModel customer)", source, StringComparison.Ordinal);
+            Assert.Contains("var reason = GetSkipReason(customer);", source, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentException(reason, nameof(customer));", source, StringComparison.Ordinal);
+            Assert.Contains("if (string.IsNullOrWhiteSpace(c.Company)) reasons.Add(\"Company missing\");", source, StringComparison.Ordinal);
+            Assert.Contains("if (string.IsNullOrWhiteSpace(c.Contact)) reasons.Add(\"Contact missing\");", source, StringComparison.Ordinal);
+            Assert.Contains("if (string.IsNullOrWhiteSpace(c.Phone) && string.IsNullOrWhiteSpace(c.Mobile)) reasons.Add(\"Phone and Mobile missing\");", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void CustomerImportAndExportHelpersHonorCancellationBeforeDatabaseWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
@@ -164,6 +225,41 @@ namespace InventoryManagementApp.Tests
             Assert.True(
                 genericImportMethod.IndexOf("if (!TryReserveImportedCustomer(importedCustomerKeys, customerModel))", StringComparison.Ordinal) < genericImportMethod.IndexOf("await InsertCustomerAsync(conn, null, customerModel, cancellationToken);", StringComparison.Ordinal),
                 "Generic customer import should reject duplicate rows from the same import batch before inserting.");
+        }
+
+        [Fact]
+        public void CustomerImportsNormalizeRowsBeforeDuplicateChecksAndInsertWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var csvImportMethod = ExtractMethod(
+                source,
+                "async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync",
+                "async Task ExportCustomersToCsvInternalAsync");
+            var genericImportMethod = ExtractMethod(
+                source,
+                "public async Task<int> ImportCustomersAsync",
+                "public async Task ExportCustomersAsync");
+
+            Assert.Contains("NormalizeCustomerForSave(c);", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("NormalizeCustomerForSave(customerModel);", genericImportMethod, StringComparison.Ordinal);
+            Assert.True(
+                csvImportMethod.IndexOf("NormalizeCustomerForSave(c);", StringComparison.Ordinal) < csvImportMethod.IndexOf("var reason = GetSkipReason(c);", StringComparison.Ordinal),
+                "CSV imports should trim row text before required-field validation.");
+            Assert.True(
+                csvImportMethod.IndexOf("NormalizeCustomerForSave(c);", StringComparison.Ordinal) < csvImportMethod.IndexOf("CustomerExistsAsync(c.Contact, c.Phone, c.Mobile, cancellationToken)", StringComparison.Ordinal),
+                "CSV imports should check duplicates using normalized customer identity fields.");
+            Assert.True(
+                csvImportMethod.IndexOf("NormalizeCustomerForSave(c);", StringComparison.Ordinal) < csvImportMethod.IndexOf("await InsertCustomerAsync(conn, tran, c, cancellationToken);", StringComparison.Ordinal),
+                "CSV imports should insert normalized customer values.");
+            Assert.True(
+                genericImportMethod.IndexOf("NormalizeCustomerForSave(customerModel);", StringComparison.Ordinal) < genericImportMethod.IndexOf("var skipReason = GetSkipReason(customerModel);", StringComparison.Ordinal),
+                "Generic imports should trim row text before required-field validation.");
+            Assert.True(
+                genericImportMethod.IndexOf("NormalizeCustomerForSave(customerModel);", StringComparison.Ordinal) < genericImportMethod.IndexOf("CustomerExistsAsync(customerModel.Contact, customerModel.Phone, customerModel.Mobile, cancellationToken)", StringComparison.Ordinal),
+                "Generic imports should check duplicates using normalized customer identity fields.");
+            Assert.True(
+                genericImportMethod.IndexOf("NormalizeCustomerForSave(customerModel);", StringComparison.Ordinal) < genericImportMethod.IndexOf("await InsertCustomerAsync(conn, null, customerModel, cancellationToken);", StringComparison.Ordinal),
+                "Generic imports should insert normalized customer values.");
         }
 
         private static void AssertCancellationGuardBeforeSqlAndConnection(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-customer-save-validation-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-customer-save-validation-guards.md
@@ -1,0 +1,19 @@
+# Customer Save Validation Guards
+
+Date: 2026-06-30
+
+## What changed
+
+- Direct customer add and update entry points now normalize customer text fields before persistence work.
+- Direct customer saves now reuse the existing customer import required-field rules: company, contact, and at least one phone or mobile value are required.
+- CSV and generic customer imports now normalize row text before required-field validation, duplicate checks, batch duplicate tracking, and insert work.
+- Source-contract coverage pins the direct-save validation ordering, shared required-field rule reuse, and import normalization ordering.
+
+## Why it matters
+
+Customer imports already rejected incomplete customer identities, but direct customer directory saves could still persist blank or whitespace-only company/contact/contact-number fields. Aligning those paths prevents low-quality customer records from entering the same checkout, document, reminder, report, and export workflows that rely on usable customer identity data.
+
+## Validation
+
+- Connector readback and compare were used to inspect the service/test changes because this scheduled Linux environment cannot directly clone the repository.
+- Local full validation still needs to be run from a Windows/.NET-capable checkout with `pwsh -File scripts/run-full-validation.ps1`.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -50,7 +50,10 @@ namespace InventoryManagementApp.Services.Customers
         {
             if (customer is null)
                 throw new ArgumentNullException(nameof(customer));
-            
+
+            NormalizeCustomerForSave(customer);
+            ValidateCustomerRequiredFields(customer);
+
             _auth.EnsureAdmin();
             return AddCustomerInternalAsync(customer, cancellationToken);
         }
@@ -69,7 +72,10 @@ namespace InventoryManagementApp.Services.Customers
                 throw new ArgumentNullException(nameof(customer));
             if (customer.CustomerID < 1)
                 throw new ArgumentOutOfRangeException(nameof(customer), "Customer ID must be greater than 0.");
-            
+
+            NormalizeCustomerForSave(customer);
+            ValidateCustomerRequiredFields(customer);
+
             _auth.EnsureAdmin();
             return UpdateCustomerInternalAsync(customer, cancellationToken);
         }
@@ -328,6 +334,7 @@ namespace InventoryManagementApp.Services.Customers
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     var c = customers[i];
+                    NormalizeCustomerForSave(c);
                     var row = i + 2;
                     var reason = GetSkipReason(c);
                     if (reason != null)
@@ -464,6 +471,23 @@ namespace InventoryManagementApp.Services.Customers
                 throw new KeyNotFoundException($"Customer {customerID} not found.");
         }
 
+        static void NormalizeCustomerForSave(CustomerModel customer)
+        {
+            customer.Company = (customer.Company ?? string.Empty).Trim();
+            customer.Email = (customer.Email ?? string.Empty).Trim();
+            customer.Contact = (customer.Contact ?? string.Empty).Trim();
+            customer.Phone = (customer.Phone ?? string.Empty).Trim();
+            customer.Mobile = (customer.Mobile ?? string.Empty).Trim();
+            customer.Address = (customer.Address ?? string.Empty).Trim();
+        }
+
+        static void ValidateCustomerRequiredFields(CustomerModel customer)
+        {
+            var reason = GetSkipReason(customer);
+            if (reason != null)
+                throw new ArgumentException(reason, nameof(customer));
+        }
+
         static bool TryReserveImportedCustomer(HashSet<string> importedCustomerKeys, CustomerModel customer)
         {
             var duplicateKeys = BuildCustomerDuplicateKeys(customer).ToList();
@@ -536,6 +560,7 @@ namespace InventoryManagementApp.Services.Customers
                     Mobile = customer.Mobile ?? string.Empty,
                     Address = customer.Address ?? string.Empty
                 };
+                NormalizeCustomerForSave(customerModel);
 
                 var skipReason = GetSkipReason(customerModel);
                 if (skipReason != null)


### PR DESCRIPTION
## What changed

- Direct customer add and update entry points now normalize customer text fields before save work.
- Direct customer saves now require the same customer identity shape already used by imports: company, contact, and at least one phone or mobile value.
- CSV and generic customer imports now normalize row text before required-field validation, duplicate checks, batch duplicate tracking, and insert work.
- Extended `CustomerServiceEntryPointContractTests` to pin direct-save validation ordering, shared required-field rule reuse, and import normalization ordering.
- Added a progress note for the completed customer directory data-quality slice.

## Why this was the highest-value next step

Full Windows/.NET validation remains the top repo need, but this scheduled environment still cannot run it. Recent merged work closed customer creation persistence and import duplicate gaps; connector readback then showed imports enforced usable customer identity fields while direct add/update service entry points could still persist blank or whitespace-only customer records. Customer records feed checkout, documents, reminders, reports, and exports, so aligning direct saves with import validation is the next concrete data-quality improvement.

## Why this is real progress

This is a focused workflow slice across direct customer saves, both import paths, source-contract coverage, and project notes. It prevents bad customer identities from entering the core customer directory rather than making a small isolated guard or stale-note-only change.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, and limited to `CustomerService`, `CustomerServiceEntryPointContractTests`, and one progress note.
- Connector readback confirmed `AddCustomerAsync` and `UpdateCustomerAsync` call `NormalizeCustomerForSave(customer)` and `ValidateCustomerRequiredFields(customer)` before admin authorization and internal write work.
- Connector readback confirmed the shared validation trims company/email/contact/phone/mobile/address, reuses `GetSkipReason`, and keeps the existing import required-field wording.
- Connector readback confirmed CSV and generic imports normalize customer rows before skip-reason validation, duplicate checks, batch duplicate tracking, and insert work.
- Connector status/workflow readback found no attached statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local `pwsh -File scripts/run-full-validation.ps1`, restore/build/test, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here because `dotnet`, `pwsh`, and `gh` are unavailable.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue replacing source-text contracts with behavior-level tests where practical when a full checkout/test runtime is available.