### PR TITLE
Cap maintenance and calibration list query result sets

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceCalibrationQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceCalibrationQueryGuardContractTests.cs
@@ -36,6 +36,53 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void MaintenanceListQueriesAreCappedWithSharedLimit()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+
+            AssertContainsAll(
+                source,
+                "private const int MaxMaintenanceListCount = 500;",
+                "cmd.Parameters.AddWithValue(\"@MaintenanceListLimit\", MaxMaintenanceListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<MaintenanceRecord>> GetAllMaintenanceRecordsAsync()",
+                    "public async Task<List<MaintenanceRecord>> GetMaintenanceRecordsByItemAsync(int itemID)"),
+                "ORDER BY m.ScheduledDate DESC",
+                "LIMIT @MaintenanceListLimit",
+                "cmd.Parameters.AddWithValue(\"@MaintenanceListLimit\", MaxMaintenanceListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<MaintenanceRecord>> GetMaintenanceRecordsByItemAsync(int itemID)",
+                    "public async Task<List<MaintenanceRecord>> GetOverdueMaintenanceAsync()"),
+                "ORDER BY m.ScheduledDate DESC",
+                "LIMIT @MaintenanceListLimit",
+                "cmd.Parameters.AddWithValue(\"@MaintenanceListLimit\", MaxMaintenanceListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<MaintenanceRecord>> GetOverdueMaintenanceAsync()",
+                    "public async Task<List<MaintenanceRecord>> GetUpcomingMaintenanceAsync(int days = 30)"),
+                "ORDER BY m.ScheduledDate ASC",
+                "LIMIT @MaintenanceListLimit",
+                "cmd.Parameters.AddWithValue(\"@MaintenanceListLimit\", MaxMaintenanceListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<MaintenanceRecord>> GetUpcomingMaintenanceAsync(int days = 30)",
+                    "public async Task<MaintenanceRecord?> GetMaintenanceRecordByIdAsync(int maintenanceID)"),
+                "ORDER BY m.ScheduledDate ASC",
+                "LIMIT @MaintenanceListLimit",
+                "cmd.Parameters.AddWithValue(\"@MaintenanceListLimit\", MaxMaintenanceListCount);");
+        }
+
+        [Fact]
         public void CalibrationItemQueriesValidateParentItemBeforeItemQueries()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
@@ -80,12 +127,72 @@ namespace InventoryManagementApp.Tests
                 "Expected latest calibration lookup to confirm the item row exists before building/executing the lookup query.");
         }
 
