### PR TITLE
Add validation artifact manifest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,33 @@ jobs:
         path: ./publish/
         retention-days: 7
 
+    - name: Summarize validation artifacts
+      if: always()
+      shell: pwsh
+      run: |
+        if (-not (Test-Path ./ValidationLogs)) { return }
+
+        $manifestPath = "./ValidationLogs/artifact-manifest.txt"
+        $artifacts = Get-ChildItem -Path ./ValidationLogs -File |
+          Where-Object { $_.Name -ne "artifact-manifest.txt" } |
+          Sort-Object Name
+
+        $lines = @(
+          "GeneratedAtUtc=$((Get-Date).ToUniversalTime().ToString('o'))",
+          "ValidationLogRoot=./ValidationLogs",
+          "ArtifactCount=$($artifacts.Count)",
+          ""
+        )
+
+        foreach ($artifact in $artifacts) {
+          $lines += "Artifact=$($artifact.Name)"
+          $lines += "SizeBytes=$($artifact.Length)"
+          $lines += "LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))"
+          $lines += ""
+        }
+
+        $lines | Set-Content -Path $manifestPath -Encoding UTF8
+
     - name: Upload validation logs
       if: always()
       uses: actions/upload-artifact@v4

--- a/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
@@ -40,6 +40,22 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void FullValidationRunnerWritesArtifactManifestDuringCleanup()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("Write-ValidationArtifactManifest", source);
+            Assert.Contains("Get-ValidationLogPath \"artifact-manifest.txt\"", source);
+            Assert.Contains("ArtifactCount=$($artifacts.Count)", source);
+            Assert.Contains("Artifact=$($artifact.Name)", source);
+            Assert.Contains("SizeBytes=$($artifact.Length)", source);
+            Assert.Contains("LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))", source);
+            Assert.Contains("Write-Warning \"Unable to write validation artifact manifest: $($_.Exception.Message)\"", source);
+            AssertAppearsBefore(source, "function Write-ValidationArtifactManifest", "try {", "The manifest helper should be available before validation steps run.");
+            AssertAppearsBefore(source, "finally {\n    try {\n        Write-ValidationArtifactManifest", "Pop-Location", "The manifest should be written before leaving the repository root.");
+        }
+
+        [Fact]
         public void BuildWorkflowCapturesEnvironmentDiagnosticsBeforeRestore()
         {
             var source = ReadRepoFile(".github", "workflows", "build.yml");
@@ -74,6 +90,22 @@ namespace InventoryManagementApp.Tests
             AssertAppearsBefore(source, "Restore dependencies", "Audit vulnerable packages", "CI package audit should run after restore resolves the solution graph.");
             AssertAppearsBefore(source, "Audit vulnerable packages", "    - name: Build", "Package advisory evidence should be captured before build can fail.");
             AssertAppearsBefore(source, "Audit vulnerable packages", "Upload validation logs", "The package audit file should be included in the validation log artifact.");
+        }
+
+        [Fact]
+        public void BuildWorkflowUploadsArtifactManifestWithValidationLogs()
+        {
+            var source = ReadRepoFile(".github", "workflows", "build.yml");
+
+            Assert.Contains("Summarize validation artifacts", source);
+            Assert.Contains("if: always()", source);
+            Assert.Contains("./ValidationLogs/artifact-manifest.txt", source);
+            Assert.Contains("ArtifactCount=$($artifacts.Count)", source);
+            Assert.Contains("Artifact=$($artifact.Name)", source);
+            Assert.Contains("SizeBytes=$($artifact.Length)", source);
+            Assert.Contains("LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))", source);
+            AssertAppearsBefore(source, "Upload build artifacts", "Summarize validation artifacts", "The manifest should summarize all validation files created by earlier workflow steps.");
+            AssertAppearsBefore(source, "Summarize validation artifacts", "Upload validation logs", "The manifest should be written before the validation log artifact is uploaded.");
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-validation-artifact-manifest.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-validation-artifact-manifest.md
@@ -1,0 +1,15 @@
+# Validation Artifact Manifest
+
+## Completed
+- The local full-validation runner now writes `ValidationLogs/artifact-manifest.txt` during cleanup so completed and partial runs leave an index of produced diagnostics.
+- The Windows Build and Test workflow now writes the same manifest with `if: always()` immediately before uploading validation logs.
+- Source-contract coverage now guards manifest content markers, cleanup-time runner generation, and CI upload ordering.
+
+## Why
+Validation now produces environment diagnostics, vulnerable-package audit output, MSBuild binary logs, and test results. A manifest makes failed runs easier to triage because operators can quickly see which diagnostics were produced before opening individual artifacts.
+
+## Validation
+- Connector readback/compare should confirm the runner writes the manifest in `finally` before leaving the repository root.
+- Connector readback/compare should confirm CI writes the manifest before uploading `ValidationLogs/`.
+- Connector readback/compare should confirm `ValidationDiagnosticsContractTests` covers the manifest contract.
+- Local .NET validation still needs to run from a Windows/.NET-capable checkout because direct checkout and local .NET execution are unavailable in this scheduled environment.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -35,6 +35,33 @@ function Get-ValidationLogPath {
     return Join-Path $validationLogsPath $Name
 }
 
+function Write-ValidationArtifactManifest {
+    if (-not (Test-Path $validationLogsPath -PathType Container)) {
+        return
+    }
+
+    $manifestPath = Get-ValidationLogPath "artifact-manifest.txt"
+    $artifacts = Get-ChildItem -Path $validationLogsPath -File |
+        Where-Object { $_.Name -ne "artifact-manifest.txt" } |
+        Sort-Object Name
+
+    $lines = @(
+        "GeneratedAtUtc=$((Get-Date).ToUniversalTime().ToString('o'))",
+        "ValidationLogRoot=$validationLogsPath",
+        "ArtifactCount=$($artifacts.Count)",
+        ""
+    )
+
+    foreach ($artifact in $artifacts) {
+        $lines += "Artifact=$($artifact.Name)"
+        $lines += "SizeBytes=$($artifact.Length)"
+        $lines += "LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))"
+        $lines += ""
+    }
+
+    $lines | Set-Content -Path $manifestPath -Encoding UTF8
+}
+
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $publishOutputPath = Join-Path $repoRoot "publish"
 $testResultsPath = Join-Path $repoRoot "TestResults"
@@ -156,5 +183,12 @@ try {
     }
 }
 finally {
+    try {
+        Write-ValidationArtifactManifest
+    }
+    catch {
+        Write-Warning "Unable to write validation artifact manifest: $($_.Exception.Message)"
+    }
+
     Pop-Location
 }


