### PR TITLE
Harden customer import transaction scope

### DIFF
--- a/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
@@ -128,7 +128,7 @@ namespace InventoryManagementApp.Tests
                 source,
                 "async Task InsertCustomerAsync",
                 "async Task<bool> CustomerExistsAsync");
-            AssertCancellationGuardBeforeSqlAndConnection(
+            AssertCancellationGuardBeforeSql(
                 source,
                 "async Task<bool> CustomerExistsAsync",
                 "static async Task EnsureCustomerRowExistsAsync");
@@ -217,14 +217,58 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("yield return $\"{contact}|mobile:{mobile}\";", source, StringComparison.Ordinal);
 
             Assert.True(
-                csvImportMethod.IndexOf("if (await CustomerExistsAsync(c.Contact, c.Phone, c.Mobile, cancellationToken))", StringComparison.Ordinal) < csvImportMethod.IndexOf("if (!TryReserveImportedCustomer(importedCustomerKeys, c))", StringComparison.Ordinal),
+                csvImportMethod.IndexOf("if (await CustomerExistsAsync(conn, tran, c.Contact, c.Phone, c.Mobile, cancellationToken))", StringComparison.Ordinal) < csvImportMethod.IndexOf("if (!TryReserveImportedCustomer(importedCustomerKeys, c))", StringComparison.Ordinal),
                 "CSV import should preserve the database duplicate check before reserving a customer identity for the current file.");
             Assert.True(
                 csvImportMethod.IndexOf("if (!TryReserveImportedCustomer(importedCustomerKeys, c))", StringComparison.Ordinal) < csvImportMethod.IndexOf("await InsertCustomerAsync(conn, tran, c, cancellationToken);", StringComparison.Ordinal),
                 "CSV import should reject duplicate rows from the same file before inserting into the transaction.");
             Assert.True(
-                genericImportMethod.IndexOf("if (!TryReserveImportedCustomer(importedCustomerKeys, customerModel))", StringComparison.Ordinal) < genericImportMethod.IndexOf("await InsertCustomerAsync(conn, null, customerModel, cancellationToken);", StringComparison.Ordinal),
+                genericImportMethod.IndexOf("if (!TryReserveImportedCustomer(importedCustomerKeys, customerModel))", StringComparison.Ordinal) < genericImportMethod.IndexOf("await InsertCustomerAsync(conn, transaction, customerModel, cancellationToken);", StringComparison.Ordinal),
                 "Generic customer import should reject duplicate rows from the same import batch before inserting.");
+        }
+
+        [Fact]
+        public void CustomerImportsUseSingleTransactionForDuplicateChecksAndInsertWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var csvImportMethod = ExtractMethod(
+                source,
+                "async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync",
+                "async Task ExportCustomersToCsvInternalAsync");
+            var genericImportMethod = ExtractMethod(
+                source,
+                "public async Task<int> ImportCustomersAsync",
+                "public async Task ExportCustomersAsync");
+            var existsMethod = ExtractMethod(
+                source,
+                "async Task<bool> CustomerExistsAsync",
+                "static async Task EnsureCustomerRowExistsAsync");
+
+            Assert.Contains("using var conn = _dbService.CreateConnection();", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("using var tran = conn.BeginTransaction();", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("CustomerExistsAsync(conn, tran, c.Contact, c.Phone, c.Mobile, cancellationToken)", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("await InsertCustomerAsync(conn, tran, c, cancellationToken);", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("tran.Commit();", csvImportMethod, StringComparison.Ordinal);
+            Assert.Contains("tran.Rollback();", csvImportMethod, StringComparison.Ordinal);
+
+            Assert.Contains("using var conn = _dbService.CreateConnection();", genericImportMethod, StringComparison.Ordinal);
+            Assert.Contains("using var transaction = conn.BeginTransaction();", genericImportMethod, StringComparison.Ordinal);
+            Assert.Contains("CustomerExistsAsync(conn, transaction, customerModel.Contact, customerModel.Phone, customerModel.Mobile, cancellationToken)", genericImportMethod, StringComparison.Ordinal);
+            Assert.Contains("await InsertCustomerAsync(conn, transaction, customerModel, cancellationToken);", genericImportMethod, StringComparison.Ordinal);
+            Assert.Contains("transaction.Commit();", genericImportMethod, StringComparison.Ordinal);
+            Assert.Contains("transaction.Rollback();", genericImportMethod, StringComparison.Ordinal);
+
+            Assert.Contains("async Task<bool> CustomerExistsAsync(SqliteConnection conn, SqliteTransaction? transaction", existsMethod, StringComparison.Ordinal);
+            Assert.Contains("using var cmd = new SqliteCommand(sql, conn, transaction);", existsMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("_dbService.CreateConnection()", existsMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("SqliteHelper.ExecuteScalarAsync(conn, sql", existsMethod, StringComparison.Ordinal);
+
+            Assert.True(
+                csvImportMethod.IndexOf("using var tran = conn.BeginTransaction();", StringComparison.Ordinal) < csvImportMethod.IndexOf("CustomerExistsAsync(conn, tran", StringComparison.Ordinal),
+                "CSV customer imports should begin the transaction before duplicate lookups.");
+            Assert.True(
+                genericImportMethod.IndexOf("using var transaction = conn.BeginTransaction();", StringComparison.Ordinal) < genericImportMethod.IndexOf("CustomerExistsAsync(conn, transaction", StringComparison.Ordinal),
+                "Generic customer imports should begin the transaction before duplicate lookups.");
         }
 
         [Fact]
@@ -246,7 +290,7 @@ namespace InventoryManagementApp.Tests
                 csvImportMethod.IndexOf("NormalizeCustomerForSave(c);", StringComparison.Ordinal) < csvImportMethod.IndexOf("var reason = GetSkipReason(c);", StringComparison.Ordinal),
                 "CSV imports should trim row text before required-field validation.");
             Assert.True(
-                csvImportMethod.IndexOf("NormalizeCustomerForSave(c);", StringComparison.Ordinal) < csvImportMethod.IndexOf("CustomerExistsAsync(c.Contact, c.Phone, c.Mobile, cancellationToken)", StringComparison.Ordinal),
+                csvImportMethod.IndexOf("NormalizeCustomerForSave(c);", StringComparison.Ordinal) < csvImportMethod.IndexOf("CustomerExistsAsync(conn, tran, c.Contact, c.Phone, c.Mobile, cancellationToken)", StringComparison.Ordinal),
                 "CSV imports should check duplicates using normalized customer identity fields.");
             Assert.True(
                 csvImportMethod.IndexOf("NormalizeCustomerForSave(c);", StringComparison.Ordinal) < csvImportMethod.IndexOf("await InsertCustomerAsync(conn, tran, c, cancellationToken);", StringComparison.Ordinal),
@@ -255,10 +299,10 @@ namespace InventoryManagementApp.Tests
                 genericImportMethod.IndexOf("NormalizeCustomerForSave(customerModel);", StringComparison.Ordinal) < genericImportMethod.IndexOf("var skipReason = GetSkipReason(customerModel);", StringComparison.Ordinal),
                 "Generic imports should trim row text before required-field validation.");
             Assert.True(
-                genericImportMethod.IndexOf("NormalizeCustomerForSave(customerModel);", StringComparison.Ordinal) < genericImportMethod.IndexOf("CustomerExistsAsync(customerModel.Contact, customerModel.Phone, customerModel.Mobile, cancellationToken)", StringComparison.Ordinal),
+                genericImportMethod.IndexOf("NormalizeCustomerForSave(customerModel);", StringComparison.Ordinal) < genericImportMethod.IndexOf("CustomerExistsAsync(conn, transaction, customerModel.Contact, customerModel.Phone, customerModel.Mobile, cancellationToken)", StringComparison.Ordinal),
                 "Generic imports should check duplicates using normalized customer identity fields.");
             Assert.True(
-                genericImportMethod.IndexOf("NormalizeCustomerForSave(customerModel);", StringComparison.Ordinal) < genericImportMethod.IndexOf("await InsertCustomerAsync(conn, null, customerModel, cancellationToken);", StringComparison.Ordinal),
+                genericImportMethod.IndexOf("NormalizeCustomerForSave(customerModel);", StringComparison.Ordinal) < genericImportMethod.IndexOf("await InsertCustomerAsync(conn, transaction, customerModel, cancellationToken);", StringComparison.Ordinal),
                 "Generic imports should insert normalized customer values.");
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-customer-import-transaction-scope.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-customer-import-transaction-scope.md
@@ -1,0 +1,26 @@
+# Customer Import Transaction Scope Hardening
+
+Date: 2026-06-30
+
+## Completed
+
+- Kept CSV customer import duplicate checks on the same SQLite connection and transaction used for insert work.
+- Wrapped the generic customer import path in a transaction so imported customers commit as one unit and roll back if a later insert or validation path throws.
+- Routed generic customer import duplicate checks and inserts through that same transaction.
+- Updated customer service source-contract coverage for the transaction, duplicate-check, insert, commit, and rollback ordering.
+
+## Why This Matters
+
+Customer imports can add many contact records at once. The CSV path already used a transaction for inserts, but duplicate checks still left that transaction, and the generic importer inserted rows without a transaction. Keeping duplicate reads and writes in one transaction reduces lock/read fragility and prevents partial generic imports when a later row fails after earlier rows were inserted.
+
+## Validation
+
+- Connector readback should confirm CSV imports call `CustomerExistsAsync(conn, tran, ...)` and `InsertCustomerAsync(conn, tran, ...)` inside the same transaction.
+- Connector readback should confirm generic customer imports now create a transaction, call `CustomerExistsAsync(conn, transaction, ...)`, insert through `InsertCustomerAsync(conn, transaction, ...)`, commit on success, and roll back on failure.
+- Connector readback should confirm `CustomerServiceEntryPointContractTests` covers the transaction-scope contract.
+
+Full local validation still needs to be run in a Windows/.NET-capable checkout:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -351,7 +351,7 @@ namespace InventoryManagementApp.Services.Customers
                         continue;
                     }
 
-                    if (await CustomerExistsAsync(c.Contact, c.Phone, c.Mobile, cancellationToken))
+                    if (await CustomerExistsAsync(conn, tran, c.Contact, c.Phone, c.Mobile, cancellationToken))
                     {
                         var msg = $"Row {row}: Duplicate customer";
                         result.SkippedRows.Add(msg);
@@ -433,22 +433,23 @@ namespace InventoryManagementApp.Services.Customers
             }
         }
 
-        async Task<bool> CustomerExistsAsync(string contact, string phone, string mobile, CancellationToken cancellationToken)
+        async Task<bool> CustomerExistsAsync(SqliteConnection conn, SqliteTransaction? transaction, string contact, string phone, string mobile, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             const string sql = @"
         SELECT COUNT(*) FROM Customers
          WHERE Contact = @Contact AND (Phone = @Phone OR Mobile = @Mobile)";
-            using var conn = _dbService.CreateConnection();
             try
             {
-                var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, new[]
+                using var cmd = new SqliteCommand(sql, conn, transaction);
+                cmd.Parameters.AddRange(new[]
                 {
                     new SqliteParameter("@Contact", contact),
                     new SqliteParameter("@Phone", phone ?? string.Empty),
                     new SqliteParameter("@Mobile", mobile ?? string.Empty)
-                }, cancellationToken) ?? 0);
+                });
+                var count = Convert.ToInt32(await cmd.ExecuteScalarAsync(cancellationToken) ?? 0);
                 return count > 0;
             }
             catch (Exception ex)
