### PR TITLE
Page image import catalog matching

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
@@ -110,11 +110,34 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", internalMethod, StringComparison.Ordinal);
             Assert.True(
-                internalMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < internalMethod.IndexOf("var items = new List<ItemModel>();", StringComparison.Ordinal),
-                "Image imports should honor cancellation before collecting item rows.");
+                internalMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < internalMethod.IndexOf("var groups = new Dictionary", StringComparison.Ordinal),
+                "Image imports should honor cancellation before collecting item match keys.");
             Assert.True(
                 internalMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", internalMethod.IndexOf("var supported = new HashSet<string>", StringComparison.Ordinal), StringComparison.Ordinal) < internalMethod.IndexOf("Directory.EnumerateFiles(folderPath)", StringComparison.Ordinal),
                 "Image imports should honor cancellation before enumerating image files.");
+        }
+
+        [Fact]
+        public void ImageImportCatalogBuildUsesBoundedPagesBeforeFileEnumeration()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var internalMethod = ExtractMethod(
+                source,
+                "private async Task<ImageImportResult> ImportItemImagesInternalAsync",
+                "protected virtual Task CopyFileAsync");
+
+            Assert.Contains("private const int ImageImportCatalogPageSize = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("var pageNumber = 1;", internalMethod, StringComparison.Ordinal);
+            Assert.Contains("while (true)", internalMethod, StringComparison.Ordinal);
+            Assert.Contains("var pageItemCount = 0;", internalMethod, StringComparison.Ordinal);
+            Assert.Contains("new ItemPage(pageNumber, ImageImportCatalogPageSize)", internalMethod, StringComparison.Ordinal);
+            Assert.Contains("pageItemCount++;", internalMethod, StringComparison.Ordinal);
+            Assert.Contains("if (pageItemCount < ImageImportCatalogPageSize)", internalMethod, StringComparison.Ordinal);
+            Assert.Contains("pageNumber++;", internalMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", internalMethod, StringComparison.Ordinal);
+            Assert.True(
+                internalMethod.IndexOf("new ItemPage(pageNumber, ImageImportCatalogPageSize)", StringComparison.Ordinal) < internalMethod.IndexOf("Directory.EnumerateFiles(folderPath)", StringComparison.Ordinal),
+                "Image imports should finish paged catalog matching before file enumeration starts.");
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-image-import-paged-catalog.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-image-import-paged-catalog.md
@@ -1,0 +1,15 @@
+# Image Import Paged Catalog Matching
+
+Date: 2026-07-01
+
+## Completed
+
+- Replaced the image import workflow's single all-items catalog read with a bounded page loop using `ImageImportCatalogPageSize`.
+- Kept image matching semantics unchanged: each item still contributes all normalized selector keys, duplicate keys still produce file conflicts, and existing item images still block replacement.
+- Preserved cancellation checks before catalog work, during each paged item pass, and before filesystem enumeration.
+- Added source-contract coverage so image import cannot regress to `new ItemPage(1, int.MaxValue)` while building the match catalog.
+
+## Validation
+
+- Connector readback should confirm the service now pages image-import catalog matching and the source-contract test covers the new bounded-page markers.
+- Local .NET validation still needs a Windows/.NET-capable checkout because this scheduled environment cannot clone the repository and does not provide `dotnet` or `pwsh`.

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -33,6 +33,7 @@ namespace InventoryManagementApp.Services.Items
         private readonly DatabaseService _dbService;
         private readonly IItemRepository _repository;
         private const int MaxQuantityOnHand = 10000;
+        private const int ImageImportCatalogPageSize = 500;
     
         private readonly ILogger<ItemService> _logger;
         private readonly IAuthorizationService _auth;
@@ -226,25 +227,36 @@ namespace InventoryManagementApp.Services.Items
             cancellationToken.ThrowIfCancellationRequested();
 
             var result = new ImageImportResult();
-            var items = new List<ItemModel>();
-            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
-                .WithCancellation(cancellationToken))
-                items.Add(item);
             var groups = new Dictionary<string, List<ItemModel>>(StringComparer.OrdinalIgnoreCase);
-            foreach (var item in items)
+            var pageNumber = 1;
+
+            while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var keys = keySelector(item);
-                if (keys == null) continue;
-                foreach (var key in keys)
+                var pageItemCount = 0;
+
+                await foreach (var item in GetItemsAsync(new ItemPage(pageNumber, ImageImportCatalogPageSize), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
+                    .WithCancellation(cancellationToken))
                 {
-                    var k = (key ?? string.Empty).Trim().ToUpperInvariant();
-                    if (string.IsNullOrWhiteSpace(k))
-                        continue;
-                    if (!groups.TryGetValue(k, out var list))
-                        groups[k] = list = new List<ItemModel>();
-                    list.Add(item);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    pageItemCount++;
+                    var keys = keySelector(item);
+                    if (keys == null) continue;
+                    foreach (var key in keys)
+                    {
+                        var k = (key ?? string.Empty).Trim().ToUpperInvariant();
+                        if (string.IsNullOrWhiteSpace(k))
+                            continue;
+                        if (!groups.TryGetValue(k, out var list))
+                            groups[k] = list = new List<ItemModel>();
+                        list.Add(item);
+                    }
                 }
+
+                if (pageItemCount < ImageImportCatalogPageSize)
+                    break;
+
+                pageNumber++;
             }
 
             string destDir;


### PR DESCRIPTION
## What changed
- Updated `ItemService.ImportItemImagesInternalAsync` so image import builds its item-key match catalog in bounded 500-item pages instead of requesting `new ItemPage(1, int.MaxValue)`.
- Kept the existing image import semantics intact: selector keys are still normalized into the same match dictionary, duplicate matches still produce conflicts, existing item images still block replacement, and progress reporting still follows file processing.
- Preserved cancellation checks before catalog work, during each paged item pass, and before image-file enumeration.
- Extended `ItemServiceImportTransactionTests` source-contract coverage to pin the paged catalog loop and reject regressions to an unbounded image-import catalog request.
- Added a progress note for the completed image import scalability slice.

## Why this was the highest-value next step
Recent merged work hardened the image import entrypoint, and that readback exposed the remaining workflow risk in the same path: the import still loaded the whole item catalog with `int.MaxValue` before looking at image files. That can make a production image import unnecessarily memory-heavy on large inventories, so this finishes the obvious reliability follow-up without inventing unrelated app scope.

## Why this is real workflow progress
This is a complete import workflow improvement across service behavior, cancellation-preserving implementation, source-contract coverage, and progress notes. It reduces large-inventory runtime risk for the image import workflow rather than making a small isolated guard or cosmetic edit.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ItemService`, `ItemServiceImportTransactionTests`, and one progress note.
- Connector readback confirmed `ImageImportCatalogPageSize = 500` and that `ImportItemImagesInternalAsync` iterates `new ItemPage(pageNumber, ImageImportCatalogPageSize)` before image-file enumeration.
- Connector readback confirmed the source-contract test asserts the bounded page loop markers and rejects `new ItemPage(1, int.MaxValue)` inside the image import internals.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Review the remaining full-item export paths separately if large inventory exports need streaming output instead of full-list materialization.