### PR DESCRIPTION
## What changed

- Updated `scripts/run-full-validation.ps1` so local full validation writes `ValidationLogs/artifact-manifest.txt` during cleanup, including generated time, log root, artifact count, artifact names, sizes, and timestamps.
- Updated the Windows Build and Test workflow so CI writes the same manifest with `if: always()` immediately before uploading `ValidationLogs/`.
- Extended `ValidationDiagnosticsContractTests` to guard the local cleanup-time manifest contract and the CI upload ordering.
- Added a progress note for the completed validation diagnostics workflow slice.

## Why this was the highest-value next step

Recent work made validation produce durable environment diagnostics, package-audit output, MSBuild binary logs, and test result artifacts. The next practical reliability gap was discoverability: when validation fails partway through, operators need a quick index of which diagnostics were actually produced before opening individual artifacts. This improves the active validation workflow without inventing unrelated product scope.

## Why this is real workflow progress

This is a complete validation-diagnostics slice across the local runner, CI workflow, source-contract coverage, and project notes. It improves failed-run triage and artifact review instead of making a tiny isolated assertion or cosmetic edit.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to the runner, Build and Test workflow, validation diagnostics tests, and one progress note.
- Connector readback confirmed the local runner writes `artifact-manifest.txt` from `finally` before leaving the repository root.
- Connector readback confirmed the CI workflow writes `./ValidationLogs/artifact-manifest.txt` in an `if: always()` step before uploading validation logs.
- Connector readback confirmed source-contract coverage guards manifest content markers, runner cleanup ordering, and CI upload ordering.
- Local text checks confirmed the expected manifest markers exist in the prepared files before connector update.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `pwsh` and `dotnet` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and full validation could not be run.
- GitHub Actions logs could not be inspected because `gh` is unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and confirm `ValidationLogs/artifact-manifest.txt` appears in both successful and failed/partial runs.
- Confirm the next Build and Test workflow upload includes `artifact-manifest.txt` in the `validation-msbuild-logs` artifact.