### PR TITLE
Group validation artifact manifest entries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,64 @@ jobs:
       run: |
         if (-not (Test-Path ./ValidationLogs)) { return }
 
+        function Get-ArtifactRelativePath {
+          param(
+            [Parameter(Mandatory = $true)]
+            [string]$RootPath,
+
+            [Parameter(Mandatory = $true)]
+            [string]$ArtifactPath
+          )
+
+          $resolvedRoot = (Resolve-Path $RootPath).Path.TrimEnd([char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar))
+          return $ArtifactPath.Substring($resolvedRoot.Length).TrimStart([char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar))
+        }
+
+        function Add-ValidationArtifactGroup {
+          param(
+            [Parameter(Mandatory = $true)]
+            [string[]]$Lines,
+
+            [Parameter(Mandatory = $true)]
+            [string]$GroupName,
+
+            [Parameter(Mandatory = $true)]
+            [string]$RootPath,
+
+            [string[]]$ExcludedNames = @()
+          )
+
+          $Lines += "ArtifactGroup=$GroupName"
+          $Lines += "ArtifactRoot=$RootPath"
+
+          if (-not (Test-Path $RootPath -PathType Container)) {
+            $Lines += "ArtifactGroupMissing=True"
+            $Lines += "ArtifactCount=0"
+            $Lines += ""
+            return $Lines
+          }
+
+          $artifacts = Get-ChildItem -Path $RootPath -File -Recurse |
+            Where-Object { $ExcludedNames -notcontains $_.Name } |
+            Sort-Object FullName
+
+          $Lines += "ArtifactCount=$($artifacts.Count)"
+
+          foreach ($artifact in $artifacts) {
+            $relativePath = Get-ArtifactRelativePath -RootPath $RootPath -ArtifactPath $artifact.FullName
+            $Lines += "Artifact=$relativePath"
+            $Lines += "SizeBytes=$($artifact.Length)"
+            $Lines += "LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))"
+            $Lines += ""
+          }
+
+          if ($artifacts.Count -eq 0) {
+            $Lines += ""
+          }
+
+          return $Lines
+        }
+
         $summaryPath = "./ValidationLogs/step-summary.txt"
         $steps = @(
           @{ Name = "Setup .NET"; Outcome = "${{ steps.setup_dotnet.outcome }}"; Conclusion = "${{ steps.setup_dotnet.conclusion }}" },
@@ -175,22 +233,22 @@ jobs:
         $summaryLines | Set-Content -Path $summaryPath -Encoding UTF8
 
         $manifestPath = "./ValidationLogs/artifact-manifest.txt"
-        $artifacts = Get-ChildItem -Path ./ValidationLogs -File |
-          Where-Object { $_.Name -ne "artifact-manifest.txt" } |
-          Sort-Object Name
+        $artifactGroups = @(
+          @{ Name = "ValidationLogs"; Root = "./ValidationLogs"; ExcludedNames = @("artifact-manifest.txt") },
+          @{ Name = "TestResults"; Root = "./TestResults"; ExcludedNames = @() },
+          @{ Name = "PublishOutput"; Root = "./publish"; ExcludedNames = @() }
+        )
 
         $lines = @(
           "GeneratedAtUtc=$((Get-Date).ToUniversalTime().ToString('o'))",
+          "ValidationArtifactManifest=2",
           "ValidationLogRoot=./ValidationLogs",
-          "ArtifactCount=$($artifacts.Count)",
+          "ArtifactGroupCount=$($artifactGroups.Count)",
           ""
         )
 
-        foreach ($artifact in $artifacts) {
-          $lines += "Artifact=$($artifact.Name)"
-          $lines += "SizeBytes=$($artifact.Length)"
-          $lines += "LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))"
-          $lines += ""
+        foreach ($group in $artifactGroups) {
+          $lines = Add-ValidationArtifactGroup -Lines $lines -GroupName $group.Name -RootPath $group.Root -ExcludedNames $group.ExcludedNames
         }
 
         $lines | Set-Content -Path $manifestPath -Encoding UTF8

--- a/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
@@ -65,13 +65,34 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("Write-ValidationArtifactManifest", source);
             Assert.Contains("Get-ValidationLogPath \"artifact-manifest.txt\"", source);
+            Assert.Contains("ValidationArtifactManifest=2", source);
+            Assert.Contains("ArtifactGroupCount=$($artifactGroups.Count)", source);
             Assert.Contains("ArtifactCount=$($artifacts.Count)", source);
-            Assert.Contains("Artifact=$($artifact.Name)", source);
+            Assert.Contains("Artifact=$relativePath", source);
             Assert.Contains("SizeBytes=$($artifact.Length)", source);
             Assert.Contains("LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))", source);
             Assert.Contains("Write-Warning \"Unable to write validation artifact manifest: $($_.Exception.Message)\"", source);
             AssertAppearsBefore(source, "function Write-ValidationArtifactManifest", "$repoRoot = Resolve-Path", "The manifest helper should be available before validation steps run.");
             AssertAppearsBefore(source, "finally {\n    try {\n        Write-ValidationArtifactManifest", "Pop-Location", "The manifest should be written before leaving the repository root.");
+        }
+
+        [Fact]
+        public void FullValidationRunnerIndexesValidationLogsTestResultsAndPublishOutput()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("function Add-ValidationArtifactGroup", source);
+            Assert.Contains("function Get-ArtifactRelativePath", source);
+            Assert.Contains("ArtifactGroup=$GroupName", source);
+            Assert.Contains("ArtifactRoot=$RootPath", source);
+            Assert.Contains("ArtifactGroupMissing=True", source);
+            Assert.Contains("Name = \"ValidationLogs\"; Root = $validationLogsPath; ExcludedNames = @(\"artifact-manifest.txt\")", source);
+            Assert.Contains("Name = \"TestResults\"; Root = $testResultsPath; ExcludedNames = @()", source);
+            Assert.Contains("Name = \"PublishOutput\"; Root = $publishOutputPath; ExcludedNames = @()", source);
+            Assert.Contains("if (-not $SkipPublish)", source);
+            Assert.Contains("SkipPublish=$SkipPublish", source);
+            AssertAppearsBefore(source, "Test solution", "finally {", "The manifest should be written after the test-results path has had a chance to be created.");
+            AssertAppearsBefore(source, "Publish app", "finally {", "The manifest should be written after publish output has had a chance to be created.");
         }
 
         [Fact]
