### PR TITLE
Harden summary report counts against capped list reads

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -34,7 +34,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void SummaryReportUsesCustomerCountWithoutMaterializingCustomerDirectory()
+        public void SummaryReportUsesCountApisWithoutMaterializingCappedDirectories()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
             var summaryReport = ExtractMethod(
@@ -42,11 +42,47 @@ namespace InventoryManagementApp.Tests
                 "public async Task<FlowDocument> GenerateSummaryReport()",
                 "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)");
 
+            Assert.Contains("var totalRentalsTask = _rentalService.CountRentalsAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var totalActiveRentalsTask = _rentalService.CountActiveRentalsAsync();", summaryReport, StringComparison.Ordinal);
             Assert.Contains("var totalCustomersTask = _customerService.CountCustomersAsync(CancellationToken.None);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var totalUsersTask = _userService.CountUsersAsync(CancellationToken.None);", summaryReport, StringComparison.Ordinal);
+
+            Assert.Contains("var totalRentals = await totalRentalsTask.ConfigureAwait(false);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var totalActiveRentals = await totalActiveRentalsTask.ConfigureAwait(false);", summaryReport, StringComparison.Ordinal);
             Assert.Contains("var totalCustomers = await totalCustomersTask.ConfigureAwait(false);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var totalUsers = await totalUsersTask.ConfigureAwait(false);", summaryReport, StringComparison.Ordinal);
