### PR TITLE
[codex] Capture validation MSBuild log artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,20 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    - name: Prepare validation logs
+      shell: pwsh
+      run: |
+        if (Test-Path ./ValidationLogs) { Remove-Item ./ValidationLogs -Recurse -Force }
+        New-Item -ItemType Directory -Path ./ValidationLogs | Out-Null
+
     - name: Restore dependencies
-      run: dotnet restore InventoryManagementApp.sln
+      run: dotnet restore InventoryManagementApp.sln -bl:./ValidationLogs/restore.binlog
 
     - name: Audit vulnerable packages
       run: dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive
 
     - name: Build
-      run: dotnet build InventoryManagementApp.sln --configuration Release --no-restore
+      run: dotnet build InventoryManagementApp.sln --configuration Release --no-restore -bl:./ValidationLogs/build.binlog
 
     - name: Prepare test results
       shell: pwsh
@@ -49,14 +55,14 @@ jobs:
         if-no-files-found: ignore
 
     - name: Restore publish runtime
-      run: dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64
+      run: dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64 -bl:./ValidationLogs/publish-restore.binlog
 
     - name: Clean publish output
       shell: pwsh
       run: if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }
 
     - name: Publish
-      run: dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish
+      run: dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish -bl:./ValidationLogs/publish.binlog
 
     - name: Verify publish artifacts
       shell: pwsh
@@ -87,3 +93,12 @@ jobs:
         name: inventory-management-app
         path: ./publish/
         retention-days: 7
+
+    - name: Upload validation logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: validation-msbuild-logs
+        path: ./ValidationLogs/
+        retention-days: 7
+        if-no-files-found: ignore

