### PR TITLE
Use exact maintenance calibration summary counts

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -120,7 +120,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void SummaryOptionalCountsShowWhenDirectoryCapsMayApply()
+        public void SummaryMaintenanceAndCalibrationCountsUseExactCountApis()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
             var summaryReport = ExtractMethod(
@@ -128,18 +128,39 @@ namespace InventoryManagementApp.Tests
                 "public async Task<FlowDocument> GenerateSummaryReport()",
                 "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)");
 
-            Assert.Contains("$\"Overdue Maintenance: {FormatLimitedCount(overdueMaintenance.Count)}\"", summaryReport, StringComparison.Ordinal);
-            Assert.Contains("$\"Upcoming Maintenance (30 days): {FormatLimitedCount(upcomingMaintenance.Count)}\"", summaryReport, StringComparison.Ordinal);
-            Assert.Contains("$\"Overdue Calibrations: {FormatLimitedCount(overdueCalibration.Count)}\"", summaryReport, StringComparison.Ordinal);
-            Assert.Contains("$\"Upcoming Calibrations (30 days): {FormatLimitedCount(upcomingCalibration.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var overdueMaintenanceTask = _maintenanceService.CountOverdueMaintenanceAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var upcomingMaintenanceTask = _maintenanceService.CountUpcomingMaintenanceAsync(30);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var overdueCalibrationTask = _calibrationService.CountOverdueCalibrationAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var upcomingCalibrationTask = _calibrationService.CountUpcomingCalibrationAsync(30);", summaryReport, StringComparison.Ordinal);
+
+            Assert.Contains("$\"Overdue Maintenance: {overdueMaintenance}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Upcoming Maintenance (30 days): {upcomingMaintenance}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Overdue Calibrations: {overdueCalibration}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Upcoming Calibrations (30 days): {upcomingCalibration}\"", summaryReport, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("var overdueMaintenanceTask = _maintenanceService.GetOverdueMaintenanceAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("var upcomingMaintenanceTask = _maintenanceService.GetUpcomingMaintenanceAsync(30);", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("var overdueCalibrationTask = _calibrationService.GetOverdueCalibrationAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("var upcomingCalibrationTask = _calibrationService.GetUpcomingCalibrationAsync(30);", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Overdue Maintenance: {FormatLimitedCount(overdueMaintenance.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Upcoming Maintenance (30 days): {FormatLimitedCount(upcomingMaintenance.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Overdue Calibrations: {FormatLimitedCount(overdueCalibration.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Upcoming Calibrations (30 days): {FormatLimitedCount(upcomingCalibration.Count)}\"", summaryReport, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RemainingSummaryOptionalCountsShowWhenDirectoryCapsMayApply()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+            var summaryReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateSummaryReport()",
+                "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)");
+
             Assert.Contains("$\"Active Reservations: {FormatLimitedCount(activeReservations.Count)}\"", summaryReport, StringComparison.Ordinal);
             Assert.Contains("$\"Upcoming Reservations (7 days): {FormatLimitedCount(upcomingReservations.Count)}\"", summaryReport, StringComparison.Ordinal);
             Assert.Contains("$\"Active Kits: {FormatLimitedCount(activeKits.Count)}\"", summaryReport, StringComparison.Ordinal);
 
-            Assert.DoesNotContain("$\"Overdue Maintenance: {overdueMaintenance.Count}\"", summaryReport, StringComparison.Ordinal);
-            Assert.DoesNotContain("$\"Upcoming Maintenance (30 days): {upcomingMaintenance.Count}\"", summaryReport, StringComparison.Ordinal);
-            Assert.DoesNotContain("$\"Overdue Calibrations: {overdueCalibration.Count}\"", summaryReport, StringComparison.Ordinal);
-            Assert.DoesNotContain("$\"Upcoming Calibrations (30 days): {upcomingCalibration.Count}\"", summaryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("$\"Active Reservations: {activeReservations.Count}\"", summaryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("$\"Upcoming Reservations (7 days): {upcomingReservations.Count}\"", summaryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("$\"Active Kits: {activeKits.Count}\"", summaryReport, StringComparison.Ordinal);
@@ -161,6 +182,55 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("JOIN Items t ON r.ItemID = t.ItemID", countMethod, StringComparison.Ordinal);
             Assert.Contains("JOIN Customers c ON r.CustomerID = c.CustomerID", countMethod, StringComparison.Ordinal);
             Assert.DoesNotContain("LIMIT @RentalListLimit", countMethod, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenanceAndCalibrationServicesProvideExactSummaryCounts()
+        {
+            var maintenanceSource = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+            var calibrationSource = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+            var overdueMaintenanceCount = ExtractMethod(
+                maintenanceSource,
+                "public async Task<int> CountOverdueMaintenanceAsync()",
+                "public async Task<List<MaintenanceRecord>> GetUpcomingMaintenanceAsync(int days = 30)");
+            var upcomingMaintenanceCount = ExtractMethod(
+                maintenanceSource,
+                "public async Task<int> CountUpcomingMaintenanceAsync(int days = 30)",
+                "public async Task<MaintenanceRecord?> GetMaintenanceRecordByIdAsync(int maintenanceID)");
+            var overdueCalibrationCount = ExtractMethod(
+                calibrationSource,
+                "public async Task<int> CountOverdueCalibrationAsync()",
+                "public async Task<List<CalibrationRecord>> GetUpcomingCalibrationAsync(int days = 30)");
+            var upcomingCalibrationCount = ExtractMethod(
+                calibrationSource,
+                "public async Task<int> CountUpcomingCalibrationAsync(int days = 30)",
+                "public async Task<CalibrationRecord?> GetLatestCalibrationForItemAsync(int itemID)");
+
+            Assert.Contains("SELECT COUNT(m.MaintenanceID)", overdueMaintenanceCount, StringComparison.Ordinal);
+            Assert.Contains("FROM MaintenanceRecords m", overdueMaintenanceCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items i ON m.ItemID = i.ItemID", overdueMaintenanceCount, StringComparison.Ordinal);
+            Assert.Contains("WHERE m.Status = 'Scheduled' AND m.ScheduledDate < @Now", overdueMaintenanceCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @MaintenanceListLimit", overdueMaintenanceCount, StringComparison.Ordinal);
+
+            Assert.Contains("SELECT COUNT(m.MaintenanceID)", upcomingMaintenanceCount, StringComparison.Ordinal);
+            Assert.Contains("FROM MaintenanceRecords m", upcomingMaintenanceCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items i ON m.ItemID = i.ItemID", upcomingMaintenanceCount, StringComparison.Ordinal);
+            Assert.Contains("AND m.ScheduledDate >= @Now", upcomingMaintenanceCount, StringComparison.Ordinal);
+            Assert.Contains("AND m.ScheduledDate <= @FutureDate", upcomingMaintenanceCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @MaintenanceListLimit", upcomingMaintenanceCount, StringComparison.Ordinal);
+
+            Assert.Contains("SELECT COUNT(c.CalibrationID)", overdueCalibrationCount, StringComparison.Ordinal);
+            Assert.Contains("FROM CalibrationRecords c", overdueCalibrationCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items i ON c.ItemID = i.ItemID", overdueCalibrationCount, StringComparison.Ordinal);
+            Assert.Contains("WHERE c.NextCalibrationDue < @Now", overdueCalibrationCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @CalibrationListLimit", overdueCalibrationCount, StringComparison.Ordinal);
+
+            Assert.Contains("SELECT COUNT(c.CalibrationID)", upcomingCalibrationCount, StringComparison.Ordinal);
+            Assert.Contains("FROM CalibrationRecords c", upcomingCalibrationCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items i ON c.ItemID = i.ItemID", upcomingCalibrationCount, StringComparison.Ordinal);
+            Assert.Contains("WHERE c.NextCalibrationDue >= @Now", upcomingCalibrationCount, StringComparison.Ordinal);
+            Assert.Contains("AND c.NextCalibrationDue <= @FutureDate", upcomingCalibrationCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @CalibrationListLimit", upcomingCalibrationCount, StringComparison.Ordinal);
         }
 
         private static void AssertUsesBoundedReportPages(string method)

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-maintenance-calibration-summary-counts.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-maintenance-calibration-summary-counts.md
@@ -1,0 +1,24 @@
+# Maintenance And Calibration Summary Count Accuracy - 2026-07-01
+
+## Completed
+
+- Added exact maintenance summary count queries for overdue and upcoming scheduled maintenance rows.
+- Added exact calibration summary count queries for overdue and upcoming calibration rows.
+- Updated the application summary report to use those count APIs instead of counting capped 500-row maintenance and calibration lists.
+- Kept detailed maintenance and calibration reports capped with visible truncation notices.
+- Extended report source-contract coverage so summary report maintenance/calibration totals cannot regress to capped list materialization.
+
+## Why It Matters
+
+The report workflow now gives operators exact maintenance and calibration summary totals while retaining capped detailed report output for safer large-directory rendering. This removes two `500+` summary placeholders from the previous capped-result disclosure pass and makes the summary report more trustworthy without reopening unbounded detail-list reads.
+
+## Validation
+
+- Source inspection confirmed `MaintenanceService` and `CalibrationService` expose exact count queries without list limits.
+- Source inspection confirmed `ReportService.GenerateSummaryReport` uses the new count methods for maintenance and calibration summary lines.
+- Source-contract tests were updated to guard the summary report count paths and the no-`LIMIT` count queries.
+
+## Still Needed
+
+- Run `pwsh -File scripts/run-full-validation.ps1` in a Windows/.NET-capable checkout.
+- Consider exact count APIs for reservation and active-kit summary totals if those workflows need exact summary counts instead of cap-aware `500+` display.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -117,6 +117,22 @@ namespace InventoryManagementApp.Services.Calibration
             });
         }
 
+        public async Task<int> CountOverdueCalibrationAsync()
+        {
+            return await Task.Run(() =>
+            {
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(c.CalibrationID)
+                    FROM CalibrationRecords c
+                    JOIN Items i ON c.ItemID = i.ItemID
+                    WHERE c.NextCalibrationDue < @Now";
+                using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@Now", DateTime.Now);
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
+            });
+        }
+
         public async Task<List<CalibrationRecord>> GetUpcomingCalibrationAsync(int days = 30)
         {
             if (days < 0)
@@ -144,6 +160,28 @@ namespace InventoryManagementApp.Services.Calibration
                     records.Add(MapCalibrationRecord(reader));
                 }
                 return records;
+            });
+        }
+
+        public async Task<int> CountUpcomingCalibrationAsync(int days = 30)
+        {
+            if (days < 0)
+                throw new ArgumentOutOfRangeException(nameof(days), "Days must be greater than or equal to 0.");
+
+            return await Task.Run(() =>
+            {
+                var now = DateTime.Now;
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(c.CalibrationID)
+                    FROM CalibrationRecords c
+                    JOIN Items i ON c.ItemID = i.ItemID
+                    WHERE c.NextCalibrationDue >= @Now
+                    AND c.NextCalibrationDue <= @FutureDate";
+                using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@Now", now);
+                cmd.Parameters.AddWithValue("@FutureDate", now.AddDays(days));
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
             });
         }
 

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -155,24 +155,24 @@ namespace InventoryManagementApp.Services.Items
 
             if (_maintenanceService != null)
             {
-                var overdueMaintenanceTask = _maintenanceService.GetOverdueMaintenanceAsync();
-                var upcomingMaintenanceTask = _maintenanceService.GetUpcomingMaintenanceAsync(30);
-                await Task.WhenAll(overdueMaintenanceTask, upcomingMaintenanceTask);
-                var overdueMaintenance = await overdueMaintenanceTask;
-                var upcomingMaintenance = await upcomingMaintenanceTask;
-                lines.Add($"Overdue Maintenance: {FormatLimitedCount(overdueMaintenance.Count)}");
-                lines.Add($"Upcoming Maintenance (30 days): {FormatLimitedCount(upcomingMaintenance.Count)}");
+                var overdueMaintenanceTask = _maintenanceService.CountOverdueMaintenanceAsync();
+                var upcomingMaintenanceTask = _maintenanceService.CountUpcomingMaintenanceAsync(30);
+                await Task.WhenAll(overdueMaintenanceTask, upcomingMaintenanceTask).ConfigureAwait(false);
+                var overdueMaintenance = await overdueMaintenanceTask.ConfigureAwait(false);
+                var upcomingMaintenance = await upcomingMaintenanceTask.ConfigureAwait(false);
+                lines.Add($"Overdue Maintenance: {overdueMaintenance}");
+                lines.Add($"Upcoming Maintenance (30 days): {upcomingMaintenance}");
             }
 
             if (_calibrationService != null)
             {
-                var overdueCalibrationTask = _calibrationService.GetOverdueCalibrationAsync();
-                var upcomingCalibrationTask = _calibrationService.GetUpcomingCalibrationAsync(30);
-                await Task.WhenAll(overdueCalibrationTask, upcomingCalibrationTask);
-                var overdueCalibration = await overdueCalibrationTask;
-                var upcomingCalibration = await upcomingCalibrationTask;
-                lines.Add($"Overdue Calibrations: {FormatLimitedCount(overdueCalibration.Count)}");
-                lines.Add($"Upcoming Calibrations (30 days): {FormatLimitedCount(upcomingCalibration.Count)}");
+                var overdueCalibrationTask = _calibrationService.CountOverdueCalibrationAsync();
+                var upcomingCalibrationTask = _calibrationService.CountUpcomingCalibrationAsync(30);
+                await Task.WhenAll(overdueCalibrationTask, upcomingCalibrationTask).ConfigureAwait(false);
+                var overdueCalibration = await overdueCalibrationTask.ConfigureAwait(false);
+                var upcomingCalibration = await upcomingCalibrationTask.ConfigureAwait(false);
+                lines.Add($"Overdue Calibrations: {overdueCalibration}");
+                lines.Add($"Upcoming Calibrations (30 days): {upcomingCalibration}");
             }
 
             if (_reservationService != null)

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -121,6 +121,22 @@ namespace InventoryManagementApp.Services.Maintenance
             });
         }
 
+        public async Task<int> CountOverdueMaintenanceAsync()
+        {
+            return await Task.Run(() =>
+            {
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(m.MaintenanceID)
+                    FROM MaintenanceRecords m
+                    JOIN Items i ON m.ItemID = i.ItemID
+                    WHERE m.Status = 'Scheduled' AND m.ScheduledDate < @Now";
+                using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@Now", DateTime.Now);
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
+            });
+        }
+
         public async Task<List<MaintenanceRecord>> GetUpcomingMaintenanceAsync(int days = 30)
         {
             if (days < 0)
@@ -149,6 +165,29 @@ namespace InventoryManagementApp.Services.Maintenance
                     records.Add(MapMaintenanceRecord(reader));
                 }
                 return records;
+            });
+        }
+
+        public async Task<int> CountUpcomingMaintenanceAsync(int days = 30)
+        {
+            if (days < 0)
+                throw new ArgumentOutOfRangeException(nameof(days), "Days must be greater than or equal to 0.");
+
+            return await Task.Run(() =>
+            {
+                var now = DateTime.Now;
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(m.MaintenanceID)
+                    FROM MaintenanceRecords m
+                    JOIN Items i ON m.ItemID = i.ItemID
+                    WHERE m.Status = 'Scheduled'
+                    AND m.ScheduledDate >= @Now
+                    AND m.ScheduledDate <= @FutureDate";
+                using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@Now", now);
+                cmd.Parameters.AddWithValue("@FutureDate", now.AddDays(days));
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
             });
         }
 


### PR DESCRIPTION
## What changed

- Added exact maintenance count queries for overdue and upcoming scheduled maintenance rows.
- Added exact calibration count queries for overdue and upcoming calibration rows.
- Updated `ReportService.GenerateSummaryReport` so maintenance and calibration summary totals use those count APIs instead of counting capped 500-row lists.
- Kept detailed maintenance and calibration reports capped with visible truncation notices.
- Updated report source-contract coverage to guard the new exact summary count paths and no-limit count queries.
- Added a progress note for the completed report accuracy slice.

## Why this was the highest-value next step

Recent merged report work made capped detailed reports honest and left follow-up evidence in the repo: optional summary sections for maintenance, calibration, reservations, and kits still used capped list counts. Maintenance and calibration were the safest next complete slice because their services already own the exact date/status filters needed for count queries, so the summary report can become exact without reopening unbounded detail-list materialization.

## Why this is large enough to count as real progress

This is a report workflow improvement across persistence queries, service behavior, report generation, regression coverage, and progress notes. It removes two cap-aware summary placeholders from an operator-facing report while preserving capped detailed report rendering for large datasets.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, ahead by 5 focused commits, and limited to maintenance/calibration services, `ReportService`, one report contract test file, and one progress note.
- Connector readback confirmed `ReportService.GenerateSummaryReport` uses `CountOverdueMaintenanceAsync`, `CountUpcomingMaintenanceAsync(30)`, `CountOverdueCalibrationAsync`, and `CountUpcomingCalibrationAsync(30)` for summary lines.
- Connector readback confirmed maintenance and calibration count queries use the same item visibility joins as their detail queries and do not include the 500-row list limits.
- Connector readback confirmed source-contract tests guard the exact summary count paths and leave reservation/kit cap-aware summary counts intact.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Consider exact count APIs for reservation and active-kit summary totals if those report sections should also move from cap-aware `500+` display to exact counts.