@@ -559,41 +560,52 @@ namespace InventoryManagementApp.Services.Customers
             int importedCount = 0;
             var importedCustomerKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             using var conn = _dbService.CreateConnection();
-            
-            foreach (var customer in customers)
+            using var transaction = conn.BeginTransaction();
+
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var customerModel = new CustomerModel
+                foreach (var customer in customers)
                 {
-                    Company = customer.Company ?? string.Empty,
-                    Email = customer.Email ?? string.Empty,
-                    Contact = customer.Contact ?? string.Empty,
-                    Phone = customer.Phone ?? string.Empty,
-                    Mobile = customer.Mobile ?? string.Empty,
-                    Address = customer.Address ?? string.Empty
-                };
-                NormalizeCustomerForSave(customerModel);
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                var skipReason = GetSkipReason(customerModel);
-                if (skipReason != null)
-                    continue;
+                    var customerModel = new CustomerModel
+                    {
+                        Company = customer.Company ?? string.Empty,
+                        Email = customer.Email ?? string.Empty,
+                        Contact = customer.Contact ?? string.Empty,
+                        Phone = customer.Phone ?? string.Empty,
+                        Mobile = customer.Mobile ?? string.Empty,
+                        Address = customer.Address ?? string.Empty
+                    };
+                    NormalizeCustomerForSave(customerModel);
 