--- a/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
@@ -99,6 +99,53 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void FullValidationRunnerCapturesMsBuildLogsForRestoreBuildAndPublish()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("$validationLogsPath = Join-Path $repoRoot \"ValidationLogs\"", source);
+            Assert.Contains("Clean validation logs", source);
+            Assert.Contains("Remove-Item $validationLogsPath -Recurse -Force", source);
+            Assert.Contains("New-Item -ItemType Directory -Path $validationLogsPath | Out-Null", source);
+            Assert.Contains("Get-ValidationLogPath \"restore.binlog\"", source);
+            Assert.Contains("Get-ValidationLogPath \"build.binlog\"", source);
+            Assert.Contains("Get-ValidationLogPath \"publish-restore.binlog\"", source);
+            Assert.Contains("Get-ValidationLogPath \"publish.binlog\"", source);
+            Assert.Contains("dotnet restore InventoryManagementApp.sln -bl:$restoreLogPath", source);
+            Assert.Contains("dotnet build InventoryManagementApp.sln --configuration $Configuration --no-restore -bl:$buildLogPath", source);
+            Assert.Contains("dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime $Runtime -bl:$publishRestoreLogPath", source);
+            Assert.Contains("dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c $Configuration -r $Runtime --self-contained false --no-restore -o ./publish -bl:$publishLogPath", source);
+            AssertAppearsBefore(source, "Clean validation logs", "Restore solution", "The full validation runner should clean stale binary logs before restore starts.");
+            AssertAppearsBefore(source, "Restore solution", "Build solution", "Restore binary log capture should happen before build starts.");
+            AssertAppearsBefore(source, "Build solution", "Test solution", "Build binary log capture should happen before test execution.");
+            AssertAppearsBefore(source, "Restore publish runtime", "Publish app", "Publish restore binary log capture should happen before publishing.");
+            AssertAppearsBefore(source, "Publish app", "Verify publish artifacts", "Publish binary log capture should happen before artifact verification.");
+        }
+
+        [Fact]
+        public void BuildWorkflowUploadsMsBuildLogsEvenWhenValidationFails()
+        {
+            var source = ReadRepoFile(".github", "workflows", "build.yml");
+
+            Assert.Contains("Prepare validation logs", source);
+            Assert.Contains("New-Item -ItemType Directory -Path ./ValidationLogs | Out-Null", source);
+            Assert.Contains("dotnet restore InventoryManagementApp.sln -bl:./ValidationLogs/restore.binlog", source);
+            Assert.Contains("dotnet build InventoryManagementApp.sln --configuration Release --no-restore -bl:./ValidationLogs/build.binlog", source);
+            Assert.Contains("dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64 -bl:./ValidationLogs/publish-restore.binlog", source);
+            Assert.Contains("dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish -bl:./ValidationLogs/publish.binlog", source);
+            Assert.Contains("Upload validation logs", source);
+            Assert.Contains("name: validation-msbuild-logs", source);
+            Assert.Contains("path: ./ValidationLogs/", source);
+            Assert.Contains("if-no-files-found: ignore", source);
+            AssertAppearsBefore(source, "Prepare validation logs", "Restore dependencies", "The Build and Test workflow should prepare a fresh ValidationLogs directory before restore.");
+            AssertAppearsBefore(source, "Restore dependencies", "- name: Build", "Restore binary log capture should happen before build starts.");
+            AssertAppearsBefore(source, "- name: Build", "- name: Test", "Build binary log capture should happen before test execution.");
+            AssertAppearsBefore(source, "Restore publish runtime", "- name: Publish", "Publish restore binary log capture should happen before publishing.");
+            AssertAppearsBefore(source, "- name: Publish", "Verify publish artifacts", "Publish binary log capture should happen before artifact verification.");
+            AssertAppearsBefore(source, "Upload build artifacts", "Upload validation logs", "Validation logs should be uploaded as the final diagnostic artifact.");
+        }
+
+        [Fact]
         public void FullValidationRunnerVerifiesPublishedDesktopArtifactsBeforeSourceScans()
         {
             var source = ReadRepoFile("scripts", "run-full-validation.ps1");

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-validation-msbuild-log-artifacts.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-validation-msbuild-log-artifacts.md
@@ -1,0 +1,19 @@
+# Validation MSBuild Log Artifacts
+
+Date: 2026-06-30
+
+## Summary
+
+The validation workflow now captures MSBuild binary logs for restore, build, publish-runtime restore, and publish work. This gives failed local or CI validation runs a durable diagnostic artifact beyond console output, which is especially useful while full Windows validation still needs external confirmation.
+
+## Changes
+
+- Added a fresh `ValidationLogs/` directory to `scripts/run-full-validation.ps1` before restore work begins.
+- Added `restore.binlog`, `build.binlog`, `publish-restore.binlog`, and `publish.binlog` capture to the matching restore/build/publish commands.
+- Updated the Windows Build and Test workflow to prepare the same `ValidationLogs/` directory, emit the same binary logs, and upload them as `validation-msbuild-logs` with `if: always()`.
+- Extended validation source-contract coverage so the runner and CI workflow keep the diagnostic log capture and upload behavior aligned.
+
+## Validation
+
+- Connector readback should confirm the runner and workflow both prepare `ValidationLogs/`, emit the four expected binary log files, and keep CI log upload as the final always-run diagnostic artifact.
+- Local .NET/PowerShell validation was not available in the scheduled Linux environment.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -26,9 +26,19 @@ function Invoke-ValidationStep {
     }
 }
 
+function Get-ValidationLogPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    return Join-Path $validationLogsPath $Name
+}
+
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $publishOutputPath = Join-Path $repoRoot "publish"
 $testResultsPath = Join-Path $repoRoot "TestResults"
