### PR TITLE
Polish generated report document layout

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
@@ -65,7 +65,7 @@ namespace InventoryManagementApp.Tests
             var kitReport = ExtractMethod(
                 source,
                 "public async Task<FlowDocument> GenerateKitReport()",
-                "private async Task<int> CountItemsAsync()");
+                "private async Task<List<ItemModel>> CollectInventoryReportItemsAsync()");
 
             Assert.Contains("Log ID: {l.LogID}", activityLogReport, StringComparison.Ordinal);
             Assert.Contains("User ID: {l.UserID}", activityLogReport, StringComparison.Ordinal);
@@ -114,6 +114,37 @@ namespace InventoryManagementApp.Tests
                 buildReport.IndexOf("if (reportLines.Count == 0)", StringComparison.Ordinal) <
                 buildReport.IndexOf("foreach (var line in reportLines)", StringComparison.Ordinal),
                 "Expected empty report output to be filled before report paragraphs are rendered.");
+        }
+
+        [Fact]
+        public void BuildReportUsesProfessionalPrintPreviewLayout()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+
+            var buildReport = ExtractMethod(
+                source,
+                "FlowDocument BuildReport(string title, IEnumerable<string> lines)",
+                "private static void AddReportLine(FlowDocument doc, string line)");
+            var addReportLine = ExtractMethod(
+                source,
+                "private static void AddReportLine(FlowDocument doc, string line)",
+                "    }\n}");
+
+            Assert.Contains("PagePadding = new Thickness(48, 40, 48, 40)", buildReport, StringComparison.Ordinal);
+            Assert.Contains("MinPageWidth = 720", buildReport, StringComparison.Ordinal);
+            Assert.Contains("MaxPageWidth = 960", buildReport, StringComparison.Ordinal);
+            Assert.Contains("ColumnWidth = double.PositiveInfinity", buildReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("PageWidth = 800", buildReport, StringComparison.Ordinal);
+
+            Assert.Contains("var preparedAt = DateTime.Now;", buildReport, StringComparison.Ordinal);
+            Assert.Contains("$\"Prepared {preparedAt:yyyy-MM-dd HH:mm}\"", buildReport, StringComparison.Ordinal);
+            Assert.Contains("new Run(\"End of report\")", buildReport, StringComparison.Ordinal);
+            Assert.Contains("AddReportLine(doc, line);", buildReport, StringComparison.Ordinal);
+
+            Assert.Contains("line.StartsWith(\"Note:\", StringComparison.Ordinal)", addReportLine, StringComparison.Ordinal);
+            Assert.Contains("paragraph.FontStyle = FontStyles.Italic;", addReportLine, StringComparison.Ordinal);
+            Assert.Contains("paragraph.Foreground = Brushes.DarkSlateGray;", addReportLine, StringComparison.Ordinal);
+            Assert.Contains("paragraph.Background = Brushes.AliceBlue;", addReportLine, StringComparison.Ordinal);
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-generated-report-document-layout.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-generated-report-document-layout.md
@@ -1,0 +1,26 @@
+# Generated Report Document Layout
+
+Date: 2026-07-01
+
+## Completed
+
+- Repaired the report label source-contract test marker that still referenced the removed private `CountItemsAsync` helper.
+- Updated the shared `ReportService.BuildReport` document shell with print-preview-friendly page padding, bounded min/max page widths, and single-column layout behavior instead of the older fixed `PageWidth = 800` canvas.
+- Added a prepared timestamp below each generated report title so printed and previewed reports carry basic review context.
+- Rendered capped-result notices as distinct italic, blue-backed paragraphs instead of ordinary report rows.
+- Added an `End of report` footer so printed output has a clear endpoint after long report bodies.
+
+## Why It Matters
+
+All generated reports flow through the same `BuildReport` helper, so improving the shared document shell upgrades inventory, rental, activity log, customer, user, summary, maintenance, calibration, reservation, and kit reports together. The stale test marker was also a likely validation failure after the obsolete item-count helper was removed, so this pass restores that source-contract path while making report output more professional.
+
+## Validation
+
+- Added/updated source-contract coverage in `ReportServiceUserFacingLabelContractTests` for the repaired kit report extraction marker and the shared report document shell.
+- GitHub connector readback/compare should confirm the focused report-service, test, and progress-note scope.
+- Local build/test/full validation could not be run in this scheduled Linux environment because direct checkout is blocked and the Windows/.NET validation stack is unavailable here.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Visually check representative report previews on Windows to confirm page padding, prepared metadata, capped-result notices, and footer spacing render as intended.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using System.Collections.Generic;
 using System.Linq;
@@ -302,11 +303,15 @@ namespace InventoryManagementApp.Services.Items
 
         FlowDocument BuildReport(string title, IEnumerable<string> lines)
         {
+            var preparedAt = DateTime.Now;
             var doc = new FlowDocument
             {
                 FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
                 FontSize = 12,
-                PageWidth = 800
+                PagePadding = new Thickness(48, 40, 48, 40),
+                MinPageWidth = 720,
+                MaxPageWidth = 960,
+                ColumnWidth = double.PositiveInfinity
             };
 
             var header = new Paragraph(new Run(title))
@@ -314,21 +319,55 @@ namespace InventoryManagementApp.Services.Items
                 FontSize = 18,
                 FontWeight = FontWeights.Bold,
                 TextAlignment = TextAlignment.Center,
-                Margin = new Thickness(0, 0, 0, 20)
+                Margin = new Thickness(0, 0, 0, 6)
             };
             doc.Blocks.Add(header);
+
+            var preparedLine = new Paragraph(new Run($"Prepared {preparedAt:yyyy-MM-dd HH:mm}"))
+            {
+                FontSize = 10,
+                Foreground = Brushes.DimGray,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 20)
+            };
+            doc.Blocks.Add(preparedLine);
 
             var reportLines = lines as IReadOnlyCollection<string> ?? lines.ToList();
             if (reportLines.Count == 0)
                 reportLines = new[] { "No report records found." };
 
             foreach (var line in reportLines)
