### PR TITLE
Harden item import insert guards

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceImportInsertGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceImportInsertGuardContractTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemServiceImportInsertGuardContractTests
+    {
+        [Fact]
+        public void ItemImportInsertChecksAffectedRowsBeforeReadingGeneratedId()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "protected virtual async Task<int> InsertItemAsync",
+                "private async Task ExportItemsToCsvInternalAsync");
+
+            Assert.Contains("const string insertSql", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("SELECT last_insert_rowid();\";", method[..method.IndexOf("var parameters = new[]", StringComparison.Ordinal)], StringComparison.Ordinal);
+            Assert.Contains("var insertedRows = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);", method, StringComparison.Ordinal);
+            Assert.Contains("EnsureItemImportCreateSucceeded(insertedRows);", method, StringComparison.Ordinal);
+            Assert.Contains("using var idCommand = new SqliteCommand(\"SELECT last_insert_rowid();\", conn, transaction);", method, StringComparison.Ordinal);
+            Assert.Contains("if (id < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException(\"Unable to import item.\");", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("var insertedRows = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);", StringComparison.Ordinal) <
+                method.IndexOf("EnsureItemImportCreateSucceeded(insertedRows);", StringComparison.Ordinal),
+                "Item import should capture affected rows before checking the insert result.");
+            Assert.True(
+                method.IndexOf("EnsureItemImportCreateSucceeded(insertedRows);", StringComparison.Ordinal) <
+                method.IndexOf("using var idCommand = new SqliteCommand(\"SELECT last_insert_rowid();\", conn, transaction);", StringComparison.Ordinal),
+                "Failed item imports should stop before reading a generated id.");
+            Assert.True(
+                method.IndexOf("if (id < 1)", StringComparison.Ordinal) >
+                method.IndexOf("var id = Convert.ToInt32(await idCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false));", StringComparison.Ordinal),
+                "Item import should reject invalid generated ids before returning success.");
+        }
+
+        [Fact]
+        public void CsvAndGenericItemImportsAssignGuardedGeneratedIds()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var csvImportMethod = ExtractMethod(
+                source,
+                "private async Task<List<int>> ImportItemsFromCsvInternalAsync",
+                "protected virtual async Task<int> InsertItemAsync");
+            var genericImportMethod = ExtractMethod(
+                source,
+                "public async Task<List<int>> ImportItemsAsync",
+                "private static string GenerateNextImportedItemNumber");
+
+            Assert.Contains("item.ItemID = await InsertItemAsync(conn, transaction, item, cancellationToken).ConfigureAwait(false);", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("item.ItemID = await InsertItemAsync(conn, transaction, item, cancellationToken).ConfigureAwait(false);", genericImportMethod, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemImportCreateGuardUsesImportFailureMessage()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+
+            Assert.Contains("static void EnsureItemImportCreateSucceeded(int affectedRows)", source, StringComparison.Ordinal);
+            Assert.Contains("if (affectedRows == 0)", source, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException(\"Unable to import item.\");", source, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-item-import-insert-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-item-import-insert-guard.md
@@ -1,0 +1,25 @@
+# Item Import Insert Guard Hardening
+
+Date: 2026-06-30
+
+## Completed
+
+- Hardened the item import insert helper used by CSV and generic item import workflows.
+- Split item import inserts from generated-id lookup so the import path checks SQLite affected rows before reading `last_insert_rowid()`.
+- Added an invalid generated-id guard with a clear import failure message before imported rows can be counted as successful.
+- Added source-contract coverage for insert result ordering, generated-id validation, and both item import entry points assigning the guarded id.
+
+## Why This Matters
+
+Recent work hardened the repository item create path, but item imports use a separate insert helper. Large inventory import workflows should not treat a row as created unless SQLite confirms the insert affected a row and returns a usable generated id.
+
+## Validation
+
+- Connector readback should confirm `ItemService.InsertItemAsync` executes the insert, checks `EnsureItemImportCreateSucceeded(insertedRows)`, then reads and validates `last_insert_rowid()`.
+- Connector readback should confirm `ItemServiceImportInsertGuardContractTests` pins the ordering and both CSV and generic item import entry points.
+
+Full local validation still needs to be run in a Windows/.NET-capable checkout:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -514,7 +514,7 @@ namespace InventoryManagementApp.Services.Items
                         IsRentalItem = TryParseBool(rental)
                     };
 
-                    await InsertItemAsync(conn, transaction, item, cancellationToken).ConfigureAwait(false);
+                    item.ItemID = await InsertItemAsync(conn, transaction, item, cancellationToken).ConfigureAwait(false);
                     existingNumbers.Add(itemNumber!);
                 }
 
@@ -537,9 +537,8 @@ namespace InventoryManagementApp.Services.Items
 
         protected virtual async Task<int> InsertItemAsync(SqliteConnection conn, SqliteTransaction? transaction, ItemModel item, CancellationToken cancellationToken)
         {
-            const string sql = @"INSERT INTO Items (ItemNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, IsPowered, IsIncomplete, MissingComponentsNotes, IssuesNotes, CheckoutCount)
-                                 VALUES (@ItemNumber,@Name,@Location,@Brand,@PartNumber,@Supplier,@PurchasedDate,@Notes,@Keywords,@QuantityOnHand,@RentedQuantity,@IsRentalItem,@Price,@ImagePath,0,@IsPowered,0,'','',0);
-                                 SELECT last_insert_rowid();";
+            const string insertSql = @"INSERT INTO Items (ItemNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, IsPowered, IsIncomplete, MissingComponentsNotes, IssuesNotes, CheckoutCount)
+                                 VALUES (@ItemNumber,@Name,@Location,@Brand,@PartNumber,@Supplier,@PurchasedDate,@Notes,@Keywords,@QuantityOnHand,@RentedQuantity,@IsRentalItem,@Price,@ImagePath,0,@IsPowered,0,'','',0);";
 
             var parameters = new[]
             {
@@ -560,10 +559,23 @@ namespace InventoryManagementApp.Services.Items
                 new SqliteParameter("@IsPowered", item.IsPowered ? 1 : 0)
             };
 
-            using var command = new SqliteCommand(sql, conn, transaction);
+            using var command = new SqliteCommand(insertSql, conn, transaction);
             command.Parameters.AddRange(parameters);
-            var id = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-            return Convert.ToInt32(id);
+            var insertedRows = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            EnsureItemImportCreateSucceeded(insertedRows);
+
+            using var idCommand = new SqliteCommand("SELECT last_insert_rowid();", conn, transaction);
+            var id = Convert.ToInt32(await idCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false));
+            if (id < 1)
+                throw new InvalidOperationException("Unable to import item.");
+
+            return id;
+        }
+
+        static void EnsureItemImportCreateSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
+                throw new InvalidOperationException("Unable to import item.");
         }
 
         private async Task ExportItemsToCsvInternalAsync(string filePath, CancellationToken cancellationToken)


