### PR TITLE
Disclose capped report result sets

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -21,7 +21,7 @@ namespace InventoryManagementApp.Tests
             var countMethod = ExtractMethod(
                 source,
                 "private async Task<int> CountItemsAsync()",
-                "FlowDocument BuildReport(string title, IEnumerable<string> lines)");
+                "private static string FormatLimitedCount(int count)");
 
             Assert.Contains("private const int InventoryReportPageSize = 500;", source, StringComparison.Ordinal);
             Assert.Contains("var items = await CollectInventoryReportItemsAsync().ConfigureAwait(false);", inventoryReport, StringComparison.Ordinal);
@@ -65,6 +65,84 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("$\"Active Rentals: {totalActiveRentals.Count}\"", summaryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("$\"Total Customers: {totalCustomers.Count}\"", summaryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("$\"Total Users: {totalUsers.Count}\"", summaryReport, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CappedDetailedReportsDisclosePotentiallyTruncatedRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+            var rentalReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateRentalReport(bool activeOnly = true)",
+                "public async Task<FlowDocument> GenerateRentalFrequencyReport(int topN = 20)");
+            var customerReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateCustomerReport()",
+                "public async Task<FlowDocument> GenerateUserReport()");
+            var userReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateUserReport()",
+                "public async Task<FlowDocument> GenerateSummaryReport()");
+            var maintenanceReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)",
+                "public async Task<FlowDocument> GenerateCalibrationReport(bool overdueOnly = false)");
+            var calibrationReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateCalibrationReport(bool overdueOnly = false)",
+                "public async Task<FlowDocument> GenerateReservationReport(bool activeOnly = true)");
+            var reservationReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateReservationReport(bool activeOnly = true)",
+                "public async Task<FlowDocument> GenerateKitReport()");
+            var kitReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateKitReport()",
+                "private async Task<List<ItemModel>> CollectInventoryReportItemsAsync()");
+            var limitNotice = ExtractMethod(
+                source,
+                "private static string FormatLimitedCount(int count)",
+                "FlowDocument BuildReport(string title, IEnumerable<string> lines)");
+
+            Assert.Contains("private const int DetailedReportResultLimit = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("AddReportLimitNotice(lines, rentals.Count, \"rental records\")", rentalReport, StringComparison.Ordinal);
+            Assert.Contains("AddReportLimitNotice(lines, customers.Count, \"customers\")", customerReport, StringComparison.Ordinal);
+            Assert.Contains("AddReportLimitNotice(lines, users.Count, \"users\")", userReport, StringComparison.Ordinal);
+            Assert.Contains("AddReportLimitNotice(lines, records.Count, \"maintenance records\")", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("AddReportLimitNotice(lines, records.Count, \"calibration records\")", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("AddReportLimitNotice(lines, reservations.Count, \"reservations\")", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("AddReportLimitNotice(lines, kits.Count, \"active kits\")", kitReport, StringComparison.Ordinal);
+            Assert.Contains("var itemCount = FormatLimitedCount(items.Count);", kitReport, StringComparison.Ordinal);
+
+            Assert.Contains("count >= DetailedReportResultLimit ? $\"{DetailedReportResultLimit}+\" : count.ToString();", limitNotice, StringComparison.Ordinal);
+            Assert.Contains("This report shows the first {DetailedReportResultLimit}", limitNotice, StringComparison.Ordinal);
+            Assert.Contains("Use filters or exports for a narrower full-detail review.", limitNotice, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SummaryOptionalCountsShowWhenDirectoryCapsMayApply()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+            var summaryReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateSummaryReport()",
+                "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)");
+
+            Assert.Contains("$\"Overdue Maintenance: {FormatLimitedCount(overdueMaintenance.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Upcoming Maintenance (30 days): {FormatLimitedCount(upcomingMaintenance.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Overdue Calibrations: {FormatLimitedCount(overdueCalibration.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Upcoming Calibrations (30 days): {FormatLimitedCount(upcomingCalibration.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Active Reservations: {FormatLimitedCount(activeReservations.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Upcoming Reservations (7 days): {FormatLimitedCount(upcomingReservations.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Active Kits: {FormatLimitedCount(activeKits.Count)}\"", summaryReport, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("$\"Overdue Maintenance: {overdueMaintenance.Count}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Upcoming Maintenance (30 days): {upcomingMaintenance.Count}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Overdue Calibrations: {overdueCalibration.Count}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Upcoming Calibrations (30 days): {upcomingCalibration.Count}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Active Reservations: {activeReservations.Count}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Upcoming Reservations (7 days): {upcomingReservations.Count}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Active Kits: {activeKits.Count}\"", summaryReport, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-report-capped-result-notices.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-report-capped-result-notices.md
@@ -1,0 +1,18 @@
+# Report Capped Result Notices
+
+Date: 2026-07-01
+
+## What changed
+
+- Detailed reports that rely on capped service directory calls now append a visible notice when they return 500 rows, so the printed/previewed report no longer looks silently complete when the backing workflow may have more records.
+- Application summary optional sections for maintenance, calibration, reservations, and kits now display `500+` when the service cap may apply, matching the recent report-count honesty work without reopening large uncapped list materialization.
+- Kit item counts in the active kit report also display `500+` when a kit membership list reaches the capped item limit.
+
+## Why it matters
+
+Recent service hardening intentionally capped large directory reads to protect UI and report workflows from unbounded materialization. Exact count APIs now cover the core summary totals, but several detailed reports still use capped list APIs by design. These notices make capped report output honest for operators until those optional sections gain dedicated count APIs or paged detail report flows.
+
+## Validation
+
+- Added source-contract coverage in `ReportServiceInventoryPagingContractTests` to guard the capped-detail notice helper, detailed report call sites, summary optional `500+` formatting, and kit item count formatting.
+- Local build/test/full validation could not be run in this scheduled environment because direct checkout is blocked and the Windows/.NET validation toolchain is unavailable here.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -23,6 +23,7 @@ namespace InventoryManagementApp.Services.Items
     public class ReportService
     {
         private const int InventoryReportPageSize = 500;
+        private const int DetailedReportResultLimit = 500;
 
         readonly IItemService _itemService;
         readonly IRentalService _rentalService;
@@ -75,7 +76,7 @@ namespace InventoryManagementApp.Services.Items
             var lines = rentals.Select(r =>
                 $"Rental ID: {r.RentalID} | Item ID: {r.ItemID} | Customer ID: {r.CustomerID} | Rental Date: {r.RentalDate:yyyy-MM-dd} | Due Date: {r.DueDate:yyyy-MM-dd} | Return Date: {(r.ReturnDate.HasValue ? r.ReturnDate.Value.ToString("yyyy-MM-dd") : "N/A")} | Status: {r.Status}");
 
-            return BuildReport(title, lines);
+            return BuildReport(title, AddReportLimitNotice(lines, rentals.Count, "rental records"));
         }
 
         public async Task<FlowDocument> GenerateRentalFrequencyReport(int topN = 20)
@@ -111,7 +112,7 @@ namespace InventoryManagementApp.Services.Items
             var customers = await _customerService.GetAllCustomersAsync().ConfigureAwait(false);
             var lines = customers.Select(c =>
                 $"Customer ID: {c.CustomerID} | Company: {c.Company} | Email: {c.Email} | Contact: {c.Contact} | Phone: {c.Phone} | Mobile: {c.Mobile} | Address: {c.Address}");
-            return BuildReport("Customer Report", lines);
+            return BuildReport("Customer Report", AddReportLimitNotice(lines, customers.Count, "customers"));
         }
 
         public async Task<FlowDocument> GenerateUserReport()
@@ -119,7 +120,7 @@ namespace InventoryManagementApp.Services.Items
             var users = await _userService.GetAllUsersAsync(CancellationToken.None).ConfigureAwait(false);
             var lines = users.Select(u =>
                 $"User ID: {u.UserID} | User Name: {u.UserName} | Admin: {u.IsAdmin}");
-            return BuildReport("User Report", lines);
+            return BuildReport("User Report", AddReportLimitNotice(lines, users.Count, "users"));
         }
 
         public async Task<FlowDocument> GenerateSummaryReport()
@@ -159,8 +160,8 @@ namespace InventoryManagementApp.Services.Items
                 await Task.WhenAll(overdueMaintenanceTask, upcomingMaintenanceTask);
                 var overdueMaintenance = await overdueMaintenanceTask;
                 var upcomingMaintenance = await upcomingMaintenanceTask;
-                lines.Add($"Overdue Maintenance: {overdueMaintenance.Count}");
-                lines.Add($"Upcoming Maintenance (30 days): {upcomingMaintenance.Count}");
+                lines.Add($"Overdue Maintenance: {FormatLimitedCount(overdueMaintenance.Count)}");
+                lines.Add($"Upcoming Maintenance (30 days): {FormatLimitedCount(upcomingMaintenance.Count)}");
             }
 
             if (_calibrationService != null)
@@ -170,8 +171,8 @@ namespace InventoryManagementApp.Services.Items
                 await Task.WhenAll(overdueCalibrationTask, upcomingCalibrationTask);
                 var overdueCalibration = await overdueCalibrationTask;
                 var upcomingCalibration = await upcomingCalibrationTask;
-                lines.Add($"Overdue Calibrations: {overdueCalibration.Count}");
-                lines.Add($"Upcoming Calibrations (30 days): {upcomingCalibration.Count}");
+                lines.Add($"Overdue Calibrations: {FormatLimitedCount(overdueCalibration.Count)}");
+                lines.Add($"Upcoming Calibrations (30 days): {FormatLimitedCount(upcomingCalibration.Count)}");
             }
 
             if (_reservationService != null)
@@ -181,14 +182,14 @@ namespace InventoryManagementApp.Services.Items
                 await Task.WhenAll(activeReservationsTask, upcomingReservationsTask);
                 var activeReservations = await activeReservationsTask;
                 var upcomingReservations = await upcomingReservationsTask;
-                lines.Add($"Active Reservations: {activeReservations.Count}");
-                lines.Add($"Upcoming Reservations (7 days): {upcomingReservations.Count}");
+                lines.Add($"Active Reservations: {FormatLimitedCount(activeReservations.Count)}");
+                lines.Add($"Upcoming Reservations (7 days): {FormatLimitedCount(upcomingReservations.Count)}");
             }
 
             if (_kitService != null)
             {
                 var activeKits = await _kitService.GetActiveKitsAsync();
-                lines.Add($"Active Kits: {activeKits.Count}");
+                lines.Add($"Active Kits: {FormatLimitedCount(activeKits.Count)}");
             }
 
             return BuildReport("Application Summary Report", lines);
@@ -208,7 +209,7 @@ namespace InventoryManagementApp.Services.Items
             var lines = records.Select(m =>
                 $"Maintenance ID: {m.MaintenanceID} | Item: {m.ItemNumber} - {m.ItemName} | Type: {m.MaintenanceType} | Scheduled: {m.ScheduledDate:yyyy-MM-dd} | Status: {m.StatusDisplay} | Cost: ${m.Cost:F2}");
 
-            return BuildReport(title, lines);
+            return BuildReport(title, AddReportLimitNotice(lines, records.Count, "maintenance records"));
         }
 
         public async Task<FlowDocument> GenerateCalibrationReport(bool overdueOnly = false)
