### PR TITLE
Harden item image import workflow

### DIFF
--- a/InventoryManagementApp.Tests/ItemImageImportWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemImageImportWorkflowContractTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemImageImportWorkflowContractTests
+    {
+        [Fact]
+        public void ImageImportReportsProgressForEveryEnumeratedFile()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "private async Task<ImageImportResult> ImportItemImagesInternalAsync",
+                "protected virtual Task CopyFileAsync");
+
+            Assert.Contains("var total = files.Count;", method, StringComparison.Ordinal);
+            Assert.Contains("finally", method, StringComparison.Ordinal);
+            Assert.Contains("processed++;", method, StringComparison.Ordinal);
+            Assert.Contains("progress?.Report(new ImageImportProgress { Processed = processed, Total = total });", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.LastIndexOf("processed++;", StringComparison.Ordinal) >
+                method.LastIndexOf("finally", StringComparison.Ordinal),
+                "Image import progress should advance from the finally block so unsupported, unmatched, conflicting, failed, and imported files all move the progress meter.");
+        }
+
+        [Fact]
+        public void ImageImportKeepsCancellationEscapingButContinuesAfterPerFileFailures()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "private async Task<ImageImportResult> ImportItemImagesInternalAsync",
+                "protected virtual Task CopyFileAsync");
+
+            Assert.Contains("catch (OperationCanceledException)", method, StringComparison.Ordinal);
+            Assert.Contains("throw;", method, StringComparison.Ordinal);
+            Assert.Contains("catch (Exception ex)", method, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to import image {Source}\", file);", method, StringComparison.Ordinal);
+            Assert.Contains("result.ConflictingFiles.Add(file);", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("catch (IOException ex)", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("catch (OperationCanceledException)", StringComparison.Ordinal) <
+                method.IndexOf("catch (Exception ex)", StringComparison.Ordinal),
+                "Cancellation must be rethrown before broad per-file failure handling.");
+            Assert.True(
+                method.IndexOf("await CopyFileAsync(file, dest, 256, 256, cancellationToken);", StringComparison.Ordinal) <
+                method.IndexOf("await UpdateItemImageAsync(item.ItemID, relative, cancellationToken);", StringComparison.Ordinal),
+                "Image imports should still copy the asset before updating the item record.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-item-image-import-workflow-hardening.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-item-image-import-workflow-hardening.md
@@ -1,0 +1,27 @@
+# Item Image Import Workflow Hardening
+
+Date: 2026-06-30
+
+## Completed
+
+- Hardened the item image import loop so progress is reported for every enumerated file, including unsupported, unmatched, conflicting, failed, and successfully imported files.
+- Kept cancellation behavior immediate by rethrowing `OperationCanceledException` before broad per-file failure handling.
+- Converted per-file image decode, copy, and item-image update failures into logged conflicts so one bad image does not abort the rest of the batch.
+- Added source-contract coverage for progress reporting, cancellation ordering, broad per-file failure handling, and copy-before-record-update ordering.
+
+## Why This Matters
+
+Image imports are an operator-facing catalog setup workflow. Before this pass, the progress meter advanced only after successful imports and a corrupt or unsupported-by-decoder image could stop the entire batch. Large image folders should keep giving honest progress and finish the rest of the usable files even when a single file is bad.
+
+## Validation
+
+- Connector readback should confirm `ItemService.ImportItemImagesInternalAsync` reports progress from a `finally` block for every enumerated file.
+- Connector readback should confirm cancellation is rethrown before broad per-file exception handling.
+- Connector readback should confirm per-file failures are logged and added to `ConflictingFiles`.
+- Connector readback should confirm `ItemImageImportWorkflowContractTests` pins the workflow contract.
+
+Full local validation still needs to be run in a Windows/.NET-capable checkout:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -239,47 +239,52 @@ namespace InventoryManagementApp.Services.Items
             foreach (var file in files)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var ext = Path.GetExtension(file);
-                if (!supported.Contains(ext))
-                    continue;
+                try
+                {
+                    var ext = Path.GetExtension(file);
+                    if (!supported.Contains(ext))
+                        continue;
 
-                var name = Path.GetFileNameWithoutExtension(file).ToUpperInvariant();
-                if (!groups.TryGetValue(name, out var list) || list.Count == 0)
-                {
-                    result.UnmatchedFiles.Add(file);
-                    continue;
-                }
-                if (list.Count > 1)
-                {
-                    result.ConflictingFiles.Add(file);
-                    continue;
-                }
-                var item = list[0];
-                if (!string.IsNullOrWhiteSpace(item.ImagePath))
-                {
-                    result.ConflictingFiles.Add(file);
-                    continue;
-                }
-                var fileName = Path.GetFileNameWithoutExtension(file) + ".jpg";
-                var dest = Path.Combine(destDir, fileName);
-                if (!File.Exists(dest))
-                {
-                    try
+                    var name = Path.GetFileNameWithoutExtension(file).ToUpperInvariant();
+                    if (!groups.TryGetValue(name, out var list) || list.Count == 0)
                     {
-                        await CopyFileAsync(file, dest, 256, 256, cancellationToken);
+                        result.UnmatchedFiles.Add(file);
+                        continue;
                     }
-                    catch (IOException ex)
+                    if (list.Count > 1)
                     {
-                        _logger.LogError(ex, "Failed to copy image from {Source} to {Destination}", file, dest);
                         result.ConflictingFiles.Add(file);
                         continue;
                     }
+                    var item = list[0];
+                    if (!string.IsNullOrWhiteSpace(item.ImagePath))
+                    {
+                        result.ConflictingFiles.Add(file);
+                        continue;
+                    }
+                    var fileName = Path.GetFileNameWithoutExtension(file) + ".jpg";
+                    var dest = Path.Combine(destDir, fileName);
+                    if (!File.Exists(dest))
+                        await CopyFileAsync(file, dest, 256, 256, cancellationToken);
+
+                    var relative = $"Assets/ItemImages/{fileName}";
+                    await UpdateItemImageAsync(item.ItemID, relative, cancellationToken);
+                    result.ImportedCount++;
                 }
-                var relative = $"Assets/ItemImages/{fileName}";
-                await UpdateItemImageAsync(item.ItemID, relative, cancellationToken);
-                result.ImportedCount++;
-                processed++;
-                progress?.Report(new ImageImportProgress { Processed = processed, Total = total });
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to import image {Source}", file);
+                    result.ConflictingFiles.Add(file);
+                }
+                finally
+                {
+                    processed++;
+                    progress?.Report(new ImageImportProgress { Processed = processed, Total = total });
+                }
             }
 
             return result;


### PR DESCRIPTION
## What changed

- Hardened `ItemService.ImportItemImagesInternalAsync` so image-import progress advances once for every enumerated file, including unsupported, unmatched, conflicting, failed, and successfully imported files.
- Kept cancellation explicit by rethrowing `OperationCanceledException` before broad per-file failure handling.
- Converted per-file image decode, copy, and item-image update failures into logged conflicts so one bad image does not abort the rest of a batch.
- Added `ItemImageImportWorkflowContractTests` coverage and a progress note.

## Why this was the highest-value next step

Recent repo work focused on import/export reliability and item import persistence. Connector readback showed the adjacent item image import workflow still had an operator-facing reliability gap: progress only moved after successful imports, and only `IOException` was handled around image processing even though WPF image decode and item-image update work can fail with other exceptions. Image imports are part of catalog setup and item media maintenance, so this improves a real workflow without repeating the most recent item CSV/generic import insert work.

## Why this is real workflow progress

This covers the full per-file item image import loop: progress reporting, unsupported/unmatched/conflicting files, successful copy/update, cancellation behavior, and per-file failure isolation. It includes service behavior, source-contract coverage, and durable progress notes as one coherent slice.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 commits, and limited to `ItemService`, one new contract test, and one progress note.
- Connector readback confirmed the image-import loop reports progress from a `finally` block for every enumerated file.
- Connector readback confirmed cancellation is rethrown before broad per-file exception handling.
- Connector readback confirmed broad per-file failures are logged and added to `ConflictingFiles` while preserving copy-before-record-update ordering.
- Connector readback confirmed `ItemImageImportWorkflowContractTests` pins the progress and failure-handling contract.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so `pwsh -File scripts/run-full-validation.ps1`, local .NET tests, WPF runtime checks, screenshots, print/layout checks, and GitHub Actions log inspection could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Add behavior-level image import tests when the full WPF test runtime is available, especially for corrupt images and mixed supported/unsupported folders.