### PR TITLE
Honor cancellation during JSON and XML imports

### DIFF
--- a/InventoryManagementApp.Tests/ImportExportImporterCancellationContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportImporterCancellationContractTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ImportExportImporterCancellationContractTests
+    {
+        [Theory]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemJsonImporter.cs", "File.ReadAllTextAsync(filePath, cancellationToken)", "JsonSerializer.Deserialize<List<ItemModel>>(json, JsonOptions)", "for (int i = 0; i < items.Count; i++)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerJsonImporter.cs", "File.ReadAllTextAsync(filePath, cancellationToken)", "JsonSerializer.Deserialize<List<Customer>>(json, JsonOptions)", "for (int i = 0; i < customers.Count; i++)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemXmlImporter.cs", "await Task.Run(() =>", "serializer.Deserialize(reader) as List<ItemModel>", "for (int i = 0; i < items.Count; i++)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerXmlImporter.cs", "await Task.Run(() =>", "serializer.Deserialize(reader) as List<Customer>", "for (int i = 0; i < customers.Count; i++)")]
+        public void ImportersHonorCancellationBeforeParsingAndRowValidation(
+            string relativePath,
+            string readMarker,
+            string parseMarker,
+            string validationLoopMarker)
+        {
+            var source = ReadRepoFile(relativePath);
+
+            AssertCancellationCheckBefore(source, readMarker);
+            AssertCancellationCheckBetween(source, readMarker, parseMarker);
+            AssertCancellationCheckBetween(source, parseMarker, validationLoopMarker);
+            AssertCancellationCheckBetween(source, validationLoopMarker, "var item = items[i];", required: relativePath.Contains("Item", StringComparison.Ordinal));
+            AssertCancellationCheckBetween(source, validationLoopMarker, "var customer = customers[i];", required: relativePath.Contains("Customer", StringComparison.Ordinal));
+        }
+
+        [Theory]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemXmlImporter.cs", "serializer.Deserialize(reader) as List<ItemModel>")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerXmlImporter.cs", "serializer.Deserialize(reader) as List<Customer>")]
+        public void SynchronousXmlImporterTasksCheckCancellationInsideDeserializeWork(string relativePath, string deserializeMarker)
+        {
+            var source = ReadRepoFile(relativePath);
+            var taskStart = source.IndexOf("await Task.Run(() =>", StringComparison.Ordinal);
+            Assert.True(taskStart >= 0, $"Expected {relativePath} to use Task.Run for synchronous XML import work.");
+
+            var deserializeIndex = source.IndexOf(deserializeMarker, taskStart, StringComparison.Ordinal);
+            Assert.True(deserializeIndex > taskStart, $"Expected XML deserialize marker in {relativePath}.");
+
+            var innerCancellationBeforeDeserialize = source.LastIndexOf("cancellationToken.ThrowIfCancellationRequested();", deserializeIndex, StringComparison.Ordinal);
+            Assert.True(
+                innerCancellationBeforeDeserialize > taskStart,
+                $"Expected cancellation check inside the XML import task before deserialization in {relativePath}.");
+
+            var taskEnd = source.IndexOf("}, cancellationToken).ConfigureAwait(false);", deserializeIndex, StringComparison.Ordinal);
+            Assert.True(taskEnd > deserializeIndex, $"Expected XML import task end in {relativePath}.");
+
+            var innerCancellationAfterDeserialize = source.IndexOf("cancellationToken.ThrowIfCancellationRequested();", deserializeIndex, StringComparison.Ordinal);
+            Assert.True(
+                innerCancellationAfterDeserialize > deserializeIndex && innerCancellationAfterDeserialize < taskEnd,
+                $"Expected cancellation check inside the XML import task after deserialization in {relativePath}.");
+        }
+
+        private static void AssertCancellationCheckBefore(string source, string marker)
+        {
+            var markerIndex = source.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(markerIndex >= 0, $"Expected source marker: {marker}");
+
+            var cancellationIndex = source.LastIndexOf("cancellationToken.ThrowIfCancellationRequested();", markerIndex, StringComparison.Ordinal);
+            Assert.True(cancellationIndex >= 0, $"Expected cancellation check before marker: {marker}");
+        }
+
+        private static void AssertCancellationCheckBetween(string source, string firstMarker, string secondMarker, bool required = true)
+        {
+            var firstIndex = source.IndexOf(firstMarker, StringComparison.Ordinal);
+            var secondIndex = source.IndexOf(secondMarker, StringComparison.Ordinal);
+
+            if (!required)
+            {
+                Assert.True(secondIndex < 0, $"Did not expect marker in this importer: {secondMarker}");
+                return;
+            }
+
+            Assert.True(firstIndex >= 0, $"Expected first source marker: {firstMarker}");
+            Assert.True(secondIndex > firstIndex, $"Expected second source marker after first marker: {secondMarker}");
+
+            var cancellationIndex = source.IndexOf("cancellationToken.ThrowIfCancellationRequested();", firstIndex, StringComparison.Ordinal);
+            Assert.True(
+                cancellationIndex > firstIndex && cancellationIndex < secondIndex,
+                $"Expected cancellation check between markers: {firstMarker} -> {secondMarker}");
+        }
+
+        private static string ReadRepoFile(string relativePath)
+        {
+            var directory = AppContext.BaseDirectory;
+            var normalizedPath = relativePath.Replace('/', Path.DirectorySeparatorChar);
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, normalizedPath);
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {relativePath}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-import-export-importer-cancellation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-import-export-importer-cancellation.md
@@ -1,0 +1,24 @@
+# Import / Export Importer Cancellation Hardening
+
+Date: 2026-06-29
+
+## Completed
+
+- Hardened item and customer JSON importers so cancellation is checked before file read work, before JSON deserialization, after deserialization, and during per-row validation.
+- Hardened item and customer XML importers so cancellation is checked before synchronous XML deserialize work starts, inside the background deserialize task, after deserialize work returns, and during per-row validation.
+- Added source-contract coverage for cancellation ordering across the JSON and XML importers.
+
+## Why This Matters
+
+Large item and customer imports can spend meaningful time reading, deserializing, and validating rows. If an operator cancels an import, the importer should stop before expensive parse or validation work continues and before stale imported rows are handed back to the caller.
+
+## Validation
+
+- Connector readback should confirm the importer files check `cancellationToken.ThrowIfCancellationRequested()` before parse work, after deserialization, and inside validation loops.
+- Connector readback should confirm `ImportExportImporterCancellationContractTests` guards the cancellation ordering.
+
+Full local validation still needs to be run in a Windows/.NET-capable checkout:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```

--- a/InventoryManagementApp/Services/ImportExport/CustomerJsonImporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/CustomerJsonImporter.cs
@@ -34,11 +34,14 @@ namespace InventoryManagementApp.Services.ImportExport
             if (!File.Exists(filePath))
                 throw new FileNotFoundException("File not found.", filePath);
 
+            cancellationToken.ThrowIfCancellationRequested();
             var skippedRows = new List<int>();
             var json = await File.ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false);
-            
+
+            cancellationToken.ThrowIfCancellationRequested();
             var customers = JsonSerializer.Deserialize<List<Customer>>(json, JsonOptions);
-            
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (customers == null || customers.Count == 0)
                 return (Enumerable.Empty<Customer>(), skippedRows);
 
@@ -46,6 +49,7 @@ namespace InventoryManagementApp.Services.ImportExport
             var validCustomers = new List<Customer>();
             for (int i = 0; i < customers.Count; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var customer = customers[i];
                 // A customer should have at least a company name or contact
                 if (string.IsNullOrWhiteSpace(customer.Company) && string.IsNullOrWhiteSpace(customer.Contact))

--- a/InventoryManagementApp/Services/ImportExport/CustomerXmlImporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/CustomerXmlImporter.cs
@@ -27,14 +27,19 @@ namespace InventoryManagementApp.Services.ImportExport
             if (!File.Exists(filePath))
                 throw new FileNotFoundException("File not found.", filePath);
 
+            cancellationToken.ThrowIfCancellationRequested();
             var skippedRows = new List<int>();
             
             var customers = await Task.Run(() =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var serializer = new XmlSerializer(typeof(List<Customer>), new XmlRootAttribute("Customers"));
                 using var reader = new StreamReader(filePath);
-                return serializer.Deserialize(reader) as List<Customer>;
+                var deserializedCustomers = serializer.Deserialize(reader) as List<Customer>;
+                cancellationToken.ThrowIfCancellationRequested();
+                return deserializedCustomers;
             }, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (customers == null || customers.Count == 0)
                 return (Enumerable.Empty<Customer>(), skippedRows);
@@ -43,6 +48,7 @@ namespace InventoryManagementApp.Services.ImportExport
             var validCustomers = new List<Customer>();
             for (int i = 0; i < customers.Count; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var customer = customers[i];
                 // A customer should have at least a company name or contact
                 if (string.IsNullOrWhiteSpace(customer.Company) && string.IsNullOrWhiteSpace(customer.Contact))

--- a/InventoryManagementApp/Services/ImportExport/ItemJsonImporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/ItemJsonImporter.cs
@@ -34,11 +34,14 @@ namespace InventoryManagementApp.Services.ImportExport
             if (!File.Exists(filePath))
                 throw new FileNotFoundException("File not found.", filePath);
 
+            cancellationToken.ThrowIfCancellationRequested();
             var skippedRows = new List<int>();
             var json = await File.ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false);
-            
+
+            cancellationToken.ThrowIfCancellationRequested();
             var items = JsonSerializer.Deserialize<List<ItemModel>>(json, JsonOptions);
-            
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (items == null || items.Count == 0)
                 return (Enumerable.Empty<ItemModel>(), skippedRows);
 
@@ -46,6 +49,7 @@ namespace InventoryManagementApp.Services.ImportExport
             var validItems = new List<ItemModel>();
             for (int i = 0; i < items.Count; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var item = items[i];
                 if (string.IsNullOrWhiteSpace(item.ItemNumber))
                 {

--- a/InventoryManagementApp/Services/ImportExport/ItemXmlImporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/ItemXmlImporter.cs
@@ -27,14 +27,19 @@ namespace InventoryManagementApp.Services.ImportExport
             if (!File.Exists(filePath))
                 throw new FileNotFoundException("File not found.", filePath);
 
+            cancellationToken.ThrowIfCancellationRequested();
             var skippedRows = new List<int>();
             
             var items = await Task.Run(() =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var serializer = new XmlSerializer(typeof(List<ItemModel>), new XmlRootAttribute("Items"));
                 using var reader = new StreamReader(filePath);
-                return serializer.Deserialize(reader) as List<ItemModel>;
+                var deserializedItems = serializer.Deserialize(reader) as List<ItemModel>;
+                cancellationToken.ThrowIfCancellationRequested();
+                return deserializedItems;
             }, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (items == null || items.Count == 0)
                 return (Enumerable.Empty<ItemModel>(), skippedRows);
@@ -43,6 +48,7 @@ namespace InventoryManagementApp.Services.ImportExport
             var validItems = new List<ItemModel>();
             for (int i = 0; i < items.Count; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var item = items[i];
                 if (string.IsNullOrWhiteSpace(item.ItemNumber))
                 {


### PR DESCRIPTION
## What changed

- Added cancellation checkpoints to item/customer JSON importers before file read work, before JSON deserialization, after deserialization, and during per-row validation.
- Added cancellation checkpoints to item/customer XML importers before synchronous deserialize work starts, inside the background deserialize task, after deserialize work returns, and during per-row validation.
- Added `ImportExportImporterCancellationContractTests` to guard the cancellation ordering across JSON and XML importers.
- Added a progress note for the import cancellation hardening.

## Why this was the highest-value next step

The most recent completed work hardened cancellation across item/customer exporters. The matching importers still accepted a cancellation token but could continue through deserialize and row-validation work after cancellation, especially for XML where the serializer work is synchronous inside `Task.Run`. Closing that matching workflow gap improves reliability for large catalog import operations without inventing a new feature area.

## Why this is real workflow progress

This covers the full JSON/XML import path for both supported domain families, from file-read handoff through parse work and row validation, and adds source-contract coverage so the behavior stays consistent.

## Validation

- GitHub connector compare confirms the branch is current with `master`, ahead by 6 commits, and limited to four importer files, one contract test, and one progress note.
- Connector readback confirmed `ItemXmlImporter` checks cancellation before and after XML deserialization and during row validation.
- Connector readback confirmed `ImportExportImporterCancellationContractTests` checks cancellation before parsing, after parsing, inside XML deserialize tasks, and inside validation loops.
- Connector status readback for branch head `d37592cf315c6fcbdeac534a591ea9a44d493bfd` found no attached statuses.

## Could not be checked here

- Local checkout/raw access is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable in this scheduled Linux workspace, so `pwsh -File scripts/run-full-validation.ps1`, local .NET tests, WPF runtime checks, screenshots, and GitHub Actions log inspection could not be run.

## Known follow-up work

- Run the full validation script in a Windows/.NET-capable checkout.
- If CSV importers exist under a less obvious name, inspect and align their cancellation behavior in a follow-up slice.