-                bool exists = await CustomerExistsAsync(customerModel.Contact, customerModel.Phone, customerModel.Mobile, cancellationToken);
-                if (exists)
-                    continue;
+                    var skipReason = GetSkipReason(customerModel);
+                    if (skipReason != null)
+                        continue;
 
-                if (!TryReserveImportedCustomer(importedCustomerKeys, customerModel))
-                    continue;
+                    bool exists = await CustomerExistsAsync(conn, transaction, customerModel.Contact, customerModel.Phone, customerModel.Mobile, cancellationToken);
+                    if (exists)
+                        continue;
 
-                await InsertCustomerAsync(conn, null, customerModel, cancellationToken);
-                importedCount++;
+                    if (!TryReserveImportedCustomer(importedCustomerKeys, customerModel))
+                        continue;
+
+                    await InsertCustomerAsync(conn, transaction, customerModel, cancellationToken);
+                    importedCount++;
+                }
+
+                transaction.Commit();
+                if (importedCount > 0)
+                    NotifyChanged(DomainDataScope.Customers | DomainDataScope.Reports);
+
+                return importedCount;
             }
-
-            if (importedCount > 0)
-                NotifyChanged(DomainDataScope.Customers | DomainDataScope.Reports);
-
-            return importedCount;
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to import customers");
+                transaction.Rollback();
+                throw;
+            }
         }
 
         public async Task ExportCustomersAsync(string filePath, IDataExporter<Customer> exporter, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## What changed

- Kept CSV customer import duplicate checks on the same SQLite connection and transaction used for insert work.
- Wrapped the generic customer import path in a transaction so imported customers commit as one unit and roll back if a later insert path throws.
- Routed generic customer import duplicate checks and inserts through the same transaction.
- Updated customer service source-contract coverage and added a progress note for the import workflow hardening.

## Why this was the highest-value next step

Recent repository work hardened import/export cancellation, customer export permissions, customer batch duplicate tracking, and item import insert handling. The remaining adjacent customer import risk was transaction consistency: CSV import inserted inside a transaction but checked persisted duplicates through another connection, while the generic importer inserted rows without any transaction. Customer imports are a data-quality workflow, so avoiding partial writes and cross-connection duplicate reads is more valuable than another isolated polish change.

## Why this is real progress

This is a workflow-level slice across the customer import service, transaction/persistence behavior, source-contract coverage, and progress notes. It changes both customer import entry points rather than a single guard clause.

## Validation

- Connector compare confirmed the branch is current with `master`, ahead by 3 commits, and limited to:
  - `InventoryManagementApp/Services/Customers/CustomerService.cs`
  - `InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-06-30-customer-import-transaction-scope.md`
- Connector readback confirmed CSV imports now call `CustomerExistsAsync(conn, tran, ...)` and `InsertCustomerAsync(conn, tran, ...)` inside the same transaction.
- Connector readback confirmed generic customer imports now create a transaction, call `CustomerExistsAsync(conn, transaction, ...)`, insert through `InsertCustomerAsync(conn, transaction, ...)`, commit on success, and roll back on failure.
- Connector readback confirmed `CustomerServiceEntryPointContractTests` covers the transaction-scope contract.

## Could not be checked

- Local `dotnet` restore/build/test, WPF runtime checks, screenshots, PowerShell validation, and `pwsh -File scripts/run-full-validation.ps1` could not be run in this scheduled Linux environment because direct checkout remains blocked and Windows/.NET tooling is unavailable.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Add behavior-level import tests for rollback semantics when the environment can run the WPF/.NET test suite directly.