### PR TITLE
Cap customer search result sets

### DIFF
--- a/InventoryManagementApp.Tests/CustomerSearchResultCapContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerSearchResultCapContractTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomerSearchResultCapContractTests
+    {
+        [Fact]
+        public void CustomerSearchCapsInteractiveResultsAfterDeterministicOrdering()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var searchMethod = ExtractMethod(
+                source,
+                "async Task<List<CustomerModel>> SearchCustomersInternalAsync",
+                "async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync");
+
+            Assert.Contains("private const int MaxCustomerSearchResults = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("ORDER BY Company ASC, Contact ASC, CustomerID ASC", searchMethod, StringComparison.Ordinal);
+            Assert.Contains("LIMIT @CustomerSearchLimit", searchMethod, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@CustomerSearchLimit\", MaxCustomerSearchResults)", searchMethod, StringComparison.Ordinal);
+
+            Assert.True(
+                searchMethod.IndexOf("ORDER BY Company ASC, Contact ASC, CustomerID ASC", StringComparison.Ordinal) <
+                searchMethod.IndexOf("LIMIT @CustomerSearchLimit", StringComparison.Ordinal),
+                "Customer search should apply the interactive cap after deterministic directory ordering.");
+            Assert.True(
+                searchMethod.IndexOf("new SqliteParameter(\"@t\", $\"%{searchTerm}%\")", StringComparison.Ordinal) <
+                searchMethod.IndexOf("new SqliteParameter(\"@CustomerSearchLimit\", MaxCustomerSearchResults)", StringComparison.Ordinal),
+                "Customer search should bind the search term and the shared cap explicitly.");
+        }
+
+        [Fact]
+        public void CustomerExportsKeepFullCustomerReadUncapped()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var allCustomersMethod = ExtractMethod(
+                source,
+                "async Task<List<CustomerModel>> GetAllCustomersInternalAsync",
+                "async Task<int> CountCustomersInternalAsync");
+            var csvExportMethod = ExtractMethod(
+                source,
+                "async Task ExportCustomersToCsvInternalAsync",
+                "async Task InsertCustomerAsync");
+            var genericExportMethod = ExtractMethod(
+                source,
+                "public async Task ExportCustomersAsync",
+                "static void NotifyChanged");
+
+            Assert.Contains("const string sql = \"SELECT * FROM Customers\";", allCustomersMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT", allCustomersMethod, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("var all = await GetAllCustomersInternalAsync(cancellationToken);", csvExportMethod, StringComparison.Ordinal);
+            Assert.Contains("var all = await GetAllCustomersAsync(cancellationToken).ConfigureAwait(false);", genericExportMethod, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-customer-search-result-cap.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-customer-search-result-cap.md
@@ -1,0 +1,15 @@
+# Customer Search Result Cap
+
+## Completed
+- Added a shared `MaxCustomerSearchResults = 500` cap to `CustomerService` interactive search results.
+- Applied deterministic customer-directory ordering before the cap with `Company`, `Contact`, and `CustomerID` sort keys.
+- Bound the customer search cap as an explicit SQLite parameter.
+- Left `GetAllCustomersInternalAsync` uncapped so CSV and generic customer exports continue to include the full customer list.
+- Added source-contract coverage for the search cap and uncapped export contract.
+
+## Why
+Recent work capped several operational list workflows, but customer search was still an unbounded interactive query. The customer export paths reuse the full customer read, so the safe reliability improvement was to cap only the search workflow while preserving full-data export behavior.
+
+## Validation
+- Source-contract coverage was added for customer search ordering, limit parameter binding, and uncapped export reads.
+- GitHub connector readback/compare should be used for this scheduled run because direct local checkout and Windows/.NET validation are unavailable in the hosted environment.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -24,6 +24,8 @@ namespace InventoryManagementApp.Services.Customers
     /// </summary>
     public class CustomerService : ICustomerService
     {
+        private const int MaxCustomerSearchResults = 500;
+
         private readonly DatabaseService _dbService;
         private readonly ILogger<CustomerService> _logger;
         private readonly IAuthorizationService _auth;
@@ -309,8 +311,14 @@ namespace InventoryManagementApp.Services.Customers
 
             const string sql = @"
                 SELECT * FROM Customers
-                WHERE Company LIKE @t OR Contact LIKE @t OR Email LIKE @t OR Phone LIKE @t OR Mobile LIKE @t OR Address LIKE @t";
-            var p = new[] { new SqliteParameter("@t", $"%{searchTerm}%") };
+                WHERE Company LIKE @t OR Contact LIKE @t OR Email LIKE @t OR Phone LIKE @t OR Mobile LIKE @t OR Address LIKE @t
+                ORDER BY Company ASC, Contact ASC, CustomerID ASC
+                LIMIT @CustomerSearchLimit";
+            var p = new[]
+            {
+                new SqliteParameter("@t", $"%{searchTerm}%"),
+                new SqliteParameter("@CustomerSearchLimit", MaxCustomerSearchResults)
+            };
             using var conn = _dbService.CreateConnection();
             try
             {


### PR DESCRIPTION
## What changed

- Added a shared `MaxCustomerSearchResults = 500` cap to `CustomerService` interactive customer search.
- Applied deterministic directory ordering before the cap with `Company`, `Contact`, and `CustomerID` sort keys.
- Bound the search cap as an explicit SQLite parameter.
- Left `GetAllCustomersInternalAsync` uncapped so CSV and generic customer export workflows still include the full customer list.
- Added focused source-contract coverage for the capped search behavior and uncapped export contract.
- Added a progress note for the completed customer search reliability slice.

## Why this was the highest-value next step

Recent merged work capped multiple operational list workflows. Current source evidence showed customer search remained an unbounded interactive query, while customer exports reuse the full customer read. This made customer search the next safe reliability target, provided export behavior stayed full-fidelity.

## Why this is real workflow progress

This is a complete customer directory/search workflow slice across service query behavior, source-contract coverage, and progress notes. It avoids a tiny isolated edit by improving interactive responsiveness while explicitly protecting the full export workflow from accidental truncation.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `CustomerService`, one new contract test file, and one progress note.
- Connector readback confirmed `CustomerService` defines `MaxCustomerSearchResults = 500`.
- Connector readback confirmed `SearchCustomersInternalAsync` orders by `Company ASC, Contact ASC, CustomerID ASC` before `LIMIT @CustomerSearchLimit` and binds `@CustomerSearchLimit` to the shared constant.
- Connector readback confirmed `GetAllCustomersInternalAsync` remains `SELECT * FROM Customers` without a `LIMIT`.
- Connector readback confirmed the new contract test covers both capped search and uncapped export behavior.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- Direct GitHub API access through the container is also blocked by HTTP 403 responses.
- Local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Consider a future dedicated customer directory paging/search flow if operators need access beyond the first 500 interactive matches without using export.