### PR TITLE
Cap rental list query result sets

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -125,6 +125,42 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void RentalListQueriesCapReturnedRowsAfterDeterministicOrdering()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            Assert.Contains("private const int MaxRentalListCount = 500;", source, StringComparison.Ordinal);
+
+            var activeMethod = ExtractMethod(
+                source,
+                "public async Task<List<Rental>> GetActiveRentalsAsync()",
+                "public async Task<List<Rental>> GetOverdueRentalsAsync()");
+            AssertContainsAll(
+                activeMethod,
+                "WHERE r.Status='Rented' ORDER BY r.DueDate ASC LIMIT @RentalListLimit",
+                "new SqliteParameter(\"@RentalListLimit\", MaxRentalListCount)");
+
+            var overdueMethod = ExtractMethod(
+                source,
+                "public async Task<List<Rental>> GetOverdueRentalsAsync()",
+                "public async Task<List<Rental>> GetAllRentalsAsync()");
+            AssertContainsAll(
+                overdueMethod,
+                "WHERE r.Status = 'Rented' AND r.DueDate < @Today ORDER BY r.DueDate ASC LIMIT @RentalListLimit",
+                "new SqliteParameter(\"@Today\", DateTime.Today)",
+                "new SqliteParameter(\"@RentalListLimit\", MaxRentalListCount)");
+
+            var allMethod = ExtractMethod(
+                source,
+                "public async Task<List<Rental>> GetAllRentalsAsync()",
+                "public async Task<List<Rental>> GetRentalHistoryForItemAsync");
+            AssertContainsAll(
+                allMethod,
+                "ORDER BY r.RentalDate DESC LIMIT @RentalListLimit",
+                "new SqliteParameter(\"@RentalListLimit\", MaxRentalListCount)");
+        }
+
+        [Fact]
         public void RentalFrequencyValidatesPositiveLimitBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-rental-list-result-caps.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-rental-list-result-caps.md
@@ -1,0 +1,18 @@
+# Rental List Result Caps
+
+## Completed
+- Added a shared `MaxRentalListCount = 500` cap to `RentalService`.
+- Applied `LIMIT @RentalListLimit` to the all-rentals, active-rentals, and overdue-rentals list reads.
+- Added deterministic ordering before each cap so capped lists remain predictable:
+  - active rentals by nearest due date
+  - overdue rentals by oldest due date first
+  - all rentals by newest rental date first
+- Bound the list cap as an explicit SQLite parameter in each query.
+- Extended `RentalServiceQueryGuardContractTests` to pin the cap constant, ordering, and parameter binding.
+
+## Why
+Recent work capped reservation, maintenance, calibration, kit, rental history, and rental frequency reads. The core rental list screens were still unbounded, so production rental data growth could make dashboards and rental management screens slower or heavier than needed.
+
+## Validation
+- Source-contract coverage was updated for the rental list query shapes.
+- GitHub connector readback/compare should be used for this scheduled run because direct local checkout and Windows/.NET validation are unavailable in the hosted environment.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -22,6 +22,7 @@ namespace InventoryManagementApp.Services.Rentals
     /// </summary>
     public class RentalService : IRentalService
     {
+        private const int MaxRentalListCount = 500;
         private const int MaxRentalHistoryCount = 500;
         private const int MaxRentalFrequencyCount = 100;
 
@@ -403,16 +404,21 @@ namespace InventoryManagementApp.Services.Rentals
 
         public async Task<List<Rental>> GetActiveRentalsAsync()
         {
+            const string sql = BaseSelect + " WHERE r.Status='Rented' ORDER BY r.DueDate ASC LIMIT @RentalListLimit";
+            var p = new[] { new SqliteParameter("@RentalListLimit", MaxRentalListCount) };
             using var conn = _dbService.CreateConnection();
-            var sql = BaseSelect + " WHERE r.Status='Rented'";
-            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
         public async Task<List<Rental>> GetOverdueRentalsAsync()
         {
-            const string sql = BaseSelect + @" WHERE r.Status = 'Rented' AND r.DueDate < @Today";
-            var p = new[] { new SqliteParameter("@Today", DateTime.Today) };
+            const string sql = BaseSelect + @" WHERE r.Status = 'Rented' AND r.DueDate < @Today ORDER BY r.DueDate ASC LIMIT @RentalListLimit";
+            var p = new[]
+            {
+                new SqliteParameter("@Today", DateTime.Today),
+                new SqliteParameter("@RentalListLimit", MaxRentalListCount)
+            };
             using var conn = _dbService.CreateConnection();
             var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
@@ -420,8 +426,10 @@ namespace InventoryManagementApp.Services.Rentals
 
         public async Task<List<Rental>> GetAllRentalsAsync()
         {
+            const string sql = BaseSelect + " ORDER BY r.RentalDate DESC LIMIT @RentalListLimit";
+            var p = new[] { new SqliteParameter("@RentalListLimit", MaxRentalListCount) };
             using var conn = _dbService.CreateConnection();
-            var list = await SqliteHelper.ExecuteReaderAsync(conn, BaseSelect, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
 


### PR DESCRIPTION
## What changed

- Added a shared `MaxRentalListCount = 500` cap to `RentalService`.
- Applied `LIMIT @RentalListLimit` to the all-rentals, active-rentals, and overdue-rentals reads.
- Added deterministic ordering before each new cap:
  - active rentals by nearest due date
  - overdue rentals by oldest due date first
  - all rentals by newest rental date first
- Bound the rental list cap as an explicit SQLite parameter in each query.
- Extended `RentalServiceQueryGuardContractTests` to pin the cap constant, ordering, and parameter binding contract.
- Added a progress note for the completed rental list hardening slice.

## Why this was the highest-value next step

Recent repository work capped reservation, maintenance, calibration, kit, rental history, and rental frequency reads. Current source evidence showed the core rental list workflows were still unbounded, which can make rental management and dashboard-facing screens heavier as production data grows.

## Why this is real workflow progress

This is a complete rental read-workflow slice across service query behavior, source-contract coverage, and project notes. It covers all, active, and overdue rental list reads together rather than making a tiny isolated guard or cosmetic edit.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `RentalService`, `RentalServiceQueryGuardContractTests`, and one progress note.
- Connector readback confirmed `RentalService` defines `MaxRentalListCount = 500`.
- Connector readback confirmed active rentals order by `r.DueDate ASC` before `LIMIT @RentalListLimit` and bind `@RentalListLimit` to `MaxRentalListCount`.
- Connector readback confirmed overdue rentals keep the `@Today` filter, order by `r.DueDate ASC`, apply `LIMIT @RentalListLimit`, and bind the cap parameter.
- Connector readback confirmed all rentals order by `r.RentalDate DESC` before `LIMIT @RentalListLimit` and bind the cap parameter.
- Connector readback confirmed `RentalServiceQueryGuardContractTests` covers the new list cap contracts.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- Local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue applying result caps only where current source evidence shows remaining production-growth list risks.