### PR TITLE
Harden customer export service guards

### DIFF
--- a/InventoryManagementApp.Tests/CustomerServiceExportGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceExportGuardContractTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomerServiceExportGuardContractTests
+    {
+        [Fact]
+        public void CsvCustomerExportRequiresImportExportPermissionBeforeExportWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var method = ExtractMethod(
+                source,
+                "public Task ExportCustomersToCsvAsync",
+                "async Task AddCustomerInternalAsync");
+
+            Assert.Contains("_auth.EnsurePermission(User.PermissionImportExport);", method, StringComparison.Ordinal);
+            Assert.Contains("return ExportCustomersToCsvInternalAsync(filePath, cancellationToken);", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("_auth.EnsurePermission(User.PermissionImportExport);", StringComparison.Ordinal) <
+                method.IndexOf("return ExportCustomersToCsvInternalAsync(filePath, cancellationToken);", StringComparison.Ordinal),
+                "CSV customer exports should enforce import/export permission before starting export work.");
+        }
+
+        [Fact]
+        public void CsvCustomerExportHonorsCancellationBeforeReadAndFileWriterWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var method = ExtractMethod(
+                source,
+                "async Task ExportCustomersToCsvInternalAsync",
+                "async Task InsertCustomerAsync");
+
+            AssertCancellationBefore(method, "GetAllCustomersInternalAsync(cancellationToken)");
+            AssertCancellationBetween(method, "GetAllCustomersInternalAsync(cancellationToken)", "Task.Run");
+            AssertCancellationBetween(method, "Task.Run", "CsvHelperUtil.ExportCustomersToCsv(filePath, all)");
+            Assert.Contains("CsvHelperUtil.ExportCustomersToCsv(filePath, all);", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GenericCustomerExportRequiresPermissionAndHonorsCancellationBeforeExporterWrites()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task ExportCustomersAsync",
+                "static void NotifyChanged");
+
+            Assert.Contains("_auth.EnsurePermission(User.PermissionImportExport);", method, StringComparison.Ordinal);
+            AssertCancellationBefore(method, "GetAllCustomersAsync(cancellationToken)");
+            AssertCancellationBetween(method, "GetAllCustomersAsync(cancellationToken)", "exporter.ExportAsync(filePath, all, cancellationToken)");
+
+            Assert.True(
+                method.IndexOf("_auth.EnsurePermission(User.PermissionImportExport);", StringComparison.Ordinal) <
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal),
+                "Generic customer exports should enforce permission before beginning cancellable export work.");
+        }
+
+        private static void AssertCancellationBefore(string source, string marker)
+        {
+            var markerIndex = source.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(markerIndex >= 0, $"Expected source marker: {marker}");
+
+            var cancellationIndex = source.LastIndexOf("cancellationToken.ThrowIfCancellationRequested();", markerIndex, StringComparison.Ordinal);
+            Assert.True(cancellationIndex >= 0, $"Expected cancellation check before marker: {marker}");
+        }
+
+        private static void AssertCancellationBetween(string source, string firstMarker, string secondMarker)
+        {
+            var firstIndex = source.IndexOf(firstMarker, StringComparison.Ordinal);
+            var secondIndex = source.IndexOf(secondMarker, firstIndex, StringComparison.Ordinal);
+
+            Assert.True(firstIndex >= 0, $"Expected first source marker: {firstMarker}");
+            Assert.True(secondIndex > firstIndex, $"Expected second source marker after first marker: {secondMarker}");
+
+            var cancellationIndex = source.IndexOf("cancellationToken.ThrowIfCancellationRequested();", firstIndex, StringComparison.Ordinal);
+            Assert.True(
+                cancellationIndex > firstIndex && cancellationIndex < secondIndex,
+                $"Expected cancellation check between markers: {firstMarker} -> {secondMarker}");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-customer-export-service-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-customer-export-service-guards.md
@@ -1,0 +1,27 @@
+# Customer Export Service Guard Hardening
+
+Date: 2026-06-30
+
+## Completed
+
+- Added import/export permission enforcement to the legacy CSV customer export service entry point before export work begins.
+- Added import/export permission enforcement to the generic customer export service entry point before export work begins.
+- Added cancellation checks after customer row collection and inside the CSV writer handoff task before the synchronous writer runs.
+- Added source-contract coverage for permission ordering and cancellation checkpoints across both customer export workflows.
+
+## Why This Matters
+
+Customer exports can expose the full customer directory, including company, contact, phone, mobile, email, and address data. Item exports already enforce the import/export permission and have cancellation checkpoints before writer handoff. This pass aligns customer export workflows with the same data-access and cancellation contract so large or unauthorized exports fail before producing files.
+
+## Validation
+
+- Connector readback should confirm `ExportCustomersToCsvAsync` enforces `User.PermissionImportExport` before calling `ExportCustomersToCsvInternalAsync`.
+- Connector readback should confirm `ExportCustomersAsync` enforces `User.PermissionImportExport` before reading and exporting customer rows.
+- Connector readback should confirm CSV and generic customer export paths check cancellation before row reads and again before writer/exporter handoff.
+- Connector readback should confirm `CustomerServiceExportGuardContractTests` pins the permission and cancellation contract.
+
+Full local validation still needs to be run in a Windows/.NET-capable checkout:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -168,7 +168,8 @@ namespace InventoryManagementApp.Services.Customers
         {
             if (string.IsNullOrWhiteSpace(filePath))
                 throw new ArgumentNullException(nameof(filePath));
-            
+
+            _auth.EnsurePermission(User.PermissionImportExport);
             return ExportCustomersToCsvInternalAsync(filePath, cancellationToken);
         }
 
@@ -387,7 +388,12 @@ namespace InventoryManagementApp.Services.Customers
             cancellationToken.ThrowIfCancellationRequested();
 
             var all = await GetAllCustomersInternalAsync(cancellationToken);
-            await Task.Run(() => CsvHelperUtil.ExportCustomersToCsv(filePath, all), cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Run(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CsvHelperUtil.ExportCustomersToCsv(filePath, all);
+            }, cancellationToken);
         }
 
         async Task InsertCustomerAsync(SqliteConnection conn, SqliteTransaction? tran, CustomerModel customer, CancellationToken cancellationToken)
