### PR TITLE
Guard generic customer import export entrypoints

### DIFF
--- a/InventoryManagementApp.Tests/CustomerImportExportEntrypointContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerImportExportEntrypointContractTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomerImportExportEntrypointContractTests
+    {
+        [Fact]
+        public void GenericCustomerImportAndExportValidateSetupBeforeAuthorizationAndWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var importMethod = ExtractMethod(
+                source,
+                "public async Task<int> ImportCustomersAsync",
+                "public async Task ExportCustomersAsync");
+            var exportMethod = ExtractMethod(
+                source,
+                "public async Task ExportCustomersAsync",
+                "static void NotifyChanged");
+
+            Assert.Contains("if (string.IsNullOrWhiteSpace(filePath))", importMethod, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(filePath));", importMethod, StringComparison.Ordinal);
+            Assert.Contains("if (importer is null)", importMethod, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(importer));", importMethod, StringComparison.Ordinal);
+            Assert.True(
+                importMethod.IndexOf("if (string.IsNullOrWhiteSpace(filePath))", StringComparison.Ordinal) < importMethod.IndexOf("_auth.EnsureAdmin();", StringComparison.Ordinal),
+                "Generic customer imports should reject a missing file path before authorization or importer work.");
+            Assert.True(
+                importMethod.IndexOf("if (importer is null)", StringComparison.Ordinal) < importMethod.IndexOf("_auth.EnsureAdmin();", StringComparison.Ordinal),
+                "Generic customer imports should reject a missing importer before authorization or importer work.");
+            Assert.True(
+                importMethod.IndexOf("_auth.EnsureAdmin();", StringComparison.Ordinal) < importMethod.IndexOf("importer.ImportAsync", StringComparison.Ordinal),
+                "Generic customer imports should still authorize before importer file work starts.");
+
+            Assert.Contains("if (string.IsNullOrWhiteSpace(filePath))", exportMethod, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(filePath));", exportMethod, StringComparison.Ordinal);
+            Assert.Contains("if (exporter is null)", exportMethod, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(exporter));", exportMethod, StringComparison.Ordinal);
+            Assert.True(
+                exportMethod.IndexOf("if (string.IsNullOrWhiteSpace(filePath))", StringComparison.Ordinal) < exportMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Generic customer exports should reject a missing file path before authorization or row collection.");
+            Assert.True(
+                exportMethod.IndexOf("if (exporter is null)", StringComparison.Ordinal) < exportMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Generic customer exports should reject a missing exporter before authorization or row collection.");
+            Assert.True(
+                exportMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal) < exportMethod.IndexOf("GetAllCustomersAsync", StringComparison.Ordinal),
+                "Generic customer exports should still authorize before collecting customer rows.");
+            Assert.True(
+                exportMethod.IndexOf("GetAllCustomersAsync", StringComparison.Ordinal) < exportMethod.IndexOf("exporter.ExportAsync", StringComparison.Ordinal),
+                "Generic customer exports should collect rows before exporter handoff.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-customer-generic-import-export-entrypoint-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-customer-generic-import-export-entrypoint-guards.md
@@ -1,0 +1,16 @@
+# Customer Generic Import Export Entrypoint Guards
+
+Date: 2026-07-01
+
+## Completed
+
+- Aligned generic customer import and export setup validation with the existing item import/export guard pattern.
+- `ImportCustomersAsync` now rejects missing file paths and missing importer implementations before admin authorization, importer parsing, or database transaction work begins.
+- `ExportCustomersAsync` now rejects missing file paths and missing exporter implementations before import/export authorization, customer row collection, or exporter handoff begins.
+- Added source-contract coverage so the customer generic import/export entry points keep validating setup before authorization and work while preserving authorization before importer/exporter execution.
+
+## Validation
+
+- Connector readback should confirm the customer service entry points validate `filePath`, `importer`, and `exporter` before authorization and downstream work.
+- Connector readback should confirm `CustomerImportExportEntrypointContractTests` guards the import and export ordering.
+- Local .NET validation still needs a Windows/.NET-capable checkout because this scheduled environment cannot clone the repository and does not provide `dotnet`, `pwsh`, or `gh`.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -563,6 +563,11 @@ namespace InventoryManagementApp.Services.Customers
 
         public async Task<int> ImportCustomersAsync(string filePath, IDataImporter<Customer> importer, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+            if (importer is null)
+                throw new ArgumentNullException(nameof(importer));
+
             _auth.EnsureAdmin();
             cancellationToken.ThrowIfCancellationRequested();
             
@@ -622,6 +627,11 @@ namespace InventoryManagementApp.Services.Customers
 
         public async Task ExportCustomersAsync(string filePath, IDataExporter<Customer> exporter, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+            if (exporter is null)
+                throw new ArgumentNullException(nameof(exporter));
+
             _auth.EnsurePermission(User.PermissionImportExport);
             cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
## What changed
- Updated generic customer import so missing file paths and missing importer implementations fail before admin authorization, importer parsing, or database transaction work starts.
- Updated generic customer export so missing file paths and missing exporter implementations fail before import/export authorization, customer row collection, or exporter handoff starts.
- Added source-contract coverage for the generic customer import/export entrypoint guard ordering.
- Added a progress note for the completed customer import/export reliability slice.

## Why this was the highest-value next step
Recent item import/export hardening left the equivalent customer generic import/export entry points behind: `ImportCustomersAsync` and `ExportCustomersAsync` authorized first and could reach importer/exporter calls with invalid setup. This is a concrete validation/error-handling gap in an existing workflow, separate from the just-completed item export paging work.

## Why this is real workflow progress
This completes the customer generic import/export setup-validation path across service behavior, source-contract coverage, and project notes. Operators and tests now get consistent immediate argument failures for invalid customer import/export setup before permissions, database work, or exporter/importer handoff are involved.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `CustomerService`, one new source-contract test file, and one progress note.
- Connector readback confirmed `ImportCustomersAsync` validates `filePath` and `importer` before `_auth.EnsureAdmin()` and importer work.
- Connector readback confirmed `ExportCustomersAsync` validates `filePath` and `exporter` before `_auth.EnsurePermission(...)`, customer row collection, and exporter handoff.
- Connector readback confirmed `CustomerImportExportEntrypointContractTests` guards the import/export ordering.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, layout/print checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue replacing brittle source-text tests with behavior-focused tests where practical.