### PR TITLE
Page item export collection

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
@@ -141,6 +141,42 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ItemExportsCollectRowsWithBoundedPagesBeforeWriterWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var csvExportMethod = ExtractMethod(
+                source,
+                "private async Task ExportItemsToCsvInternalAsync",
+                "private async Task<List<ItemModel>> CollectItemsForExportAsync");
+            var collectorMethod = ExtractMethod(
+                source,
+                "private async Task<List<ItemModel>> CollectItemsForExportAsync",
+                "public async Task UpdateItemQuantitiesAsync");
+            var genericExportMethod = ExtractMethod(
+                source,
+                "public async Task ExportItemsAsync",
+                "static void NotifyChanged");
+
+            Assert.Contains("private const int ItemExportPageSize = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("var pageNumber = 1;", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("while (true)", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("var pageItemCount = 0;", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("new ItemPage(pageNumber, ItemExportPageSize)", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("pageItemCount++;", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("if (pageItemCount < ItemExportPageSize)", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("pageNumber++;", collectorMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", csvExportMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", genericExportMethod, StringComparison.Ordinal);
+
+            Assert.True(
+                csvExportMethod.IndexOf("var items = await CollectItemsForExportAsync(cancellationToken)", StringComparison.Ordinal) < csvExportMethod.IndexOf("CsvHelperUtil.ExportItemsToCsvAsync", StringComparison.Ordinal),
+                "CSV item exports should finish bounded collection before handing rows to the CSV writer.");
+            Assert.True(
+                genericExportMethod.IndexOf("var items = await CollectItemsForExportAsync(cancellationToken)", StringComparison.Ordinal) < genericExportMethod.IndexOf("exporter.ExportAsync", StringComparison.Ordinal),
+                "Generic item exports should finish bounded collection before handing rows to the exporter.");
+        }
+
+        [Fact]
         public void GenericImportExportEntrypointsValidateInputsBeforeAuthorizationAndWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
@@ -173,8 +209,8 @@ namespace InventoryManagementApp.Tests
                 exportMethod.IndexOf("if (exporter is null)", StringComparison.Ordinal) < exportMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
                 "Generic item exports should reject a missing exporter before authorization or item collection work.");
             Assert.True(
-                exportMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < exportMethod.IndexOf("var items = new List<ItemModel>();", StringComparison.Ordinal),
-                "Generic item exports should honor cancellation before collecting rows.");
+                exportMethod.IndexOf("var items = await CollectItemsForExportAsync(cancellationToken)", StringComparison.Ordinal) < exportMethod.IndexOf("exporter.ExportAsync", StringComparison.Ordinal),
+                "Generic item exports should collect rows before exporter handoff.");
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-item-export-paged-collection.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-item-export-paged-collection.md
@@ -1,0 +1,15 @@
+# Item Export Paged Collection
+
+Date: 2026-07-01
+
+## Completed
+
+- Replaced item export workflows' single all-items page request with a shared bounded page collector using `ItemExportPageSize`.
+- Applied the paged collection path to both CSV item export and generic item exporter handoff while preserving sorted export order and existing writer/exporter contracts.
+- Preserved cancellation checks before collection, during each page pass, and immediately before writer/exporter handoff.
+- Added source-contract coverage so item exports keep using the bounded page loop and do not regress to `new ItemPage(1, int.MaxValue)`.
+
+## Validation
+
+- Connector readback should confirm the service now pages item export collection and the source-contract test covers both CSV and generic export paths.
+- Local .NET validation still needs a Windows/.NET-capable checkout because this scheduled environment cannot clone the repository and does not provide `dotnet`, `pwsh`, or `gh`.

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -34,6 +34,7 @@ namespace InventoryManagementApp.Services.Items
         private readonly IItemRepository _repository;
         private const int MaxQuantityOnHand = 10000;
         private const int ImageImportCatalogPageSize = 500;
+        private const int ItemExportPageSize = 500;
     
         private readonly ILogger<ItemService> _logger;
         private readonly IAuthorizationService _auth;
@@ -637,17 +638,38 @@ namespace InventoryManagementApp.Services.Items
 
         private async Task ExportItemsToCsvInternalAsync(string filePath, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var items = new List<ItemModel>();
-            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
-                .WithCancellation(cancellationToken))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                items.Add(item);
-            }
+            var items = await CollectItemsForExportAsync(cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
             await CsvHelperUtil.ExportItemsToCsvAsync(filePath, items).ConfigureAwait(false);
+        }
+
+        private async Task<List<ItemModel>> CollectItemsForExportAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var items = new List<ItemModel>();
+            var pageNumber = 1;
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var pageItemCount = 0;
+
+                await foreach (var item in GetItemsAsync(new ItemPage(pageNumber, ItemExportPageSize), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
+                    .WithCancellation(cancellationToken))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    pageItemCount++;
+                    items.Add(item);
+                }
+
+                if (pageItemCount < ItemExportPageSize)
+                    break;
+
+                pageNumber++;
+            }
+
+            return items;
         }
 
         public async Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SqliteConnection? conn = null, SqliteTransaction? tx = null, CancellationToken cancellationToken = default)
@@ -782,18 +804,7 @@ namespace InventoryManagementApp.Services.Items
                 throw new ArgumentNullException(nameof(exporter));
 
             _auth.EnsurePermission(User.PermissionImportExport);
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Note: Using int.MaxValue as page size loads all items into memory.
-            // For very large inventories (>10,000 items), consider implementing streaming export.
-            // Current implementation matches existing CSV export behavior.
-            var items = new List<ItemModel>();
-            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
-                .WithCancellation(cancellationToken))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                items.Add(item);
-            }
+            var items = await CollectItemsForExportAsync(cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
             await exporter.ExportAsync(filePath, items, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## What changed
- Added shared `ItemExportPageSize` paging for item export row collection.
- Updated both CSV item export and generic item exporter handoff to collect rows through bounded `ItemPage` requests instead of `new ItemPage(1, int.MaxValue)`.
- Preserved sorted export order and cancellation checks before collection, during each page pass, and immediately before writer/exporter handoff.
- Extended `ItemServiceImportTransactionTests` source-contract coverage to guard the bounded export collector and both export entry points.
- Added a progress note for the completed item export reliability slice.

## Why this was the highest-value next step
The latest image-import scalability work removed an unbounded item catalog read, and current source showed the same remaining large-inventory risk in item export workflows: both CSV and generic exports still requested all items with `int.MaxValue`. This is a direct follow-up in the active import/export workflow, avoids repeating the completed image-import work, and reduces runtime risk for large inventories.

## Why this is real workflow progress
This is a complete export workflow slice across CSV export, generic exporter handoff, shared service collection logic, source-contract coverage, and project notes. It improves reliability for a real operator workflow rather than making a small isolated rename or cosmetic change.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ItemService`, `ItemServiceImportTransactionTests`, and one progress note.
- Connector readback confirmed `ItemExportPageSize = 500` and the shared `CollectItemsForExportAsync` loops through `new ItemPage(pageNumber, ItemExportPageSize)`.
- Connector readback confirmed CSV export and generic export both call `CollectItemsForExportAsync(cancellationToken)` before writer/exporter handoff.
- Connector readback confirmed the source-contract test guards the bounded collector and rejects `new ItemPage(1, int.MaxValue)` in both export paths.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Review whether future exporter implementations should support true streaming output instead of collecting the bounded pages into a list before writer handoff.