### PR TITLE
Clean local validation artifact groups before early failures

### DIFF
--- a/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDiagnosticsContractTests.cs
@@ -96,6 +96,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void FullValidationRunnerClearsManifestArtifactGroupsBeforeFallibleValidationSteps()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("if (Test-Path $testResultsPath)", source);
+            Assert.Contains("Remove-Item $testResultsPath -Recurse -Force", source);
+            Assert.Contains("if (-not $SkipPublish -and (Test-Path $publishOutputPath))", source);
+            Assert.Contains("Remove-Item $publishOutputPath -Recurse -Force", source);
+            AssertAppearsBefore(source, "Remove-Item $testResultsPath -Recurse -Force", "Invoke-ValidationStep \"Capture validation environment\"", "The runner should clear stale test results before any restore, audit, build, or environment step can fail and write a manifest.");
+            AssertAppearsBefore(source, "Remove-Item $publishOutputPath -Recurse -Force", "Invoke-ValidationStep \"Capture validation environment\"", "Full validation should clear stale publish output before any early failure can write a manifest.");
+            AssertAppearsBefore(source, "if (-not $SkipPublish -and (Test-Path $publishOutputPath))", "Invoke-ValidationStep \"Capture validation environment\"", "SkipPublish runs should avoid touching publish output while full runs clear stale publish artifacts up front.");
+        }
+
+        [Fact]
         public void BuildWorkflowCapturesEnvironmentDiagnosticsBeforeRestore()
         {
             var source = ReadRepoFile(".github", "workflows", "build.yml");

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-validation-artifact-group-cleanup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-validation-artifact-group-cleanup.md
@@ -1,0 +1,16 @@
+# Validation Artifact Group Cleanup
+
+## Completed
+- The local full-validation runner now clears stale `TestResults/` during the opening validation-log cleanup step before restore, audit, build, or environment capture can fail.
+- Full validation runs now also clear stale `publish/` output during the opening cleanup step, while `-SkipPublish` runs continue to leave publish output untouched and omit it from the manifest.
+- The existing pre-publish cleanup remains in place so successful full runs still publish from a fresh output folder immediately before `dotnet publish`.
+- Source-contract coverage now guards that manifest artifact groups are cleared before early fallible validation steps can write `ValidationLogs/artifact-manifest.txt`.
+- `ToDo.md` now calls out the up-front artifact cleanup when describing the next Windows/.NET validation pass.
+
+## Why
+Recent validation work made `artifact-manifest.txt` the starting point for diagnosing failed and partial local validation runs. Before this change, an early restore, audit, or build failure could leave the manifest indexing `TestResults/` or `publish/` files from a previous run because those folders were only cleaned later. Clearing the manifest artifact groups up front keeps failed-run evidence honest.
+
+## Validation
+- Connector readback/compare should confirm the runner clears `TestResults/` before `Capture validation environment` and clears `publish/` before early full-validation failures, guarded by `-SkipPublish`.
+- Connector readback/compare should confirm `ValidationDiagnosticsContractTests` covers the cleanup ordering.
+- Local .NET validation still needs to run from a Windows/.NET-capable checkout because direct checkout and local .NET execution are unavailable in this scheduled environment.

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,6 +1,6 @@
 # Current Status And Remaining Work
 
-Last updated: 2026-06-25.
+Last updated: 2026-07-01.
 
 ## Build And Validation
 
@@ -22,7 +22,7 @@ Last updated: 2026-06-25.
 - A 2026-06-24 banned-word fallback hardening pass aligned the `rg` path and PowerShell fallback so both skip generated `bin` and `obj` folders, with dependency-contract coverage for both exclusion paths.
 - A 2026-06-24 CI validation consolidation pass added `BANNED_WORD_CHECK_FORCE_POWERSHELL=1` so the Build and Test workflow exercises the PowerShell banned-word fallback even when `rg` is available.
 - A 2026-06-24 banned-word fallback scan hardening pass limited the PowerShell fallback to known text/source file extensions and a few text file names, avoiding binary asset scans when the forced fallback runs in CI.
-- A 2026-06-24 validation readiness pass added `scripts/run-full-validation.ps1` to run the current restore, build, test, publish, normal banned-word, and forced PowerShell fallback checks from one Windows/.NET-capable checkout.
+- A 2026-06-24 validation readiness pass added `scripts/run-full-validation.ps1` to run the current restore, build, test, publish, normal banned-word, and forced PowerShell fallback validation sequence from one Windows/.NET-capable checkout.
 - A 2026-06-25 validation hardening pass excluded generated `publish/` output from both banned-word scan paths so the full validation runner can publish before running banned-word checks without scanning publish artifacts.
 - A 2026-06-25 validation runner hardening pass cleans the `publish/` output folder before publishing so full validation reports only freshly produced artifacts.
 - A 2026-06-25 validation runner visibility pass adds an explicit `dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive` audit step after restore so dependency advisory review has a dedicated log section.
@@ -32,23 +32,25 @@ Last updated: 2026-06-25.
 - A 2026-06-25 validation runner robustness pass resets and captures `$LASTEXITCODE` around each named validation step so PowerShell-native steps cannot inherit stale external-process exit codes.
 - A 2026-06-25 CI sequence alignment pass moves both Build and Test workflow banned-word scans after publish and before artifact upload so CI mirrors the full validation runner and README manual validation order.
 - A 2026-06-25 validation runner fast-path pass keeps `-SkipPublish` as a restore/audit/build/test-only shortcut and guards that publish, cleanup, and banned-word scans remain in the full validation path.
+- A 2026-07-01 validation diagnostics honesty pass clears stale `TestResults/` and full-run `publish/` output during the runner's opening cleanup step so early-failure artifact manifests cannot report previous-run test or publish artifacts.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, the checked-in validation runner, generated `publish/` output exclusion, publish-output cleanup, the explicit dependency-audit runner step, the matching CI vulnerable-package audit step, CI publish-output cleanup, README manual validation cleanup documentation, validation runner exit-code hardening, CI validation-sequence alignment, and SkipPublish fast-path scoping:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, the checked-in validation runner, generated `publish/` output exclusion, publish-output cleanup, the explicit dependency-audit runner step, the matching CI vulnerable-package audit step, CI publish-output cleanup, README manual validation cleanup documentation, validation runner exit-code hardening, CI validation-sequence alignment, SkipPublish fast-path scoping, and up-front cleanup of manifest artifact groups:
 
 - `pwsh -File scripts/run-full-validation.ps1`
 
 The runner executes:
 
+- clean existing validation logs, stale `TestResults/`, and, for full validation, stale `publish/` output before restore/build/test can fail and write a manifest
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive`
 - `dotnet build InventoryManagementApp.sln --configuration Release --no-restore`
 - `dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal`
 - `dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64`
-- clean existing `publish/` output
+- clean existing `publish/` output again immediately before publish
 - `dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish`
 - `scripts/check-banned-words.sh`
 - `BANNED_WORD_CHECK_FORCE_POWERSHELL=1 scripts/check-banned-words.sh`
@@ -57,11 +59,11 @@ For the faster compile-and-test checkpoint, run:
 
 - `pwsh -File scripts/run-full-validation.ps1 -SkipPublish`
 
-Confirm during restore and dependency audit that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the explicit vulnerable-package audit prints any remaining direct/transitive advisories in its own section, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that stale files are removed from `publish/` before fresh artifacts are produced in both the local runner and Build and Test workflow, that PowerShell-native runner steps are not affected by stale external-process exit codes, that the full validation path still runs the banned-word script through its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin`, `obj`, and `publish` folders, that the forced fallback mode works while `rg` is present, that the PowerShell fallback scans source/text files without scanning binary assets, that `-SkipPublish` stops after restore/audit/build/test, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests with restore, the dedicated vulnerable-package audit, build, test, runtime restore, clean publish output, publish, both banned-word validation paths, and artifact upload. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore and dependency audit that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the explicit vulnerable-package audit prints any remaining direct/transitive advisories in its own section, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that stale `TestResults/` and full-run `publish/` output are removed before early validation steps can fail and write an artifact manifest, that stale files are removed from `publish/` again before fresh artifacts are produced in both the local runner and Build and Test workflow, that PowerShell-native runner steps are not affected by stale external-process exit codes, that the full validation path still runs the banned-word script through its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin`, `obj`, and `publish` folders, that the forced fallback mode works while `rg` is present, that the PowerShell fallback scans source/text files without scanning binary assets, that `-SkipPublish` stops after restore/audit/build/test without touching publish output, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests with restore, the dedicated vulnerable-package audit, build, test, runtime restore, clean publish output, publish, both banned-word validation paths, and artifact upload. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 
-1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup, dependency pins, publish-output scan exclusion, publish-output cleanup, explicit dependency audit step, matching CI audit step, CI publish cleanup, README manual validation cleanup documentation, runner exit-code hardening, CI validation-sequence alignment, and SkipPublish fast-path scoping.
+1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup, dependency pins, publish-output scan exclusion, publish-output cleanup, explicit dependency audit step, matching CI audit step, CI publish cleanup, README manual validation cleanup documentation, runner exit-code hardening, CI validation-sequence alignment, SkipPublish fast-path scoping, and up-front manifest artifact cleanup.
 2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK, dedicated vulnerable-package audit, build/test, runtime restore, clean publish output, publish, both banned-word validation paths, and artifact upload.
 3. Review the runner's dedicated vulnerable-package audit output plus any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing, then update affected packages or document intentional risk decisions.
 4. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -200,6 +200,14 @@ try {
             Remove-Item $validationLogsPath -Recurse -Force
         }
 
+        if (Test-Path $testResultsPath) {
+            Remove-Item $testResultsPath -Recurse -Force
+        }
+
+        if (-not $SkipPublish -and (Test-Path $publishOutputPath)) {
+            Remove-Item $publishOutputPath -Recurse -Force
+        }
+
         New-Item -ItemType Directory -Path $validationLogsPath | Out-Null
     }
 


### PR DESCRIPTION
## What changed
- Updated `scripts/run-full-validation.ps1` so the opening cleanup step clears stale `TestResults/` before any restore, audit, build, or environment step can fail.
- Full validation runs now also clear stale `publish/` output up front, while `-SkipPublish` keeps leaving publish output untouched and omits it from the manifest.
- Kept the existing pre-publish cleanup so successful full runs still publish from a fresh folder immediately before `dotnet publish`.
- Added `ValidationDiagnosticsContractTests` coverage for the up-front artifact cleanup ordering.
- Updated `ToDo.md` and added a progress note for the completed validation-diagnostics reliability slice.

## Why this was the highest-value next step
Recent repo evidence shows validation readiness is still the release blocker, and the latest completed slices made `ValidationLogs/artifact-manifest.txt` the entry point for failed-run triage. Current source showed the local runner could write that manifest after an early failure while still indexing old `TestResults/` or `publish/` files from a previous run. Cleaning the manifest artifact groups before fallible validation work keeps diagnostics honest.

## Why this is real workflow progress
This improves the complete local validation workflow rather than one isolated assertion: failed and partial runs now report only current validation logs plus missing/fresh artifact groups, so operators do not chase previous-run test or publish output while diagnosing restore/audit/build failures.

## Validation
- GitHub connector compare confirmed the branch is 4 focused files ahead of `master`: the runner, validation diagnostics contract tests, `ToDo.md`, and one progress note.
- Connector readback confirmed `scripts/run-full-validation.ps1` clears `TestResults/` before `Capture validation environment`.
- Connector readback confirmed full validation clears `publish/` before `Capture validation environment`, guarded by `-not $SkipPublish`.
- Connector readback confirmed `ValidationDiagnosticsContractTests.FullValidationRunnerClearsManifestArtifactGroupsBeforeFallibleValidationSteps` covers the cleanup markers and ordering.

## Could not check
- Local `dotnet`, `pwsh`, and `gh` are unavailable in this scheduled Linux environment.
- Direct checkout is blocked by network policy, so `pwsh -File scripts/run-full-validation.ps1`, `dotnet test`, WPF runtime checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and confirm early-failure manifests no longer include stale `TestResults/` or `publish/` artifacts.
- Continue reviewing any NU190x/package-audit output and the remaining full validation queue once a capable environment is available.