### PR TITLE
Guard customer import duplicate keys against blank fields

### DIFF
--- a/InventoryManagementApp.Tests/CustomerImportDuplicateKeyContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerImportDuplicateKeyContractTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomerImportDuplicateKeyContractTests
+    {
+        [Fact]
+        public void PersistedDuplicateLookupIgnoresBlankPhoneAndMobileKeys()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var method = ExtractMethod(
+                source,
+                "async Task<bool> CustomerExistsAsync",
+                "static async Task EnsureCustomerRowExistsAsync");
+
+            Assert.Contains("WHERE Contact = @Contact", method, StringComparison.Ordinal);
+            Assert.Contains("(@Phone <> '' AND Phone = @Phone)", method, StringComparison.Ordinal);
+            Assert.Contains("OR (@Mobile <> '' AND Mobile = @Mobile)", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("Phone = @Phone OR Mobile = @Mobile", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteCommand(sql, conn, transaction)", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("_dbService.CreateConnection()", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerImportsCheckPersistedDuplicatesBeforeBatchReservationsAndInsertWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var csvImportMethod = ExtractMethod(
+                source,
+                "async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync",
+                "async Task ExportCustomersToCsvInternalAsync");
+            var genericImportMethod = ExtractMethod(
+                source,
+                "public async Task<int> ImportCustomersAsync",
+                "public async Task ExportCustomersAsync");
+
+            AssertImportOrdering(
+                csvImportMethod,
+                "CustomerExistsAsync(conn, tran, c.Contact, c.Phone, c.Mobile, cancellationToken)",
+                "if (!TryReserveImportedCustomer(importedCustomerKeys, c))",
+                "await InsertCustomerAsync(conn, tran, c, cancellationToken);");
+            AssertImportOrdering(
+                genericImportMethod,
+                "CustomerExistsAsync(conn, transaction, customerModel.Contact, customerModel.Phone, customerModel.Mobile, cancellationToken)",
+                "if (!TryReserveImportedCustomer(importedCustomerKeys, customerModel))",
+                "await InsertCustomerAsync(conn, transaction, customerModel, cancellationToken);");
+        }
+
+        private static void AssertImportOrdering(string method, string duplicateLookup, string batchReservation, string insertCall)
+        {
+            var lookupIndex = method.IndexOf(duplicateLookup, StringComparison.Ordinal);
+            var reservationIndex = method.IndexOf(batchReservation, StringComparison.Ordinal);
+            var insertIndex = method.IndexOf(insertCall, StringComparison.Ordinal);
+
+            Assert.True(lookupIndex >= 0, $"Expected duplicate lookup call: {duplicateLookup}");
+            Assert.True(reservationIndex >= 0, $"Expected batch reservation call: {batchReservation}");
+            Assert.True(insertIndex >= 0, $"Expected insert call: {insertCall}");
+            Assert.True(lookupIndex < reservationIndex, "Imports should check persisted duplicates before reserving identities for the current file or batch.");
+            Assert.True(reservationIndex < insertIndex, "Imports should reserve nonblank duplicate keys before insert work.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-customer-import-duplicate-key-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-customer-import-duplicate-key-guards.md
@@ -1,0 +1,23 @@
+# Customer Import Duplicate Key Guard
+
+Date: 2026-06-30
+
+## Completed
+
+- Tightened customer import persisted-duplicate lookup so blank phone/mobile values no longer match blank database fields.
+- Preserved the existing same-transaction duplicate lookup for both CSV and generic customer imports.
+- Added source-contract coverage for the duplicate SQL shape and import ordering before batch reservation and insert work.
+
+## Why This Matters
+
+Customer imports use contact plus phone or mobile as the duplicate identity. The batch duplicate guard already ignores blank phone/mobile keys, but the persisted lookup still compared blank values in SQL. That could cause valid rows with the same contact and different real numbers to be skipped as duplicates when the opposite contact field was blank.
+
+## Validation
+
+- Connector readback should confirm `CustomerExistsAsync` requires `@Phone <> ''` before matching `Phone = @Phone` and `@Mobile <> ''` before matching `Mobile = @Mobile`.
+- Connector readback should confirm CSV and generic imports still call the persisted duplicate lookup before reserving batch duplicate keys and before insert work.
+- Local full validation still needs to be run in a Windows/.NET-capable checkout:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -439,7 +439,11 @@ namespace InventoryManagementApp.Services.Customers
 
             const string sql = @"
         SELECT COUNT(*) FROM Customers
-         WHERE Contact = @Contact AND (Phone = @Phone OR Mobile = @Mobile)";
+         WHERE Contact = @Contact
+           AND (
+                (@Phone <> '' AND Phone = @Phone)
+                OR (@Mobile <> '' AND Mobile = @Mobile)
+           )";
             try
             {
                 using var cmd = new SqliteCommand(sql, conn, transaction);


### PR DESCRIPTION
## What changed

- Tightened `CustomerService.CustomerExistsAsync` so persisted duplicate checks only match phone/mobile identities when the imported value is nonblank.
- Preserved same-transaction duplicate lookup behavior for CSV and generic customer imports.
- Added focused source-contract coverage for the duplicate SQL shape and import ordering before batch duplicate reservation and insert work.
- Added a progress note for the completed customer import data-quality slice.

## Why this was the highest-value next step

Recent repository work hardened customer import transaction scope and batch duplicate tracking. The remaining adjacent data-quality risk was that persisted duplicate lookup still compared blank phone/mobile values, which could silently skip valid imported customers sharing a contact name but having different real phone or mobile values.

## Why this is real workflow progress

This is a complete customer import workflow hardening slice across service duplicate-detection logic, source-contract coverage, and project notes. It fixes a real import acceptance risk rather than changing a single isolated assertion or doing cosmetic cleanup.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `CustomerService`, one new contract test file, and one progress note.
- Connector readback confirmed `CustomerExistsAsync` now requires `@Phone <> ''` before `Phone = @Phone` and `@Mobile <> ''` before `Mobile = @Mobile`.
- Connector readback confirmed the new contract tests cover the duplicate SQL shape and preserve CSV/generic import ordering before batch reservation and insert work.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled Linux environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, banned-word checks, and GitHub Actions log inspection could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Add database-backed import behavior coverage for blank alternate contact fields when the test suite can be executed locally.