### PR TITLE
[codex] Use customer count API in summary report

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -33,6 +33,22 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", countMethod, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void SummaryReportUsesCustomerCountWithoutMaterializingCustomerDirectory()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+            var summaryReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateSummaryReport()",
+                "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)");
+
+            Assert.Contains("var totalCustomersTask = _customerService.CountCustomersAsync(CancellationToken.None);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var totalCustomers = await totalCustomersTask.ConfigureAwait(false);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Total Customers: {totalCustomers}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("var totalCustomersTask = _customerService.GetAllCustomersAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Total Customers: {totalCustomers.Count}\"", summaryReport, StringComparison.Ordinal);
+        }
+
         private static void AssertUsesBoundedReportPages(string method)
         {
             Assert.Contains("var pageNumber = 1;", method, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-summary-report-customer-count.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-summary-report-customer-count.md
@@ -1,0 +1,20 @@
+# Summary Report Customer Count
+
+Date: 2026-07-01
+
+## Completed
+
+- Updated `ReportService.GenerateSummaryReport` so the application summary counts customers through `ICustomerService.CountCustomersAsync(CancellationToken.None)` instead of loading the full customer directory with `GetAllCustomersAsync()` just to read `.Count`.
+- Kept the displayed `Total Customers` line unchanged while reducing large-customer-directory memory and query materialization risk in the summary report workflow.
+- Extended `ReportServiceInventoryPagingContractTests` to guard the summary report customer-count path and reject a regression back to materializing all customers for the summary count.
+
+## Why This Mattered
+
+Recent report work already removed unbounded item materialization from the inventory report and summary item count. Current source showed the same pattern still existed for the summary customer count, so this finishes another reports workflow reliability slice without changing report output semantics or inventing unrelated scope.
+
+## Validation
+
+- Connector readback should confirm `GenerateSummaryReport` calls `_customerService.CountCustomersAsync(CancellationToken.None)` for the customer total.
+- Connector readback should confirm the summary report renders `Total Customers` from the integer count rather than `totalCustomers.Count`.
+- Connector readback should confirm `ReportServiceInventoryPagingContractTests` guards the count API path and rejects the old `GetAllCustomersAsync()` summary pattern.
+- Local build, tests, WPF runtime checks, print/layout checks, and full validation still need a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -127,7 +127,7 @@ namespace InventoryManagementApp.Services.Items
             var totalItemsTask = CountItemsAsync();
             var totalRentalsTask = _rentalService.GetAllRentalsAsync();
             var totalActiveRentalsTask = _rentalService.GetActiveRentalsAsync();
-            var totalCustomersTask = _customerService.GetAllCustomersAsync();
+            var totalCustomersTask = _customerService.CountCustomersAsync(CancellationToken.None);
             var totalUsersTask = _userService.GetAllUsersAsync(CancellationToken.None);
 
             await Task.WhenAll(
@@ -148,7 +148,7 @@ namespace InventoryManagementApp.Services.Items
                 $"Total Items: {totalItems}",
                 $"Total Rentals (History): {totalRentals.Count}",
                 $"Active Rentals: {totalActiveRentals.Count}",
-                $"Total Customers: {totalCustomers.Count}",
+                $"Total Customers: {totalCustomers}",
                 $"Total Users: {totalUsers.Count}"
             };
 


### PR DESCRIPTION
## What changed
- Updated `ReportService.GenerateSummaryReport` to get the customer total through `_customerService.CountCustomersAsync(CancellationToken.None)` instead of loading all customers and reading `.Count`.
- Kept the user-facing `Total Customers` summary line unchanged while avoiding full customer-directory materialization for that count.
- Extended `ReportServiceInventoryPagingContractTests` to guard the summary report customer-count path and reject a regression to `GetAllCustomersAsync()` for the summary total.
- Added a progress note for the completed reports reliability slice.

## Why this was the highest-value next step
Recent merged report work removed unbounded item collection from the inventory report and summary item count. Current `ReportService` still had the same large-directory pattern for the application summary customer total, using `GetAllCustomersAsync()` only to count rows. This is a direct reports workflow reliability improvement and does not revisit completed item paging work.

## Why this is real workflow progress
This completes another summary-report counting path across service behavior, regression coverage, and project notes. It improves large-customer-directory reliability in an existing operator report without changing report wording or broadening app scope.

## Validation
- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ReportService`, `ReportServiceInventoryPagingContractTests`, and one progress note.
- Connector readback confirmed `GenerateSummaryReport` calls `_customerService.CountCustomersAsync(CancellationToken.None)` for the customer total.
- Connector readback confirmed the `Total Customers` line renders from the integer `totalCustomers` value instead of `totalCustomers.Count`.
- Connector readback confirmed `ReportServiceInventoryPagingContractTests` guards the count API path and rejects the old `GetAllCustomersAsync()` summary pattern.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked
- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work
- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue replacing summary/report list counts with direct count APIs where service contracts already expose them and user-facing report detail does not need row materialization.