### PR TITLE
Capture validation test result artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,23 @@ jobs:
     - name: Build
       run: dotnet build InventoryManagementApp.sln --configuration Release --no-restore
 
+    - name: Prepare test results
+      shell: pwsh
+      run: |
+        if (Test-Path ./TestResults) { Remove-Item ./TestResults -Recurse -Force }
+        New-Item -ItemType Directory -Path ./TestResults | Out-Null
+
     - name: Test
-      run: dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal
+      run: dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=validation-tests.trx" --results-directory ./TestResults
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: validation-test-results
+        path: ./TestResults/
+        retention-days: 7
+        if-no-files-found: ignore
 
     - name: Restore publish runtime
       run: dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64

--- a/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
@@ -64,6 +64,41 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void FullValidationRunnerCapturesDedicatedTestResultsBeforePublishWork()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("$testResultsPath = Join-Path $repoRoot \"TestResults\"", source);
+            Assert.Contains("Clean test results", source);
+            Assert.Contains("Remove-Item $testResultsPath -Recurse -Force", source);
+            Assert.Contains("New-Item -ItemType Directory -Path $testResultsPath | Out-Null", source);
+            Assert.Contains("--logger \"trx;LogFileName=validation-tests.trx\"", source);
+            Assert.Contains("--results-directory $testResultsPath", source);
+            AssertAppearsBefore(source, "Build solution", "Clean test results", "The full validation runner should clean stale test results after the build succeeds.");
+            AssertAppearsBefore(source, "Clean test results", "Test solution", "The full validation runner should prepare a fresh TestResults directory before tests run.");
+            AssertAppearsBefore(source, "Test solution", "if (-not $SkipPublish)", "The full validation runner should capture test diagnostics before optional publish work starts.");
+        }
+
+        [Fact]
+        public void BuildWorkflowUploadsTestResultsEvenWhenValidationFails()
+        {
+            var source = ReadRepoFile(".github", "workflows", "build.yml");
+
+            Assert.Contains("Prepare test results", source);
+            Assert.Contains("New-Item -ItemType Directory -Path ./TestResults | Out-Null", source);
+            Assert.Contains("--logger \"trx;LogFileName=validation-tests.trx\"", source);
+            Assert.Contains("--results-directory ./TestResults", source);
+            Assert.Contains("Upload test results", source);
+            Assert.Contains("if: always()", source);
+            Assert.Contains("name: validation-test-results", source);
+            Assert.Contains("path: ./TestResults/", source);
+            Assert.Contains("if-no-files-found: ignore", source);
+            AssertAppearsBefore(source, "Prepare test results", "- name: Test", "The Build and Test workflow should prepare a fresh TestResults directory before tests run.");
+            AssertAppearsBefore(source, "- name: Test", "Upload test results", "The Build and Test workflow should upload test diagnostics after the test step.");
+            AssertAppearsBefore(source, "Upload test results", "Restore publish runtime", "The Build and Test workflow should preserve test diagnostics before publish work begins.");
+        }
+
+        [Fact]
         public void FullValidationRunnerVerifiesPublishedDesktopArtifactsBeforeSourceScans()
         {
             var source = ReadRepoFile("scripts", "run-full-validation.ps1");

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-validation-test-results-artifacts.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-validation-test-results-artifacts.md
@@ -1,0 +1,19 @@
+# Validation Test Result Artifacts
+
+Date: 2026-06-30
+
+## Completed
+
+- Updated `scripts/run-full-validation.ps1` to clean and recreate `TestResults/` before running tests.
+- Changed the local validation test command to emit `validation-tests.trx` through the standard Visual Studio Test TRX logger.
+- Updated the Windows Build and Test workflow to prepare the same `TestResults/` folder and upload it as a `validation-test-results` artifact with `if: always()`.
+- Extended `ValidationRunnerContractTests` so the local runner and CI workflow keep test-result capture before publish work.
+
+## Why It Matters
+
+The current cleanup queue still calls out full validation as the highest-priority release-readiness checkpoint. If tests fail in the next Windows-capable run, the workflow now preserves structured test diagnostics instead of relying only on console scrollback.
+
+## Validation
+
+- Connector readback and compare were used to confirm the focused validation workflow scope and source-contract coverage.
+- Local restore/build/test/publish validation could not be run in this scheduled environment because direct checkout is blocked and `dotnet`/`pwsh` are unavailable.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -28,6 +28,7 @@ function Invoke-ValidationStep {
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $publishOutputPath = Join-Path $repoRoot "publish"
+$testResultsPath = Join-Path $repoRoot "TestResults"
 $requiredPublishArtifacts = @(
     "InventoryManagementApp.exe",
     "InventoryManagementApp.dll",
@@ -48,8 +49,16 @@ try {
         dotnet build InventoryManagementApp.sln --configuration $Configuration --no-restore
     }
 
+    Invoke-ValidationStep "Clean test results" {
+        if (Test-Path $testResultsPath) {
+            Remove-Item $testResultsPath -Recurse -Force
+        }
+
+        New-Item -ItemType Directory -Path $testResultsPath | Out-Null
+    }
+
     Invoke-ValidationStep "Test solution" {
-        dotnet test InventoryManagementApp.sln --configuration $Configuration --no-build --verbosity normal
+        dotnet test InventoryManagementApp.sln --configuration $Configuration --no-build --verbosity normal --logger "trx;LogFileName=validation-tests.trx" --results-directory $testResultsPath
     }
 
     if (-not $SkipPublish) {


### PR DESCRIPTION
## What changed

- Updated `scripts/run-full-validation.ps1` to clean and recreate `TestResults/` before running tests.
- Changed the local validation test command to emit a dedicated `validation-tests.trx` result file.
- Updated the Windows Build and Test workflow to prepare `TestResults/` and upload it as a `validation-test-results` artifact with `if: always()`.
- Extended `ValidationRunnerContractTests` to guard the local runner and CI workflow ordering.
- Added a progress note for the validation diagnostics slice.

## Why this was the highest-value next step

The repo's current cleanup queue still puts full validation and possible test failures at the top. This scheduled environment cannot run the Windows/.NET validation stack, so the safest useful improvement is to make the next real validation run preserve structured test evidence instead of relying only on console output.

## Why this is real workflow progress

This is a focused validation workflow slice across the local runner, GitHub Actions, source-contract coverage, and project notes. It improves future restore/build/test release-readiness work by making failures diagnosable from a durable test-results artifact.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by four focused commits, and limited to the validation runner, CI workflow, contract tests, and one progress note.
- Connector readback confirmed the local runner now writes TRX output to `TestResults/validation-tests.trx` before optional publish work.
- Connector readback confirmed the Build and Test workflow uploads `./TestResults/` as `validation-test-results` with `if: always()` and `if-no-files-found: ignore` before publish work.
- Connector readback confirmed `ValidationRunnerContractTests` guards the local and CI test-results flow.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so `pwsh -File scripts/run-full-validation.ps1`, local .NET tests, WPF runtime checks, screenshots, banned-word checks, publish execution, and GitHub Actions log inspection could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and review the generated TRX file if tests fail.
- Let the next Build and Test workflow run confirm the uploaded `validation-test-results` artifact on Windows.