### PR TITLE
Clean CI validation artifact groups before early failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
       shell: pwsh
       run: |
         if (Test-Path ./ValidationLogs) { Remove-Item ./ValidationLogs -Recurse -Force }
+        if (Test-Path ./TestResults) { Remove-Item ./TestResults -Recurse -Force }
+        if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }
         New-Item -ItemType Directory -Path ./ValidationLogs | Out-Null
 
     - name: Capture validation environment

--- a/InventoryManagementApp.Tests/ValidationWorkflowCleanupContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationWorkflowCleanupContractTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ValidationWorkflowCleanupContractTests
+    {
+        [Fact]
+        public void BuildWorkflowClearsManifestArtifactGroupsBeforeFallibleValidationSteps()
+        {
+            var source = ReadRepoFile(".github", "workflows", "build.yml");
+
+            Assert.Contains("if (Test-Path ./ValidationLogs) { Remove-Item ./ValidationLogs -Recurse -Force }", source);
+            Assert.Contains("if (Test-Path ./TestResults) { Remove-Item ./TestResults -Recurse -Force }", source);
+            Assert.Contains("if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }", source);
+            Assert.Contains("New-Item -ItemType Directory -Path ./ValidationLogs | Out-Null", source);
+            AssertAppearsBefore(source, "if (Test-Path ./TestResults) { Remove-Item ./TestResults -Recurse -Force }", "Capture validation environment", "The workflow should clear stale test results before environment capture, restore, audit, or build can fail and write a manifest.");
+            AssertAppearsBefore(source, "if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }", "Capture validation environment", "The workflow should clear stale publish output before early failures can write a manifest.");
+            AssertAppearsBefore(source, "if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }", "Restore dependencies", "The workflow should clear stale publish output before restore can fail.");
+            AssertAppearsBefore(source, "Prepare test results", "- name: Test", "The workflow should still recreate TestResults immediately before tests run.");
+            AssertAppearsBefore(source, "Clean publish output", "- name: Publish", "The workflow should still clean publish output immediately before fresh publish artifacts are produced.");
+        }
+
+        [Fact]
+        public void LocalAndCiValidationCleanupStayAligned()
+        {
+            var runner = ReadRepoFile("scripts", "run-full-validation.ps1");
+            var workflow = ReadRepoFile(".github", "workflows", "build.yml");
+
+            Assert.Contains("Remove-Item $testResultsPath -Recurse -Force", runner);
+            Assert.Contains("Remove-Item $publishOutputPath -Recurse -Force", runner);
+            Assert.Contains("if (Test-Path ./TestResults) { Remove-Item ./TestResults -Recurse -Force }", workflow);
+            Assert.Contains("if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }", workflow);
+            AssertAppearsBefore(runner, "Remove-Item $testResultsPath -Recurse -Force", "Invoke-ValidationStep \"Capture validation environment\"", "The local runner should clear stale test results before early fallible steps.");
+            AssertAppearsBefore(runner, "Remove-Item $publishOutputPath -Recurse -Force", "Invoke-ValidationStep \"Capture validation environment\"", "The local runner should clear stale publish output before early fallible full-validation steps.");
+            AssertAppearsBefore(workflow, "if (Test-Path ./TestResults) { Remove-Item ./TestResults -Recurse -Force }", "Capture validation environment", "The workflow should match the local runner's early test-results cleanup.");
+            AssertAppearsBefore(workflow, "if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }", "Capture validation environment", "The workflow should match the local runner's early publish-output cleanup.");
+        }
+
+        private static void AssertAppearsBefore(string source, string first, string second, string because)
+        {
+            var firstIndex = source.IndexOf(first, StringComparison.Ordinal);
+            var secondIndex = source.IndexOf(second, StringComparison.Ordinal);
+
+            Assert.True(firstIndex >= 0, $"Expected to find '{first}'.");
+            Assert.True(secondIndex >= 0, $"Expected to find '{second}'.");
+            Assert.True(firstIndex < secondIndex, because);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-ci-validation-artifact-group-cleanup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-ci-validation-artifact-group-cleanup.md
@@ -1,0 +1,14 @@
+# CI Validation Artifact Group Cleanup
+
+## Completed
+- The Build and Test workflow now clears stale `TestResults/` and `publish/` output during its opening validation-log preparation step, before environment capture, restore, package audit, or build can fail.
+- The existing later `Prepare test results` and `Clean publish output` steps remain in place so successful test and publish phases still create fresh phase-specific artifacts immediately before use.
+- Added source-contract coverage that pins the CI cleanup ordering and checks that the CI workflow stays aligned with the local full-validation runner's early artifact-group cleanup.
+
+## Why
+Recent validation diagnostics work made `ValidationLogs/artifact-manifest.txt` the starting point for failed-run triage. The local runner already removed stale manifest artifact groups up front, but CI only cleaned `ValidationLogs/` before early fallible steps. Clearing the CI `TestResults/` and `publish/` groups at the start keeps failed workflow manifests from reporting previous-run artifacts on reused workspaces or rerun jobs.
+
+## Validation
+- Connector readback/compare should confirm `.github/workflows/build.yml` clears `ValidationLogs/`, `TestResults/`, and `publish/` before `Capture validation environment`.
+- Connector readback/compare should confirm `ValidationWorkflowCleanupContractTests` covers CI cleanup ordering and local/CI cleanup alignment.
+- Local .NET validation and the Windows Build and Test workflow still need to run in a Windows/.NET-capable environment because direct checkout and local .NET execution are unavailable in this scheduled environment.


### PR DESCRIPTION
## What changed
- Updated the Build and Test workflow so the opening validation-log preparation step also clears stale `TestResults/` and `publish/` output before environment capture, restore, package audit, or build can fail.
- Kept the existing later `Prepare test results` and `Clean publish output` steps so successful test and publish phases still recreate fresh phase-specific artifacts immediately before use.
- Added `ValidationWorkflowCleanupContractTests` to pin the CI cleanup ordering and check that CI stays aligned with the local full-validation runner's early artifact-group cleanup.
- Added a progress note for the completed CI validation-diagnostics reliability slice.

## Why this was the highest-value next step
Recent repo evidence shows full validation remains the release-readiness blocker, and the latest merged local-runner change made early artifact manifests honest by clearing stale `TestResults/` and `publish/` output up front. Current CI source still only cleared `ValidationLogs/` before early fallible steps, leaving its grouped manifest vulnerable to stale test/publish artifacts on reused workspaces or rerun jobs. Aligning CI with the local runner is the next direct validation reliability improvement.

## Why this is real workflow progress
This completes the artifact-group cleanup behavior across both local and CI validation paths. It improves failed-run triage end to end by ensuring the manifest's grouped `TestResults` and `PublishOutput` sections represent the current workflow attempt instead of previous output, while preserving fresh cleanup immediately before test and publish work.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to the Build and Test workflow, one new source-contract test file, and one progress note.
- Connector readback confirmed `.github/workflows/build.yml` clears `ValidationLogs/`, `TestResults/`, and `publish/` in the opening `Prepare validation logs` step before `Capture validation environment`.
- Connector readback confirmed `ValidationWorkflowCleanupContractTests` covers CI cleanup ordering and local/CI cleanup alignment.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Confirm the next Build and Test workflow writes a grouped artifact manifest with current-run `ValidationLogs`, `TestResults`, and `PublishOutput` sections after the up-front cleanup.