### PR TITLE
Remove obsolete report item count helper

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -7,7 +7,7 @@ namespace InventoryManagementApp.Tests
     public class ReportServiceInventoryPagingContractTests
     {
         [Fact]
-        public void InventoryReportAndSummaryCountUseBoundedItemPages()
+        public void InventoryReportUsesBoundedItemPagesWithoutObsoleteCountHelper()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
             var inventoryReport = ExtractMethod(
@@ -17,10 +17,6 @@ namespace InventoryManagementApp.Tests
             var collectorMethod = ExtractMethod(
                 source,
                 "private async Task<List<ItemModel>> CollectInventoryReportItemsAsync()",
-                "private async Task<int> CountItemsAsync()");
-            var countMethod = ExtractMethod(
-                source,
-                "private async Task<int> CountItemsAsync()",
                 "private static string FormatLimitedCount(int count)");
 
             Assert.Contains("private const int InventoryReportPageSize = 500;", source, StringComparison.Ordinal);
@@ -28,9 +24,8 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", inventoryReport, StringComparison.Ordinal);
 
             AssertUsesBoundedReportPages(collectorMethod);
-            AssertUsesBoundedReportPages(countMethod);
             Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", collectorMethod, StringComparison.Ordinal);
-            Assert.DoesNotContain("new ItemPage(1, int.MaxValue)", countMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("private async Task<int> CountItemsAsync()", source, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-summary-item-count-api.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-summary-item-count-api.md
@@ -8,16 +8,22 @@ Date: 2026-07-01
 - Kept `GenerateInventoryReport` on bounded 500-item pages for detailed printable output.
 - Added source-contract coverage to guard the summary item total against drifting back to row enumeration or `ItemPage` usage.
 
+## Completed Follow-Up
+
+- Removed the obsolete private report item-count paging helper after the summary item total moved to the item count API.
+- Updated the older inventory paging contract so it protects the still-used bounded inventory report collector and rejects reintroducing the obsolete private counter.
+
 ## Why It Matters
 
 The Application Summary Report should use exact count queries for totals instead of walking every visible item row. This keeps the summary fast and accurate for large inventories while preserving the bounded detailed report behavior introduced for printable inventory output.
 
+Removing the unused private counter keeps `ReportService` aligned with that design: detailed printable inventory output still pages rows intentionally, while summary totals stay on exact count APIs instead of carrying a second dead counting path.
+
 ## Validation
 
-- GitHub connector readback/compare should confirm the report-service change, focused source-contract test, and progress note.
+- GitHub connector readback/compare should confirm the report-service cleanup, focused source-contract update, and progress note.
 - Local validation was not available in the scheduled Linux environment because direct checkout is blocked and the Windows/.NET validation stack is unavailable here.
 
 ## Follow-Up
 
 - Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
-- Remove the now-unused private report item-count paging helper during a future local checkout cleanup if no source-contract tests still depend on it.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -288,30 +288,6 @@ namespace InventoryManagementApp.Services.Items
             return items;
         }
 
-        private async Task<int> CountItemsAsync()
-        {
-            var count = 0;
-            var pageNumber = 1;
-
-            while (true)
-            {
-                var pageItemCount = 0;
-                await foreach (var _ in _itemService.GetItemsAsync(new ItemPage(pageNumber, InventoryReportPageSize), SortField.Name, SortDirection.Ascending, isRentalItem: false)
-                    .WithCancellation(CancellationToken.None).ConfigureAwait(false))
-                {
-                    count++;
-                    pageItemCount++;
-                }
-
-                if (pageItemCount < InventoryReportPageSize)
-                    break;
-
-                pageNumber++;
-            }
-
-            return count;
-        }
-
         private static string FormatLimitedCount(int count) =>
             count >= DetailedReportResultLimit ? $"{DetailedReportResultLimit}+" : count.ToString();
 


### PR DESCRIPTION
## What changed

- Removed the obsolete private `ReportService.CountItemsAsync()` helper that still paged item rows after the Application Summary Report moved to `IItemService.CountItemsAsync(...)`.
- Updated `ReportServiceInventoryPagingContractTests` so the inventory report contract protects the still-used bounded item collector and rejects reintroducing the obsolete private counter.
- Updated the summary item count progress note to record the completed cleanup follow-up.

## Why this was the highest-value next step

The latest merged report work made the `Total Items` summary row use the exact item count API, and the repo's own progress note identified the old private paging count helper as a cleanup follow-up. Current source confirmed that helper was no longer called but was still kept alive by an older source-contract test. Removing it keeps the report code aligned with the completed summary-count design instead of carrying two competing count paths.

## Why this is large enough to count as real progress

This completes a report workflow maintenance slice across production report code, source-contract coverage, and checked-in progress notes. It is not a cosmetic rename: it removes dead report counting logic and updates the guardrail so future work preserves the intended split between exact summary counts and bounded printable detail rows.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ReportService`, `ReportServiceInventoryPagingContractTests`, and the existing summary item count progress note.
- Connector readback confirmed `ReportService` now flows directly from `CollectInventoryReportItemsAsync()` to `FormatLimitedCount(...)`, with no private `CountItemsAsync()` helper between them.
- Connector readback confirmed the updated contract test extracts `CollectInventoryReportItemsAsync()` through `FormatLimitedCount(...)`, still verifies bounded report pages, and asserts `private async Task<int> CountItemsAsync()` is absent.
- Connector status/workflow readback found no attached commit statuses or workflow runs for branch head `87e136b7cecfae37952400e42927c33fd15b9e48`.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue using exact service count APIs for summary report totals and bounded row collection only for printable/detail reports.