### PR TITLE
Harden item import and export entrypoint guards

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
@@ -187,8 +187,12 @@ namespace InventoryManagementApp.Tests
         private static void AssertCancellationGuardBeforeSqlAndConnection(string method, string methodName)
         {
             Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            var sqlIndex = method.IndexOf("const string sql", StringComparison.Ordinal);
+            if (sqlIndex < 0)
+                sqlIndex = method.IndexOf("var sql", StringComparison.Ordinal);
+            Assert.True(sqlIndex >= 0, $"Could not find SQL declaration in {methodName}.");
             Assert.True(
-                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("var sql", StringComparison.Ordinal),
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < sqlIndex,
                 $"{methodName} should honor cancellation before SQL work starts.");
             Assert.True(
                 method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("_dbService.CreateConnection()", StringComparison.Ordinal),

--- a/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
@@ -50,6 +50,94 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void CsvImportExportEntrypointsValidateInputsBeforeAuthorizationAndWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var importMethod = ExtractMethod(
+                source,
+                "public Task<List<int>> ImportItemsFromCsvAsync",
+                "public Task ExportItemsToCsvAsync");
+            var exportMethod = ExtractMethod(
+                source,
+                "public Task ExportItemsToCsvAsync",
+                "public Task<ImageImportResult> ImportItemImagesAsync");
+
+            AssertEntrypointPathGuardBeforeAuthorization(importMethod, "ImportItemsFromCsvAsync");
+            Assert.Contains("if (map is null)", importMethod, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(map));", importMethod, StringComparison.Ordinal);
+            Assert.True(
+                importMethod.IndexOf("if (map is null)", StringComparison.Ordinal) < importMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "CSV item imports should reject a missing column map before authorization or file work.");
+            Assert.True(
+                importMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal) < importMethod.IndexOf("return ImportItemsFromCsvInternalAsync", StringComparison.Ordinal),
+                "CSV item imports should keep authorization before import work starts.");
+
+            AssertEntrypointPathGuardBeforeAuthorization(exportMethod, "ExportItemsToCsvAsync");
+            Assert.True(
+                exportMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal) < exportMethod.IndexOf("return ExportItemsToCsvInternalAsync", StringComparison.Ordinal),
+                "CSV item exports should keep authorization before export work starts.");
+        }
+
+        [Fact]
+        public void GenericImportExportEntrypointsValidateInputsBeforeAuthorizationAndWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var importMethod = ExtractMethod(
+                source,
+                "public async Task<List<int>> ImportItemsAsync",
+                "private static string GenerateNextImportedItemNumber");
+            var exportMethod = ExtractMethod(
+                source,
+                "public async Task ExportItemsAsync",
+                "static void NotifyChanged");
+
+            AssertEntrypointPathGuardBeforeAuthorization(importMethod, "ImportItemsAsync");
+            Assert.Contains("if (importer is null)", importMethod, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(importer));", importMethod, StringComparison.Ordinal);
+            Assert.True(
+                importMethod.IndexOf("if (importer is null)", StringComparison.Ordinal) < importMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Generic item imports should reject a missing importer before authorization or file work.");
+            Assert.True(
+                importMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < importMethod.IndexOf("var (items, skippedRows) = await importer.ImportAsync", StringComparison.Ordinal),
+                "Generic item imports should honor cancellation before importer file work starts.");
+            Assert.True(
+                importMethod.IndexOf("var (items, skippedRows) = await importer.ImportAsync", StringComparison.Ordinal) < importMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", importMethod.IndexOf("var (items, skippedRows) = await importer.ImportAsync", StringComparison.Ordinal), StringComparison.Ordinal),
+                "Generic item imports should honor cancellation again after importer parsing and before database work.");
+
+            AssertEntrypointPathGuardBeforeAuthorization(exportMethod, "ExportItemsAsync");
+            Assert.Contains("if (exporter is null)", exportMethod, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(exporter));", exportMethod, StringComparison.Ordinal);
+            Assert.True(
+                exportMethod.IndexOf("if (exporter is null)", StringComparison.Ordinal) < exportMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Generic item exports should reject a missing exporter before authorization or item collection work.");
+            Assert.True(
+                exportMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < exportMethod.IndexOf("var items = new List<ItemModel>();", StringComparison.Ordinal),
+                "Generic item exports should honor cancellation before collecting rows.");
+        }
+
+        [Fact]
+        public void ItemNumberAndDuplicateHelpersHonorCancellationBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var numberMethod = ExtractMethod(
+                source,
+                "public async Task<string> GenerateNextItemNumberAsync",
+                "private async Task<ImageImportResult> ImportItemImagesInternalAsync");
+            var existsMethod = ExtractMethod(
+                source,
+                "private async Task<bool> ItemExistsAsync",
+                "private async Task AddItemInternalAsync");
+
+            AssertCancellationGuardBeforeSqlAndConnection(numberMethod, "GenerateNextItemNumberAsync");
+            Assert.Contains("if (string.IsNullOrWhiteSpace(itemNumber))", existsMethod, StringComparison.Ordinal);
+            Assert.Contains("return false;", existsMethod, StringComparison.Ordinal);
+            AssertCancellationGuardBeforeSqlAndConnection(existsMethod, "ItemExistsAsync");
+            Assert.True(
+                existsMethod.IndexOf("if (string.IsNullOrWhiteSpace(itemNumber))", StringComparison.Ordinal) < existsMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal),
+                "Blank duplicate checks should keep returning false without treating cancellation as a database operation.");
+        }
+
+        [Fact]
         public void CsvImportRejectsOutOfRangeQuantitiesBeforeInsert()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
