### PR TITLE
Capture package audit validation logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,11 @@ jobs:
       run: dotnet restore InventoryManagementApp.sln -bl:./ValidationLogs/restore.binlog
 
     - name: Audit vulnerable packages
-      run: dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive
+      shell: pwsh
+      run: |
+        $auditLogPath = "./ValidationLogs/package-audit.txt"
+        dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive 2>&1 | Tee-Object -FilePath $auditLogPath
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Build
       run: dotnet build InventoryManagementApp.sln --configuration Release --no-restore -bl:./ValidationLogs/build.binlog

--- a/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
@@ -72,7 +72,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }", source);
             AssertAppearsBefore(source, "Prepare validation logs", "Audit vulnerable packages", "The workflow should write the package audit log into a freshly prepared diagnostics directory.");
             AssertAppearsBefore(source, "Restore dependencies", "Audit vulnerable packages", "CI package audit should run after restore resolves the solution graph.");
-            AssertAppearsBefore(source, "Audit vulnerable packages", "Build", "Package advisory evidence should be captured before build can fail.");
+            AssertAppearsBefore(source, "Audit vulnerable packages", "    - name: Build", "Package advisory evidence should be captured before build can fail.");
             AssertAppearsBefore(source, "Audit vulnerable packages", "Upload validation logs", "The package audit file should be included in the validation log artifact.");
         }
 