### PR DESCRIPTION
## What changed

- Hardened the `ItemService` import insert helper used by CSV and generic item imports.
- Split item import inserts from `last_insert_rowid()` lookup so SQLite affected rows are checked before a generated id is read.
- Added invalid generated-id rejection with a clear `Unable to import item.` failure before imported rows can be treated as successful.
- Assigned the guarded generated id back to CSV-imported item rows, matching the generic import path.
- Added `ItemServiceImportInsertGuardContractTests` source-contract coverage and a progress note.

## Why this was the highest-value next step

Recent repo work hardened repository item creation and import/export cancellation, but connector readback showed the older item import helper still used the fragile combined insert plus generated-id scalar command. Item imports are a core inventory setup workflow, so closing this remaining import persistence gap improves data integrity without inventing a new feature area.

## Why this is real workflow progress

This covers both item import entry points that use the helper: mapped CSV imports and generic JSON/XML-style imports. It updates service behavior, source-contract coverage, and progress notes as one complete workflow reliability slice.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, 3 commits ahead, and limited to `ItemService`, one new contract test, and one progress note.
- Connector readback confirmed `InsertItemAsync` now executes the insert, checks `EnsureItemImportCreateSucceeded(insertedRows)`, then reads and validates `last_insert_rowid()`.
- Connector readback confirmed CSV item imports now assign the guarded id returned by `InsertItemAsync`.
- Connector readback confirmed `ItemServiceImportInsertGuardContractTests` pins insert-result ordering, generated-id validation, both item import entry points, and the import failure message.

## Could not be checked

- Direct local checkout and raw API access are blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so `pwsh -File scripts/run-full-validation.ps1`, local .NET tests, WPF runtime checks, screenshots, and GitHub Actions log inspection could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue scanning for concrete import or persistence gaps, but avoid repeating create-write guard work unless current source evidence shows a real remaining issue.