@@ -77,6 +165,34 @@ namespace InventoryManagementApp.Tests
                 method.IndexOf("if (!skip && (parsedQuantity < 0 || parsedQuantity > MaxQuantityOnHand))", StringComparison.Ordinal) <
                 method.IndexOf("await InsertItemAsync", StringComparison.Ordinal),
                 "CSV import should reject out-of-range quantities before direct insert work.");
+
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("using var parser = new TextFieldParser", StringComparison.Ordinal),
+                "CSV imports should honor cancellation before opening the input file parser.");
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", method.IndexOf("if (headers == null", StringComparison.Ordinal), StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                "CSV imports should honor cancellation again after header parsing and before database work.");
+        }
+
+        private static void AssertEntrypointPathGuardBeforeAuthorization(string method, string methodName)
+        {
+            Assert.Contains("if (string.IsNullOrWhiteSpace(filePath))", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(filePath));", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(filePath))", StringComparison.Ordinal) < method.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                $"{methodName} should reject missing file paths before authorization or file work.");
+        }
+
+        private static void AssertCancellationGuardBeforeSqlAndConnection(string method, string methodName)
+        {
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("var sql", StringComparison.Ordinal),
+                $"{methodName} should honor cancellation before SQL work starts.");
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("_dbService.CreateConnection()", StringComparison.Ordinal),
+                $"{methodName} should honor cancellation before opening a database connection.");
         }
 
         private static ItemModel CreateItem(string itemNumber, string name) => new()

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-item-import-export-entrypoint-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-item-import-export-entrypoint-guards.md
@@ -1,0 +1,18 @@
+# Item Import Export Entrypoint Guards
+
+## Completed
+- Added explicit file-path and column-map validation to CSV item import before authorization or file parsing work begins.
+- Added explicit file-path validation to CSV item export before authorization or export collection work begins.
+- Added explicit file-path and importer/exporter validation to generic item import/export before authorization or workflow work begins.
+- Honored cancellation before generic importer parsing, after importer parsing before database work, before CSV parser/database work, and before item-number/duplicate SQL setup.
+- Kept the existing CSV quantity-range and import transaction behavior intact.
+- Added source-contract coverage for guard ordering, cancellation ordering, and the existing quantity import guard.
+
+## Why
+The parallel customer import/export entrypoints already validate file paths and maps before service authorization and workflow work. Current item source evidence showed item import/export entrypoints were less defensive, while item-number generation and duplicate checks accepted cancellation tokens but did not check them until lower-level database execution. This pass reduces avoidable file/database work and gives operators clearer argument failures for item import/export workflows.
+
+## Validation
+- Source-contract coverage was added for CSV and generic item import/export guard ordering.
+- Source-contract coverage was added for cancellation before item-number and duplicate-check SQL/connection work.
+- Source-contract coverage was extended to ensure CSV import cancellation is honored before parser/database work while retaining quantity-range validation.
+- GitHub connector readback/compare should be used for this scheduled run because direct local checkout and Windows/.NET validation are unavailable in the hosted environment.

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -177,12 +177,20 @@ namespace InventoryManagementApp.Services.Items
 
         public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+            if (map is null)
+                throw new ArgumentNullException(nameof(map));
+
             _auth.EnsurePermission(User.PermissionImportExport);
             return ImportItemsFromCsvInternalAsync(filePath, map, cancellationToken);
         }
 
         public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+
             _auth.EnsurePermission(User.PermissionImportExport);
             return ExportItemsToCsvInternalAsync(filePath, cancellationToken);
         }