+$validationLogsPath = Join-Path $repoRoot "ValidationLogs"
 $requiredPublishArtifacts = @(
     "InventoryManagementApp.exe",
     "InventoryManagementApp.dll",
@@ -37,8 +47,17 @@ $requiredPublishArtifacts = @(
 Push-Location $repoRoot
 
 try {
+    Invoke-ValidationStep "Clean validation logs" {
+        if (Test-Path $validationLogsPath) {
+            Remove-Item $validationLogsPath -Recurse -Force
+        }
+
+        New-Item -ItemType Directory -Path $validationLogsPath | Out-Null
+    }
+
     Invoke-ValidationStep "Restore solution" {
-        dotnet restore InventoryManagementApp.sln
+        $restoreLogPath = Get-ValidationLogPath "restore.binlog"
+        dotnet restore InventoryManagementApp.sln -bl:$restoreLogPath
     }
 
     Invoke-ValidationStep "Audit vulnerable packages" {
@@ -46,7 +65,8 @@ try {
     }
 
     Invoke-ValidationStep "Build solution" {
-        dotnet build InventoryManagementApp.sln --configuration $Configuration --no-restore
+        $buildLogPath = Get-ValidationLogPath "build.binlog"
+        dotnet build InventoryManagementApp.sln --configuration $Configuration --no-restore -bl:$buildLogPath
     }
 
     Invoke-ValidationStep "Clean test results" {
@@ -63,7 +83,8 @@ try {
 
     if (-not $SkipPublish) {
         Invoke-ValidationStep "Restore publish runtime" {
-            dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime $Runtime
+            $publishRestoreLogPath = Get-ValidationLogPath "publish-restore.binlog"
+            dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime $Runtime -bl:$publishRestoreLogPath
         }
 
         Invoke-ValidationStep "Clean publish output" {
@@ -73,7 +94,8 @@ try {
         }
 
         Invoke-ValidationStep "Publish app" {
-            dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c $Configuration -r $Runtime --self-contained false --no-restore -o ./publish
+            $publishLogPath = Get-ValidationLogPath "publish.binlog"
+            dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c $Configuration -r $Runtime --self-contained false --no-restore -o ./publish -bl:$publishLogPath
         }
 
         Invoke-ValidationStep "Verify publish artifacts" {


### PR DESCRIPTION
## What changed

- Added a fresh `ValidationLogs/` directory to the local full-validation runner.
- Captured MSBuild binary logs for solution restore, solution build, publish runtime restore, and desktop publish.
- Updated the Windows Build and Test workflow to emit the same binary logs and upload them as `validation-msbuild-logs` with `if: always()`.
- Extended validation source-contract coverage for the local runner and CI workflow, plus added a progress note.

## Why this was the highest-value next step

Current repo evidence shows full Windows validation still needs better remote diagnostics because the scheduled environment cannot run the WPF/.NET validation stack locally. Recent work already captures test TRX output, but restore/build/publish failures still depended mostly on console logs. Binary logs make those failure modes easier to inspect and preserve.

## Why this is real workflow progress

This is not an isolated assertion or note update: it improves the validation workflow end to end across local runner behavior, CI artifact capture, and source-contract coverage that keeps both paths aligned.

## Validation

- GitHub connector compare confirmed the PR is 4 files and scoped to validation runner, CI workflow, validation contract tests, and a progress note.
- Connector readback confirmed `scripts/run-full-validation.ps1` prepares `ValidationLogs/` and emits `restore.binlog`, `build.binlog`, `publish-restore.binlog`, and `publish.binlog`.
- Connector readback confirmed `.github/workflows/build.yml` prepares `ValidationLogs/`, emits matching binary logs, and uploads `validation-msbuild-logs` with `if: always()`.
- Connector readback confirmed `ValidationRunnerContractTests` now guards the runner and workflow log capture/upload contract.

## Could not check

- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, and local banned-word checks could not be run because direct checkout/raw access is blocked in this scheduled Linux environment and the Windows/.NET desktop validation stack is unavailable here.

## Known follow-up work

- Run the Windows Build and Test workflow on the PR and inspect the uploaded `validation-msbuild-logs` artifact if any restore/build/publish step fails.
- Continue toward a full Windows validation pass once a Windows/.NET-capable checkout is available.