### PR TITLE
Harden item export service guards

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceExportGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceExportGuardContractTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemServiceExportGuardContractTests
+    {
+        [Fact]
+        public void CsvItemExportRequiresImportExportPermissionBeforeExportWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "public Task ExportItemsToCsvAsync",
+                "public Task<ImageImportResult> ImportItemImagesAsync");
+
+            Assert.Contains("_auth.EnsurePermission(User.PermissionImportExport);", method, StringComparison.Ordinal);
+            Assert.Contains("return ExportItemsToCsvInternalAsync(filePath, cancellationToken);", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("_auth.EnsurePermission(User.PermissionImportExport);", StringComparison.Ordinal) <
+                method.IndexOf("return ExportItemsToCsvInternalAsync(filePath, cancellationToken);", StringComparison.Ordinal),
+                "CSV item exports should enforce import/export permission before starting export work.");
+        }
+
+        [Fact]
+        public void CsvItemExportHonorsCancellationBeforeEnumerationDuringEnumerationAndBeforeWriting()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "private async Task ExportItemsToCsvInternalAsync",
+                "public async Task UpdateItemQuantitiesAsync");
+
+            AssertCancellationBefore(method, "var items = new List<ItemModel>();");
+            AssertCancellationBetween(method, "await foreach", "items.Add(item);");
+            AssertCancellationBetween(method, "items.Add(item);", "CsvHelperUtil.ExportItemsToCsvAsync(filePath, items)");
+            Assert.Contains("await CsvHelperUtil.ExportItemsToCsvAsync(filePath, items).ConfigureAwait(false);", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GenericItemExportRequiresPermissionAndHonorsCancellationBeforeExporterWrites()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task ExportItemsAsync",
+                "static void NotifyChanged");
+
+            Assert.Contains("_auth.EnsurePermission(User.PermissionImportExport);", method, StringComparison.Ordinal);
+            AssertCancellationBefore(method, "var items = new List<ItemModel>();");
+            AssertCancellationBetween(method, "await foreach", "items.Add(item);");
+            AssertCancellationBetween(method, "items.Add(item);", "exporter.ExportAsync(filePath, items, cancellationToken)");
+
+            Assert.True(
+                method.IndexOf("_auth.EnsurePermission(User.PermissionImportExport);", StringComparison.Ordinal) <
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal),
+                "Generic item exports should enforce permission before beginning cancellable export work.");
+        }
+
+        private static void AssertCancellationBefore(string source, string marker)
+        {
+            var markerIndex = source.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(markerIndex >= 0, $"Expected source marker: {marker}");
+
+            var cancellationIndex = source.LastIndexOf("cancellationToken.ThrowIfCancellationRequested();", markerIndex, StringComparison.Ordinal);
+            Assert.True(cancellationIndex >= 0, $"Expected cancellation check before marker: {marker}");
+        }
+
+        private static void AssertCancellationBetween(string source, string firstMarker, string secondMarker)
+        {
+            var firstIndex = source.IndexOf(firstMarker, StringComparison.Ordinal);
+            var secondIndex = source.IndexOf(secondMarker, firstIndex, StringComparison.Ordinal);
+
+            Assert.True(firstIndex >= 0, $"Expected first source marker: {firstMarker}");
+            Assert.True(secondIndex > firstIndex, $"Expected second source marker after first marker: {secondMarker}");
+
+            var cancellationIndex = source.IndexOf("cancellationToken.ThrowIfCancellationRequested();", firstIndex, StringComparison.Ordinal);
+            Assert.True(
+                cancellationIndex > firstIndex && cancellationIndex < secondIndex,
+                $"Expected cancellation check between markers: {firstMarker} -> {secondMarker}");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-item-export-service-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-item-export-service-guards.md
@@ -1,0 +1,27 @@
+# Item Export Service Guard Hardening
+
+Date: 2026-06-30
+
+## Completed
+
+- Added import/export permission enforcement to the legacy CSV item export service entry point before export work begins.
+- Added import/export permission enforcement to the generic item export service entry point before export work begins.
+- Added cancellation checks before item export enumeration, during row collection, and before file writer/exporter handoff for both CSV and generic item export paths.
+- Added source-contract coverage for permission ordering and cancellation checkpoints across both service export workflows.
+
+## Why This Matters
+
+Item exports can expose the full inventory catalog and can spend noticeable time collecting and writing large item sets. Import and image import entry points already enforced the import/export permission, and the dedicated exporters already had cancellation checks. This pass aligns the older service-level item export workflows with that same security and cancellation contract.
+
+## Validation
+
+- Connector readback should confirm `ExportItemsToCsvAsync` enforces `User.PermissionImportExport` before calling `ExportItemsToCsvInternalAsync`.
+- Connector readback should confirm `ExportItemsAsync` enforces `User.PermissionImportExport` before collecting export rows.
+- Connector readback should confirm both export paths check cancellation before row collection, inside the collection loop, and before writer/exporter handoff.
+- Connector readback should confirm `ItemServiceExportGuardContractTests` pins the permission and cancellation contract.
+
+Full local validation still needs to be run in a Windows/.NET-capable checkout:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -182,7 +182,10 @@ namespace InventoryManagementApp.Services.Items
         }
 
         public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