@@ -134,18 +155,27 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void BuildWorkflowUploadsArtifactManifestWithValidationLogs()
+        public void BuildWorkflowUploadsGroupedArtifactManifestWithValidationLogs()
         {
             var source = ReadRepoFile(".github", "workflows", "build.yml");
 
             Assert.Contains("Summarize validation artifacts", source);
             Assert.Contains("if: always()", source);
             Assert.Contains("./ValidationLogs/artifact-manifest.txt", source);
-            Assert.Contains("ArtifactCount=$($artifacts.Count)", source);
-            Assert.Contains("Artifact=$($artifact.Name)", source);
+            Assert.Contains("function Add-ValidationArtifactGroup", source);
+            Assert.Contains("function Get-ArtifactRelativePath", source);
+            Assert.Contains("ValidationArtifactManifest=2", source);
+            Assert.Contains("ArtifactGroupCount=$($artifactGroups.Count)", source);
+            Assert.Contains("ArtifactGroup=$GroupName", source);
+            Assert.Contains("ArtifactRoot=$RootPath", source);
+            Assert.Contains("ArtifactGroupMissing=True", source);
+            Assert.Contains("Name = \"ValidationLogs\"; Root = \"./ValidationLogs\"; ExcludedNames = @(\"artifact-manifest.txt\")", source);
+            Assert.Contains("Name = \"TestResults\"; Root = \"./TestResults\"; ExcludedNames = @()", source);
+            Assert.Contains("Name = \"PublishOutput\"; Root = \"./publish\"; ExcludedNames = @()", source);
+            Assert.Contains("Artifact=$relativePath", source);
             Assert.Contains("SizeBytes=$($artifact.Length)", source);
             Assert.Contains("LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))", source);
-            AssertAppearsBefore(source, "Upload build artifacts", "Summarize validation artifacts", "The manifest should summarize all validation files created by earlier workflow steps.");
+            AssertAppearsBefore(source, "Upload build artifacts", "Summarize validation artifacts", "The manifest should summarize validation logs, test results, and publish output after those paths have had a chance to be produced.");
             AssertAppearsBefore(source, "Summarize validation artifacts", "Upload validation logs", "The manifest should be written before the validation log artifact is uploaded.");
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-validation-manifest-artifact-groups.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-validation-manifest-artifact-groups.md
@@ -1,0 +1,17 @@
+# Validation Manifest Artifact Groups
+
+## Completed
+- The local full-validation runner now writes `ValidationLogs/artifact-manifest.txt` as a grouped artifact index instead of only listing files inside `ValidationLogs/`.
+- The manifest now records validation logs, `TestResults/`, and full-run publish output with artifact counts, relative paths, sizes, timestamps, and missing-group markers for failed or partial runs.
+- The `-SkipPublish` runner path records `SkipPublish=True` and avoids indexing stale publish output from earlier runs.
+- The Windows Build and Test workflow now writes the same grouped manifest before uploading `ValidationLogs/` so CI artifact review can start from one index.
+- Source-contract coverage and README validation guidance now pin the grouped manifest workflow.
+
+## Why
+Full validation is still the release-readiness blocker, and recent diagnostics made individual logs durable. The remaining triage gap was that test results and publish output are produced outside `ValidationLogs/`, so a reviewer opening the validation log artifact did not have one authoritative index of everything the run produced. Grouping all validation artifact locations in the manifest makes failed and partial runs easier to inspect.
+
+## Validation
+- Connector readback/compare should confirm the local runner writes grouped manifest sections for validation logs, test results, and publish output.
+- Connector readback/compare should confirm CI writes the same grouped manifest before uploading validation logs.
+- Connector readback/compare should confirm `ValidationDiagnosticsContractTests` and README guidance cover the grouped manifest contract.
+- Local .NET validation still needs to run from a Windows/.NET-capable checkout because direct checkout and local .NET execution are unavailable in this scheduled environment.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ For a faster compile-and-test pass without publishing or source scan checks:
 pwsh -File scripts/run-full-validation.ps1 -SkipPublish
 ```
 
+Validation diagnostics are written to `ValidationLogs/`, with `environment.txt`, `package-audit.txt`, MSBuild binary logs, `step-summary.txt`, and `artifact-manifest.txt`. The manifest groups the validation logs, `TestResults/`, and publish output so failed or partial runs can be triaged from one index before opening larger artifacts.
+
 See [ToDo.md](ToDo.md) for the current cleanup queue and known remaining work.
 
 ## Core Workflows
@@ -77,6 +79,8 @@ dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -
 bash scripts/check-banned-words.sh
 $env:BANNED_WORD_CHECK_FORCE_POWERSHELL = "1"; bash scripts/check-banned-words.sh; Remove-Item Env:BANNED_WORD_CHECK_FORCE_POWERSHELL
 ```
+
+After running the checked-in validation runner or the Build and Test workflow, inspect `ValidationLogs/artifact-manifest.txt` first. It lists the generated validation logs, test result files, and publish output files with sizes and timestamps.
 
 Repository rules:
 

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -94,28 +94,90 @@ function Write-ValidationStepSummary {
     }
 }
 
