### PR TITLE
Cap user directory result sets

### DIFF
--- a/InventoryManagementApp.Tests/UserDirectoryResultCapContractTests.cs
+++ b/InventoryManagementApp.Tests/UserDirectoryResultCapContractTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserDirectoryResultCapContractTests
+    {
+        [Fact]
+        public void UserDirectoryCapsResultsAfterDeterministicOrdering()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<List<User>> GetAllUsersAsync",
+                "public async Task<int> CountUsersAsync");
+
+            Assert.Contains("private const int MaxUserListCount = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("ORDER BY UserName ASC, UserID ASC", method, StringComparison.Ordinal);
+            Assert.Contains("LIMIT @UserListLimit", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@UserListLimit\", MaxUserListCount)", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("ORDER BY UserName ASC, UserID ASC", StringComparison.Ordinal) <
+                method.IndexOf("LIMIT @UserListLimit", StringComparison.Ordinal),
+                "User directory reads should apply the list cap after deterministic username ordering.");
+            Assert.True(
+                method.IndexOf("var parameters = new[]", StringComparison.Ordinal) <
+                method.IndexOf("SqliteHelper.ExecuteReaderAsync(conn, sql, MapUser, parameters", StringComparison.Ordinal),
+                "User directory reads should bind the shared cap explicitly before executing the query.");
+        }
+
+        [Fact]
+        public void UserCountAndExactLookupRemainUncapped()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var countMethod = ExtractMethod(
+                source,
+                "public async Task<int> CountUsersAsync",
+                "public async Task<User?> GetUserByIDAsync");
+            var exactLookupMethod = ExtractMethod(
+                source,
+                "public async Task<User?> GetUserByIDAsync",
+                "public async Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync");
+
+            Assert.Contains("const string sql = \"SELECT COUNT(*) FROM Users\";", countMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT", countMethod, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("SELECT * FROM Users WHERE UserID=@ID", exactLookupMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT", exactLookupMethod, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void UserUpdatesUseSharedStaleWriteGuardDirectly()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateUserAsync",
+                "public async Task<bool> ChangeUserPasswordAsync");
+
+            Assert.Contains("int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);", method, StringComparison.Ordinal);
+            Assert.Contains("EnsureUserWriteSucceeded(rows, user.UserID);", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (rows == 0)\n                    throw new KeyNotFoundException", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);", StringComparison.Ordinal) <
+                method.IndexOf("EnsureUserWriteSucceeded(rows, user.UserID);", StringComparison.Ordinal),
+                "User updates should flow through the shared stale-write guard after capturing affected rows.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-user-directory-result-cap.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-user-directory-result-cap.md
@@ -1,0 +1,16 @@
+# User Directory Result Cap
+
+## Completed
+- Added a shared `MaxUserListCount = 500` cap to `UserService` directory reads.
+- Applied deterministic ordering by `UserName` and `UserID` before the cap so the admin user list is stable.
+- Bound the user directory cap as an explicit SQLite parameter.
+- Left `CountUsersAsync` and exact `GetUserByIDAsync` lookups uncapped so first-user detection, counts, and exact account operations keep their full-data behavior.
+- Removed a redundant zero-row check in `UpdateUserAsync` so stale user updates use the shared `EnsureUserWriteSucceeded` guard directly.
+- Added source-contract coverage for the directory cap, uncapped count/exact lookup paths, and shared stale-write guard usage.
+
+## Why
+Recent work capped several production-growth list workflows. The user-management directory was still an unbounded read with no deterministic ordering, which could make admin account management heavier as the account table grows. Capping only the directory read improves responsiveness while preserving exact lookup and count behavior used by account workflows.
+
+## Validation
+- Source-contract coverage was added for user directory ordering, limit parameter binding, uncapped count/exact lookup reads, and the shared update stale-write guard.
+- GitHub connector readback/compare should be used for this scheduled run because direct local checkout and Windows/.NET validation are unavailable in the hosted environment.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -29,6 +29,7 @@ namespace InventoryManagementApp.Services.Users
         private readonly IAuthorizationService _auth;
         private readonly ActivityLogService? _activityLog;
         private const int MaxFailedLoginAttempts = 5;
