### PR TITLE
Add validation step summary diagnostics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,17 +17,20 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup .NET
+      id: setup_dotnet
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
 
     - name: Prepare validation logs
+      id: prepare_validation_logs
       shell: pwsh
       run: |
         if (Test-Path ./ValidationLogs) { Remove-Item ./ValidationLogs -Recurse -Force }
         New-Item -ItemType Directory -Path ./ValidationLogs | Out-Null
 
     - name: Capture validation environment
+      id: capture_validation_environment
       shell: pwsh
       run: |
         $environmentLogPath = "./ValidationLogs/environment.txt"
@@ -47,9 +50,11 @@ jobs:
         dotnet --info | Out-File -FilePath $environmentLogPath -Append -Encoding UTF8
 
     - name: Restore dependencies
+      id: restore_dependencies
       run: dotnet restore InventoryManagementApp.sln -bl:./ValidationLogs/restore.binlog
 
     - name: Audit vulnerable packages
+      id: audit_vulnerable_packages
       shell: pwsh
       run: |
         $auditLogPath = "./ValidationLogs/package-audit.txt"
@@ -57,18 +62,22 @@ jobs:
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Build
+      id: build_solution
       run: dotnet build InventoryManagementApp.sln --configuration Release --no-restore -bl:./ValidationLogs/build.binlog
 
     - name: Prepare test results
+      id: prepare_test_results
       shell: pwsh
       run: |
         if (Test-Path ./TestResults) { Remove-Item ./TestResults -Recurse -Force }
         New-Item -ItemType Directory -Path ./TestResults | Out-Null
 
     - name: Test
+      id: test_solution
       run: dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=validation-tests.trx" --results-directory ./TestResults
 
     - name: Upload test results
+      id: upload_test_results
       if: always()
       uses: actions/upload-artifact@v4
       with:
@@ -78,16 +87,20 @@ jobs:
         if-no-files-found: ignore
 
     - name: Restore publish runtime
+      id: restore_publish_runtime
       run: dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64 -bl:./ValidationLogs/publish-restore.binlog
 
     - name: Clean publish output
+      id: clean_publish_output
       shell: pwsh
       run: if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }
 
     - name: Publish
+      id: publish_app
       run: dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish -bl:./ValidationLogs/publish.binlog
 
     - name: Verify publish artifacts
+      id: verify_publish_artifacts
       shell: pwsh
       run: |
         $requiredPublishArtifacts = @(
@@ -103,14 +116,17 @@ jobs:
         }
 
     - name: Check banned words
+      id: check_banned_words
       shell: bash
       run: bash scripts/check-banned-words.sh
 
     - name: Check banned words PowerShell fallback
+      id: check_banned_words_powershell_fallback
       shell: bash
       run: BANNED_WORD_CHECK_FORCE_POWERSHELL=1 bash scripts/check-banned-words.sh
 
     - name: Upload build artifacts
+      id: upload_build_artifacts
       uses: actions/upload-artifact@v4
       with:
         name: inventory-management-app
@@ -122,6 +138,41 @@ jobs:
       shell: pwsh
       run: |
         if (-not (Test-Path ./ValidationLogs)) { return }
