### PR TITLE
Use exact reservation and kit summary counts

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -149,7 +149,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RemainingSummaryOptionalCountsShowWhenDirectoryCapsMayApply()
+        public void SummaryReservationAndKitCountsUseExactCountApis()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
             var summaryReport = ExtractMethod(
@@ -157,13 +157,20 @@ namespace InventoryManagementApp.Tests
                 "public async Task<FlowDocument> GenerateSummaryReport()",
                 "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)");
 
-            Assert.Contains("$\"Active Reservations: {FormatLimitedCount(activeReservations.Count)}\"", summaryReport, StringComparison.Ordinal);
-            Assert.Contains("$\"Upcoming Reservations (7 days): {FormatLimitedCount(upcomingReservations.Count)}\"", summaryReport, StringComparison.Ordinal);
-            Assert.Contains("$\"Active Kits: {FormatLimitedCount(activeKits.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var activeReservationsTask = _reservationService.CountActiveReservationsAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var upcomingReservationsTask = _reservationService.CountUpcomingReservationsAsync(7);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var activeKits = await _kitService.CountActiveKitsAsync().ConfigureAwait(false);", summaryReport, StringComparison.Ordinal);
 
-            Assert.DoesNotContain("$\"Active Reservations: {activeReservations.Count}\"", summaryReport, StringComparison.Ordinal);
-            Assert.DoesNotContain("$\"Upcoming Reservations (7 days): {upcomingReservations.Count}\"", summaryReport, StringComparison.Ordinal);
-            Assert.DoesNotContain("$\"Active Kits: {activeKits.Count}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Active Reservations: {activeReservations}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Upcoming Reservations (7 days): {upcomingReservations}\"", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Active Kits: {activeKits}\"", summaryReport, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("var activeReservationsTask = _reservationService.GetActiveReservationsAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("var upcomingReservationsTask = _reservationService.GetUpcomingReservationsAsync(7);", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("var activeKits = await _kitService.GetActiveKitsAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Active Reservations: {FormatLimitedCount(activeReservations.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Upcoming Reservations (7 days): {FormatLimitedCount(upcomingReservations.Count)}\"", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"Active Kits: {FormatLimitedCount(activeKits.Count)}\"", summaryReport, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -231,6 +238,45 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("WHERE c.NextCalibrationDue >= @Now", upcomingCalibrationCount, StringComparison.Ordinal);
             Assert.Contains("AND c.NextCalibrationDue <= @FutureDate", upcomingCalibrationCount, StringComparison.Ordinal);
             Assert.DoesNotContain("LIMIT @CalibrationListLimit", upcomingCalibrationCount, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationAndKitServicesProvideExactSummaryCounts()
+        {
+            var reservationSource = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+            var kitSource = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+            var activeReservationCount = ExtractMethod(
+                reservationSource,
+                "public async Task<int> CountActiveReservationsAsync()",
+                "public async Task<int> CountUpcomingReservationsAsync(int days = 7)");
+            var upcomingReservationCount = ExtractMethod(
+                reservationSource,
+                "public async Task<int> CountUpcomingReservationsAsync(int days = 7)",
+                "public async Task<Reservation?> GetReservationByIdAsync(int reservationID)");
+            var activeKitCount = ExtractMethod(
+                kitSource,
+                "public async Task<int> CountActiveKitsAsync()",
+                "public async Task<Kit?> GetKitByIdAsync(int kitID)");
+
+            Assert.Contains("SELECT COUNT(r.ReservationID)", activeReservationCount, StringComparison.Ordinal);
+            Assert.Contains("FROM Reservations r", activeReservationCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items i ON r.ItemID = i.ItemID", activeReservationCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Customers c ON r.CustomerID = c.CustomerID", activeReservationCount, StringComparison.Ordinal);
+            Assert.Contains("WHERE r.Status IN ('Pending', 'Confirmed')", activeReservationCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @ReservationListLimit", activeReservationCount, StringComparison.Ordinal);
+
+            Assert.Contains("if (days < 0)", upcomingReservationCount, StringComparison.Ordinal);
+            Assert.Contains("SELECT COUNT(r.ReservationID)", upcomingReservationCount, StringComparison.Ordinal);
+            Assert.Contains("FROM Reservations r", upcomingReservationCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items i ON r.ItemID = i.ItemID", upcomingReservationCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Customers c ON r.CustomerID = c.CustomerID", upcomingReservationCount, StringComparison.Ordinal);
+            Assert.Contains("AND r.StartDate <= @FutureDate", upcomingReservationCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @ReservationListLimit", upcomingReservationCount, StringComparison.Ordinal);
+
+            Assert.Contains("SELECT COUNT(KitID)", activeKitCount, StringComparison.Ordinal);
+            Assert.Contains("FROM Kits", activeKitCount, StringComparison.Ordinal);
+            Assert.Contains("WHERE IsActive = 1", activeKitCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @KitListLimit", activeKitCount, StringComparison.Ordinal);
         }
 
         private static void AssertUsesBoundedReportPages(string method)

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-reservation-kit-summary-counts.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-reservation-kit-summary-counts.md
@@ -1,0 +1,25 @@
+# Reservation And Kit Summary Counts
+
+Date: 2026-07-01
+
+## Completed
+
+- Added exact reservation count APIs for active reservations and upcoming reservations.
+- Added an exact active-kit count API.
+- Updated `ReportService.GenerateSummaryReport` so reservation and kit summary totals use those count APIs instead of counting capped 500-row directory lists.
+- Kept detailed reservation and kit reports capped with existing visible truncation notices.
+- Updated report source-contract coverage so summary report wiring and uncapped service count queries are guarded.
+
+## Why It Matters
+
+Application Summary Report totals should reflect the full database, not the first capped directory page. This finishes the report accuracy follow-up left after exact maintenance and calibration summary counts, while preserving the bounded detailed-report behavior that keeps large printable reports manageable.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused service, report, test, and progress-note diff.
+- Local validation was not available in the scheduled Linux environment because direct checkout is blocked and the Windows/.NET validation stack is unavailable here.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Continue using exact service count APIs for future summary-report totals instead of deriving counts from capped detail lists.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -177,19 +177,19 @@ namespace InventoryManagementApp.Services.Items
 
             if (_reservationService != null)
             {
-                var activeReservationsTask = _reservationService.GetActiveReservationsAsync();
-                var upcomingReservationsTask = _reservationService.GetUpcomingReservationsAsync(7);
-                await Task.WhenAll(activeReservationsTask, upcomingReservationsTask);
-                var activeReservations = await activeReservationsTask;
-                var upcomingReservations = await upcomingReservationsTask;
-                lines.Add($"Active Reservations: {FormatLimitedCount(activeReservations.Count)}");
-                lines.Add($"Upcoming Reservations (7 days): {FormatLimitedCount(upcomingReservations.Count)}");
+                var activeReservationsTask = _reservationService.CountActiveReservationsAsync();
+                var upcomingReservationsTask = _reservationService.CountUpcomingReservationsAsync(7);
+                await Task.WhenAll(activeReservationsTask, upcomingReservationsTask).ConfigureAwait(false);
+                var activeReservations = await activeReservationsTask.ConfigureAwait(false);
+                var upcomingReservations = await upcomingReservationsTask.ConfigureAwait(false);
+                lines.Add($"Active Reservations: {activeReservations}");
+                lines.Add($"Upcoming Reservations (7 days): {upcomingReservations}");
             }
 
             if (_kitService != null)
             {
-                var activeKits = await _kitService.GetActiveKitsAsync();
-                lines.Add($"Active Kits: {FormatLimitedCount(activeKits.Count)}");
+                var activeKits = await _kitService.CountActiveKitsAsync().ConfigureAwait(false);
+                lines.Add($"Active Kits: {activeKits}");
             }
 
             return BuildReport("Application Summary Report", lines);

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -83,6 +83,20 @@ namespace InventoryManagementApp.Services.Kits
             });
         }
 
+        public async Task<int> CountActiveKitsAsync()
+        {
+            return await Task.Run(() =>
+            {
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(KitID)
+                    FROM Kits
+                    WHERE IsActive = 1";
+                using var cmd = new SqliteCommand(sql, conn);
+                return Convert.ToInt32(cmd.ExecuteScalar());
+            });
+        }
+
         /// <summary>
         /// Retrieves a specific kit by its ID.
         /// </summary>

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -183,6 +183,43 @@ namespace InventoryManagementApp.Services.Reservations
             });
         }
 
+        public async Task<int> CountActiveReservationsAsync()
+        {
+            return await Task.Run(() =>
+            {
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(r.ReservationID)
+                    FROM Reservations r
+                    JOIN Items i ON r.ItemID = i.ItemID
+                    JOIN Customers c ON r.CustomerID = c.CustomerID
+                    WHERE r.Status IN ('Pending', 'Confirmed')";
+                using var cmd = new SqliteCommand(sql, conn);
+                return Convert.ToInt32(cmd.ExecuteScalar());
+            });
+        }
+
+        public async Task<int> CountUpcomingReservationsAsync(int days = 7)
+        {
+            if (days < 0)
+                throw new ArgumentOutOfRangeException(nameof(days), "Days must be greater than or equal to 0.");
+
+            return await Task.Run(() =>
+            {
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(r.ReservationID)
+                    FROM Reservations r
+                    JOIN Items i ON r.ItemID = i.ItemID
+                    JOIN Customers c ON r.CustomerID = c.CustomerID
+                    WHERE r.Status IN ('Pending', 'Confirmed')
+                    AND r.StartDate <= @FutureDate";
+                using var cmd = new SqliteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@FutureDate", DateTime.Now.AddDays(days));
+                return Convert.ToInt32(cmd.ExecuteScalar());
+            });
+        }
+
         public async Task<Reservation?> GetReservationByIdAsync(int reservationID)
         {
             if (reservationID < 1)


### PR DESCRIPTION
## What changed

- Added exact reservation count queries for active reservations and upcoming reservations.
- Added an exact active-kit count query.
- Updated `ReportService.GenerateSummaryReport` so reservation and kit summary totals use those counters instead of counting capped 500-row directory lists.
- Kept detailed reservation and kit reports capped with the existing visible truncation notices.
- Updated report source-contract coverage to guard the new summary wiring and uncapped service count queries.
- Added a progress note for the completed report accuracy slice.

## Why this was the highest-value next step

The latest merged report work made maintenance and calibration summary totals exact and left reservation plus active-kit totals as the remaining report-count follow-up. Current source confirmed those summary lines still came from capped 500-row list reads, so large databases could show `500+` instead of exact summary totals.

## Why this is large enough to count as real progress

This is a complete report workflow slice across persistence queries, service behavior, summary-report generation, source-contract coverage, and project notes. It completes the current summary-report accuracy thread while preserving bounded detailed reports for printable output.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 focused commits, and limited to reservation/kit services, `ReportService`, one report contract test file, and one progress note.
- Connector readback confirmed `ReportService.GenerateSummaryReport` now calls `CountActiveReservationsAsync`, `CountUpcomingReservationsAsync(7)`, and `CountActiveKitsAsync` for summary rows.
- Connector readback confirmed reservation count queries use the same item/customer joins and active/upcoming filters as their detailed reads without `LIMIT @ReservationListLimit`.
- Connector readback confirmed the kit count query counts active kits directly without `LIMIT @KitListLimit`.
- Connector status readback found no attached commit statuses on the branch head before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub `CONNECT tunnel failed, response 403`.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue using exact service count APIs for future summary-report totals instead of deriving counts from capped detail lists.