+
+            Assert.Contains("$\"Total Rentals (History): {totalRentals}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Active Rentals: {totalActiveRentals}\"", summaryReport, StringComparison.Ordinal);
             Assert.Contains("$\"Total Customers: {totalCustomers}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Total Users: {totalUsers}\"", summaryReport, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("var totalRentalsTask = _rentalService.GetAllRentalsAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("var totalActiveRentalsTask = _rentalService.GetActiveRentalsAsync();", summaryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("var totalCustomersTask = _customerService.GetAllCustomersAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("var totalUsersTask = _userService.GetAllUsersAsync(CancellationToken.None);", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Total Rentals (History): {totalRentals.Count}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Active Rentals: {totalActiveRentals.Count}\"", summaryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("$\"Total Customers: {totalCustomers.Count}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Total Users: {totalUsers.Count}\"", summaryReport, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalServiceProvidesVisibleTotalRentalCountForSummaryReports()
+        {
+            var interfaceSource = ReadRepoFile("InventoryManagementApp", "Interfaces", "IRentalService.cs");
+            var rentalServiceSource = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+            var countMethod = ExtractMethod(
+                rentalServiceSource,
+                "public async Task<int> CountRentalsAsync()",
+                "public async Task<int> CountActiveRentalsAsync()");
+
+            Assert.Contains("Task<int> CountRentalsAsync();", interfaceSource, StringComparison.Ordinal);
+            Assert.Contains("SELECT COUNT(r.RentalID)", countMethod, StringComparison.Ordinal);
+            Assert.Contains("FROM Rentals r", countMethod, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items t ON r.ItemID = t.ItemID", countMethod, StringComparison.Ordinal);
+            Assert.Contains("JOIN Customers c ON r.CustomerID = c.CustomerID", countMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @RentalListLimit", countMethod, StringComparison.Ordinal);
         }
 
         private static void AssertUsesBoundedReportPages(string method)

--- a/InventoryManagementApp/Interfaces/IRentalService.cs
+++ b/InventoryManagementApp/Interfaces/IRentalService.cs
@@ -32,6 +32,7 @@ namespace InventoryManagementApp.Interfaces
             throw new NotSupportedException("This rental service does not support swapping rental items.");
         Task DeleteRentalAsync(int rentalID);
         Task<List<Rental>> GetActiveRentalsAsync();
+        Task<int> CountRentalsAsync();
         Task<int> CountActiveRentalsAsync();
         Task<List<Rental>> GetOverdueRentalsAsync();
         Task<List<Rental>> GetAllRentalsAsync();

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-summary-report-count-apis.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-summary-report-count-apis.md
@@ -1,0 +1,21 @@
+# Summary Report Count APIs
+
+Date: 2026-07-01
+
+## Completed
+
+- Updated `ReportService.GenerateSummaryReport` so total rentals, active rentals, customers, and users are read through count APIs instead of materializing capped list workflows and reading `.Count`.
+- Added `IRentalService.CountRentalsAsync()` and implemented it in `RentalService` with the same required item/customer joins used by visible rental projections, so legacy orphan rental rows do not inflate the total rental summary.
+- Kept detail reports list-based, preserving their existing printable output while making the application summary totals accurate beyond the 500-row list caps.
+- Extended `ReportServiceInventoryPagingContractTests` to guard the count API paths and reject regressions back to list materialization for summary totals.
+
+## Why This Mattered
+
+Recent paging work capped rental and user list-style reads at 500 rows, which is good for interactive grids but risky for summary totals if the report counts the returned list. The application summary report should show true totals, not capped-list counts, and should avoid loading rows when a count query is enough.
+
+## Validation
+
+- Connector readback should confirm `GenerateSummaryReport` calls `_rentalService.CountRentalsAsync()`, `_rentalService.CountActiveRentalsAsync()`, `_customerService.CountCustomersAsync(CancellationToken.None)`, and `_userService.CountUsersAsync(CancellationToken.None)` for core totals.
+- Connector readback should confirm `RentalService.CountRentalsAsync()` counts visible rental rows with required item and customer joins and no list limit.
+- Connector readback should confirm `ReportServiceInventoryPagingContractTests` covers the count API paths and rejects the old list-materialization summary patterns.
+- Local build, tests, WPF runtime checks, print/layout checks, and full validation still require a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -125,10 +125,10 @@ namespace InventoryManagementApp.Services.Items
         public async Task<FlowDocument> GenerateSummaryReport()
         {
             var totalItemsTask = CountItemsAsync();
-            var totalRentalsTask = _rentalService.GetAllRentalsAsync();
-            var totalActiveRentalsTask = _rentalService.GetActiveRentalsAsync();
+            var totalRentalsTask = _rentalService.CountRentalsAsync();
+            var totalActiveRentalsTask = _rentalService.CountActiveRentalsAsync();
             var totalCustomersTask = _customerService.CountCustomersAsync(CancellationToken.None);
-            var totalUsersTask = _userService.GetAllUsersAsync(CancellationToken.None);
+            var totalUsersTask = _userService.CountUsersAsync(CancellationToken.None);
 
             await Task.WhenAll(
                 totalItemsTask,
@@ -146,10 +146,10 @@ namespace InventoryManagementApp.Services.Items
             var lines = new List<string>
             {
                 $"Total Items: {totalItems}",
-                $"Total Rentals (History): {totalRentals.Count}",
-                $"Active Rentals: {totalActiveRentals.Count}",
+                $"Total Rentals (History): {totalRentals}",
+                $"Active Rentals: {totalActiveRentals}",
                 $"Total Customers: {totalCustomers}",
-                $"Total Users: {totalUsers.Count}"
+                $"Total Users: {totalUsers}"
             };
 
             if (_maintenanceService != null)

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -390,6 +390,17 @@ namespace InventoryManagementApp.Services.Rentals
             WeakReferenceMessenger.Default.Send(new DomainDataChangedMessage(scope, entityId));
         }
 
+        public async Task<int> CountRentalsAsync()
+        {
+            using var conn = _dbService.CreateConnection();
+            const string sql = @"
+                SELECT COUNT(r.RentalID)
+                FROM Rentals r
+                JOIN Items t ON r.ItemID = t.ItemID
+                JOIN Customers c ON r.CustomerID = c.CustomerID";
+            return Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql).ConfigureAwait(false) ?? 0);
+        }
+
         public async Task<int> CountActiveRentalsAsync()
         {
             using var conn = _dbService.CreateConnection();


### PR DESCRIPTION
## What changed

- Added `IRentalService.CountRentalsAsync()` and implemented it in `RentalService` with the same required item/customer joins used by visible rental projections.
- Updated `ReportService.GenerateSummaryReport` so total rentals, active rentals, customers, and users use count APIs instead of materializing capped list workflows and reading `.Count`.
- Extended `ReportServiceInventoryPagingContractTests` to guard the summary count API paths and reject regressions back to list materialization.
- Added a progress note for the completed report reliability slice.

## Why this was the highest-value next step

Current repo evidence shows recent work capped list-style reads at 500 rows for reliability. That made the application summary report risky because it was still counting returned rental/user lists, which could under-report true totals after the caps. Fixing the summary report keeps the reliability gains from capped lists while preserving accurate operational totals.

## Why this is large enough to count as real progress

This is a complete workflow-level slice across service contract, persistence query, report generation, source-contract coverage, and progress notes. It improves a user-facing report rather than only changing a guard clause or isolated assertion.

## Validation

- Connector compare confirmed this branch is 5 focused files ahead of `master` and only touches the rental service contract/query, summary report, report source-contract tests, and one progress note.
- Connector readback confirmed `GenerateSummaryReport` calls `_rentalService.CountRentalsAsync()`, `_rentalService.CountActiveRentalsAsync()`, `_customerService.CountCustomersAsync(CancellationToken.None)`, and `_userService.CountUsersAsync(CancellationToken.None)`.
- Connector readback confirmed `RentalService.CountRentalsAsync()` counts visible rental rows with required item/customer joins and no list limit.
- Connector readback confirmed `ReportServiceInventoryPagingContractTests` guards the new count API paths and rejects old list-materialization patterns.
- Connector status readback found no attached statuses on branch head `792b42b28989337dd71d381869c924a274287c97`.

## Could not be checked

- Local `pwsh -File scripts/run-full-validation.ps1`, .NET build/tests, WPF runtime checks, screenshots, print/layout checks, and GitHub Actions log inspection could not be run in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 responses and `dotnet`, `pwsh`, and `gh` are unavailable.

## Known follow-up work

- Run the checked-in full validation from a Windows/.NET-capable checkout.
- Continue reviewing optional summary sections that still count capped maintenance, calibration, reservation, or kit lists if count APIs already exist or are worth adding.