### PR TITLE
Cap reservation list query result sets

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
@@ -78,6 +78,40 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ReservationListQueriesCapReturnedRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+
+            Assert.Contains("private const int MaxReservationListCount = 500;", source, StringComparison.Ordinal);
+
+            AssertListQueryUsesCap(
+                source,
+                "public async Task<List<Reservation>> GetAllReservationsAsync()",
+                "public async Task<List<Reservation>> GetActiveReservationsAsync()",
+                "ORDER BY r.StartDate DESC\n                    LIMIT @ReservationListLimit");
+            AssertListQueryUsesCap(
+                source,
+                "public async Task<List<Reservation>> GetActiveReservationsAsync()",
+                "public async Task<List<Reservation>> GetReservationsByItemAsync(int itemID)",
+                "ORDER BY r.StartDate ASC\n                    LIMIT @ReservationListLimit");
+            AssertListQueryUsesCap(
+                source,
+                "public async Task<List<Reservation>> GetReservationsByItemAsync(int itemID)",
+                "public async Task<List<Reservation>> GetReservationsByCustomerAsync(int customerID)",
+                "ORDER BY r.StartDate DESC\n                    LIMIT @ReservationListLimit");
+            AssertListQueryUsesCap(
+                source,
+                "public async Task<List<Reservation>> GetReservationsByCustomerAsync(int customerID)",
+                "public async Task<List<Reservation>> GetUpcomingReservationsAsync",
+                "ORDER BY r.StartDate DESC\n                    LIMIT @ReservationListLimit");
+            AssertListQueryUsesCap(
+                source,
+                "public async Task<List<Reservation>> GetUpcomingReservationsAsync(int days = 7)",
+                "public async Task<Reservation?> GetReservationByIdAsync(int reservationID)",
+                "ORDER BY r.StartDate ASC\n                    LIMIT @ReservationListLimit");
+        }
+
+        [Fact]
         public void ReservationAvailabilityValidatesItemRowBeforeAvailabilityQuery()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
@@ -125,6 +159,20 @@ namespace InventoryManagementApp.Tests
             {
                 Assert.Contains(snippet, source, StringComparison.Ordinal);
             }