@@ -195,6 +203,8 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = "SELECT IFNULL(MAX(CAST(SUBSTR(ItemNumber, 2) AS INTEGER)), 0) FROM Items WHERE ItemNumber LIKE 'T%'";
             using var conn = _dbService.CreateConnection();
             var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, null, cancellationToken);
@@ -342,6 +352,7 @@ namespace InventoryManagementApp.Services.Items
         {
             if (string.IsNullOrWhiteSpace(itemNumber))
                 return false;
+            cancellationToken.ThrowIfCancellationRequested();
 
             var sql = "SELECT COUNT(*) FROM Items WHERE ItemNumber = @TN";
             var parameters = new List<SqliteParameter>
@@ -419,6 +430,7 @@ namespace InventoryManagementApp.Services.Items
         {
             if (map == null || !map.TryGetValue("ItemNumber", out var _) || string.IsNullOrWhiteSpace(map["ItemNumber"]))
                 throw new ArgumentException("Mapping for required field 'ItemNumber' is missing.", nameof(map));
+            cancellationToken.ThrowIfCancellationRequested();
 
             var invalidRows = new List<int>();
             using var parser = new TextFieldParser(filePath);
@@ -430,6 +442,7 @@ namespace InventoryManagementApp.Services.Items
             if (headers == null || headers.Length == 0)
                 throw new InvalidDataException("CSV header row is missing or empty.");
 
+            cancellationToken.ThrowIfCancellationRequested();
             using var conn = _dbService.CreateConnection();
             var existingNumbers = new HashSet<string>(
                 await SqliteHelper.ExecuteReaderAsync(conn,
@@ -672,9 +685,16 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<List<int>> ImportItemsAsync(string filePath, IDataImporter<ItemModel> importer, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+            if (importer is null)
+                throw new ArgumentNullException(nameof(importer));
+
             _auth.EnsurePermission(User.PermissionImportExport);
+            cancellationToken.ThrowIfCancellationRequested();
             
             var (items, skippedRows) = await importer.ImportAsync(filePath, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
             
             using var conn = _dbService.CreateConnection();
             var existingNumbers = new HashSet<string>(
@@ -736,6 +756,11 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task ExportItemsAsync(string filePath, IDataExporter<ItemModel> exporter, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+            if (exporter is null)
+                throw new ArgumentNullException(nameof(exporter));
+
             _auth.EnsurePermission(User.PermissionImportExport);
             cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
## What changed

- Added explicit missing-file-path and missing-map validation to CSV item import before authorization or parser work.
- Added explicit missing-file-path validation to CSV item export before authorization or export collection work.
- Added explicit missing-file-path and missing importer/exporter validation to generic item import/export before authorization or workflow work.
- Honored cancellation before generic importer parsing, after importer parsing before database work, before CSV parser/database work, and before item-number/duplicate-check SQL setup.
- Extended item import/export source-contract coverage while preserving the existing CSV quantity-range and import transaction coverage.
- Added a progress note for the completed item import/export guard slice.

## Why this was the highest-value next step

Recent merged work focused heavily on result caps and service hardening. Current source evidence showed the item import/export entrypoints were less defensive than the parallel customer workflows, and item-number/duplicate helper paths accepted cancellation tokens without checking them before SQL/connection setup. This made item import/export validation and cancellation a concrete persistence/workflow reliability improvement before lower-priority UI polish or speculative features.

## Why this is real workflow progress

This is a complete item import/export guard slice across service entrypoints, helper cancellation behavior, source-contract coverage, and progress notes. It improves operator-facing import/export failure clarity and reduces avoidable file/database work rather than making a tiny isolated assertion or cosmetic edit.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to `ItemService`, `ItemServiceImportTransactionTests`, and one progress note.
- Connector readback confirmed CSV item import validates `filePath` and `map` before `_auth.EnsurePermission(...)` and import work.
- Connector readback confirmed CSV item export validates `filePath` before `_auth.EnsurePermission(...)` and export work.
- Connector readback confirmed generic item import/export validate `filePath` plus `importer`/`exporter` before `_auth.EnsurePermission(...)` and workflow work.
- Connector readback confirmed `GenerateNextItemNumberAsync`, `ItemExistsAsync`, CSV import, and generic import/export now honor cancellation before the targeted file/database/SQL setup points.
- Connector readback confirmed source-contract coverage was added for the new guard ordering and adjusted to accept both `const string sql` and `var sql` declarations.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- Direct raw GitHub reads through the container are also blocked by HTTP 403 responses.
- Local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Consider a future streaming item export path if large inventories make the existing all-items export memory load too heavy.