@@ -225,7 +226,7 @@ namespace InventoryManagementApp.Services.Items
             var lines = records.Select(c =>
                 $"Calibration ID: {c.CalibrationID} | Item: {c.ItemNumber} - {c.ItemName} | Date: {c.CalibrationDate:yyyy-MM-dd} | Next Due: {c.NextCalibrationDue:yyyy-MM-dd} | Status: {c.StatusDisplay} | Certificate Number: {c.CertificateNumber}");
 
-            return BuildReport(title, lines);
+            return BuildReport(title, AddReportLimitNotice(lines, records.Count, "calibration records"));
         }
 
         public async Task<FlowDocument> GenerateReservationReport(bool activeOnly = true)
@@ -242,7 +243,7 @@ namespace InventoryManagementApp.Services.Items
             var lines = reservations.Select(r =>
                 $"Reservation ID: {r.ReservationID} | Item: {r.ItemNumber} - {r.ItemName} | Customer: {r.CustomerName} | Start: {r.StartDate:yyyy-MM-dd} | End: {r.EndDate:yyyy-MM-dd} | Quantity: {r.Quantity} | Status: {r.StatusDisplay}");
 
-            return BuildReport(title, lines);
+            return BuildReport(title, AddReportLimitNotice(lines, reservations.Count, "reservations"));
         }
 
         public async Task<FlowDocument> GenerateKitReport()
