### PR TITLE
Honor borderless theme setting for search bars

### DIFF
--- a/InventoryManagementApp.Tests/ThemeServiceTests.cs
+++ b/InventoryManagementApp.Tests/ThemeServiceTests.cs
@@ -116,6 +116,10 @@ namespace InventoryManagementApp.Tests
                 var service = new ThemeService();
                 var settings = AppThemeSettings.CreateDefault("Dark");
                 settings.BordersVisible = false;
+                settings.SearchBarBorderColor = "#FFFFCC00";
+                settings.SearchBarInnerBorderColor = "#FF334455";
+                settings.SearchBarBorderThickness = 4;
+                settings.SearchBarInnerBorderThickness = 2;
                 settings.SurfaceOpacity = 0.25;
                 settings.SurfaceAltOpacity = 0.2;
                 settings.InputOpacity = 0.3;
@@ -129,12 +133,16 @@ namespace InventoryManagementApp.Tests
 
                 Assert.Equal(new Thickness(0), (Thickness)app.Resources["ThemeBorderThickness"]);
                 Assert.Equal(new Thickness(0), (Thickness)app.Resources["ThemeControlBorderThickness"]);
+                Assert.Equal(new Thickness(0), (Thickness)app.Resources["SearchBarBorderThickness"]);
+                Assert.Equal(new Thickness(0), (Thickness)app.Resources["SearchBarInnerBorderThickness"]);
                 Assert.Equal("Aptos", ((FontFamily)app.Resources["ThemeFontFamily"]).Source);
                 Assert.Equal(15.6, (double)app.Resources["ThemeBodyFontSize"]);
                 Assert.Equal(23.8, (double)app.Resources["ThemeTitleFontSize"]);
                 Assert.Equal(0x40, ((SolidColorBrush)app.Resources["SurfaceBrush"]).Color.A);
                 Assert.Equal(0x59, ((SolidColorBrush)app.Resources["BtnBg"]).Color.A);
                 Assert.Same(Brushes.Transparent, app.Resources["BtnBorder"]);
+                Assert.Same(Brushes.Transparent, app.Resources["SearchBarBorderBrush"]);
+                Assert.Same(Brushes.Transparent, app.Resources["SearchBarInnerBorderBrush"]);
                 WpfTestHelper.ShutdownApplication();
                 await Task.CompletedTask;
             });

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-search-bar-border-visibility.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-search-bar-border-visibility.md
@@ -1,0 +1,16 @@
+# Search Bar Border Visibility
+
+Date: 2026-07-01
+
+## Completed
+
+- Aligned customized search bar border resources with the global `BordersVisible` theme setting.
+- When borders are hidden, both outer and inner search bar border thickness resources now become zero and both search bar border brushes become transparent.
+- Preserved independent search bar background color/opacity so borderless search bars still keep their configured fill.
+- Extended runtime `ThemeServiceTests` coverage so the borderless theme path guards the newer search bar resources alongside existing border resources.
+
+## Validation
+
+- Connector readback should confirm `ThemeService.ApplyCustomTheme` routes search bar border brushes and thicknesses through the global border visibility decision.
+- Connector readback should confirm `ThemeServiceTests.ApplyCustomTheme_UpdatesBorderlessTransparentAndTypographyResources` covers zero search bar thicknesses and transparent search bar brushes.
+- Local .NET validation still needs a Windows/.NET-capable checkout because this scheduled environment cannot clone the repository and does not provide `dotnet` or `pwsh`.

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -67,9 +67,13 @@ namespace InventoryManagementApp.Services
                 var resources = app.Resources;
                 var borderThickness = settings.BordersVisible ? new Thickness(settings.BorderThickness) : new Thickness(0);
                 var controlBorderThickness = settings.BordersVisible ? new Thickness(settings.ControlBorderThickness) : new Thickness(0);
+                var searchBarBorderThickness = settings.BordersVisible ? new Thickness(settings.SearchBarBorderThickness) : new Thickness(0);
+                var searchBarInnerBorderThickness = settings.BordersVisible ? new Thickness(settings.SearchBarInnerBorderThickness) : new Thickness(0);
                 var dividerThickness = settings.BordersVisible ? new Thickness(0, 0, 0, settings.BorderThickness) : new Thickness(0);
                 var borderBrush = CreateBrush(settings.BorderColor, settings.BorderOpacity * 0.55);
                 var dividerBrush = CreateBrush(settings.BorderColor, settings.BorderOpacity * settings.DividerOpacity * 0.55);