+                AddReportLine(doc, line);
+
+            var footer = new Paragraph(new Run("End of report"))
             {
-                var p = new Paragraph(new Run(line)) { Margin = new Thickness(0, 0, 0, 10) };
-                doc.Blocks.Add(p);
-            }
+                FontSize = 10,
+                Foreground = Brushes.DimGray,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(0, 18, 0, 0)
+            };
+            doc.Blocks.Add(footer);
 
             return doc;
+        }
+
+        private static void AddReportLine(FlowDocument doc, string line)
+        {
+            var isNotice = line.StartsWith("Note:", StringComparison.Ordinal);
+            var paragraph = new Paragraph(new Run(line))
+            {
+                Margin = isNotice ? new Thickness(0, 8, 0, 14) : new Thickness(0, 0, 0, 8),
+                LineHeight = 18
+            };
+
+            if (isNotice)
+            {
+                paragraph.FontStyle = FontStyles.Italic;
+                paragraph.Foreground = Brushes.DarkSlateGray;
+                paragraph.Background = Brushes.AliceBlue;
+            }
+
+            doc.Blocks.Add(paragraph);
         }
     }
 }


### PR DESCRIPTION
## What changed

- Repaired `ReportServiceUserFacingLabelContractTests` so kit report extraction uses the current `CollectInventoryReportItemsAsync` boundary instead of the removed private `CountItemsAsync` helper.
- Updated the shared `ReportService.BuildReport` shell with print-preview-friendly page padding, bounded min/max page widths, and single-column flow behavior instead of the older fixed `PageWidth = 800` canvas.
- Added a prepared timestamp below generated report titles.
- Rendered capped-result notices as distinct italic, blue-backed paragraphs instead of ordinary report rows.
- Added an `End of report` footer for clearer printed output.
- Added source-contract coverage for the shared report document shell and recorded the completed progress note.

## Why this was the highest-value next step

The newest merged report cleanup removed the obsolete private `CountItemsAsync` helper, but current source still had a label contract test using that removed method as an extraction end marker. That made report validation likely fragile or broken. The same inspection showed the shared report document builder still produced bare fixed-width documents with no prepared metadata or footer, so the safest workflow-level improvement was to repair the stale contract and improve every generated report through the shared builder.

## Why this is large enough to count as real progress

This is a full generated-report workflow slice across production document generation, validation contracts, and progress notes. The shared builder affects inventory, rental, activity log, customer, user, summary, maintenance, calibration, reservation, and kit reports, so the change improves a broad operator-facing workflow without adding unrelated scope.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `ReportService`, `ReportServiceUserFacingLabelContractTests`, and one progress note.
- Connector readback confirmed the stale kit-report test marker now targets `CollectInventoryReportItemsAsync` instead of `CountItemsAsync`.
- Connector readback confirmed the report document shell uses page padding, min/max page widths, `double.PositiveInfinity` column width, prepared timestamp text, `End of report`, and distinct notice styling.
- Connector status readback found no attached commit statuses on branch head `1621a98e504d4032bbdcc7e31c9639ac250ca948` before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP 403 responses.
- `dotnet`, `pwsh`, and `gh` are unavailable here, so local .NET tests, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, print-preview/layout checks, banned-word checks, and GitHub Actions log inspection could not be run locally.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Visually smoke test representative report previews on Windows to confirm page padding, prepared metadata, capped-result notices, and footer spacing render as intended.