### PR TITLE
Honor cancellation in import export exporters

### DIFF
--- a/InventoryManagementApp.Tests/ImportExportExporterCancellationContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportExporterCancellationContractTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ImportExportExporterCancellationContractTests
+    {
+        [Theory]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemCsvExporter.cs", "var items = data.ToList();", "CsvHelperUtil.ExportItemsToCsvAsync(filePath, items)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerCsvExporter.cs", "var customers = data.Select(c => new CustomerModel", "CsvHelperUtil.ExportCustomersToCsv(filePath, customers)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemJsonExporter.cs", "var items = data.ToList();", "File.WriteAllTextAsync(filePath, json, cancellationToken)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerJsonExporter.cs", "var customers = data.ToList();", "File.WriteAllTextAsync(filePath, json, cancellationToken)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemXmlExporter.cs", "var items = data.ToList();", "new StreamWriter(filePath)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerXmlExporter.cs", "var customers = data.ToList();", "new StreamWriter(filePath)")]
+        public void ExportersHonorCancellationBeforeMaterializingRowsAndWritingFiles(
+            string relativePath,
+            string materializeMarker,
+            string writeMarker)
+        {
+            var source = ReadRepoFile(relativePath);
+
+            AssertCancellationCheckBefore(source, materializeMarker);
+            AssertCancellationCheckBetween(source, materializeMarker, writeMarker);
+        }
+
+        [Theory]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerCsvExporter.cs")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemXmlExporter.cs")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerXmlExporter.cs")]
+        public void SynchronousExporterTasksCheckCancellationInsideTheWriterTask(string relativePath)
+        {
+            var source = ReadRepoFile(relativePath);
+            var taskStart = source.IndexOf("await Task.Run(() =>", StringComparison.Ordinal);
+            Assert.True(taskStart >= 0, $"Expected {relativePath} to use Task.Run for synchronous export work.");
+
+            var innerCancellation = source.IndexOf("cancellationToken.ThrowIfCancellationRequested();", taskStart, StringComparison.Ordinal);
+            Assert.True(innerCancellation > taskStart, $"Expected {relativePath} to check cancellation inside the synchronous export task.");
+        }
+
+        private static void AssertCancellationCheckBefore(string source, string marker)
+        {
+            var markerIndex = source.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(markerIndex >= 0, $"Expected source marker: {marker}");
+
+            var cancellationIndex = source.LastIndexOf("cancellationToken.ThrowIfCancellationRequested();", markerIndex, StringComparison.Ordinal);
+            Assert.True(cancellationIndex >= 0, $"Expected cancellation check before marker: {marker}");
+        }
+
+        private static void AssertCancellationCheckBetween(string source, string firstMarker, string secondMarker)
+        {
+            var firstIndex = source.IndexOf(firstMarker, StringComparison.Ordinal);
+            var secondIndex = source.IndexOf(secondMarker, StringComparison.Ordinal);
+
+            Assert.True(firstIndex >= 0, $"Expected first source marker: {firstMarker}");
+            Assert.True(secondIndex > firstIndex, $"Expected second source marker after first marker: {secondMarker}");
+
+            var cancellationIndex = source.IndexOf("cancellationToken.ThrowIfCancellationRequested();", firstIndex, StringComparison.Ordinal);
+            Assert.True(
+                cancellationIndex > firstIndex && cancellationIndex < secondIndex,
+                $"Expected cancellation check between markers: {firstMarker} -> {secondMarker}");
+        }
+
+        private static string ReadRepoFile(string relativePath)
+        {
+            var directory = AppContext.BaseDirectory;
+            var normalizedPath = relativePath.Replace('/', Path.DirectorySeparatorChar);
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, normalizedPath);
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {relativePath}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-import-export-exporter-cancellation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-import-export-exporter-cancellation.md
@@ -1,0 +1,25 @@
+# Import / Export Exporter Cancellation Hardening
+
+Date: 2026-06-29
+
+## Completed
+
+- Hardened item and customer CSV, JSON, and XML exporters so cancellation is checked before export data is materialized.
+- Added a second cancellation checkpoint before destination file writes begin, reducing the chance that a canceled large export still creates or overwrites a file.
+- Checked cancellation inside synchronous CSV/XML writer tasks where the underlying helper or serializer does not accept a cancellation token.
+- Added source-contract coverage for cancellation ordering across all six exporters.
+
+## Why This Matters
+
+Import/export can operate on large item and customer catalogs. If an operator cancels an export from the UI, the exporter should stop before expensive enumeration or destination-file writes instead of continuing into a stale file operation.
+
+## Validation
+
+- Connector readback should confirm the exporter files check `cancellationToken.ThrowIfCancellationRequested()` before materialization and before file writer calls.
+- Connector readback should confirm `ImportExportExporterCancellationContractTests` guards the cancellation ordering.
+
+Full local validation still needs to be run in a Windows/.NET-capable checkout:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```

--- a/InventoryManagementApp/Services/ImportExport/CustomerCsvExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/CustomerCsvExporter.cs
@@ -26,6 +26,8 @@ namespace InventoryManagementApp.Services.ImportExport
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Convert Customer to CustomerModel for CSV export
             var customers = data.Select(c => new CustomerModel
             {
@@ -38,7 +40,13 @@ namespace InventoryManagementApp.Services.ImportExport
                 Address = c.Address
             }).ToList();
 
-            await Task.Run(() => CsvHelperUtil.ExportCustomersToCsv(filePath, customers), cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await Task.Run(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CsvHelperUtil.ExportCustomersToCsv(filePath, customers);
+            }, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/InventoryManagementApp/Services/ImportExport/CustomerJsonExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/CustomerJsonExporter.cs
@@ -35,7 +35,10 @@ namespace InventoryManagementApp.Services.ImportExport
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
+            cancellationToken.ThrowIfCancellationRequested();
             var customers = data.ToList();
+            cancellationToken.ThrowIfCancellationRequested();
+
             var json = JsonSerializer.Serialize(customers, JsonOptions);
             await File.WriteAllTextAsync(filePath, json, cancellationToken).ConfigureAwait(false);
         }

--- a/InventoryManagementApp/Services/ImportExport/CustomerXmlExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/CustomerXmlExporter.cs
@@ -27,9 +27,14 @@ namespace InventoryManagementApp.Services.ImportExport
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             await Task.Run(() =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var customers = data.ToList();
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var serializer = new XmlSerializer(typeof(List<Customer>), new XmlRootAttribute("Customers"));
                 using var writer = new StreamWriter(filePath);
                 serializer.Serialize(writer, customers);

--- a/InventoryManagementApp/Services/ImportExport/ItemCsvExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/ItemCsvExporter.cs
@@ -26,7 +26,10 @@ namespace InventoryManagementApp.Services.ImportExport
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
+            cancellationToken.ThrowIfCancellationRequested();
             var items = data.ToList();
+            cancellationToken.ThrowIfCancellationRequested();
+
             await CsvHelperUtil.ExportItemsToCsvAsync(filePath, items).ConfigureAwait(false);
         }
     }

--- a/InventoryManagementApp/Services/ImportExport/ItemJsonExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/ItemJsonExporter.cs
@@ -35,7 +35,10 @@ namespace InventoryManagementApp.Services.ImportExport
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
+            cancellationToken.ThrowIfCancellationRequested();
             var items = data.ToList();
+            cancellationToken.ThrowIfCancellationRequested();
+
             var json = JsonSerializer.Serialize(items, JsonOptions);
             await File.WriteAllTextAsync(filePath, json, cancellationToken).ConfigureAwait(false);
         }

--- a/InventoryManagementApp/Services/ImportExport/ItemXmlExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/ItemXmlExporter.cs
@@ -27,9 +27,14 @@ namespace InventoryManagementApp.Services.ImportExport
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             await Task.Run(() =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var items = data.ToList();
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var serializer = new XmlSerializer(typeof(List<ItemModel>), new XmlRootAttribute("Items"));
                 using var writer = new StreamWriter(filePath);
                 serializer.Serialize(writer, items);


### PR DESCRIPTION
## What changed

- Item and customer CSV, JSON, and XML exporters now check cancellation before materializing export rows.
- Exporters now check cancellation again before destination-file writes begin, reducing the chance that a canceled large export still creates or overwrites a file.
- Synchronous CSV/XML writer tasks now check cancellation inside the background task before invoking the file writer or XML serializer.
- Added `ImportExportExporterCancellationContractTests` source-contract coverage for cancellation ordering across all six exporters.
- Added a progress note for the completed import/export reliability slice.

## Why this was the highest-value next step

Full Windows/.NET validation remains the top repo need, but this scheduled environment still cannot run it. Recent merged work already covered customer/user/settings persistence guards, import duplicate validation, and rental query caps. Import/export is a core workflow and the exporter implementations accepted cancellation tokens while several paths still did expensive enumeration or synchronous file writes without checking cancellation first.

## Why this is real progress

This is a complete workflow-level reliability slice across every item/customer exporter format plus contract coverage and notes. It improves cancellation behavior consistently for CSV, JSON, and XML export operations instead of making a narrow one-file guard.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, 8 commits ahead, and limited to six exporter files, one source-contract test, and one progress note.
- Connector readback confirmed item/customer CSV and JSON exporters check `cancellationToken.ThrowIfCancellationRequested()` before materialization and before writer calls.
- Connector readback confirmed item/customer XML exporters check cancellation before entering `Task.Run`, inside the synchronous writer task, after materialization, and before `StreamWriter`/serialization starts.
- Connector readback confirmed `ImportExportExporterCancellationContractTests` guards cancellation before materialization, cancellation before file writes, and in-task cancellation checks for synchronous writers.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- Local `pwsh -File scripts/run-full-validation.ps1`, restore/build/test, WPF runtime checks, screenshots, banned-word checks, and full Windows validation could not be run here because `dotnet`, `pwsh`, and `gh` are unavailable.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Replace source-contract checks with behavior-level cancellation tests where practical when a full checkout and test runtime are available.