### PR TITLE
Cap rental query result sizes

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -151,9 +151,9 @@ namespace InventoryManagementApp.Tests
                 "public async Task<List<ItemRentalFrequency>> GetRentalFrequencyAsync(int topN = 10)",
                 "private static async Task<int> GetAvailableQuantityForExistingItemAsync");
 
+            Assert.Contains("private const int MaxRentalFrequencyCount = 100;", source, StringComparison.Ordinal);
             AssertContainsAll(
                 frequencyMethod,
-                "private const int MaxRentalFrequencyCount = 100;",
                 "if (topN > MaxRentalFrequencyCount)",
                 "throw new ArgumentOutOfRangeException(nameof(topN), $\"Top rental frequency count cannot exceed {MaxRentalFrequencyCount}.\");",
                 "LIMIT @TopN");

--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -52,8 +52,9 @@ namespace InventoryManagementApp.Tests
                 itemMethod,
                 "using var conn = _dbService.CreateConnection();",
                 "await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);",
-                "const string sql = BaseSelect + @\" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC\";",
-                "var p = new[] { new SqliteParameter(\"@ItemID\", itemID) };");
+                "const string sql = BaseSelect + @\" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC LIMIT @RentalHistoryLimit\";",
+                "new SqliteParameter(\"@ItemID\", itemID)",
+                "new SqliteParameter(\"@RentalHistoryLimit\", MaxRentalHistoryCount)");
             Assert.True(
                 itemMethod.IndexOf("await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);", StringComparison.Ordinal) <
                 itemMethod.IndexOf("const string sql = BaseSelect", StringComparison.Ordinal),
@@ -71,8 +72,9 @@ namespace InventoryManagementApp.Tests
                 customerMethod,
                 "using var conn = _dbService.CreateConnection();",
                 "await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);",
-                "const string sql = BaseSelect + @\" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC\";",
-                "var p = new[] { new SqliteParameter(\"@CustomerID\", customerID) };");
+                "const string sql = BaseSelect + @\" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC LIMIT @RentalHistoryLimit\";",
+                "new SqliteParameter(\"@CustomerID\", customerID)",
+                "new SqliteParameter(\"@RentalHistoryLimit\", MaxRentalHistoryCount)");
             Assert.True(
                 customerMethod.IndexOf("await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);", StringComparison.Ordinal) <
                 customerMethod.IndexOf("const string sql = BaseSelect", StringComparison.Ordinal),
@@ -81,6 +83,23 @@ namespace InventoryManagementApp.Tests
                 customerMethod.IndexOf("await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);", StringComparison.Ordinal) <
                 customerMethod.IndexOf("new SqliteParameter(\"@CustomerID\", customerID)", StringComparison.Ordinal),
                 "Expected customer rental history to confirm the customer row exists before preparing query parameters.");
+        }
+
+        [Fact]
+        public void RentalHistoryQueriesCapReturnedRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            AssertContainsAll(
+                source,
+                "private const int MaxRentalHistoryCount = 500;",
+                "ORDER BY r.RentalDate DESC LIMIT @RentalHistoryLimit",
+                "new SqliteParameter(\"@RentalHistoryLimit\", MaxRentalHistoryCount)");
+
+            Assert.True(
+                source.IndexOf("private const int MaxRentalHistoryCount = 500;", StringComparison.Ordinal) <
+                source.IndexOf("ORDER BY r.RentalDate DESC LIMIT @RentalHistoryLimit", StringComparison.Ordinal),
+                "Expected rental history queries to use the shared max-history cap.");
         }
 
         [Fact]
@@ -121,6 +140,28 @@ namespace InventoryManagementApp.Tests
                 source.IndexOf("throw new ArgumentOutOfRangeException(nameof(topN)", StringComparison.Ordinal) <
                 source.IndexOf("LIMIT @TopN", StringComparison.Ordinal),
                 "Expected rental frequency to validate the limit before building/executing SQL.");
