### PR TITLE
[codex] Page inventory report item collection

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReportServiceInventoryPagingContractTests
+    {
+        [Fact]
+        public void InventoryReportAndSummaryCountUseBoundedItemPages()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+            var inventoryReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateInventoryReport()",
+                "public async Task<FlowDocument> GenerateRentalReport(bool activeOnly = true)");
+            var collectorMethod = ExtractMethod(
+                source,
+                "private async Task<List<ItemModel>> CollectInventoryReportItemsAsync()",
+                "private async Task<int> CountItemsAsync()");
+            var countMethod = ExtractMethod(
+                source,
+                "private async Task<int> CountItemsAsync()",
+                "FlowDocument BuildReport(string title, IEnumerable<string> lines)");
+
+            Assert.Contains("private const int InventoryReportPageSize = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("var items = await CollectInventoryReportItemsAsync().ConfigureAwait(false);", inventoryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", inventoryReport, StringComparison.Ordinal);
+
+            AssertUsesBoundedReportPages(collectorMethod);
+            AssertUsesBoundedReportPages(countMethod);
+            Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", collectorMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", countMethod, StringComparison.Ordinal);
+        }
+
+        private static void AssertUsesBoundedReportPages(string method)
+        {
+            Assert.Contains("var pageNumber = 1;", method, StringComparison.Ordinal);
+            Assert.Contains("while (true)", method, StringComparison.Ordinal);
+            Assert.Contains("var pageItemCount = 0;", method, StringComparison.Ordinal);
+            Assert.Contains("new ItemPage(pageNumber, InventoryReportPageSize)", method, StringComparison.Ordinal);
+            Assert.Contains("pageItemCount++;", method, StringComparison.Ordinal);
+            Assert.Contains("if (pageItemCount < InventoryReportPageSize)", method, StringComparison.Ordinal);
+            Assert.Contains("pageNumber++;", method, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-inventory-report-paged-items.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-inventory-report-paged-items.md
@@ -1,0 +1,20 @@
+# Inventory Report Paged Item Collection
+
+Date: 2026-07-01
+
+## Completed
+
+- Updated `ReportService.GenerateInventoryReport` so the inventory report collects item rows through bounded 500-item pages instead of requesting every item with `new ItemPage(1, int.MaxValue)`.
+- Updated the application summary item count path to use the same bounded page size, counting rows page by page without materializing the whole inventory report item list.
+- Added source-contract coverage in `ReportServiceInventoryPagingContractTests` to guard the inventory report and summary count paging markers and reject a return to unbounded item page requests.
+
+## Why This Mattered
+
+Recent import/export work removed unbounded item collection from large inventory workflows. Current report source still had the same risk in the inventory report and summary item count paths, which could make report generation fragile for larger catalogs. This keeps the reports workflow aligned with the newer bounded-list pattern without changing report labels or output content.
+
+## Validation
+
+- Connector readback confirmed `InventoryReportPageSize = 500` is used by report item collection.
+- Connector readback confirmed both `CollectInventoryReportItemsAsync` and `CountItemsAsync` loop through `new ItemPage(pageNumber, InventoryReportPageSize)` and stop when a short page is reached.
+- Connector readback confirmed `GenerateInventoryReport` calls the bounded collector before rendering report lines.
+- Local build, tests, WPF runtime checks, print/layout checks, and full validation still need a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -22,6 +22,8 @@ namespace InventoryManagementApp.Services.Items
 {
     public class ReportService
     {
+        private const int InventoryReportPageSize = 500;
+
         readonly IItemService _itemService;
         readonly IRentalService _rentalService;
         readonly ActivityLogService _activityLogService;
@@ -56,10 +58,7 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<FlowDocument> GenerateInventoryReport()
         {
-            var items = new List<ItemModel>();
-            await foreach (var item in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, isRentalItem: false)
-                .WithCancellation(CancellationToken.None).ConfigureAwait(false))
-                items.Add(item);
+            var items = await CollectInventoryReportItemsAsync().ConfigureAwait(false);
             var lines = items.Select(t =>
                 $"Item ID: {t.ItemID} | Item Number: {t.ItemNumber} | Quantity: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
             return BuildReport("Inventory Report", lines);
@@ -264,12 +263,51 @@ namespace InventoryManagementApp.Services.Items
             return BuildReport("Active Kits Report", lines);
         }
 
+        private async Task<List<ItemModel>> CollectInventoryReportItemsAsync()
+        {
+            var items = new List<ItemModel>();
+            var pageNumber = 1;
+
+            while (true)
+            {
+                var pageItemCount = 0;
+                await foreach (var item in _itemService.GetItemsAsync(new ItemPage(pageNumber, InventoryReportPageSize), SortField.Name, SortDirection.Ascending, isRentalItem: false)
+                    .WithCancellation(CancellationToken.None).ConfigureAwait(false))
+                {
+                    items.Add(item);
+                    pageItemCount++;
+                }
+
+                if (pageItemCount < InventoryReportPageSize)
+                    break;
+
+                pageNumber++;
+            }
+
+            return items;
+        }
+
         private async Task<int> CountItemsAsync()
         {
             var count = 0;
-            await foreach (var _ in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, isRentalItem: false)
-                .WithCancellation(CancellationToken.None))
-                count++;
+            var pageNumber = 1;
+
+            while (true)
+            {
+                var pageItemCount = 0;
+                await foreach (var _ in _itemService.GetItemsAsync(new ItemPage(pageNumber, InventoryReportPageSize), SortField.Name, SortDirection.Ascending, isRentalItem: false)
+                    .WithCancellation(CancellationToken.None).ConfigureAwait(false))
+                {
+                    count++;
+                    pageItemCount++;
+                }
+
+                if (pageItemCount < InventoryReportPageSize)
+                    break;
+
+                pageNumber++;
+            }
+
             return count;
         }
 


### PR DESCRIPTION
## What changed
- Updated `ReportService.GenerateInventoryReport` to collect inventory report rows through bounded 500-item pages instead of requesting every item with `new ItemPage(1, int.MaxValue)`.
- Updated the application summary item count path to count item rows page by page with the same bounded page size instead of issuing an unbounded item read.
- Added `ReportServiceInventoryPagingContractTests` to guard the bounded report collection/counting pattern and reject regressions to unbounded item page requests.
- Added a progress note for the completed reports reliability slice.

## Why this was the highest-value next step
Recent repo evidence shows large-list import/export paths have been hardened, and current `ReportService` still had the same unbounded item catalog request in the inventory report and summary count workflow. Reports are a user-facing workflow, so removing this remaining large-inventory risk was more valuable than revisiting already-completed validation or import/export guard work.

## Why this is real workflow progress
This is a complete reports workflow slice across report service behavior, summary-count behavior, regression coverage, and project notes. It improves large-inventory report reliability without changing the report labels or user-facing document content.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ReportService`, one new source-contract test file, and one progress note.
- Connector readback confirmed `InventoryReportPageSize = 500` is used by report item collection.
- Connector readback confirmed `GenerateInventoryReport` calls `CollectInventoryReportItemsAsync()` before rendering report lines.
- Connector readback confirmed both `CollectInventoryReportItemsAsync` and `CountItemsAsync` loop through `new ItemPage(pageNumber, InventoryReportPageSize)` and stop when a short page is reached.
- Connector readback confirmed `ReportServiceInventoryPagingContractTests` guards the bounded paging markers and rejects `new ItemPage(1, int.MaxValue)` inside the report and count paths.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue replacing brittle source-text tests with behavior-focused tests where practical.