@@ -256,11 +257,11 @@ namespace InventoryManagementApp.Services.Items
             foreach (var kit in kits)
             {
                 var items = await _kitService.GetKitItemsAsync(kit.KitID).ConfigureAwait(false);
-                var itemCount = items.Count;
+                var itemCount = FormatLimitedCount(items.Count);
                 lines.Add($"Kit Number: {kit.KitNumber} | Kit Name: {kit.Name} | Category: {kit.Category} | Item Count: {itemCount} | Status: {(kit.IsActive ? "Active" : "Inactive")}");
             }
 
-            return BuildReport("Active Kits Report", lines);
+            return BuildReport("Active Kits Report", AddReportLimitNotice(lines, kits.Count, "active kits"));
         }
 
         private async Task<List<ItemModel>> CollectInventoryReportItemsAsync()
@@ -311,6 +312,17 @@ namespace InventoryManagementApp.Services.Items
             return count;
         }
 
+        private static string FormatLimitedCount(int count) =>
+            count >= DetailedReportResultLimit ? $"{DetailedReportResultLimit}+" : count.ToString();
+
+        private static IEnumerable<string> AddReportLimitNotice(IEnumerable<string> lines, int recordCount, string recordLabel)
+        {
+            foreach (var line in lines)
+                yield return line;
+
+            if (recordCount >= DetailedReportResultLimit)
+                yield return $"Note: This report shows the first {DetailedReportResultLimit} {recordLabel}. Use filters or exports for a narrower full-detail review.";
+        }
 
         FlowDocument BuildReport(string title, IEnumerable<string> lines)
         {


### PR DESCRIPTION
## What changed

- Added a shared report helper that appends a visible note when detailed report data reaches the current 500-row directory cap.
- Applied the notice to rental, customer, user, maintenance, calibration, reservation, and active-kit detail reports.
- Updated optional application summary sections and kit item counts to display `500+` when the backing capped list may not represent the full count.
- Added source-contract coverage for the new report notice behavior and recorded the progress note.

## Why this was the highest-value next step

Recent repo evidence shows the app has intentionally capped several service directory reads to avoid unbounded UI/report materialization. Core application summary totals now use exact count APIs, but optional summary/detail reports still rely on capped lists. This change makes those workflow outputs honest for operators instead of silently presenting capped rows as complete reports.

## Why this is real progress

This is a report workflow slice, not an isolated string tweak: it updates the report generation path, covers every capped detailed report call site in `ReportService`, adjusts summary display where exact optional count APIs do not yet exist, and adds tests plus a progress note.

## Validation

- GitHub connector compare/readback confirmed the PR is focused on `ReportService`, `ReportServiceInventoryPagingContractTests`, and one progress note.
- Connector readback confirmed the capped-result helper, detailed report notice call sites, `500+` summary formatting, and kit item count formatting are present.

## Could not check

- Local `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime checks, screenshot/layout checks, and print-preview checks could not run in this scheduled environment because direct checkout/raw access is blocked and the Windows/.NET validation toolchain is unavailable here.

## Known follow-up work

- Add dedicated count APIs for maintenance, calibration, reservation, and kit summary totals so those optional summary lines can become exact counts instead of `500+` cap-aware display.
- Run full Windows/.NET validation from a capable checkout.