+        }
+
+        [Fact]
+        public void RentalFrequencyRejectsOversizedLimitsBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            AssertContainsAll(
+                source,
+                "private const int MaxRentalFrequencyCount = 100;",
+                "if (topN > MaxRentalFrequencyCount)",
+                "throw new ArgumentOutOfRangeException(nameof(topN), $\"Top rental frequency count cannot exceed {MaxRentalFrequencyCount}.\");",
+                "LIMIT @TopN");
+
+            Assert.True(
+                source.IndexOf("if (topN > MaxRentalFrequencyCount)", StringComparison.Ordinal) <
+                source.IndexOf("const string sql = @\"", StringComparison.Ordinal),
+                "Expected oversized rental frequency requests to fail before SQL text is prepared.");
+            Assert.True(
+                source.IndexOf("if (topN > MaxRentalFrequencyCount)", StringComparison.Ordinal) <
+                source.IndexOf("new SqliteParameter(\"@TopN\", topN)", StringComparison.Ordinal),
+                "Expected oversized rental frequency requests to fail before query parameters are prepared.");
         }
 
         [Fact]

--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -146,21 +146,25 @@ namespace InventoryManagementApp.Tests
         public void RentalFrequencyRejectsOversizedLimitsBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+            var frequencyMethod = ExtractMethod(
+                source,
+                "public async Task<List<ItemRentalFrequency>> GetRentalFrequencyAsync(int topN = 10)",
+                "private static async Task<int> GetAvailableQuantityForExistingItemAsync");
 
             AssertContainsAll(
-                source,
+                frequencyMethod,
                 "private const int MaxRentalFrequencyCount = 100;",
                 "if (topN > MaxRentalFrequencyCount)",
                 "throw new ArgumentOutOfRangeException(nameof(topN), $\"Top rental frequency count cannot exceed {MaxRentalFrequencyCount}.\");",
                 "LIMIT @TopN");
 
             Assert.True(
-                source.IndexOf("if (topN > MaxRentalFrequencyCount)", StringComparison.Ordinal) <
-                source.IndexOf("const string sql = @\"", StringComparison.Ordinal),
+                frequencyMethod.IndexOf("if (topN > MaxRentalFrequencyCount)", StringComparison.Ordinal) <
+                frequencyMethod.IndexOf("const string sql = @\"", StringComparison.Ordinal),
                 "Expected oversized rental frequency requests to fail before SQL text is prepared.");
             Assert.True(
-                source.IndexOf("if (topN > MaxRentalFrequencyCount)", StringComparison.Ordinal) <
-                source.IndexOf("new SqliteParameter(\"@TopN\", topN)", StringComparison.Ordinal),
+                frequencyMethod.IndexOf("if (topN > MaxRentalFrequencyCount)", StringComparison.Ordinal) <
+                frequencyMethod.IndexOf("new SqliteParameter(\"@TopN\", topN)", StringComparison.Ordinal),
                 "Expected oversized rental frequency requests to fail before query parameters are prepared.");
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-rental-query-result-caps.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-rental-query-result-caps.md
@@ -1,0 +1,16 @@
+# Rental Query Result Caps
+
+## Completed
+- Added a `MaxRentalHistoryCount` cap to rental history lookups for both item and customer detail workflows.
+- Kept rental histories ordered newest first while limiting each query to the most recent 500 visible rental rows.
+- Added a `MaxRentalFrequencyCount` guard so oversized rental-frequency requests fail before SQL text, parameters, or database work are prepared.
+- Extended `RentalServiceQueryGuardContractTests` to pin the history SQL limit, shared history cap, bound limit parameter, oversized frequency guard, and existing visible-rental projection behavior.
+
+## Why
+Rental history and frequency data feed operational screens, reports, handoffs, and print workflows. The service already validated positive identifiers and preserved visible item/customer joins, but item/customer rental histories still read every matching row and rental frequency accepted arbitrary `topN` values. Bounding those reads keeps large historical datasets from slowing normal workstation workflows while preserving the newest and most useful rows.
+
+## Validation
+- GitHub connector readback should confirm item and customer history SQL uses `ORDER BY r.RentalDate DESC LIMIT @RentalHistoryLimit` with `MaxRentalHistoryCount` bound as a parameter.
+- GitHub connector readback should confirm rental frequency rejects `topN > MaxRentalFrequencyCount` before SQL preparation and still uses the caller-provided bounded `@TopN` parameter.
+- Local .NET/WPF validation was not available in this scheduled Linux environment because direct checkout is blocked and the Windows/.NET toolchain is unavailable.
+- Layout impact: this is not a visual layout change. It reduces the maximum rows feeding existing rental history and frequency displays without changing control sizing or screen layout.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -20,6 +20,9 @@ namespace InventoryManagementApp.Services.Rentals
     /// </summary>
     public class RentalService : IRentalService
     {
+        private const int MaxRentalHistoryCount = 500;
+        private const int MaxRentalFrequencyCount = 100;
+
         private readonly DatabaseService _dbService;
         private readonly IItemService? _itemService;
         private readonly ILogger<RentalService> _logger;
@@ -367,8 +370,12 @@ namespace InventoryManagementApp.Services.Rentals
             using var conn = _dbService.CreateConnection();
             await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);
 