-            => ExportItemsToCsvInternalAsync(filePath, cancellationToken);
+        {
+            _auth.EnsurePermission(User.PermissionImportExport);
+            return ExportItemsToCsvInternalAsync(filePath, cancellationToken);
+        }
 
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default)
         {
@@ -601,11 +604,17 @@ namespace InventoryManagementApp.Services.Items
 
         private async Task ExportItemsToCsvInternalAsync(string filePath, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var items = new List<ItemModel>();
             await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
                 .WithCancellation(cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
                 items.Add(item);
-            await CsvHelperUtil.ExportItemsToCsvAsync(filePath, items);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await CsvHelperUtil.ExportItemsToCsvAsync(filePath, items).ConfigureAwait(false);
         }
 
         public async Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SqliteConnection? conn = null, SqliteTransaction? tx = null, CancellationToken cancellationToken = default)
@@ -727,14 +736,21 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task ExportItemsAsync(string filePath, IDataExporter<ItemModel> exporter, CancellationToken cancellationToken = default)
         {
+            _auth.EnsurePermission(User.PermissionImportExport);
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Note: Using int.MaxValue as page size loads all items into memory.
             // For very large inventories (>10,000 items), consider implementing streaming export.
             // Current implementation matches existing CSV export behavior.
             var items = new List<ItemModel>();
             await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
                 .WithCancellation(cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
                 items.Add(item);
-            
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
             await exporter.ExportAsync(filePath, items, cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
## What changed

- Added import/export permission enforcement to `ItemService.ExportItemsToCsvAsync` before legacy CSV item export work begins.
- Added import/export permission enforcement to `ItemService.ExportItemsAsync` before generic item export work begins.
- Added cancellation checkpoints before item export row collection, during row collection, and before CSV writer/exporter handoff for both item export paths.
- Added `ItemServiceExportGuardContractTests` coverage and a progress note.

## Why this was the highest-value next step

Recent work hardened item imports, image imports, and dedicated import/export format handlers. Connector readback showed the older service-level item export paths still lacked the same import/export permission guard as imports and image imports, and the legacy CSV path did not have the newer cancellation checkpoints before file writer handoff. Item exports can expose the full inventory catalog and can be expensive on large inventories, making this the next concrete workflow reliability and data-access improvement without repeating the same recently completed import work.

## Why this is real workflow progress

This covers both item export entry points exposed by `IItemService`: the legacy CSV helper path and the generic exporter path used by CSV/JSON/XML-style exporters. It updates service access control, cancellation behavior, source-contract coverage, and progress notes as one coherent export workflow slice.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 commits, and limited to `ItemService`, one new contract test, and one progress note.
- Connector readback confirmed `ExportItemsToCsvAsync` enforces `User.PermissionImportExport` before calling `ExportItemsToCsvInternalAsync`.
- Connector readback confirmed `ExportItemsAsync` enforces `User.PermissionImportExport` before cancellation checks, row collection, and exporter handoff.
- Connector readback confirmed both service export paths check cancellation before collecting rows, inside the row collection loop, and before writer/exporter handoff.
- Connector readback confirmed `ItemServiceExportGuardContractTests` pins the permission and cancellation contract.
- Connector status/workflow readback found no attached statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so `pwsh -File scripts/run-full-validation.ps1`, local .NET tests, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Add behavior-level service tests for unauthorized item export attempts when the full Windows/.NET test runtime is available.