+
+        $summaryPath = "./ValidationLogs/step-summary.txt"
+        $steps = @(
+          @{ Name = "Setup .NET"; Outcome = "${{ steps.setup_dotnet.outcome }}"; Conclusion = "${{ steps.setup_dotnet.conclusion }}" },
+          @{ Name = "Prepare validation logs"; Outcome = "${{ steps.prepare_validation_logs.outcome }}"; Conclusion = "${{ steps.prepare_validation_logs.conclusion }}" },
+          @{ Name = "Capture validation environment"; Outcome = "${{ steps.capture_validation_environment.outcome }}"; Conclusion = "${{ steps.capture_validation_environment.conclusion }}" },
+          @{ Name = "Restore dependencies"; Outcome = "${{ steps.restore_dependencies.outcome }}"; Conclusion = "${{ steps.restore_dependencies.conclusion }}" },
+          @{ Name = "Audit vulnerable packages"; Outcome = "${{ steps.audit_vulnerable_packages.outcome }}"; Conclusion = "${{ steps.audit_vulnerable_packages.conclusion }}" },
+          @{ Name = "Build"; Outcome = "${{ steps.build_solution.outcome }}"; Conclusion = "${{ steps.build_solution.conclusion }}" },
+          @{ Name = "Prepare test results"; Outcome = "${{ steps.prepare_test_results.outcome }}"; Conclusion = "${{ steps.prepare_test_results.conclusion }}" },
+          @{ Name = "Test"; Outcome = "${{ steps.test_solution.outcome }}"; Conclusion = "${{ steps.test_solution.conclusion }}" },
+          @{ Name = "Upload test results"; Outcome = "${{ steps.upload_test_results.outcome }}"; Conclusion = "${{ steps.upload_test_results.conclusion }}" },
+          @{ Name = "Restore publish runtime"; Outcome = "${{ steps.restore_publish_runtime.outcome }}"; Conclusion = "${{ steps.restore_publish_runtime.conclusion }}" },
+          @{ Name = "Clean publish output"; Outcome = "${{ steps.clean_publish_output.outcome }}"; Conclusion = "${{ steps.clean_publish_output.conclusion }}" },
+          @{ Name = "Publish"; Outcome = "${{ steps.publish_app.outcome }}"; Conclusion = "${{ steps.publish_app.conclusion }}" },
+          @{ Name = "Verify publish artifacts"; Outcome = "${{ steps.verify_publish_artifacts.outcome }}"; Conclusion = "${{ steps.verify_publish_artifacts.conclusion }}" },
+          @{ Name = "Check banned words"; Outcome = "${{ steps.check_banned_words.outcome }}"; Conclusion = "${{ steps.check_banned_words.conclusion }}" },
+          @{ Name = "Check banned words PowerShell fallback"; Outcome = "${{ steps.check_banned_words_powershell_fallback.outcome }}"; Conclusion = "${{ steps.check_banned_words_powershell_fallback.conclusion }}" },
+          @{ Name = "Upload build artifacts"; Outcome = "${{ steps.upload_build_artifacts.outcome }}"; Conclusion = "${{ steps.upload_build_artifacts.conclusion }}" }
+        )
+
+        $summaryLines = @(
+          "GeneratedAtUtc=$((Get-Date).ToUniversalTime().ToString('o'))",
+          "ValidationStepSummary=1",
+          ""
+        )
+
+        foreach ($step in $steps) {
+          $summaryLines += "Step=$($step.Name)"
+          $summaryLines += "Status=$($step.Outcome)"
+          $summaryLines += "Conclusion=$($step.Conclusion)"
+          $summaryLines += ""
+        }
+
+        $summaryLines | Set-Content -Path $summaryPath -Encoding UTF8
 
         $manifestPath = "./ValidationLogs/artifact-manifest.txt"
         $artifacts = Get-ChildItem -Path ./ValidationLogs -File |

--- a/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
@@ -40,6 +40,25 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void FullValidationRunnerWritesStepSummaryForSucceededAndFailedSteps()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("Write-ValidationStepSummary", source);
+            Assert.Contains("Get-ValidationLogPath \"step-summary.txt\"", source);
+            Assert.Contains("ValidationStepSummary=1", source);
+            Assert.Contains("Step=$Name", source);
+            Assert.Contains("Status=$Status", source);
+            Assert.Contains("DurationSeconds=$durationText", source);
+            Assert.Contains("Detail=$Detail", source);
+            Assert.Contains("Write-ValidationStepSummary -Name $Name -Status \"Succeeded\" -DurationSeconds $durationSeconds", source);
+            Assert.Contains("Write-ValidationStepSummary -Name $Name -Status \"Failed\" -DurationSeconds $durationSeconds -Detail $_.Exception.Message", source);
+            Assert.Contains("Write-Warning \"Unable to write validation step summary: $($_.Exception.Message)\"", source);
+            AssertAppearsBefore(source, "Write-ValidationStepSummary -Name $Name -Status \"Succeeded\"", "function Write-ValidationArtifactManifest", "The runner should record each successful validation step before the final manifest is generated.");
+            AssertAppearsBefore(source, "Write-ValidationStepSummary -Name $Name -Status \"Failed\"", "throw\n    }", "The runner should record failed validation steps before rethrowing the original failure.");
+        }
+
+        [Fact]
         public void FullValidationRunnerWritesArtifactManifestDuringCleanup()
         {
             var source = ReadRepoFile("scripts", "run-full-validation.ps1");
@@ -51,7 +70,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("SizeBytes=$($artifact.Length)", source);
             Assert.Contains("LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))", source);
             Assert.Contains("Write-Warning \"Unable to write validation artifact manifest: $($_.Exception.Message)\"", source);
-            AssertAppearsBefore(source, "function Write-ValidationArtifactManifest", "try {", "The manifest helper should be available before validation steps run.");
+            AssertAppearsBefore(source, "function Write-ValidationArtifactManifest", "$repoRoot = Resolve-Path", "The manifest helper should be available before validation steps run.");
             AssertAppearsBefore(source, "finally {\n    try {\n        Write-ValidationArtifactManifest", "Pop-Location", "The manifest should be written before leaving the repository root.");
         }
 