+        }
+
+        private static void AssertListQueryUsesCap(string source, string startMarker, string endMarker, string orderAndLimitSnippet)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            AssertContainsAll(
+                method,
+                orderAndLimitSnippet,
+                "cmd.Parameters.AddWithValue(\"@ReservationListLimit\", MaxReservationListCount);");
+            Assert.True(
+                method.IndexOf("LIMIT @ReservationListLimit", StringComparison.Ordinal) <
+                method.IndexOf("cmd.Parameters.AddWithValue(\"@ReservationListLimit\", MaxReservationListCount);", StringComparison.Ordinal),
+                $"Expected {startMarker} to bind the reservation list limit used by the SQL query.");
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-reservation-list-result-caps.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-reservation-list-result-caps.md
@@ -1,0 +1,18 @@
+# Reservation List Result Caps
+
+## Completed
+
+- Added a shared `MaxReservationListCount` limit to reservation list-style queries.
+- Capped all reservation, active reservation, item history, customer history, and upcoming reservation list queries with `LIMIT @ReservationListLimit`.
+- Bound the limit as a SQLite parameter in each query so the cap remains explicit and consistent with the existing rental-history query pattern.
+- Extended reservation source-contract coverage to guard the shared cap, SQL ordering, and parameter binding for each reservation list workflow.
+
+## Why
+
+Reservation list screens can grow quickly in active rental environments. The service already guarded invalid references and stale writes, but list and history reads could still return every matching reservation row. Capping these operational reads keeps reservation dashboards and history views responsive while preserving the most relevant ordering for each workflow.
+
+## Validation
+
+- Connector readback confirmed `ReservationService` now defines `MaxReservationListCount = 500` and applies `LIMIT @ReservationListLimit` to reservation list, active list, item/customer history, and upcoming list queries.
+- Connector readback confirmed `ReservationServiceQueryGuardContractTests` covers the new cap and parameter binding contract.
+- Local .NET tests and full Windows validation could not be run in this scheduled environment because direct checkout is blocked and the Windows/.NET validation stack is unavailable here.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -15,6 +15,8 @@ namespace InventoryManagementApp.Services.Reservations
     /// </summary>
     public class ReservationService
     {
+        private const int MaxReservationListCount = 500;
+
         private readonly DatabaseService _databaseService;
         private readonly IUserContext _userContext;
 
@@ -44,8 +46,10 @@ namespace InventoryManagementApp.Services.Reservations
                     FROM Reservations r
                     JOIN Items i ON r.ItemID = i.ItemID
                     JOIN Customers c ON r.CustomerID = c.CustomerID
-                    ORDER BY r.StartDate DESC";
+                    ORDER BY r.StartDate DESC
+                    LIMIT @ReservationListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@ReservationListLimit", MaxReservationListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -71,8 +75,10 @@ namespace InventoryManagementApp.Services.Reservations
                     JOIN Items i ON r.ItemID = i.ItemID
                     JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.Status IN ('Pending', 'Confirmed')
-                    ORDER BY r.StartDate ASC";
+                    ORDER BY r.StartDate ASC
+                    LIMIT @ReservationListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@ReservationListLimit", MaxReservationListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -103,9 +109,11 @@ namespace InventoryManagementApp.Services.Reservations
                     JOIN Items i ON r.ItemID = i.ItemID
                     JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.ItemID = @ItemID
-                    ORDER BY r.StartDate DESC";
+                    ORDER BY r.StartDate DESC
+                    LIMIT @ReservationListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ItemID", itemID);
+                cmd.Parameters.AddWithValue("@ReservationListLimit", MaxReservationListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -131,9 +139,11 @@ namespace InventoryManagementApp.Services.Reservations
                     JOIN Items i ON r.ItemID = i.ItemID
                     JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.CustomerID = @CustomerID
-                    ORDER BY r.StartDate DESC";
+                    ORDER BY r.StartDate DESC
+                    LIMIT @ReservationListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@CustomerID", customerID);
+                cmd.Parameters.AddWithValue("@ReservationListLimit", MaxReservationListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -159,9 +169,11 @@ namespace InventoryManagementApp.Services.Reservations
                     JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.Status IN ('Pending', 'Confirmed')
                     AND r.StartDate <= @FutureDate
-                    ORDER BY r.StartDate ASC";
+                    ORDER BY r.StartDate ASC
+                    LIMIT @ReservationListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@FutureDate", DateTime.Now.AddDays(days));
+                cmd.Parameters.AddWithValue("@ReservationListLimit", MaxReservationListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {


### PR DESCRIPTION
## What changed

- Added a shared `MaxReservationListCount` cap to `ReservationService`.
- Applied `LIMIT @ReservationListLimit` to all reservation list-style reads: all reservations, active reservations, item history, customer history, and upcoming reservations.
- Bound the reservation list cap as a SQLite parameter in each query, matching the existing rental-history limit pattern.
- Extended `ReservationServiceQueryGuardContractTests` to pin the new list cap, ordering, and parameter binding contract.
- Added a progress note for the completed reservation workflow hardening.

## Why this was the highest-value next step

Recent repo work hardened rental history caps, reservation parent-row guards, and reservation stale-write guards. The remaining adjacent runtime risk was that reservation operational screens could still load every matching row, which can make dashboards and history views sluggish as production data grows.

## Why this is real workflow progress

This is a complete reservation read-workflow slice across service query behavior, source-contract coverage, and project notes. It covers every reservation list/history entry point instead of a tiny isolated guard or cosmetic change.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ReservationService`, `ReservationServiceQueryGuardContractTests`, and one progress note.
- Connector readback confirmed `MaxReservationListCount = 500` is defined in `ReservationService`.
- Connector readback confirmed all reservation list-style queries now include `LIMIT @ReservationListLimit` and bind `@ReservationListLimit` to `MaxReservationListCount`.
- Connector readback confirmed the reservation query contract test covers each capped reservation list workflow.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, banned-word checks, and GitHub Actions log inspection could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Consider applying the same named result-cap pattern to maintenance and calibration list screens if later evidence shows those views are still unbounded under production-sized data.