### PR TITLE
Cap kit list query result sets

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceQueryGuardContractTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class KitServiceQueryGuardContractTests
+    {
+        [Fact]
+        public void KitDirectoryQueriesAreCappedWithSharedLimit()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+
+            AssertContainsAll(
+                source,
+                "private const int MaxKitListCount = 500;",
+                "cmd.Parameters.AddWithValue(\"@KitListLimit\", MaxKitListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<Kit>> GetAllKitsAsync()",
+                    "public async Task<List<Kit>> GetActiveKitsAsync()"),
+                "ORDER BY Name ASC",
+                "LIMIT @KitListLimit",
+                "cmd.Parameters.AddWithValue(\"@KitListLimit\", MaxKitListCount);");
+
+            AssertCappedQuery(
+                ExtractMethod(
+                    source,
+                    "public async Task<List<Kit>> GetActiveKitsAsync()",
+                    "public async Task<Kit?> GetKitByIdAsync(int kitID)"),
+                "ORDER BY Name ASC",
+                "LIMIT @KitListLimit",
+                "cmd.Parameters.AddWithValue(\"@KitListLimit\", MaxKitListCount);");
+        }
+
+        [Fact]
+        public void KitMembershipQueryIsCappedAfterParentValidation()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+
+            AssertContainsAll(
+                source,
+                "private const int MaxKitItemListCount = 500;",
+                "cmd.Parameters.AddWithValue(\"@KitItemListLimit\", MaxKitItemListCount);");
+
+            var method = ExtractMethod(
+                source,
+                "public async Task<List<KitItem>> GetKitItemsAsync(int kitID)",
+                "public async Task<int> CreateKitAsync(Kit kit)");
+
+            AssertContainsAll(
+                method,
+                "if (kitID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(kitID), \"Kit ID must be greater than 0.\");",
+                "using var conn = _databaseService.CreateConnection();",
+                "EnsureKitExists(conn, kitID);",
+                "WHERE ki.KitID = @KitID",
+                "ORDER BY i.ItemNumber",
+                "LIMIT @KitItemListLimit",
+                "cmd.Parameters.AddWithValue(\"@KitID\", kitID);",
+                "cmd.Parameters.AddWithValue(\"@KitItemListLimit\", MaxKitItemListCount);");
+
+            Assert.True(
+                method.IndexOf("EnsureKitExists(conn, kitID);", StringComparison.Ordinal) <
+                method.IndexOf("var sql = @\"", StringComparison.Ordinal),
+                "Expected kit item membership reads to confirm the parent kit exists before building/executing the membership query.");
+            Assert.True(
+                method.IndexOf("ORDER BY i.ItemNumber", StringComparison.Ordinal) <
+                method.IndexOf("LIMIT @KitItemListLimit", StringComparison.Ordinal),
+                "Expected kit membership caps to apply after ordering so the visible membership list remains deterministic.");
+            Assert.True(
+                method.IndexOf("LIMIT @KitItemListLimit", StringComparison.Ordinal) <
+                method.IndexOf("cmd.Parameters.AddWithValue(\"@KitItemListLimit\", MaxKitItemListCount);", StringComparison.Ordinal),
+                "Expected the kit item list cap SQL placeholder to be bound before the query is executed.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static void AssertCappedQuery(string method, string orderBySnippet, string limitSnippet, string parameterSnippet)
+        {
+            AssertContainsAll(method, orderBySnippet, limitSnippet, parameterSnippet);
+            Assert.True(
+                method.IndexOf(orderBySnippet, StringComparison.Ordinal) <
+                method.IndexOf(limitSnippet, StringComparison.Ordinal),
+                "Expected list cap to be applied after the query ordering so the visible rows remain deterministic.");
+            Assert.True(
+                method.IndexOf(limitSnippet, StringComparison.Ordinal) <
+                method.IndexOf(parameterSnippet, StringComparison.Ordinal),
+                "Expected the list cap SQL placeholder to be bound before the query is executed.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-kit-list-result-caps.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-kit-list-result-caps.md
@@ -1,0 +1,21 @@
+# Kit List Result Caps
+
+## Completed
+
+- Added shared 500-row caps to kit directory and kit membership list-style service queries.
+- Capped all kits and active kits reads with `LIMIT @KitListLimit` after the existing name ordering.
+- Capped kit membership reads with `LIMIT @KitItemListLimit` after the existing item-number ordering.
+- Bound each cap as an explicit SQLite parameter so the query contract matches the recent reservation, maintenance, and calibration result-cap patterns.
+- Added `KitServiceQueryGuardContractTests` coverage to guard the cap constants, SQL ordering, parent-kit validation, and parameter binding.
+
+## Why
+
+Kit directory and membership screens are operational workbench views that can grow as shops define more bundled equipment and add more kit components. Recent work capped reservation, maintenance, and calibration list reads, but the adjacent kit directory and kit membership paths still returned every matching row. Capping those reads keeps kit setup and membership views responsive while preserving deterministic name and item-number ordering.
+
+## Validation
+
+- Connector readback confirmed `KitService` defines `MaxKitListCount = 500` and `MaxKitItemListCount = 500`.
+- Connector readback confirmed all kit and active-kit directory reads apply `LIMIT @KitListLimit` after `ORDER BY Name ASC` and bind the cap parameter before executing each query.
+- Connector readback confirmed kit membership reads apply `LIMIT @KitItemListLimit` after `ORDER BY i.ItemNumber`, preserve parent kit validation before SQL execution, and bind the cap parameter before reading rows.
+- Connector readback confirmed `KitServiceQueryGuardContractTests` covers the kit directory and kit membership cap contracts.
+- Local .NET tests and full Windows validation could not be run in this scheduled environment because direct checkout is blocked and the Windows/.NET validation stack is unavailable here.

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -15,6 +15,9 @@ namespace InventoryManagementApp.Services.Kits
     /// </summary>
     public class KitService
     {
+        private const int MaxKitListCount = 500;
+        private const int MaxKitItemListCount = 500;
+
         private readonly DatabaseService _databaseService;
         private readonly IUserContext _userContext;
 
@@ -41,8 +44,10 @@ namespace InventoryManagementApp.Services.Kits
                 using var conn = _databaseService.CreateConnection();
                 var sql = @"
                     SELECT * FROM Kits
-                    ORDER BY Name ASC";
+                    ORDER BY Name ASC
+                    LIMIT @KitListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@KitListLimit", MaxKitListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -65,8 +70,10 @@ namespace InventoryManagementApp.Services.Kits
                 var sql = @"
                     SELECT * FROM Kits
                     WHERE IsActive = 1
-                    ORDER BY Name ASC";
+                    ORDER BY Name ASC
+                    LIMIT @KitListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@KitListLimit", MaxKitListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -123,9 +130,11 @@ namespace InventoryManagementApp.Services.Kits
                     FROM KitItems ki
                     LEFT JOIN Items i ON ki.ItemID = i.ItemID
                     WHERE ki.KitID = @KitID
-                    ORDER BY i.ItemNumber";
+                    ORDER BY i.ItemNumber
+                    LIMIT @KitItemListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@KitID", kitID);
+                cmd.Parameters.AddWithValue("@KitItemListLimit", MaxKitItemListCount);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {


### PR DESCRIPTION
## What changed

- Added shared 500-row caps to `KitService` list-style kit directory and kit membership queries.
- Applied `LIMIT @KitListLimit` to all-kit and active-kit reads after the existing name ordering.
- Applied `LIMIT @KitItemListLimit` to kit membership reads after the existing item-number ordering while preserving parent kit validation before query execution.
- Bound each cap as an explicit SQLite parameter, matching the recent reservation, maintenance, and calibration result-cap pattern.
- Added `KitServiceQueryGuardContractTests` to pin the cap constants, ordering, parent validation, and parameter binding.
- Added a progress note for the completed kit workflow hardening slice.

## Why this was the highest-value next step

The latest completed work capped reservation, maintenance, and calibration list/history reads. Repo evidence showed the adjacent kit directory and kit membership service queries were still unbounded, so this was the next concrete runtime reliability improvement before lower-priority UI polish or cleanup.

## Why this is real workflow progress

This is a complete kit setup workflow slice across service query behavior, source-contract coverage, and project notes. It covers both the kit directory and kit membership list paths rather than making a tiny isolated guard or cosmetic edit.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `KitService`, one new contract test file, and one progress note.
- Connector readback confirmed `KitService` defines `MaxKitListCount = 500` and `MaxKitItemListCount = 500`.
- Connector readback confirmed kit and active-kit directory reads apply `LIMIT @KitListLimit` after `ORDER BY Name ASC` and bind the cap parameter before executing each query.
- Connector readback confirmed kit membership reads preserve parent kit validation before SQL execution, apply `LIMIT @KitItemListLimit` after `ORDER BY i.ItemNumber`, and bind the cap parameter before executing the query.
- Connector readback confirmed `KitServiceQueryGuardContractTests` covers the kit directory and kit membership cap contracts.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- Local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue applying named result-cap patterns only to remaining operational list screens where current source evidence shows unbounded production-growth risk.