@@ -90,6 +109,28 @@ namespace InventoryManagementApp.Tests
             AssertAppearsBefore(source, "Restore dependencies", "Audit vulnerable packages", "CI package audit should run after restore resolves the solution graph.");
             AssertAppearsBefore(source, "Audit vulnerable packages", "    - name: Build", "Package advisory evidence should be captured before build can fail.");
             AssertAppearsBefore(source, "Audit vulnerable packages", "Upload validation logs", "The package audit file should be included in the validation log artifact.");
+        }
+
+        [Fact]
+        public void BuildWorkflowWritesStepSummaryBeforeArtifactManifest()
+        {
+            var source = ReadRepoFile(".github", "workflows", "build.yml");
+
+            Assert.Contains("id: setup_dotnet", source);
+            Assert.Contains("id: restore_dependencies", source);
+            Assert.Contains("id: test_solution", source);
+            Assert.Contains("id: upload_build_artifacts", source);
+            Assert.Contains("./ValidationLogs/step-summary.txt", source);
+            Assert.Contains("ValidationStepSummary=1", source);
+            Assert.Contains("Step=$($step.Name)", source);
+            Assert.Contains("Status=$($step.Outcome)", source);
+            Assert.Contains("Conclusion=$($step.Conclusion)", source);
+            Assert.Contains("${{ steps.restore_dependencies.outcome }}", source);
+            Assert.Contains("${{ steps.restore_dependencies.conclusion }}", source);
+            Assert.Contains("${{ steps.upload_build_artifacts.outcome }}", source);
+            Assert.Contains("${{ steps.upload_build_artifacts.conclusion }}", source);
+            AssertAppearsBefore(source, "$summaryLines | Set-Content -Path $summaryPath -Encoding UTF8", "$manifestPath = \"./ValidationLogs/artifact-manifest.txt\"", "CI should write the step summary before building the artifact manifest so the manifest indexes it.");
+            AssertAppearsBefore(source, "./ValidationLogs/step-summary.txt", "Upload validation logs", "The CI step summary should be included in uploaded validation logs.");
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-validation-step-summary.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-validation-step-summary.md
@@ -1,0 +1,16 @@
+# Validation Step Summary
+
+## Completed
+- The local full-validation runner now writes `ValidationLogs/step-summary.txt` as named validation steps succeed or fail, including status, elapsed seconds, and failure detail when available.
+- The Windows Build and Test workflow now assigns stable IDs to validation steps and writes the same `./ValidationLogs/step-summary.txt` from GitHub step outcomes before creating the artifact manifest.
+- The artifact manifest now indexes `step-summary.txt` because CI writes the summary before summarizing validation artifacts.
+- Source-contract coverage now guards local runner step-summary logging, CI outcome capture, and ordering before validation-log upload.
+
+## Why
+The validation workflow is the current release blocker, and recent work made individual diagnostics durable. A compact step summary makes failed or partial runs easier to triage because operators can quickly see which phase failed or was skipped before opening larger logs and binary build artifacts.
+
+## Validation
+- Connector readback/compare should confirm the runner writes `step-summary.txt` for successful and failed named steps.
+- Connector readback/compare should confirm CI writes `step-summary.txt` from stable step IDs before `artifact-manifest.txt` and before uploading `ValidationLogs/`.
+- Connector readback/compare should confirm `ValidationDiagnosticsContractTests` covers the step-summary contract.
+- Local .NET validation still needs to run from a Windows/.NET-capable checkout because direct checkout and local .NET execution are unavailable in this scheduled environment.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -17,12 +17,24 @@ function Invoke-ValidationStep {
 
     Write-Host ""
     Write-Host "==> $Name"
+    $startedAt = Get-Date
     $global:LASTEXITCODE = 0
-    & $Action
 
-    $exitCode = $global:LASTEXITCODE
-    if ($null -ne $exitCode -and $exitCode -ne 0) {
-        throw "$Name failed with exit code $exitCode."
+    try {
+        & $Action
+
+        $exitCode = $global:LASTEXITCODE
+        if ($null -ne $exitCode -and $exitCode -ne 0) {
+            throw "$Name failed with exit code $exitCode."
+        }
+
+        $durationSeconds = ((Get-Date) - $startedAt).TotalSeconds
+        Write-ValidationStepSummary -Name $Name -Status "Succeeded" -DurationSeconds $durationSeconds
+    }
+    catch {
+        $durationSeconds = ((Get-Date) - $startedAt).TotalSeconds
+        Write-ValidationStepSummary -Name $Name -Status "Failed" -DurationSeconds $durationSeconds -Detail $_.Exception.Message
+        throw
     }
 }
 
@@ -33,6 +45,53 @@ function Get-ValidationLogPath {
     )
 
     return Join-Path $validationLogsPath $Name
+}
+
+function Write-ValidationStepSummary {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Status,
+
+        [Parameter(Mandatory = $true)]
+        [double]$DurationSeconds,
+
+        [string]$Detail = ""
+    )
+
+    try {
+        if ([string]::IsNullOrWhiteSpace($validationLogsPath) -or -not (Test-Path $validationLogsPath -PathType Container)) {
+            return
+        }
+
+        $summaryPath = Get-ValidationLogPath "step-summary.txt"
+        if (-not (Test-Path $summaryPath -PathType Leaf)) {
+            @(
+                "GeneratedAtUtc=$((Get-Date).ToUniversalTime().ToString('o'))",
+                "ValidationStepSummary=1",
+                ""
+            ) | Set-Content -Path $summaryPath -Encoding UTF8
+        }
+
+        $durationText = $DurationSeconds.ToString('0.###', [System.Globalization.CultureInfo]::InvariantCulture)
+        $lines = @(
+            "Step=$Name",
+            "Status=$Status",
+            "DurationSeconds=$durationText"
+        )
+
+        if (-not [string]::IsNullOrWhiteSpace($Detail)) {
+            $lines += "Detail=$Detail"
+        }
+
+        $lines += ""
+        $lines | Add-Content -Path $summaryPath -Encoding UTF8
+    }
+    catch {
+        Write-Warning "Unable to write validation step summary: $($_.Exception.Message)"
+    }
 }
 
 function Write-ValidationArtifactManifest {


### PR DESCRIPTION
## What changed

- Updated `scripts/run-full-validation.ps1` so each named validation step appends to `ValidationLogs/step-summary.txt` when it succeeds or fails, including elapsed seconds and failure detail when available.
- Updated the Windows Build and Test workflow with stable step IDs and a final `if: always()` summary that writes `./ValidationLogs/step-summary.txt` from GitHub step outcomes.
- Kept CI artifact-manifest generation after the step summary so `artifact-manifest.txt` indexes `step-summary.txt` before `ValidationLogs/` is uploaded.
- Extended `ValidationDiagnosticsContractTests` to guard the local runner and CI step-summary contracts.
- Added a progress note for the completed validation diagnostics slice.

## Why this was the highest-value next step

`ToDo.md` still identifies full validation as the current release blocker, and recent work made validation logs, package audit output, binlogs, test results, and artifact manifests durable. The remaining triage gap was a compact phase-by-phase status trail for failed or partial runs, so operators can quickly see which validation phase failed or was skipped before opening larger logs.

## Why this is real workflow progress

This is a complete validation-diagnostics workflow slice across the local runner, CI workflow, source-contract coverage, and project notes. It improves failed-run triage end to end rather than changing one isolated assertion or adding cosmetic logging.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to the validation runner, Build and Test workflow, validation diagnostics tests, and one progress note.
- Connector readback confirmed the local runner writes `ValidationLogs/step-summary.txt` for successful and failed named steps and preserves the original failure by rethrowing.
- Connector readback confirmed the CI workflow assigns stable step IDs, writes `./ValidationLogs/step-summary.txt` from step outcomes, writes the artifact manifest afterward, and uploads `ValidationLogs/` with `if: always()`.
- Connector readback confirmed source-contract coverage guards the runner and CI step-summary behavior.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, GitHub Actions log inspection, and full validation could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and confirm `ValidationLogs/step-summary.txt` records both successful steps and the failing step when validation is interrupted.
- Confirm the next Build and Test workflow upload includes `step-summary.txt` in the `validation-msbuild-logs` artifact and that `artifact-manifest.txt` indexes it.