### PR TITLE
Use item count API for summary report total

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceSummaryItemCountContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceSummaryItemCountContractTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReportServiceSummaryItemCountContractTests
+    {
+        [Fact]
+        public void SummaryReportUsesItemCountApiForInventoryTotal()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+            var summaryReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateSummaryReport()",
+                "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)");
+
+            Assert.Contains("var totalItemsTask = _itemService.CountItemsAsync(new ItemFilter(null, SortField.Name, SortDirection.Ascending, false), CancellationToken.None);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var totalItems = await totalItemsTask.ConfigureAwait(false);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Total Items: {totalItems}\"", summaryReport, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("var totalItemsTask = CountItemsAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("new ItemPage(", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetItemsAsync(", summaryReport, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-summary-item-count-api.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-summary-item-count-api.md
@@ -1,0 +1,23 @@
+# Summary Item Count API
+
+Date: 2026-07-01
+
+## Completed
+
+- Updated `ReportService.GenerateSummaryReport` so the `Total Items` row uses `IItemService.CountItemsAsync(...)` instead of counting inventory rows through report-detail pages.
+- Kept `GenerateInventoryReport` on bounded 500-item pages for detailed printable output.
+- Added source-contract coverage to guard the summary item total against drifting back to row enumeration or `ItemPage` usage.
+
+## Why It Matters
+
+The Application Summary Report should use exact count queries for totals instead of walking every visible item row. This keeps the summary fast and accurate for large inventories while preserving the bounded detailed report behavior introduced for printable inventory output.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the report-service change, focused source-contract test, and progress note.
+- Local validation was not available in the scheduled Linux environment because direct checkout is blocked and the Windows/.NET validation stack is unavailable here.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Remove the now-unused private report item-count paging helper during a future local checkout cleanup if no source-contract tests still depend on it.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -125,7 +125,7 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<FlowDocument> GenerateSummaryReport()
         {
-            var totalItemsTask = CountItemsAsync();
+            var totalItemsTask = _itemService.CountItemsAsync(new ItemFilter(null, SortField.Name, SortDirection.Ascending, false), CancellationToken.None);
             var totalRentalsTask = _rentalService.CountRentalsAsync();
             var totalActiveRentalsTask = _rentalService.CountActiveRentalsAsync();
             var totalCustomersTask = _customerService.CountCustomersAsync(CancellationToken.None);


### PR DESCRIPTION
## What changed

- Updated `ReportService.GenerateSummaryReport` so the `Total Items` row uses `IItemService.CountItemsAsync(...)` instead of counting inventory rows by walking report-detail pages.
- Kept `GenerateInventoryReport` on bounded 500-item pages for detailed printable inventory output.
- Added a focused source-contract test to guard the summary item total against drifting back to `ItemPage` or `GetItemsAsync` row enumeration.
- Added a progress note for the completed report reliability slice.

## Why this was the highest-value next step

Recent report work made summary totals exact for rentals, customers, users, maintenance, calibration, reservations, and kits. Current source still showed the item summary total using report-row paging through `CountItemsAsync()`, even though `IItemService` already exposes an exact count API. This keeps the active report accuracy/reliability thread moving without repeating the already-completed optional summary count work.

## Why this is large enough to count as real progress

This is a complete report workflow slice across report generation, item service count-contract usage, regression coverage, and project notes. It improves the operator-facing Application Summary Report while preserving bounded detailed report behavior for printable inventory output.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ReportService`, one new source-contract test, and one progress note.
- Connector readback confirmed `GenerateSummaryReport` now calls `_itemService.CountItemsAsync(new ItemFilter(null, SortField.Name, SortDirection.Ascending, false), CancellationToken.None)` for the `Total Items` row.
- Connector readback confirmed the new contract test rejects `CountItemsAsync()`, `ItemPage`, and `GetItemsAsync` usage in the summary report method.
- Connector status readback found no attached commit statuses on branch head `09727fd70a7cbe984aaed9dad360b623e2b9c21c`.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Remove the now-unused private report item-count paging helper during a future local checkout cleanup if no source-contract tests still depend on it.