-            const string sql = BaseSelect + @" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC";
-            var p = new[] { new SqliteParameter("@ItemID", itemID) };
+            const string sql = BaseSelect + @" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC LIMIT @RentalHistoryLimit";
+            var p = new[]
+            {
+                new SqliteParameter("@ItemID", itemID),
+                new SqliteParameter("@RentalHistoryLimit", MaxRentalHistoryCount)
+            };
             var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
@@ -381,8 +388,12 @@ namespace InventoryManagementApp.Services.Rentals
             using var conn = _dbService.CreateConnection();
             await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);
 
-            const string sql = BaseSelect + @" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC";
-            var p = new[] { new SqliteParameter("@CustomerID", customerID) };
+            const string sql = BaseSelect + @" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC LIMIT @RentalHistoryLimit";
+            var p = new[]
+            {
+                new SqliteParameter("@CustomerID", customerID),
+                new SqliteParameter("@RentalHistoryLimit", MaxRentalHistoryCount)
+            };
             var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
@@ -391,6 +402,8 @@ namespace InventoryManagementApp.Services.Rentals
         {
             if (topN < 1)
                 throw new ArgumentOutOfRangeException(nameof(topN), "Top rental frequency count must be greater than 0.");
+            if (topN > MaxRentalFrequencyCount)
+                throw new ArgumentOutOfRangeException(nameof(topN), $"Top rental frequency count cannot exceed {MaxRentalFrequencyCount}.");
 
             const string sql = @"
                 SELECT t.ItemID, t.ItemNumber, t.NameDescription, COUNT(r.RentalID) AS RentalCount


### PR DESCRIPTION
## What changed

- Added a `MaxRentalHistoryCount` cap to item and customer rental-history lookups.
- Kept rental histories newest-first while binding `@RentalHistoryLimit` as a SQL parameter.
- Added a `MaxRentalFrequencyCount` guard so oversized rental-frequency requests fail before SQL text, parameters, or database work are prepared.
- Extended `RentalServiceQueryGuardContractTests` to pin history limits, bound parameters, oversized frequency rejection, and the existing visible-rental projection behavior.
- Added a progress note for the completed rental query reliability slice.

## Why this was the highest-value next step

Full Windows/.NET validation remains the top repo need, but this scheduled environment still cannot run it. Recent merged work closed write and validation gaps across customers, users, settings, items, categories, kits, reservations, and activity logs. Connector readback showed rental writes already have affected-row guards, while rental history/frequency reads still allowed unbounded result sizes. Rental history feeds item/customer detail workflows, reports, handoffs, and print flows, so bounding those reads is the next concrete reliability improvement without repeating the same recently completed write-guard work.

## Why this is real progress

This is a focused workflow slice across service query behavior, source-contract coverage, and project notes. It improves runtime reliability for rental history and frequency workflows instead of making a tiny isolated guard or stale-note-only update.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, five commits ahead, and limited to `RentalService`, `RentalServiceQueryGuardContractTests`, and one progress note.
- Connector readback confirmed item and customer rental-history SQL now uses `ORDER BY r.RentalDate DESC LIMIT @RentalHistoryLimit` with `MaxRentalHistoryCount` bound as a parameter.
- Connector readback confirmed rental frequency rejects `topN > MaxRentalFrequencyCount` before SQL preparation and still binds bounded `@TopN` values.
- Connector readback confirmed contract tests cover the new history cap, bounded history parameter, oversized frequency guard, and existing visible-rental projection behavior.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local `pwsh -File scripts/run-full-validation.ps1`, restore/build/test, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here because the checkout is blocked and the Windows/.NET toolchain is unavailable.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue replacing source-text contracts with behavior-level tests where practical when a full checkout/test runtime is available.