@@ -592,9 +598,11 @@ namespace InventoryManagementApp.Services.Customers
 
         public async Task ExportCustomersAsync(string filePath, IDataExporter<Customer> exporter, CancellationToken cancellationToken = default)
         {
+            _auth.EnsurePermission(User.PermissionImportExport);
             cancellationToken.ThrowIfCancellationRequested();
 
             var all = await GetAllCustomersAsync(cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
             await exporter.ExportAsync(filePath, all, cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
## What changed

- Added import/export permission enforcement to `CustomerService.ExportCustomersToCsvAsync` before legacy CSV customer export work begins.
- Added import/export permission enforcement to `CustomerService.ExportCustomersAsync` before generic customer export work begins.
- Added cancellation checkpoints after customer row collection and inside the CSV writer handoff task before the synchronous CSV writer runs.
- Added `CustomerServiceExportGuardContractTests` coverage and a progress note.

## Why this was the highest-value next step

Recent work hardened item export service guards, but connector readback showed the adjacent customer export service paths still allowed customer directory exports without the same import/export permission guard. Customer exports can expose company, contact, phone, mobile, email, and address data, so aligning customer exports with the item export access-control and cancellation contract is the next concrete data-access improvement.

## Why this is real workflow progress

This covers both customer export entry points exposed by `CustomerService`: the legacy CSV helper path and the generic exporter path. It updates service access control, cancellation behavior, source-contract coverage, and progress notes as one coherent customer-directory export workflow slice.

## Validation

- GitHub connector compare confirmed the branch is limited to `CustomerService`, one new contract test, and one progress note.
- Connector compare against the latest `master` showed the branch is behind by one unrelated direct master commit touching rental screens/theme/items behavior, but the PR remains mergeable and this branch's changed-file scope is unchanged.
- Connector readback confirmed `ExportCustomersToCsvAsync` enforces `User.PermissionImportExport` before calling `ExportCustomersToCsvInternalAsync`.
- Connector readback confirmed `ExportCustomersAsync` enforces `User.PermissionImportExport` before cancellation checks, row collection, and exporter handoff.
- Connector readback confirmed CSV customer export checks cancellation before reading rows, after reading rows, and inside the `Task.Run` writer handoff before `CsvHelperUtil.ExportCustomersToCsv` runs.
- Connector readback confirmed `CustomerServiceExportGuardContractTests` pins the permission and cancellation contract.
- Connector status/workflow readback found no attached statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so `pwsh -File scripts/run-full-validation.ps1`, local .NET tests, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Add behavior-level unauthorized customer export tests when the full Windows/.NET test runtime is available.