--- a/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
@@ -26,6 +26,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void FullValidationRunnerCapturesPackageAuditDiagnosticsBeforeBuild()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("Audit vulnerable packages", source);
+            Assert.Contains("Get-ValidationLogPath \"package-audit.txt\"", source);
+            Assert.Contains("dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive 2>&1 | Tee-Object -FilePath $auditLogPath", source);
+            Assert.Contains("$global:LASTEXITCODE = $LASTEXITCODE", source);
+            AssertAppearsBefore(source, "Clean validation logs", "Audit vulnerable packages", "The package audit log should be written into a freshly prepared validation log directory.");
+            AssertAppearsBefore(source, "Restore solution", "Audit vulnerable packages", "The package audit should run after restore resolves the solution graph.");
+            AssertAppearsBefore(source, "Audit vulnerable packages", "Build solution", "Package advisory evidence should be captured before build can fail.");
+        }
+
+        [Fact]
         public void BuildWorkflowCapturesEnvironmentDiagnosticsBeforeRestore()
         {
             var source = ReadRepoFile(".github", "workflows", "build.yml");
@@ -44,6 +58,22 @@ namespace InventoryManagementApp.Tests
             AssertAppearsBefore(source, "Prepare validation logs", "Capture validation environment", "The workflow should create a fresh diagnostics directory before writing environment details.");
             AssertAppearsBefore(source, "Capture validation environment", "Restore dependencies", "CI environment diagnostics should be captured before restore can fail.");
             AssertAppearsBefore(source, "Capture validation environment", "Upload validation logs", "The environment diagnostics file should be included in the validation log artifact.");
+        }
+
+        [Fact]
+        public void BuildWorkflowCapturesPackageAuditDiagnosticsBeforeBuild()
+        {
+            var source = ReadRepoFile(".github", "workflows", "build.yml");
+
+            Assert.Contains("Audit vulnerable packages", source);
+            Assert.Contains("shell: pwsh", source);
+            Assert.Contains("./ValidationLogs/package-audit.txt", source);
+            Assert.Contains("dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive 2>&1 | Tee-Object -FilePath $auditLogPath", source);
+            Assert.Contains("if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }", source);
+            AssertAppearsBefore(source, "Prepare validation logs", "Audit vulnerable packages", "The workflow should write the package audit log into a freshly prepared diagnostics directory.");
+            AssertAppearsBefore(source, "Restore dependencies", "Audit vulnerable packages", "CI package audit should run after restore resolves the solution graph.");
+            AssertAppearsBefore(source, "Audit vulnerable packages", "Build", "Package advisory evidence should be captured before build can fail.");
+            AssertAppearsBefore(source, "Audit vulnerable packages", "Upload validation logs", "The package audit file should be included in the validation log artifact.");
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-package-audit-validation-log.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-package-audit-validation-log.md
@@ -1,0 +1,14 @@
+# Package Audit Validation Log
+
+## Completed
+- The local full-validation runner now writes vulnerable-package audit output to `ValidationLogs/package-audit.txt` while preserving the `dotnet list package --vulnerable --include-transitive` exit code.
+- The Windows Build and Test workflow now writes the same `./ValidationLogs/package-audit.txt` file and includes it in the existing validation log artifact upload.
+- Source-contract coverage now guards local and CI package audit log capture, ordering after restore, ordering before build, and inclusion in uploaded validation logs.
+
+## Why
+`ToDo.md` calls out reviewing the dedicated vulnerable-package audit output as a current validation priority. Capturing that output as a durable validation artifact makes the next Windows/.NET-capable run easier to audit, especially when restore/build/test/publish failures interrupt the console log review.
+
+## Validation
+- Connector readback/compare should confirm the runner and CI workflow both tee package audit output into `ValidationLogs/package-audit.txt`.
+- Connector readback/compare should confirm `ValidationDiagnosticsContractTests` covers the local runner and CI workflow contracts.
+- Local .NET validation still needs to run from a Windows/.NET-capable checkout because direct checkout and local .NET execution are unavailable in this scheduled environment.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -78,7 +78,9 @@ try {
     }
 
     Invoke-ValidationStep "Audit vulnerable packages" {
-        dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive
+        $auditLogPath = Get-ValidationLogPath "package-audit.txt"
+        dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive 2>&1 | Tee-Object -FilePath $auditLogPath
+        $global:LASTEXITCODE = $LASTEXITCODE
     }
 
     Invoke-ValidationStep "Build solution" {


### PR DESCRIPTION
## What changed

- Updated `scripts/run-full-validation.ps1` so the vulnerable-package audit writes `ValidationLogs/package-audit.txt` while preserving the audit command exit code.
- Updated the Windows Build and Test workflow so CI writes the same `./ValidationLogs/package-audit.txt` file and includes it in the existing validation log artifact upload.
- Extended `ValidationDiagnosticsContractTests` to guard local and CI package-audit log capture, restore-before-audit ordering, audit-before-build ordering, and validation-log artifact inclusion.
- Added a progress note for the completed validation evidence slice.

## Why this was the highest-value next step

Current `ToDo.md` identifies rerunning full validation and reviewing the vulnerable-package audit output as the top cleanup priority. The audit previously appeared only in command output, which makes advisory review easier to lose when restore/build/test/publish failures interrupt a run. Capturing it as a durable validation artifact improves the next Windows/.NET-capable validation workflow without adding unrelated product scope.

## Why this is real workflow progress

This is a complete validation-evidence slice across the local runner, CI workflow, source-contract coverage, and progress notes. It improves the reliability and auditability of the full validation workflow rather than changing one isolated assertion or making cosmetic edits.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 focused commits, and limited to the validation runner, Build and Test workflow, validation diagnostics contract tests, and one progress note.
- Connector readback confirmed the local runner tees `dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive` output into `ValidationLogs/package-audit.txt` after restore and before build.
- Connector readback confirmed the Windows workflow tees the same audit output into `./ValidationLogs/package-audit.txt` and preserves non-zero audit exit codes.
- Connector readback confirmed source-contract coverage guards the runner and workflow audit log contract, including artifact upload ordering.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- Direct raw GitHub reads through the container are also blocked by HTTP 403 responses.
- Local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and review `ValidationLogs/package-audit.txt` alongside any NU190x warnings.
- Confirm the Build and Test workflow uploads `package-audit.txt` in the `validation-msbuild-logs` artifact on the next PR/push run.