+                var searchBarBorderBrush = settings.BordersVisible ? CreateBrush(settings.SearchBarBorderColor, settings.BorderOpacity) : Brushes.Transparent;
+                var searchBarInnerBorderBrush = settings.BordersVisible ? CreateBrush(settings.SearchBarInnerBorderColor, settings.BorderOpacity) : Brushes.Transparent;
                 var surfaceOpacity = settings.UseGlassSurfaces ? Math.Min(settings.SurfaceOpacity, 0.72) : settings.SurfaceOpacity;
                 var surfaceAltOpacity = settings.UseGlassSurfaces ? Math.Min(settings.SurfaceAltOpacity, 0.62) : settings.SurfaceAltOpacity;
                 var navigationOpacity = settings.UseGlassSurfaces ? Math.Min(settings.NavigationOpacity, 0.74) : settings.NavigationOpacity;
@@ -119,10 +123,10 @@ namespace InventoryManagementApp.Services
                 Set(resources, "TransparentSurfaceBrush", Brushes.Transparent);
                 Set(resources, "TextBoxBackgroundBrush", inputBrush);
                 Set(resources, "SearchBarBackgroundBrush", CreateBrush(settings.SearchBarBackgroundColor, settings.InputOpacity));
-                Set(resources, "SearchBarBorderBrush", CreateBrush(settings.SearchBarBorderColor, settings.BorderOpacity));
-                Set(resources, "SearchBarInnerBorderBrush", CreateBrush(settings.SearchBarInnerBorderColor, settings.BorderOpacity));
-                Set(resources, "SearchBarBorderThickness", new Thickness(settings.SearchBarBorderThickness));
-                Set(resources, "SearchBarInnerBorderThickness", new Thickness(settings.SearchBarInnerBorderThickness));
+                Set(resources, "SearchBarBorderBrush", searchBarBorderBrush);
+                Set(resources, "SearchBarInnerBorderBrush", searchBarInnerBorderBrush);
+                Set(resources, "SearchBarBorderThickness", searchBarBorderThickness);
+                Set(resources, "SearchBarInnerBorderThickness", searchBarInnerBorderThickness);
                 Set(resources, "ComboBoxPopupBackgroundBrush", CreateBrush(settings.SurfaceAltColor, settings.MenuDropDownOpacity));
                 Set(resources, "ForegroundBrush", CreateBrush(settings.TextColor, 1));
                 Set(resources, "ForegroundMutedBrush", CreateBrush(settings.MutedTextColor, 1));


### PR DESCRIPTION
## What changed
- Updated `ThemeService.ApplyCustomTheme` so customized search bar outer and inner border resources respect the global `BordersVisible` setting.
- When borders are hidden, `SearchBarBorderThickness` and `SearchBarInnerBorderThickness` now become zero and both search bar border brushes become transparent.
- Preserved independent search bar background color/opacity so borderless search bars still keep their configured fill.
- Extended `ThemeServiceTests.ApplyCustomTheme_UpdatesBorderlessTransparentAndTypographyResources` to pin the runtime resources for the newer search bar border controls.
- Added a progress note for the completed theme consistency slice.

## Why this was the highest-value next step
The latest `master` commit expanded Admin Settings theme customization for search bar borders. Current source showed the global border visibility toggle still disabled normal border resources, button borders, grid lines, and shape strokes, but did not suppress the new search bar border resources. That made the fresh theme workflow internally inconsistent and was the most current repo-backed issue to finish.

## Why this is real workflow progress
This completes the search bar theme customization slice across runtime theme application, WPF resource behavior, regression coverage, and project notes. It fixes a user-visible theme consistency gap instead of making an isolated rename or cosmetic tweak.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ThemeService`, `ThemeServiceTests`, and one progress note.
- Connector readback confirmed `ApplyCustomTheme` routes both search bar border thickness resources through `settings.BordersVisible` and uses transparent brushes when borders are hidden.
- Connector readback confirmed the runtime theme test asserts zero search bar border thicknesses and transparent search bar border brushes in the borderless theme path.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, layout checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Visually smoke test Admin Settings theme presets with borders hidden to confirm search boxes, buttons, grids, and focus rings still look intentional in light and dark themes.