+        [Fact]
+        public void CalibrationListQueriesAreCappedWithSharedLimit()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+
+            AssertContainsAll(
+                source,
+                "private const int MaxCalibrationListCount = 500;",
+                "cmd.Parameters.AddWithValue(\"@CalibrationListLimit\", MaxCalibrationListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<CalibrationRecord>> GetAllCalibrationRecordsAsync()",
+                    "public async Task<List<CalibrationRecord>> GetCalibrationRecordsByItemAsync(int itemID)"),
+                "ORDER BY c.CalibrationDate DESC",
+                "LIMIT @CalibrationListLimit",
+                "cmd.Parameters.AddWithValue(\"@CalibrationListLimit\", MaxCalibrationListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<CalibrationRecord>> GetCalibrationRecordsByItemAsync(int itemID)",
+                    "public async Task<List<CalibrationRecord>> GetOverdueCalibrationAsync()"),
+                "ORDER BY c.CalibrationDate DESC",
+                "LIMIT @CalibrationListLimit",
+                "cmd.Parameters.AddWithValue(\"@CalibrationListLimit\", MaxCalibrationListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<CalibrationRecord>> GetOverdueCalibrationAsync()",
+                    "public async Task<List<CalibrationRecord>> GetUpcomingCalibrationAsync(int days = 30)"),
+                "ORDER BY c.NextCalibrationDue ASC",
+                "LIMIT @CalibrationListLimit",
+                "cmd.Parameters.AddWithValue(\"@CalibrationListLimit\", MaxCalibrationListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<CalibrationRecord>> GetUpcomingCalibrationAsync(int days = 30)",
+                    "public async Task<CalibrationRecord?> GetLatestCalibrationForItemAsync(int itemID)"),
+                "ORDER BY c.NextCalibrationDue ASC",
+                "LIMIT @CalibrationListLimit",
+                "cmd.Parameters.AddWithValue(\"@CalibrationListLimit\", MaxCalibrationListCount);");
+        }
+
         private static void AssertContainsAll(string source, params string[] expectedSnippets)
         {
             foreach (var snippet in expectedSnippets)
             {
                 Assert.Contains(snippet, source, StringComparison.Ordinal);
             }
+        }
+
+        private static void AssertCappedQuery(string method, string orderBySnippet, string limitSnippet, string parameterSnippet)
+        {
+            AssertContainsAll(method, orderBySnippet, limitSnippet, parameterSnippet);
+            Assert.True(
+                method.IndexOf(orderBySnippet, StringComparison.Ordinal) <
+                method.IndexOf(limitSnippet, StringComparison.Ordinal),
+                "Expected list cap to be applied after the query ordering so the most relevant rows are retained.");
+            Assert.True(
+                method.IndexOf(limitSnippet, StringComparison.Ordinal) <
+                method.IndexOf(parameterSnippet, StringComparison.Ordinal),
+                "Expected the list cap SQL placeholder to be bound before the query is executed.");
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-30-maintenance-calibration-list-result-caps.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-30-maintenance-calibration-list-result-caps.md
@@ -1,0 +1,20 @@
+# Maintenance and Calibration List Result Caps
+
+## Completed
+
+- Added shared 500-row caps to maintenance and calibration list-style service queries.
+- Capped all maintenance records, maintenance item history, overdue maintenance, and upcoming maintenance reads with `LIMIT @MaintenanceListLimit`.
+- Capped all calibration records, calibration item history, overdue calibration, and upcoming calibration reads with `LIMIT @CalibrationListLimit`.
+- Bound each cap as an explicit SQLite parameter so the query contract matches the reservation and rental result-cap patterns.
+- Extended maintenance/calibration source-contract coverage to guard the shared caps, ordering, and parameter binding across each affected workflow.
+
+## Why
+
+Maintenance and calibration schedules are operational workbench views that can grow indefinitely in active shops. Recent reservation work capped the same kind of list and history reads, but the technician maintenance and calibration paths still returned every matching row. Capping these reads keeps schedule, overdue, upcoming, and item-history views responsive while preserving the newest or nearest-due ordering that makes each list useful.
+
+## Validation
+
+- Connector readback confirmed `MaintenanceService` defines `MaxMaintenanceListCount = 500`, applies `LIMIT @MaintenanceListLimit` after ordering in every maintenance list-style query, and binds the cap parameter before executing each query.
+- Connector readback confirmed `CalibrationService` defines `MaxCalibrationListCount = 500`, applies `LIMIT @CalibrationListLimit` after ordering in every calibration list-style query, and binds the cap parameter before executing each query.
+- Connector readback confirmed `MaintenanceCalibrationQueryGuardContractTests` covers the new maintenance and calibration list cap contracts.
+- Local .NET tests and full Windows validation could not be run in this scheduled environment because direct checkout is blocked and the Windows/.NET validation stack is unavailable here.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -15,6 +15,8 @@ namespace InventoryManagementApp.Services.Calibration
     /// </summary>
     public class CalibrationService
     {
+        private const int MaxCalibrationListCount = 500;
+
         private readonly DatabaseService _databaseService;
         private readonly IUserContext _userContext;
 
@@ -43,8 +45,10 @@ namespace InventoryManagementApp.Services.Calibration
                     SELECT c.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM CalibrationRecords c
                     JOIN Items i ON c.ItemID = i.ItemID
-                    ORDER BY c.CalibrationDate DESC";
+                    ORDER BY c.CalibrationDate DESC
+                    LIMIT @CalibrationListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@CalibrationListLimit", MaxCalibrationListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -74,9 +78,11 @@ namespace InventoryManagementApp.Services.Calibration
                     FROM CalibrationRecords c
                     JOIN Items i ON c.ItemID = i.ItemID
                     WHERE c.ItemID = @ItemID
-                    ORDER BY c.CalibrationDate DESC";
+                    ORDER BY c.CalibrationDate DESC
+                    LIMIT @CalibrationListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ItemID", itemID);
+                cmd.Parameters.AddWithValue("@CalibrationListLimit", MaxCalibrationListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -97,9 +103,11 @@ namespace InventoryManagementApp.Services.Calibration
                     FROM CalibrationRecords c
                     JOIN Items i ON c.ItemID = i.ItemID
                     WHERE c.NextCalibrationDue < @Now
-                    ORDER BY c.NextCalibrationDue ASC";
+                    ORDER BY c.NextCalibrationDue ASC
+                    LIMIT @CalibrationListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@Now", DateTime.Now);
+                cmd.Parameters.AddWithValue("@CalibrationListLimit", MaxCalibrationListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -124,10 +132,12 @@ namespace InventoryManagementApp.Services.Calibration
                     JOIN Items i ON c.ItemID = i.ItemID
                     WHERE c.NextCalibrationDue >= @Now 
                     AND c.NextCalibrationDue <= @FutureDate
-                    ORDER BY c.NextCalibrationDue ASC";
+                    ORDER BY c.NextCalibrationDue ASC
+                    LIMIT @CalibrationListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@Now", DateTime.Now);
                 cmd.Parameters.AddWithValue("@FutureDate", DateTime.Now.AddDays(days));
+                cmd.Parameters.AddWithValue("@CalibrationListLimit", MaxCalibrationListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -15,6 +15,8 @@ namespace InventoryManagementApp.Services.Maintenance
     /// </summary>
     public class MaintenanceService
     {
+        private const int MaxMaintenanceListCount = 500;
+
         private readonly DatabaseService _databaseService;
         private readonly IUserContext _userContext;
 
@@ -43,8 +45,10 @@ namespace InventoryManagementApp.Services.Maintenance
                     SELECT m.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM MaintenanceRecords m
                     JOIN Items i ON m.ItemID = i.ItemID
-                    ORDER BY m.ScheduledDate DESC";
+                    ORDER BY m.ScheduledDate DESC
+                    LIMIT @MaintenanceListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@MaintenanceListLimit", MaxMaintenanceListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -74,9 +78,11 @@ namespace InventoryManagementApp.Services.Maintenance
                     FROM MaintenanceRecords m
                     JOIN Items i ON m.ItemID = i.ItemID
                     WHERE m.ItemID = @ItemID
-                    ORDER BY m.ScheduledDate DESC";
+                    ORDER BY m.ScheduledDate DESC
+                    LIMIT @MaintenanceListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ItemID", itemID);
+                cmd.Parameters.AddWithValue("@MaintenanceListLimit", MaxMaintenanceListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -101,9 +107,11 @@ namespace InventoryManagementApp.Services.Maintenance
                     FROM MaintenanceRecords m
                     JOIN Items i ON m.ItemID = i.ItemID
                     WHERE m.Status = 'Scheduled' AND m.ScheduledDate < @Now
-                    ORDER BY m.ScheduledDate ASC";
+                    ORDER BY m.ScheduledDate ASC
+                    LIMIT @MaintenanceListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@Now", DateTime.Now);
+                cmd.Parameters.AddWithValue("@MaintenanceListLimit", MaxMaintenanceListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -129,10 +137,12 @@ namespace InventoryManagementApp.Services.Maintenance
                     WHERE m.Status = 'Scheduled' 
                     AND m.ScheduledDate >= @Now 
                     AND m.ScheduledDate <= @FutureDate
-                    ORDER BY m.ScheduledDate ASC";
+                    ORDER BY m.ScheduledDate ASC
+                    LIMIT @MaintenanceListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@Now", DateTime.Now);
                 cmd.Parameters.AddWithValue("@FutureDate", DateTime.Now.AddDays(days));
+                cmd.Parameters.AddWithValue("@MaintenanceListLimit", MaxMaintenanceListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {


### PR DESCRIPTION
## What changed

- Added shared 500-row caps to `MaintenanceService` and `CalibrationService` list-style queries.
- Applied `LIMIT @MaintenanceListLimit` to all maintenance records, item maintenance history, overdue maintenance, and upcoming maintenance reads.
- Applied `LIMIT @CalibrationListLimit` to all calibration records, item calibration history, overdue calibration, and upcoming calibration reads.
- Bound each result cap as an explicit SQLite parameter after the existing ordering, preserving newest-first history and nearest-due schedule behavior.
- Extended `MaintenanceCalibrationQueryGuardContractTests` to pin both services' cap constants, SQL ordering, and parameter binding.
- Added a progress note for the completed technician schedule/history hardening slice.

## Why this was the highest-value next step

The latest merged reservation work capped the same kind of operational list/history reads, and repo evidence showed the adjacent maintenance and calibration schedule/history paths were still unbounded. These technician workbench workflows can grow indefinitely in active shops, so capping them is the next concrete runtime reliability improvement before moving to lower-priority polish.

## Why this is real workflow progress

This is a paired workflow slice across two related service areas, all/history/overdue/upcoming query behavior, source-contract coverage, and progress notes. It completes the same result-cap pattern for technician schedule workflows rather than making a tiny isolated guard or cosmetic edit.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to maintenance/calibration services, one existing contract test file, and one progress note.
- Connector readback confirmed `MaintenanceService` defines `MaxMaintenanceListCount = 500`, applies `LIMIT @MaintenanceListLimit` after ordering in every maintenance list-style query, and binds the cap parameter before executing each query.
- Connector readback confirmed `CalibrationService` defines `MaxCalibrationListCount = 500`, applies `LIMIT @CalibrationListLimit` after ordering in every calibration list-style query, and binds the cap parameter before executing each query.
- Connector readback confirmed `MaintenanceCalibrationQueryGuardContractTests` covers the new cap contracts.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- Local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Consider applying the named result-cap pattern to any remaining operational list screens only when current source evidence shows they are still unbounded.