+        private const int MaxUserListCount = 500;
         private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(15);
 
         public UserService(DatabaseService dbService, IUserContext context, IAuthorizationService? authorizationService = null, ILogger<UserService>? logger = null, ActivityLogService? activityLogService = null)
@@ -117,8 +118,13 @@ namespace InventoryManagementApp.Services.Users
             cancellationToken.ThrowIfCancellationRequested();
 
             using var conn = _dbService.CreateConnection();
-            const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired, FailedLoginAttempts, LockoutEndUtc, Permissions FROM Users";
-            return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapUser, cancellationToken: cancellationToken);
+            const string sql = @"
+                SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired, FailedLoginAttempts, LockoutEndUtc, Permissions
+                FROM Users
+                ORDER BY UserName ASC, UserID ASC
+                LIMIT @UserListLimit";
+            var parameters = new[] { new SqliteParameter("@UserListLimit", MaxUserListCount) };
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapUser, parameters, cancellationToken: cancellationToken);
         }
 
         public async Task<int> CountUsersAsync(CancellationToken cancellationToken = default)
@@ -429,8 +435,6 @@ namespace InventoryManagementApp.Services.Users
             {
                 using var conn = _dbService.CreateConnection();
                 int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
-                if (rows == 0)
-                    throw new KeyNotFoundException($"User {user.UserID} not found.");
                 EnsureUserWriteSucceeded(rows, user.UserID);
             }
             catch (SqliteException ex) when (ex.SqliteErrorCode == SQLitePCL.raw.SQLITE_CONSTRAINT &&


### PR DESCRIPTION
## What changed

- Added a shared `MaxUserListCount = 500` cap to `UserService` directory reads.
- Applied deterministic ordering by `UserName` and `UserID` before the cap so the admin user list is stable.
- Bound the user directory cap as an explicit SQLite parameter.
- Left `CountUsersAsync` and exact `GetUserByIDAsync` lookups uncapped so first-user detection, counts, and exact account workflows keep their full-data behavior.
- Removed a redundant zero-row check in `UpdateUserAsync` so stale user updates flow through the shared `EnsureUserWriteSucceeded` guard directly.
- Added focused source-contract coverage and a progress note for the completed user-management reliability slice.

## Why this was the highest-value next step

Recent merged work capped multiple production-growth list workflows, and current source evidence showed the user-management directory still loaded every user row with no deterministic ordering. User administration is an operational screen, so capping only the directory read improves responsiveness while preserving exact lookup and count behavior used by account workflows.

## Why this is real workflow progress

This is a complete user-management directory hardening slice across service query behavior, source-contract coverage, and project notes. It improves an admin workflow and cleans an adjacent stale-write guard pattern instead of making a tiny isolated assertion or cosmetic edit.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `UserService`, one new source-contract test file, and one progress note.
- Connector readback confirmed `UserService` defines `MaxUserListCount = 500`.
- Connector readback confirmed `GetAllUsersAsync` orders by `UserName ASC, UserID ASC` before `LIMIT @UserListLimit` and binds `@UserListLimit` to the shared constant.
- Connector readback confirmed `CountUsersAsync` remains `SELECT COUNT(*) FROM Users` without a `LIMIT`.
- Connector readback confirmed `GetUserByIDAsync` remains an exact `UserID` lookup without a `LIMIT`.
- Connector readback confirmed `UpdateUserAsync` now uses `EnsureUserWriteSucceeded(rows, user.UserID);` directly after capturing affected rows.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- Direct raw GitHub file access through the container is also blocked by HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Consider a future dedicated user paging/search workflow if an installation needs admin access beyond the first 500 directory rows without using exact account lookup.