+function Get-ArtifactRelativePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RootPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ArtifactPath
+    )
+
+    $resolvedRoot = (Resolve-Path $RootPath).Path.TrimEnd([char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar))
+    return $ArtifactPath.Substring($resolvedRoot.Length).TrimStart([char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar))
+}
+
+function Add-ValidationArtifactGroup {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Lines,
+
+        [Parameter(Mandatory = $true)]
+        [string]$GroupName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RootPath,
+
+        [string[]]$ExcludedNames = @()
+    )
+
+    $Lines += "ArtifactGroup=$GroupName"
+    $Lines += "ArtifactRoot=$RootPath"
+
+    if (-not (Test-Path $RootPath -PathType Container)) {
+        $Lines += "ArtifactGroupMissing=True"
+        $Lines += "ArtifactCount=0"
+        $Lines += ""
+        return $Lines
+    }
+
+    $artifacts = Get-ChildItem -Path $RootPath -File -Recurse |
+        Where-Object { $ExcludedNames -notcontains $_.Name } |
+        Sort-Object FullName
+
+    $Lines += "ArtifactCount=$($artifacts.Count)"
+
+    foreach ($artifact in $artifacts) {
+        $relativePath = Get-ArtifactRelativePath -RootPath $RootPath -ArtifactPath $artifact.FullName
+        $Lines += "Artifact=$relativePath"
+        $Lines += "SizeBytes=$($artifact.Length)"
+        $Lines += "LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))"
+        $Lines += ""
+    }
+
+    if ($artifacts.Count -eq 0) {
+        $Lines += ""
+    }
+
+    return $Lines
+}
+
 function Write-ValidationArtifactManifest {
     if (-not (Test-Path $validationLogsPath -PathType Container)) {
         return
     }
 
     $manifestPath = Get-ValidationLogPath "artifact-manifest.txt"
-    $artifacts = Get-ChildItem -Path $validationLogsPath -File |
-        Where-Object { $_.Name -ne "artifact-manifest.txt" } |
-        Sort-Object Name
+    $artifactGroups = @(
+        @{ Name = "ValidationLogs"; Root = $validationLogsPath; ExcludedNames = @("artifact-manifest.txt") },
+        @{ Name = "TestResults"; Root = $testResultsPath; ExcludedNames = @() }
+    )
+
+    if (-not $SkipPublish) {
+        $artifactGroups += @{ Name = "PublishOutput"; Root = $publishOutputPath; ExcludedNames = @() }
+    }
 
     $lines = @(
         "GeneratedAtUtc=$((Get-Date).ToUniversalTime().ToString('o'))",
+        "ValidationArtifactManifest=2",
         "ValidationLogRoot=$validationLogsPath",
-        "ArtifactCount=$($artifacts.Count)",
+        "ArtifactGroupCount=$($artifactGroups.Count)",
+        "SkipPublish=$SkipPublish",
         ""
     )
 
-    foreach ($artifact in $artifacts) {
-        $lines += "Artifact=$($artifact.Name)"
-        $lines += "SizeBytes=$($artifact.Length)"
-        $lines += "LastWriteUtc=$($artifact.LastWriteTimeUtc.ToString('o'))"
-        $lines += ""
+    foreach ($group in $artifactGroups) {
+        $lines = Add-ValidationArtifactGroup -Lines $lines -GroupName $group.Name -RootPath $group.Root -ExcludedNames $group.ExcludedNames
     }
 
     $lines | Set-Content -Path $manifestPath -Encoding UTF8


### PR DESCRIPTION
## What changed

- Updated `scripts/run-full-validation.ps1` so `ValidationLogs/artifact-manifest.txt` indexes grouped validation artifacts instead of only files inside `ValidationLogs/`.
- Added manifest groups for validation logs, `TestResults/`, and full-run publish output, including artifact counts, relative paths, sizes, timestamps, and missing-group markers for failed or partial runs.
- Kept the local `-SkipPublish` path honest by recording `SkipPublish=True` and avoiding stale publish-output indexing when publish work is skipped.
- Updated the Windows Build and Test workflow to write the same grouped manifest before uploading validation logs.
- Extended `ValidationDiagnosticsContractTests` and README guidance for the grouped manifest workflow.
- Added a progress note for this validation-triage slice.

## Why this was the highest-value next step

`ToDo.md` still identifies full validation as the release-readiness blocker, and recent completed work made individual diagnostics durable. The remaining practical triage gap was that key outputs live in separate locations: `ValidationLogs/`, `TestResults/`, and `publish/`. A reviewer opening the validation log artifact needed one authoritative index of what the run produced before opening larger logs, test result files, or publish output.

## Why this is real workflow progress

This is a complete validation-artifact review slice across the local runner, CI workflow, source-contract coverage, documentation, and progress notes. It improves failed and partial validation triage end to end instead of adding an isolated assertion or another single log file.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 focused commits, and limited to the validation runner, Build and Test workflow, validation diagnostics tests, README, and one progress note.
- Connector readback confirmed the local runner writes grouped manifest sections for `ValidationLogs`, `TestResults`, and publish output.
- Connector readback confirmed the local runner records `SkipPublish=$SkipPublish` and only adds the publish-output group inside `if (-not $SkipPublish)`.
- Connector readback confirmed the CI workflow writes matching grouped manifest sections before uploading `ValidationLogs/`.
- Connector readback confirmed `ValidationDiagnosticsContractTests` covers grouped local and CI manifest contracts.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, GitHub Actions log inspection, and full validation could not be run.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and confirm `ValidationLogs/artifact-manifest.txt` lists validation logs, `TestResults/validation-tests.trx`, and publish output files.
- Confirm the next Build and Test workflow upload includes the grouped manifest in the `validation-msbuild-logs` artifact.