### PR TITLE
Harden item image import entrypoint guards

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
@@ -79,6 +79,45 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ImageImportEntrypointValidatesInputsBeforeAuthorizationAndCatalogWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var entrypoint = ExtractMethod(
+                source,
+                "public Task<ImageImportResult> ImportItemImagesAsync",
+                "public async Task<string> GenerateNextItemNumberAsync");
+            var internalMethod = ExtractMethod(
+                source,
+                "private async Task<ImageImportResult> ImportItemImagesInternalAsync",
+                "protected virtual Task CopyFileAsync");
+
+            Assert.Contains("if (string.IsNullOrWhiteSpace(folderPath))", entrypoint, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(folderPath));", entrypoint, StringComparison.Ordinal);
+            Assert.Contains("if (keySelector is null)", entrypoint, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(keySelector));", entrypoint, StringComparison.Ordinal);
+            Assert.True(
+                entrypoint.IndexOf("if (string.IsNullOrWhiteSpace(folderPath))", StringComparison.Ordinal) < entrypoint.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Image imports should reject a missing folder path before authorization or catalog work.");
+            Assert.True(
+                entrypoint.IndexOf("if (keySelector is null)", StringComparison.Ordinal) < entrypoint.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Image imports should reject a missing key selector before authorization or catalog work.");
+            Assert.True(
+                entrypoint.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < entrypoint.IndexOf("Directory.Exists(folderPath)", StringComparison.Ordinal),
+                "Image imports should honor cancellation before checking the image folder.");
+            Assert.True(
+                entrypoint.IndexOf("Directory.Exists(folderPath)", StringComparison.Ordinal) < entrypoint.IndexOf("return ImportItemImagesInternalAsync", StringComparison.Ordinal),
+                "Image imports should reject missing folders before scanning the item catalog.");
+
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", internalMethod, StringComparison.Ordinal);
+            Assert.True(
+                internalMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < internalMethod.IndexOf("var items = new List<ItemModel>();", StringComparison.Ordinal),
+                "Image imports should honor cancellation before collecting item rows.");
+            Assert.True(
+                internalMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", internalMethod.IndexOf("var supported = new HashSet<string>", StringComparison.Ordinal), StringComparison.Ordinal) < internalMethod.IndexOf("Directory.EnumerateFiles(folderPath)", StringComparison.Ordinal),
+                "Image imports should honor cancellation before enumerating image files.");
+        }
+
+        [Fact]
         public void GenericImportExportEntrypointsValidateInputsBeforeAuthorizationAndWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-item-image-import-entrypoint-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-item-image-import-entrypoint-guards.md
@@ -1,0 +1,16 @@
+# Item Image Import Entrypoint Guards
+
+Date: 2026-07-01
+
+## Completed
+
+- Hardened `ItemService.ImportItemImagesAsync` so missing image folders and missing key selectors fail with explicit argument exceptions before authorization or catalog work starts.
+- Added an early cancellation check before folder existence validation and before the image import workflow scans item rows.
+- Added a missing-folder check before `ImportItemImagesInternalAsync` loads the item catalog, avoiding expensive database work when the selected image folder is invalid.
+- Added another cancellation checkpoint before enumerating image files so cancellation can stop the workflow before filesystem scanning.
+- Extended item import/export source-contract coverage to pin the image import guard ordering alongside the existing CSV and generic import/export entrypoint guards.
+
+## Validation
+
+- Connector readback should confirm the service and test markers on the branch.
+- Local .NET validation still needs a Windows/.NET-capable checkout because this scheduled environment cannot clone the repository and does not provide `dotnet` or `pwsh`.

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -197,7 +197,16 @@ namespace InventoryManagementApp.Services.Items
 
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrWhiteSpace(folderPath))
+                throw new ArgumentNullException(nameof(folderPath));
+            if (keySelector is null)
+                throw new ArgumentNullException(nameof(keySelector));
+
             _auth.EnsurePermission(User.PermissionImportExport);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!Directory.Exists(folderPath))
+                throw new DirectoryNotFoundException($"Image import folder not found: {folderPath}");
+
             return ImportItemImagesInternalAsync(folderPath, keySelector, progress, cancellationToken);
         }
 
@@ -214,11 +223,9 @@ namespace InventoryManagementApp.Services.Items
 
         private async Task<ImageImportResult> ImportItemImagesInternalAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress, CancellationToken cancellationToken)
         {
-            var result = new ImageImportResult();
-            if (string.IsNullOrWhiteSpace(folderPath) || keySelector == null)
-                return result;
-
             cancellationToken.ThrowIfCancellationRequested();
+
+            var result = new ImageImportResult();
             var items = new List<ItemModel>();
             await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
                 .WithCancellation(cancellationToken))
@@ -258,6 +265,7 @@ namespace InventoryManagementApp.Services.Items
 
             var supported = new HashSet<string>(new[] { ".png", ".jpg", ".jpeg", ".bmp", ".gif" }, StringComparer.OrdinalIgnoreCase);
 
+            cancellationToken.ThrowIfCancellationRequested();
             var files = await Task.Run(() => Directory.EnumerateFiles(folderPath).ToList(), cancellationToken);
             var total = files.Count;
             var processed = 0;


### PR DESCRIPTION
## What changed
- Updated `ItemService.ImportItemImagesAsync` so missing image folders and missing key selectors fail with explicit argument exceptions before authorization or catalog work starts.
- Added an early cancellation checkpoint before folder validation and before the image import workflow collects item rows.
- Added a missing-folder check before `ImportItemImagesInternalAsync` scans the item catalog, avoiding unnecessary database work when the selected image folder is invalid.
- Added a cancellation checkpoint immediately before image-file enumeration.
- Extended `ItemServiceImportTransactionTests` source-contract coverage to pin image import guard ordering alongside the existing CSV and generic import/export guards.
- Added a progress note for the completed item image import reliability slice.

## Why this was the highest-value next step
Recent repo evidence shows the broad validation-diagnostics loop has already been improved repeatedly, and the latest service hardening work focused on import/export guard clarity. Current source still left the item image import path behind the CSV/generic item import/export entrypoints: it authorized first, silently returned an empty result for bad inputs, and could scan the item catalog before discovering a missing image folder. This is a concrete import/export workflow reliability gap without inventing unrelated product scope.

## Why this is real workflow progress
This completes the item import/export entrypoint guard slice across the remaining image import workflow, not just a one-line cleanup. Operators now get clear failures for invalid image import setup, cancellation is honored before expensive work, and source-contract coverage keeps the behavior aligned with the rest of the item import/export surface.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ItemService`, `ItemServiceImportTransactionTests`, and one progress note.
- Connector readback confirmed `ImportItemImagesAsync` validates `folderPath` and `keySelector` before `_auth.EnsurePermission(...)`.
- Connector readback confirmed cancellation is checked before `Directory.Exists(folderPath)` and that missing folders are rejected before `ImportItemImagesInternalAsync(...)` scans the catalog.
- Connector readback confirmed `ImportItemImagesInternalAsync` checks cancellation before item collection and before `Directory.EnumerateFiles(folderPath)`.
- Connector readback confirmed the new source-contract test covers the image import entrypoint and internal guard ordering.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Consider a future streaming image import catalog lookup if very large inventories make the existing all-items image matching pass too heavy.