### PR TITLE
[codex] Harden detailed report truncation notices

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -63,7 +63,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void CappedDetailedReportsUseExactTruncationNoticesWhereCountsExist()
+        public void CappedDetailedReportsUseParallelExactTruncationCounts()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
             var rentalReport = ExtractMethod(
@@ -102,10 +102,16 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("private const int DetailedReportResultLimit = 500;", source, StringComparison.Ordinal);
             Assert.DoesNotContain("AddReportLimitNotice", source, StringComparison.Ordinal);
 
+            Assert.Contains("var rentalsTask = activeOnly", rentalReport, StringComparison.Ordinal);
+            Assert.Contains("? _rentalService.GetActiveRentalsAsync()", rentalReport, StringComparison.Ordinal);
+            Assert.Contains(": _rentalService.GetAllRentalsAsync();", rentalReport, StringComparison.Ordinal);
+            Assert.Contains("var totalRentalsTask = activeOnly", rentalReport, StringComparison.Ordinal);
+            Assert.Contains("? _rentalService.CountActiveRentalsAsync()", rentalReport, StringComparison.Ordinal);
+            Assert.Contains(": _rentalService.CountRentalsAsync();", rentalReport, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(rentalsTask, totalRentalsTask).ConfigureAwait(false);", rentalReport, StringComparison.Ordinal);
+            Assert.Contains("var rentals = await rentalsTask.ConfigureAwait(false);", rentalReport, StringComparison.Ordinal);
+            Assert.Contains("var totalRentals = await totalRentalsTask.ConfigureAwait(false);", rentalReport, StringComparison.Ordinal);
             Assert.Contains("AddExactReportLimitNotice(lines, rentals.Count, totalRentals, \"rental records\")", rentalReport, StringComparison.Ordinal);
-            Assert.Contains("var totalRentals = activeOnly", rentalReport, StringComparison.Ordinal);
-            Assert.Contains("? await _rentalService.CountActiveRentalsAsync().ConfigureAwait(false)", rentalReport, StringComparison.Ordinal);
-            Assert.Contains(": await _rentalService.CountRentalsAsync().ConfigureAwait(false);", rentalReport, StringComparison.Ordinal);
 
             Assert.Contains("var customersTask = _customerService.SearchCustomersAsync(string.Empty, CancellationToken.None);", customerReport, StringComparison.Ordinal);
             Assert.Contains("var totalCustomersTask = _customerService.CountCustomersAsync(CancellationToken.None);", customerReport, StringComparison.Ordinal);
@@ -116,24 +122,51 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("_customerService.GetAllCustomersAsync()", customerReport, StringComparison.Ordinal);
             Assert.DoesNotContain("customers.Take(DetailedReportResultLimit)", customerReport, StringComparison.Ordinal);
 
-            Assert.Contains("var totalUsers = await _userService.CountUsersAsync(CancellationToken.None).ConfigureAwait(false);", userReport, StringComparison.Ordinal);
+            Assert.Contains("var usersTask = _userService.GetAllUsersAsync(CancellationToken.None);", userReport, StringComparison.Ordinal);
+            Assert.Contains("var totalUsersTask = _userService.CountUsersAsync(CancellationToken.None);", userReport, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(usersTask, totalUsersTask).ConfigureAwait(false);", userReport, StringComparison.Ordinal);
+            Assert.Contains("var users = await usersTask.ConfigureAwait(false);", userReport, StringComparison.Ordinal);
+            Assert.Contains("var totalUsers = await totalUsersTask.ConfigureAwait(false);", userReport, StringComparison.Ordinal);
             Assert.Contains("AddExactReportLimitNotice(lines, users.Count, totalUsers, \"users\")", userReport, StringComparison.Ordinal);
 
-            Assert.Contains("var totalRecords = overdueOnly", maintenanceReport, StringComparison.Ordinal);
-            Assert.Contains("? await _maintenanceService.CountOverdueMaintenanceAsync().ConfigureAwait(false)", maintenanceReport, StringComparison.Ordinal);
-            Assert.Contains(": await _maintenanceService.CountMaintenanceRecordsAsync().ConfigureAwait(false);", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("var recordsTask = overdueOnly", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("? _maintenanceService.GetOverdueMaintenanceAsync()", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains(": _maintenanceService.GetAllMaintenanceRecordsAsync();", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("var totalRecordsTask = overdueOnly", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("? _maintenanceService.CountOverdueMaintenanceAsync()", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains(": _maintenanceService.CountMaintenanceRecordsAsync();", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(recordsTask, totalRecordsTask).ConfigureAwait(false);", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("var records = await recordsTask.ConfigureAwait(false);", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("var totalRecords = await totalRecordsTask.ConfigureAwait(false);", maintenanceReport, StringComparison.Ordinal);
             Assert.Contains("AddExactReportLimitNotice(lines, records.Count, totalRecords, \"maintenance records\")", maintenanceReport, StringComparison.Ordinal);
 
-            Assert.Contains("var totalRecords = overdueOnly", calibrationReport, StringComparison.Ordinal);
-            Assert.Contains("? await _calibrationService.CountOverdueCalibrationAsync().ConfigureAwait(false)", calibrationReport, StringComparison.Ordinal);
-            Assert.Contains(": await _calibrationService.CountCalibrationRecordsAsync().ConfigureAwait(false);", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("var recordsTask = overdueOnly", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("? _calibrationService.GetOverdueCalibrationAsync()", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains(": _calibrationService.GetAllCalibrationRecordsAsync();", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("var totalRecordsTask = overdueOnly", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("? _calibrationService.CountOverdueCalibrationAsync()", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains(": _calibrationService.CountCalibrationRecordsAsync();", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(recordsTask, totalRecordsTask).ConfigureAwait(false);", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("var records = await recordsTask.ConfigureAwait(false);", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("var totalRecords = await totalRecordsTask.ConfigureAwait(false);", calibrationReport, StringComparison.Ordinal);
             Assert.Contains("AddExactReportLimitNotice(lines, records.Count, totalRecords, \"calibration records\")", calibrationReport, StringComparison.Ordinal);
 
-            Assert.Contains("var totalReservations = activeOnly", reservationReport, StringComparison.Ordinal);
-            Assert.Contains("? await _reservationService.CountActiveReservationsAsync().ConfigureAwait(false)", reservationReport, StringComparison.Ordinal);
-            Assert.Contains(": await _reservationService.CountReservationsAsync().ConfigureAwait(false);", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("var reservationsTask = activeOnly", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("? _reservationService.GetActiveReservationsAsync()", reservationReport, StringComparison.Ordinal);
+            Assert.Contains(": _reservationService.GetAllReservationsAsync();", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("var totalReservationsTask = activeOnly", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("? _reservationService.CountActiveReservationsAsync()", reservationReport, StringComparison.Ordinal);
+            Assert.Contains(": _reservationService.CountReservationsAsync();", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(reservationsTask, totalReservationsTask).ConfigureAwait(false);", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("var reservations = await reservationsTask.ConfigureAwait(false);", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("var totalReservations = await totalReservationsTask.ConfigureAwait(false);", reservationReport, StringComparison.Ordinal);
             Assert.Contains("AddExactReportLimitNotice(lines, reservations.Count, totalReservations, \"reservations\")", reservationReport, StringComparison.Ordinal);
 
+            Assert.Contains("var kitsTask = _kitService.GetActiveKitsAsync();", kitReport, StringComparison.Ordinal);
+            Assert.Contains("var totalActiveKitsTask = _kitService.CountActiveKitsAsync();", kitReport, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(kitsTask, totalActiveKitsTask).ConfigureAwait(false);", kitReport, StringComparison.Ordinal);
+            Assert.Contains("var kits = await kitsTask.ConfigureAwait(false);", kitReport, StringComparison.Ordinal);
+            Assert.Contains("var totalActiveKits = await totalActiveKitsTask.ConfigureAwait(false);", kitReport, StringComparison.Ordinal);
             Assert.Contains("AddExactReportLimitNotice(lines, kits.Count, totalActiveKits, \"active kits\")", kitReport, StringComparison.Ordinal);
             Assert.Contains("var itemCount = FormatLimitedCount(items.Count);", kitReport, StringComparison.Ordinal);
 

--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -100,17 +100,32 @@ namespace InventoryManagementApp.Tests
                 "FlowDocument BuildReport(string title, IEnumerable<string> lines)");
 
             Assert.Contains("private const int DetailedReportResultLimit = 500;", source, StringComparison.Ordinal);
-            Assert.Contains("AddReportLimitNotice(lines, rentals.Count, \"rental records\")", rentalReport, StringComparison.Ordinal);
-            Assert.Contains("AddReportLimitNotice(lines, customers.Count, \"customers\")", customerReport, StringComparison.Ordinal);
-            Assert.Contains("AddReportLimitNotice(lines, users.Count, \"users\")", userReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, rentals.Count, totalRentals, \"rental records\")", rentalReport, StringComparison.Ordinal);
+            Assert.Contains("var totalRentals = activeOnly", rentalReport, StringComparison.Ordinal);
+            Assert.Contains("? await _rentalService.CountActiveRentalsAsync().ConfigureAwait(false)", rentalReport, StringComparison.Ordinal);
+            Assert.Contains(": await _rentalService.CountRentalsAsync().ConfigureAwait(false);", rentalReport, StringComparison.Ordinal);
+
+            Assert.Contains("var totalCustomers = await _customerService.CountCustomersAsync(CancellationToken.None).ConfigureAwait(false);", customerReport, StringComparison.Ordinal);
+            Assert.Contains("var reportCustomers = customers.Take(DetailedReportResultLimit).ToList();", customerReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, reportCustomers.Count, totalCustomers, \"customers\")", customerReport, StringComparison.Ordinal);
+
+            Assert.Contains("var totalUsers = await _userService.CountUsersAsync(CancellationToken.None).ConfigureAwait(false);", userReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, users.Count, totalUsers, \"users\")", userReport, StringComparison.Ordinal);
+
             Assert.Contains("AddReportLimitNotice(lines, records.Count, \"maintenance records\")", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, records.Count, totalOverdueMaintenance, \"maintenance records\")", maintenanceReport, StringComparison.Ordinal);
             Assert.Contains("AddReportLimitNotice(lines, records.Count, \"calibration records\")", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, records.Count, totalOverdueCalibration, \"calibration records\")", calibrationReport, StringComparison.Ordinal);
             Assert.Contains("AddReportLimitNotice(lines, reservations.Count, \"reservations\")", reservationReport, StringComparison.Ordinal);
-            Assert.Contains("AddReportLimitNotice(lines, kits.Count, \"active kits\")", kitReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, reservations.Count, totalActiveReservations, \"reservations\")", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, kits.Count, totalActiveKits, \"active kits\")", kitReport, StringComparison.Ordinal);
             Assert.Contains("var itemCount = FormatLimitedCount(items.Count);", kitReport, StringComparison.Ordinal);
 
             Assert.Contains("count >= DetailedReportResultLimit ? $\"{DetailedReportResultLimit}+\" : count.ToString();", limitNotice, StringComparison.Ordinal);
-            Assert.Contains("This report shows the first {DetailedReportResultLimit}", limitNotice, StringComparison.Ordinal);
+            Assert.Contains("recordCount >= DetailedReportResultLimit", limitNotice, StringComparison.Ordinal);
+            Assert.Contains("Additional records may exist.", limitNotice, StringComparison.Ordinal);
+            Assert.Contains("totalCount > displayedCount", limitNotice, StringComparison.Ordinal);
+            Assert.Contains("$\"Note: This report shows the first {displayedCount} of {totalCount} {recordLabel}.", limitNotice, StringComparison.Ordinal);
             Assert.Contains("Use filters or exports for a narrower full-detail review.", limitNotice, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -107,9 +107,14 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("? await _rentalService.CountActiveRentalsAsync().ConfigureAwait(false)", rentalReport, StringComparison.Ordinal);
             Assert.Contains(": await _rentalService.CountRentalsAsync().ConfigureAwait(false);", rentalReport, StringComparison.Ordinal);
 
-            Assert.Contains("var totalCustomers = await _customerService.CountCustomersAsync(CancellationToken.None).ConfigureAwait(false);", customerReport, StringComparison.Ordinal);
-            Assert.Contains("var reportCustomers = customers.Take(DetailedReportResultLimit).ToList();", customerReport, StringComparison.Ordinal);
-            Assert.Contains("AddExactReportLimitNotice(lines, reportCustomers.Count, totalCustomers, \"customers\")", customerReport, StringComparison.Ordinal);
+            Assert.Contains("var customersTask = _customerService.SearchCustomersAsync(string.Empty, CancellationToken.None);", customerReport, StringComparison.Ordinal);
+            Assert.Contains("var totalCustomersTask = _customerService.CountCustomersAsync(CancellationToken.None);", customerReport, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(customersTask, totalCustomersTask).ConfigureAwait(false);", customerReport, StringComparison.Ordinal);
+            Assert.Contains("var customers = await customersTask.ConfigureAwait(false);", customerReport, StringComparison.Ordinal);
+            Assert.Contains("var totalCustomers = await totalCustomersTask.ConfigureAwait(false);", customerReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, customers.Count, totalCustomers, \"customers\")", customerReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("_customerService.GetAllCustomersAsync()", customerReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("customers.Take(DetailedReportResultLimit)", customerReport, StringComparison.Ordinal);
 
             Assert.Contains("var totalUsers = await _userService.CountUsersAsync(CancellationToken.None).ConfigureAwait(false);", userReport, StringComparison.Ordinal);
             Assert.Contains("AddExactReportLimitNotice(lines, users.Count, totalUsers, \"users\")", userReport, StringComparison.Ordinal);
@@ -136,6 +141,23 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("totalCount > displayedCount", limitNotice, StringComparison.Ordinal);
             Assert.Contains("$\"Note: This report shows the first {displayedCount} of {totalCount} {recordLabel}.", limitNotice, StringComparison.Ordinal);
             Assert.Contains("Use filters or exports for a narrower full-detail review.", limitNotice, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerServiceProvidesBoundedCustomerReportSource()
+        {
+            var interfaceSource = ReadRepoFile("InventoryManagementApp", "Interfaces", "ICustomerService.cs");
+            var customerServiceSource = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var searchMethod = ExtractMethod(
+                customerServiceSource,
+                "async Task<List<CustomerModel>> SearchCustomersInternalAsync(string searchTerm, CancellationToken cancellationToken)",
+                "async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)");
+
+            Assert.Contains("Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default);", interfaceSource, StringComparison.Ordinal);
+            Assert.Contains("private const int MaxCustomerSearchResults = 500;", customerServiceSource, StringComparison.Ordinal);
+            Assert.Contains("ORDER BY Company ASC, Contact ASC, CustomerID ASC", searchMethod, StringComparison.Ordinal);
+            Assert.Contains("LIMIT @CustomerSearchLimit", searchMethod, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@CustomerSearchLimit\", MaxCustomerSearchResults)", searchMethod, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceInventoryPagingContractTests.cs
@@ -63,7 +63,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void CappedDetailedReportsDisclosePotentiallyTruncatedRows()
+        public void CappedDetailedReportsUseExactTruncationNoticesWhereCountsExist()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
             var rentalReport = ExtractMethod(
@@ -100,6 +100,8 @@ namespace InventoryManagementApp.Tests
                 "FlowDocument BuildReport(string title, IEnumerable<string> lines)");
 
             Assert.Contains("private const int DetailedReportResultLimit = 500;", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("AddReportLimitNotice", source, StringComparison.Ordinal);
+
             Assert.Contains("AddExactReportLimitNotice(lines, rentals.Count, totalRentals, \"rental records\")", rentalReport, StringComparison.Ordinal);
             Assert.Contains("var totalRentals = activeOnly", rentalReport, StringComparison.Ordinal);
             Assert.Contains("? await _rentalService.CountActiveRentalsAsync().ConfigureAwait(false)", rentalReport, StringComparison.Ordinal);
@@ -112,18 +114,25 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("var totalUsers = await _userService.CountUsersAsync(CancellationToken.None).ConfigureAwait(false);", userReport, StringComparison.Ordinal);
             Assert.Contains("AddExactReportLimitNotice(lines, users.Count, totalUsers, \"users\")", userReport, StringComparison.Ordinal);
 
-            Assert.Contains("AddReportLimitNotice(lines, records.Count, \"maintenance records\")", maintenanceReport, StringComparison.Ordinal);
-            Assert.Contains("AddExactReportLimitNotice(lines, records.Count, totalOverdueMaintenance, \"maintenance records\")", maintenanceReport, StringComparison.Ordinal);
-            Assert.Contains("AddReportLimitNotice(lines, records.Count, \"calibration records\")", calibrationReport, StringComparison.Ordinal);
-            Assert.Contains("AddExactReportLimitNotice(lines, records.Count, totalOverdueCalibration, \"calibration records\")", calibrationReport, StringComparison.Ordinal);
-            Assert.Contains("AddReportLimitNotice(lines, reservations.Count, \"reservations\")", reservationReport, StringComparison.Ordinal);
-            Assert.Contains("AddExactReportLimitNotice(lines, reservations.Count, totalActiveReservations, \"reservations\")", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("var totalRecords = overdueOnly", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("? await _maintenanceService.CountOverdueMaintenanceAsync().ConfigureAwait(false)", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains(": await _maintenanceService.CountMaintenanceRecordsAsync().ConfigureAwait(false);", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, records.Count, totalRecords, \"maintenance records\")", maintenanceReport, StringComparison.Ordinal);
+
+            Assert.Contains("var totalRecords = overdueOnly", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("? await _calibrationService.CountOverdueCalibrationAsync().ConfigureAwait(false)", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains(": await _calibrationService.CountCalibrationRecordsAsync().ConfigureAwait(false);", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, records.Count, totalRecords, \"calibration records\")", calibrationReport, StringComparison.Ordinal);
+
+            Assert.Contains("var totalReservations = activeOnly", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("? await _reservationService.CountActiveReservationsAsync().ConfigureAwait(false)", reservationReport, StringComparison.Ordinal);
+            Assert.Contains(": await _reservationService.CountReservationsAsync().ConfigureAwait(false);", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, reservations.Count, totalReservations, \"reservations\")", reservationReport, StringComparison.Ordinal);
+
             Assert.Contains("AddExactReportLimitNotice(lines, kits.Count, totalActiveKits, \"active kits\")", kitReport, StringComparison.Ordinal);
             Assert.Contains("var itemCount = FormatLimitedCount(items.Count);", kitReport, StringComparison.Ordinal);
 
             Assert.Contains("count >= DetailedReportResultLimit ? $\"{DetailedReportResultLimit}+\" : count.ToString();", limitNotice, StringComparison.Ordinal);
-            Assert.Contains("recordCount >= DetailedReportResultLimit", limitNotice, StringComparison.Ordinal);
-            Assert.Contains("Additional records may exist.", limitNotice, StringComparison.Ordinal);
             Assert.Contains("totalCount > displayedCount", limitNotice, StringComparison.Ordinal);
             Assert.Contains("$\"Note: This report shows the first {displayedCount} of {totalCount} {recordLabel}.", limitNotice, StringComparison.Ordinal);
             Assert.Contains("Use filters or exports for a narrower full-detail review.", limitNotice, StringComparison.Ordinal);
@@ -202,10 +211,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void MaintenanceAndCalibrationServicesProvideExactSummaryCounts()
+        public void MaintenanceAndCalibrationServicesProvideExactReportCounts()
         {
             var maintenanceSource = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
             var calibrationSource = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+            var maintenanceCount = ExtractMethod(
+                maintenanceSource,
+                "public async Task<int> CountMaintenanceRecordsAsync()",
+                "public async Task<List<MaintenanceRecord>> GetMaintenanceRecordsByItemAsync(int itemID)");
             var overdueMaintenanceCount = ExtractMethod(
                 maintenanceSource,
                 "public async Task<int> CountOverdueMaintenanceAsync()",
@@ -214,6 +227,10 @@ namespace InventoryManagementApp.Tests
                 maintenanceSource,
                 "public async Task<int> CountUpcomingMaintenanceAsync(int days = 30)",
                 "public async Task<MaintenanceRecord?> GetMaintenanceRecordByIdAsync(int maintenanceID)");
+            var calibrationCount = ExtractMethod(
+                calibrationSource,
+                "public async Task<int> CountCalibrationRecordsAsync()",
+                "public async Task<List<CalibrationRecord>> GetCalibrationRecordsByItemAsync(int itemID)");
             var overdueCalibrationCount = ExtractMethod(
                 calibrationSource,
                 "public async Task<int> CountOverdueCalibrationAsync()",
@@ -222,6 +239,11 @@ namespace InventoryManagementApp.Tests
                 calibrationSource,
                 "public async Task<int> CountUpcomingCalibrationAsync(int days = 30)",
                 "public async Task<CalibrationRecord?> GetLatestCalibrationForItemAsync(int itemID)");
+
+            Assert.Contains("SELECT COUNT(m.MaintenanceID)", maintenanceCount, StringComparison.Ordinal);
+            Assert.Contains("FROM MaintenanceRecords m", maintenanceCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items i ON m.ItemID = i.ItemID", maintenanceCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @MaintenanceListLimit", maintenanceCount, StringComparison.Ordinal);
 
             Assert.Contains("SELECT COUNT(m.MaintenanceID)", overdueMaintenanceCount, StringComparison.Ordinal);
             Assert.Contains("FROM MaintenanceRecords m", overdueMaintenanceCount, StringComparison.Ordinal);
@@ -235,6 +257,11 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("AND m.ScheduledDate >= @Now", upcomingMaintenanceCount, StringComparison.Ordinal);
             Assert.Contains("AND m.ScheduledDate <= @FutureDate", upcomingMaintenanceCount, StringComparison.Ordinal);
             Assert.DoesNotContain("LIMIT @MaintenanceListLimit", upcomingMaintenanceCount, StringComparison.Ordinal);
+
+            Assert.Contains("SELECT COUNT(c.CalibrationID)", calibrationCount, StringComparison.Ordinal);
+            Assert.Contains("FROM CalibrationRecords c", calibrationCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items i ON c.ItemID = i.ItemID", calibrationCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @CalibrationListLimit", calibrationCount, StringComparison.Ordinal);
 
             Assert.Contains("SELECT COUNT(c.CalibrationID)", overdueCalibrationCount, StringComparison.Ordinal);
             Assert.Contains("FROM CalibrationRecords c", overdueCalibrationCount, StringComparison.Ordinal);
@@ -251,10 +278,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void ReservationAndKitServicesProvideExactSummaryCounts()
+        public void ReservationAndKitServicesProvideExactReportCounts()
         {
             var reservationSource = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
             var kitSource = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+            var reservationCount = ExtractMethod(
+                reservationSource,
+                "public async Task<int> CountReservationsAsync()",
+                "public async Task<List<Reservation>> GetActiveReservationsAsync()");
             var activeReservationCount = ExtractMethod(
                 reservationSource,
                 "public async Task<int> CountActiveReservationsAsync()",
@@ -267,6 +298,12 @@ namespace InventoryManagementApp.Tests
                 kitSource,
                 "public async Task<int> CountActiveKitsAsync()",
                 "public async Task<Kit?> GetKitByIdAsync(int kitID)");
+
+            Assert.Contains("SELECT COUNT(r.ReservationID)", reservationCount, StringComparison.Ordinal);
+            Assert.Contains("FROM Reservations r", reservationCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Items i ON r.ItemID = i.ItemID", reservationCount, StringComparison.Ordinal);
+            Assert.Contains("JOIN Customers c ON r.CustomerID = c.CustomerID", reservationCount, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @ReservationListLimit", reservationCount, StringComparison.Ordinal);
 
             Assert.Contains("SELECT COUNT(r.ReservationID)", activeReservationCount, StringComparison.Ordinal);
             Assert.Contains("FROM Reservations r", activeReservationCount, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ReportServiceSummaryAndKitContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceSummaryAndKitContractTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReportServiceSummaryAndKitContractTests
+    {
+        [Fact]
+        public void SummaryReportStartsOptionalCountReadsBeforeSingleAwait()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+            var summaryReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateSummaryReport()",
+                "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)");
+
+            Assert.Contains("var overdueMaintenanceTask = _maintenanceService?.CountOverdueMaintenanceAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var upcomingMaintenanceTask = _maintenanceService?.CountUpcomingMaintenanceAsync(30);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var overdueCalibrationTask = _calibrationService?.CountOverdueCalibrationAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var upcomingCalibrationTask = _calibrationService?.CountUpcomingCalibrationAsync(30);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var activeReservationsTask = _reservationService?.CountActiveReservationsAsync();", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var upcomingReservationsTask = _reservationService?.CountUpcomingReservationsAsync(7);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("var activeKitsTask = _kitService?.CountActiveKitsAsync();", summaryReport, StringComparison.Ordinal);
+
+            Assert.Contains("var summaryTasks = new List<Task>", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("AddIfNotNull(summaryTasks, overdueMaintenanceTask);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("AddIfNotNull(summaryTasks, upcomingMaintenanceTask);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("AddIfNotNull(summaryTasks, overdueCalibrationTask);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("AddIfNotNull(summaryTasks, upcomingCalibrationTask);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("AddIfNotNull(summaryTasks, activeReservationsTask);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("AddIfNotNull(summaryTasks, upcomingReservationsTask);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("AddIfNotNull(summaryTasks, activeKitsTask);", summaryReport, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(summaryTasks).ConfigureAwait(false);", summaryReport, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("await Task.WhenAll(overdueMaintenanceTask, upcomingMaintenanceTask)", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("await Task.WhenAll(overdueCalibrationTask, upcomingCalibrationTask)", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("await Task.WhenAll(activeReservationsTask, upcomingReservationsTask)", summaryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("var activeKits = await _kitService.CountActiveKitsAsync().ConfigureAwait(false);", summaryReport, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitReportUsesGroupedItemCountsInsteadOfLoadingEachKitItemList()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+            var kitReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateKitReport()",
+                "private async Task<List<ItemModel>> CollectInventoryReportItemsAsync()");
+
+            Assert.Contains("var kitsTask = _kitService.GetActiveKitsAsync();", kitReport, StringComparison.Ordinal);
+            Assert.Contains("var totalActiveKitsTask = _kitService.CountActiveKitsAsync();", kitReport, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(kitsTask, totalActiveKitsTask).ConfigureAwait(false);", kitReport, StringComparison.Ordinal);
+            Assert.Contains("var itemCounts = await _kitService.CountKitItemsByKitIdsAsync(kits.Select(kit => kit.KitID)).ConfigureAwait(false);", kitReport, StringComparison.Ordinal);
+            Assert.Contains("itemCounts.TryGetValue(kit.KitID, out var count)", kitReport, StringComparison.Ordinal);
+            Assert.Contains("? FormatLimitedCount(count)", kitReport, StringComparison.Ordinal);
+            Assert.Contains(": \"0\";", kitReport, StringComparison.Ordinal);
+            Assert.Contains("AddExactReportLimitNotice(lines, kits.Count, totalActiveKits, \"active kits\")", kitReport, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("await _kitService.GetKitItemsAsync(kit.KitID)", kitReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("items.Count", kitReport, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitServiceProvidesGroupedItemCountQueryForReportRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+            var countMethod = ExtractMethod(
+                source,
+                "public async Task<Dictionary<int, int>> CountKitItemsByKitIdsAsync(IEnumerable<int> kitIds)",
+                "/// <summary>\n        /// Retrieves a specific kit by its ID.");
+
+            Assert.Contains("using System.Linq;", source, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(kitIds));", countMethod, StringComparison.Ordinal);
+            Assert.Contains("var distinctKitIds = kitIds.Distinct().ToList();", countMethod, StringComparison.Ordinal);
+            Assert.Contains("distinctKitIds.Any(id => id < 1)", countMethod, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentOutOfRangeException(nameof(kitIds), \"Kit IDs must be greater than 0.\");", countMethod, StringComparison.Ordinal);
+            Assert.Contains("return new Dictionary<int, int>();", countMethod, StringComparison.Ordinal);
+            Assert.Contains("var counts = distinctKitIds.ToDictionary(id => id, _ => 0);", countMethod, StringComparison.Ordinal);
+            Assert.Contains("SELECT KitID, COUNT(KitItemID) AS ItemCount", countMethod, StringComparison.Ordinal);
+            Assert.Contains("FROM KitItems", countMethod, StringComparison.Ordinal);
+            Assert.Contains("WHERE KitID IN ({string.Join(\", \", parameterNames)})", countMethod, StringComparison.Ordinal);
+            Assert.Contains("GROUP BY KitID", countMethod, StringComparison.Ordinal);
+            Assert.Contains("cmd.Parameters.AddWithValue(parameterNames[index], distinctKitIds[index]);", countMethod, StringComparison.Ordinal);
+            Assert.Contains("counts[kitId] = reader.GetInt32(reader.GetOrdinal(\"ItemCount\"));", countMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("LIMIT @KitItemListLimit", countMethod, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReportServiceKeepsNullableTaskHelperLocalAndTiny()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+            var helper = ExtractMethod(
+                source,
+                "private static void AddIfNotNull(List<Task> tasks, Task? task)",
+                "private static IEnumerable<string> AddExactReportLimitNotice");
+
+            Assert.Contains("if (task != null)", helper, StringComparison.Ordinal);
+            Assert.Contains("tasks.Add(task);", helper, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp.Tests/ReportServiceSummaryAndKitContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceSummaryAndKitContractTests.cs
@@ -82,7 +82,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("WHERE KitID IN ({string.Join(\", \", parameterNames)})", countMethod, StringComparison.Ordinal);
             Assert.Contains("GROUP BY KitID", countMethod, StringComparison.Ordinal);
             Assert.Contains("cmd.Parameters.AddWithValue(parameterNames[index], distinctKitIds[index]);", countMethod, StringComparison.Ordinal);
-            Assert.Contains("counts[kitId] = reader.GetInt32(reader.GetOrdinal(\"ItemCount\"));", countMethod, StringComparison.Ordinal);
+            Assert.Contains("counts[kitId] = Convert.ToInt32(reader[\"ItemCount\"] ?? 0);", countMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("reader.GetInt32(reader.GetOrdinal(\"ItemCount\"))", countMethod, StringComparison.Ordinal);
             Assert.DoesNotContain("LIMIT @KitItemListLimit", countMethod, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
@@ -1,0 +1,24 @@
+# Honest Detailed Report Truncation
+
+Date: 2026-07-01
+
+## Completed
+
+- Bounded the customer detail report to the shared detailed-report row limit before rendering printable rows.
+- Added exact-count truncation notices for detailed reports that already have reliable count APIs: rentals, customers, users, active reservations, active kits, overdue maintenance, and overdue calibration.
+- Kept bounded fallback notices for detailed report paths that are capped by service queries but do not yet expose matching exact total counts.
+- Updated report source-contract coverage so future changes preserve bounded printable output and honest "first N of total" notices where exact totals are available.
+
+## Why It Matters
+
+Detailed reports should remain printable and should not imply that exactly 500 rows were hidden when the app actually knows the true total. This makes large customer/user/rental/reservation/kit report output safer and clearer while avoiding unbounded print documents.
+
+## Validation
+
+- Connector readback/compare should confirm the focused `ReportService`, report contract test, and progress-note diff.
+- Local validation was not available in the scheduled Linux environment because direct checkout is blocked and `dotnet`, PowerShell/`pwsh`, and GitHub CLI are unavailable here.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Consider adding exact total count APIs for all maintenance, all calibration, and all reservation detail reports so their fallback "additional records may exist" notices can become exact as well.

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
@@ -5,20 +5,24 @@ Date: 2026-07-01
 ## Completed
 
 - Bounded the customer detail report to the shared detailed-report row limit before rendering printable rows.
+- Switched the customer detail report to the existing bounded customer search source instead of materializing every customer and trimming afterward.
 - Added exact-count truncation notices for rentals, customers, users, maintenance, calibration, reservations, and active kits so capped detailed reports can say exactly how many records were shown and how many exist.
 - Added exact total count APIs for all maintenance records, all calibration records, and all reservations to remove the remaining vague fallback notices from full-detail report paths.
-- Updated report source-contract coverage so future changes preserve bounded printable output, exact count query wiring, and honest "first N of total" notices across detailed report variants.
+- Updated report source-contract coverage so future changes preserve bounded printable output, exact count query wiring, deterministic customer ordering, and honest "first N of total" notices across detailed report variants.
 
 ## Why It Matters
 
 Detailed reports should remain printable without implying that capped output is complete. This keeps large customer/user/rental/maintenance/calibration/reservation/kit reports bounded while giving operators an exact total whenever the report list is truncated.
 
+The customer report is now bounded at the data-access source as well as in the printable output, avoiding an unnecessary full customer-table read before producing the capped report preview.
+
 ## Validation
 
-- Connector readback/compare should confirm the focused report service, maintenance/calibration/reservation count APIs, report contract test, and progress-note diff.
+- Connector readback/compare should confirm the focused report service, maintenance/calibration/reservation count APIs, bounded customer report source wiring, report contract test, and progress-note diff.
 - Local validation was not available in the scheduled Linux environment because direct checkout is blocked and `dotnet`, PowerShell/`pwsh`, GitHub CLI, and WPF runtime checks are unavailable here.
 
 ## Follow-Up
 
 - Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Consider a dedicated customer report page API if future reports need filters beyond the current deterministic first-page customer listing.
 - Consider true streaming/export-specific workflows for very large detailed report review if operators need full-row output beyond printable capped previews.

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
@@ -9,7 +9,10 @@ Date: 2026-07-01
 - Added exact-count truncation notices for rentals, customers, users, maintenance, calibration, reservations, and active kits so capped detailed reports can say exactly how many records were shown and how many exist.
 - Added exact total count APIs for all maintenance records, all calibration records, and all reservations to remove the remaining vague fallback notices from full-detail report paths.
 - Started independent detailed-report row and exact-count reads together for rental, customer, user, maintenance, calibration, reservation, and active-kit reports so honest totals do not add avoidable serial wait time before preview rendering.
-- Updated report source-contract coverage so future changes preserve bounded printable output, exact count query wiring, deterministic customer ordering, parallel row/count reads, and honest "first N of total" notices across detailed report variants.
+- Started optional application-summary counts for maintenance, calibration, reservations, and kits before the single summary await so the summary report no longer waits through each optional section in sequence.
+- Replaced active-kit report per-kit item-list loading with one grouped kit-item count query, preserving zero counts for kits without rows and exact 500+ formatting for very large kits.
+- Added grouped kit-item count validation for null, duplicate, empty, and invalid kit-ID inputs before building the SQL parameter list.
+- Updated report source-contract coverage so future changes preserve bounded printable output, exact count query wiring, deterministic customer ordering, parallel row/count reads, summary count concurrency, grouped kit item counts, and honest "first N of total" notices across detailed report variants.
 
 ## Why It Matters
 
@@ -17,9 +20,11 @@ Detailed reports should remain printable without implying that capped output is 
 
 The customer report is now bounded at the data-access source as well as in the printable output, avoiding an unnecessary full customer-table read before producing the capped report preview. Detailed report row reads and exact-count reads now run together where they are independent, keeping the more honest report preview path responsive.
 
+The summary report now starts optional service counts together instead of waiting through maintenance, then calibration, then reservations, then kits. Active kit reports now use one grouped count query for row item counts instead of one item-list read per displayed kit, which keeps large kit previews much lighter while preserving the operator-facing item-count column.
+
 ## Validation
 
-- Connector readback/compare should confirm the focused report service, maintenance/calibration/reservation count APIs, bounded customer report source wiring, parallel detailed report row/count reads, report contract test, and progress-note diff.
+- Connector readback/compare should confirm the focused report service, maintenance/calibration/reservation count APIs, grouped kit item count API, bounded customer report source wiring, parallel detailed report row/count reads, summary count concurrency, report contract tests, and progress-note diff.
 - Local validation was not available in the scheduled Linux environment because direct checkout is blocked and `dotnet`, PowerShell/`pwsh`, GitHub CLI, and WPF runtime checks are unavailable here.
 
 ## Follow-Up

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
@@ -5,20 +5,20 @@ Date: 2026-07-01
 ## Completed
 
 - Bounded the customer detail report to the shared detailed-report row limit before rendering printable rows.
-- Added exact-count truncation notices for detailed reports that already have reliable count APIs: rentals, customers, users, active reservations, active kits, overdue maintenance, and overdue calibration.
-- Kept bounded fallback notices for detailed report paths that are capped by service queries but do not yet expose matching exact total counts.
-- Updated report source-contract coverage so future changes preserve bounded printable output and honest "first N of total" notices where exact totals are available.
+- Added exact-count truncation notices for rentals, customers, users, maintenance, calibration, reservations, and active kits so capped detailed reports can say exactly how many records were shown and how many exist.
+- Added exact total count APIs for all maintenance records, all calibration records, and all reservations to remove the remaining vague fallback notices from full-detail report paths.
+- Updated report source-contract coverage so future changes preserve bounded printable output, exact count query wiring, and honest "first N of total" notices across detailed report variants.
 
 ## Why It Matters
 
-Detailed reports should remain printable and should not imply that exactly 500 rows were hidden when the app actually knows the true total. This makes large customer/user/rental/reservation/kit report output safer and clearer while avoiding unbounded print documents.
+Detailed reports should remain printable without implying that capped output is complete. This keeps large customer/user/rental/maintenance/calibration/reservation/kit reports bounded while giving operators an exact total whenever the report list is truncated.
 
 ## Validation
 
-- Connector readback/compare should confirm the focused `ReportService`, report contract test, and progress-note diff.
-- Local validation was not available in the scheduled Linux environment because direct checkout is blocked and `dotnet`, PowerShell/`pwsh`, and GitHub CLI are unavailable here.
+- Connector readback/compare should confirm the focused report service, maintenance/calibration/reservation count APIs, report contract test, and progress-note diff.
+- Local validation was not available in the scheduled Linux environment because direct checkout is blocked and `dotnet`, PowerShell/`pwsh`, GitHub CLI, and WPF runtime checks are unavailable here.
 
 ## Follow-Up
 
 - Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
-- Consider adding exact total count APIs for all maintenance, all calibration, and all reservation detail reports so their fallback "additional records may exist" notices can become exact as well.
+- Consider true streaming/export-specific workflows for very large detailed report review if operators need full-row output beyond printable capped previews.

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-honest-detailed-report-truncation.md
@@ -8,17 +8,18 @@ Date: 2026-07-01
 - Switched the customer detail report to the existing bounded customer search source instead of materializing every customer and trimming afterward.
 - Added exact-count truncation notices for rentals, customers, users, maintenance, calibration, reservations, and active kits so capped detailed reports can say exactly how many records were shown and how many exist.
 - Added exact total count APIs for all maintenance records, all calibration records, and all reservations to remove the remaining vague fallback notices from full-detail report paths.
-- Updated report source-contract coverage so future changes preserve bounded printable output, exact count query wiring, deterministic customer ordering, and honest "first N of total" notices across detailed report variants.
+- Started independent detailed-report row and exact-count reads together for rental, customer, user, maintenance, calibration, reservation, and active-kit reports so honest totals do not add avoidable serial wait time before preview rendering.
+- Updated report source-contract coverage so future changes preserve bounded printable output, exact count query wiring, deterministic customer ordering, parallel row/count reads, and honest "first N of total" notices across detailed report variants.
 
 ## Why It Matters
 
 Detailed reports should remain printable without implying that capped output is complete. This keeps large customer/user/rental/maintenance/calibration/reservation/kit reports bounded while giving operators an exact total whenever the report list is truncated.
 
-The customer report is now bounded at the data-access source as well as in the printable output, avoiding an unnecessary full customer-table read before producing the capped report preview.
+The customer report is now bounded at the data-access source as well as in the printable output, avoiding an unnecessary full customer-table read before producing the capped report preview. Detailed report row reads and exact-count reads now run together where they are independent, keeping the more honest report preview path responsive.
 
 ## Validation
 
-- Connector readback/compare should confirm the focused report service, maintenance/calibration/reservation count APIs, bounded customer report source wiring, report contract test, and progress-note diff.
+- Connector readback/compare should confirm the focused report service, maintenance/calibration/reservation count APIs, bounded customer report source wiring, parallel detailed report row/count reads, report contract test, and progress-note diff.
 - Local validation was not available in the scheduled Linux environment because direct checkout is blocked and `dotnet`, PowerShell/`pwsh`, GitHub CLI, and WPF runtime checks are unavailable here.
 
 ## Follow-Up

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -58,6 +58,20 @@ namespace InventoryManagementApp.Services.Calibration
             });
         }
 
+        public async Task<int> CountCalibrationRecordsAsync()
+        {
+            return await Task.Run(() =>
+            {
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(c.CalibrationID)
+                    FROM CalibrationRecords c
+                    JOIN Items i ON c.ItemID = i.ItemID";
+                using var cmd = new SqliteCommand(sql, conn);
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
+            });
+        }
+
         /// <summary>
         /// Retrieves all calibration records for a specific item.
         /// </summary>

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -113,12 +113,16 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<FlowDocument> GenerateCustomerReport()
         {
-            var customers = await _customerService.GetAllCustomersAsync().ConfigureAwait(false);
-            var totalCustomers = await _customerService.CountCustomersAsync(CancellationToken.None).ConfigureAwait(false);
-            var reportCustomers = customers.Take(DetailedReportResultLimit).ToList();
-            var lines = reportCustomers.Select(c =>
+            var customersTask = _customerService.SearchCustomersAsync(string.Empty, CancellationToken.None);
+            var totalCustomersTask = _customerService.CountCustomersAsync(CancellationToken.None);
+
+            await Task.WhenAll(customersTask, totalCustomersTask).ConfigureAwait(false);
+            var customers = await customersTask.ConfigureAwait(false);
+            var totalCustomers = await totalCustomersTask.ConfigureAwait(false);
+
+            var lines = customers.Select(c =>
                 $"Customer ID: {c.CustomerID} | Company: {c.Company} | Email: {c.Email} | Contact: {c.Contact} | Phone: {c.Phone} | Mobile: {c.Mobile} | Address: {c.Address}");
-            return BuildReport("Customer Report", AddExactReportLimitNotice(lines, reportCustomers.Count, totalCustomers, "customers"));
+            return BuildReport("Customer Report", AddExactReportLimitNotice(lines, customers.Count, totalCustomers, "customers"));
         }
 
         public async Task<FlowDocument> GenerateUserReport()

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -71,13 +71,16 @@ namespace InventoryManagementApp.Services.Items
             var rentals = activeOnly
                 ? await _rentalService.GetActiveRentalsAsync().ConfigureAwait(false)
                 : await _rentalService.GetAllRentalsAsync().ConfigureAwait(false);
+            var totalRentals = activeOnly
+                ? await _rentalService.CountActiveRentalsAsync().ConfigureAwait(false)
+                : await _rentalService.CountRentalsAsync().ConfigureAwait(false);
 
             var title = activeOnly ? "Active Rental Report" : "Full Rental History Report";
 
             var lines = rentals.Select(r =>
                 $"Rental ID: {r.RentalID} | Item ID: {r.ItemID} | Customer ID: {r.CustomerID} | Rental Date: {r.RentalDate:yyyy-MM-dd} | Due Date: {r.DueDate:yyyy-MM-dd} | Return Date: {(r.ReturnDate.HasValue ? r.ReturnDate.Value.ToString("yyyy-MM-dd") : "N/A")} | Status: {r.Status}");
 
-            return BuildReport(title, AddReportLimitNotice(lines, rentals.Count, "rental records"));
+            return BuildReport(title, AddExactReportLimitNotice(lines, rentals.Count, totalRentals, "rental records"));
         }
 
         public async Task<FlowDocument> GenerateRentalFrequencyReport(int topN = 20)
@@ -111,17 +114,20 @@ namespace InventoryManagementApp.Services.Items
         public async Task<FlowDocument> GenerateCustomerReport()
         {
             var customers = await _customerService.GetAllCustomersAsync().ConfigureAwait(false);
-            var lines = customers.Select(c =>
+            var totalCustomers = await _customerService.CountCustomersAsync(CancellationToken.None).ConfigureAwait(false);
+            var reportCustomers = customers.Take(DetailedReportResultLimit).ToList();
+            var lines = reportCustomers.Select(c =>
                 $"Customer ID: {c.CustomerID} | Company: {c.Company} | Email: {c.Email} | Contact: {c.Contact} | Phone: {c.Phone} | Mobile: {c.Mobile} | Address: {c.Address}");
-            return BuildReport("Customer Report", AddReportLimitNotice(lines, customers.Count, "customers"));
+            return BuildReport("Customer Report", AddExactReportLimitNotice(lines, reportCustomers.Count, totalCustomers, "customers"));
         }
 
         public async Task<FlowDocument> GenerateUserReport()
         {
             var users = await _userService.GetAllUsersAsync(CancellationToken.None).ConfigureAwait(false);
+            var totalUsers = await _userService.CountUsersAsync(CancellationToken.None).ConfigureAwait(false);
             var lines = users.Select(u =>
                 $"User ID: {u.UserID} | User Name: {u.UserName} | Admin: {u.IsAdmin}");
-            return BuildReport("User Report", AddReportLimitNotice(lines, users.Count, "users"));
+            return BuildReport("User Report", AddExactReportLimitNotice(lines, users.Count, totalUsers, "users"));
         }
 
         public async Task<FlowDocument> GenerateSummaryReport()
@@ -210,6 +216,12 @@ namespace InventoryManagementApp.Services.Items
             var lines = records.Select(m =>
                 $"Maintenance ID: {m.MaintenanceID} | Item: {m.ItemNumber} - {m.ItemName} | Type: {m.MaintenanceType} | Scheduled: {m.ScheduledDate:yyyy-MM-dd} | Status: {m.StatusDisplay} | Cost: ${m.Cost:F2}");
 
+            if (overdueOnly)
+            {
+                var totalOverdueMaintenance = await _maintenanceService.CountOverdueMaintenanceAsync().ConfigureAwait(false);
+                return BuildReport(title, AddExactReportLimitNotice(lines, records.Count, totalOverdueMaintenance, "maintenance records"));
+            }
+
             return BuildReport(title, AddReportLimitNotice(lines, records.Count, "maintenance records"));
         }
 
@@ -226,6 +238,12 @@ namespace InventoryManagementApp.Services.Items
 
             var lines = records.Select(c =>
                 $"Calibration ID: {c.CalibrationID} | Item: {c.ItemNumber} - {c.ItemName} | Date: {c.CalibrationDate:yyyy-MM-dd} | Next Due: {c.NextCalibrationDue:yyyy-MM-dd} | Status: {c.StatusDisplay} | Certificate Number: {c.CertificateNumber}");
+
+            if (overdueOnly)
+            {
+                var totalOverdueCalibration = await _calibrationService.CountOverdueCalibrationAsync().ConfigureAwait(false);
+                return BuildReport(title, AddExactReportLimitNotice(lines, records.Count, totalOverdueCalibration, "calibration records"));
+            }
 
             return BuildReport(title, AddReportLimitNotice(lines, records.Count, "calibration records"));
         }
@@ -244,6 +262,12 @@ namespace InventoryManagementApp.Services.Items
             var lines = reservations.Select(r =>
                 $"Reservation ID: {r.ReservationID} | Item: {r.ItemNumber} - {r.ItemName} | Customer: {r.CustomerName} | Start: {r.StartDate:yyyy-MM-dd} | End: {r.EndDate:yyyy-MM-dd} | Quantity: {r.Quantity} | Status: {r.StatusDisplay}");
 
+            if (activeOnly)
+            {
+                var totalActiveReservations = await _reservationService.CountActiveReservationsAsync().ConfigureAwait(false);
+                return BuildReport(title, AddExactReportLimitNotice(lines, reservations.Count, totalActiveReservations, "reservations"));
+            }
+
             return BuildReport(title, AddReportLimitNotice(lines, reservations.Count, "reservations"));
         }
 
@@ -253,6 +277,7 @@ namespace InventoryManagementApp.Services.Items
                 return BuildReport("Kit Report", new[] { "Kit service not available" });
 
             var kits = await _kitService.GetActiveKitsAsync().ConfigureAwait(false);
+            var totalActiveKits = await _kitService.CountActiveKitsAsync().ConfigureAwait(false);
             var lines = new List<string>();
 
             foreach (var kit in kits)
@@ -262,7 +287,7 @@ namespace InventoryManagementApp.Services.Items
                 lines.Add($"Kit Number: {kit.KitNumber} | Kit Name: {kit.Name} | Category: {kit.Category} | Item Count: {itemCount} | Status: {(kit.IsActive ? "Active" : "Inactive")}");
             }
 
-            return BuildReport("Active Kits Report", AddReportLimitNotice(lines, kits.Count, "active kits"));
+            return BuildReport("Active Kits Report", AddExactReportLimitNotice(lines, kits.Count, totalActiveKits, "active kits"));
         }
 
         private async Task<List<ItemModel>> CollectInventoryReportItemsAsync()
@@ -298,7 +323,16 @@ namespace InventoryManagementApp.Services.Items
                 yield return line;
 
             if (recordCount >= DetailedReportResultLimit)
-                yield return $"Note: This report shows the first {DetailedReportResultLimit} {recordLabel}. Use filters or exports for a narrower full-detail review.";
+                yield return $"Note: This report shows the first {DetailedReportResultLimit} {recordLabel}. Additional records may exist. Use filters or exports for a narrower full-detail review.";
+        }
+
+        private static IEnumerable<string> AddExactReportLimitNotice(IEnumerable<string> lines, int displayedCount, int totalCount, string recordLabel)
+        {
+            foreach (var line in lines)
+                yield return line;
+
+            if (totalCount > displayedCount)
+                yield return $"Note: This report shows the first {displayedCount} of {totalCount} {recordLabel}. Use filters or exports for a narrower full-detail review.";
         }
 
         FlowDocument BuildReport(string title, IEnumerable<string> lines)

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -150,13 +150,31 @@ namespace InventoryManagementApp.Services.Items
             var totalActiveRentalsTask = _rentalService.CountActiveRentalsAsync();
             var totalCustomersTask = _customerService.CountCustomersAsync(CancellationToken.None);
             var totalUsersTask = _userService.CountUsersAsync(CancellationToken.None);
+            var overdueMaintenanceTask = _maintenanceService?.CountOverdueMaintenanceAsync();
+            var upcomingMaintenanceTask = _maintenanceService?.CountUpcomingMaintenanceAsync(30);
+            var overdueCalibrationTask = _calibrationService?.CountOverdueCalibrationAsync();
+            var upcomingCalibrationTask = _calibrationService?.CountUpcomingCalibrationAsync(30);
+            var activeReservationsTask = _reservationService?.CountActiveReservationsAsync();
+            var upcomingReservationsTask = _reservationService?.CountUpcomingReservationsAsync(7);
+            var activeKitsTask = _kitService?.CountActiveKitsAsync();
 
-            await Task.WhenAll(
+            var summaryTasks = new List<Task>
+            {
                 totalItemsTask,
                 totalRentalsTask,
                 totalActiveRentalsTask,
                 totalCustomersTask,
-                totalUsersTask).ConfigureAwait(false);
+                totalUsersTask
+            };
+            AddIfNotNull(summaryTasks, overdueMaintenanceTask);
+            AddIfNotNull(summaryTasks, upcomingMaintenanceTask);
+            AddIfNotNull(summaryTasks, overdueCalibrationTask);
+            AddIfNotNull(summaryTasks, upcomingCalibrationTask);
+            AddIfNotNull(summaryTasks, activeReservationsTask);
+            AddIfNotNull(summaryTasks, upcomingReservationsTask);
+            AddIfNotNull(summaryTasks, activeKitsTask);
+
+            await Task.WhenAll(summaryTasks).ConfigureAwait(false);
 
             var totalItems = await totalItemsTask.ConfigureAwait(false);
             var totalRentals = await totalRentalsTask.ConfigureAwait(false);
@@ -173,42 +191,33 @@ namespace InventoryManagementApp.Services.Items
                 $"Total Users: {totalUsers}"
             };
 
-            if (_maintenanceService != null)
+            if (overdueMaintenanceTask != null && upcomingMaintenanceTask != null)
             {
-                var overdueMaintenanceTask = _maintenanceService.CountOverdueMaintenanceAsync();
-                var upcomingMaintenanceTask = _maintenanceService.CountUpcomingMaintenanceAsync(30);
-                await Task.WhenAll(overdueMaintenanceTask, upcomingMaintenanceTask).ConfigureAwait(false);
                 var overdueMaintenance = await overdueMaintenanceTask.ConfigureAwait(false);
                 var upcomingMaintenance = await upcomingMaintenanceTask.ConfigureAwait(false);
                 lines.Add($"Overdue Maintenance: {overdueMaintenance}");
                 lines.Add($"Upcoming Maintenance (30 days): {upcomingMaintenance}");
             }
 
-            if (_calibrationService != null)
+            if (overdueCalibrationTask != null && upcomingCalibrationTask != null)
             {
-                var overdueCalibrationTask = _calibrationService.CountOverdueCalibrationAsync();
-                var upcomingCalibrationTask = _calibrationService.CountUpcomingCalibrationAsync(30);
-                await Task.WhenAll(overdueCalibrationTask, upcomingCalibrationTask).ConfigureAwait(false);
                 var overdueCalibration = await overdueCalibrationTask.ConfigureAwait(false);
                 var upcomingCalibration = await upcomingCalibrationTask.ConfigureAwait(false);
                 lines.Add($"Overdue Calibrations: {overdueCalibration}");
                 lines.Add($"Upcoming Calibrations (30 days): {upcomingCalibration}");
             }
 
-            if (_reservationService != null)
+            if (activeReservationsTask != null && upcomingReservationsTask != null)
             {
-                var activeReservationsTask = _reservationService.CountActiveReservationsAsync();
-                var upcomingReservationsTask = _reservationService.CountUpcomingReservationsAsync(7);
-                await Task.WhenAll(activeReservationsTask, upcomingReservationsTask).ConfigureAwait(false);
                 var activeReservations = await activeReservationsTask.ConfigureAwait(false);
                 var upcomingReservations = await upcomingReservationsTask.ConfigureAwait(false);
                 lines.Add($"Active Reservations: {activeReservations}");
                 lines.Add($"Upcoming Reservations (7 days): {upcomingReservations}");
             }
 
-            if (_kitService != null)
+            if (activeKitsTask != null)
             {
-                var activeKits = await _kitService.CountActiveKitsAsync().ConfigureAwait(false);
+                var activeKits = await activeKitsTask.ConfigureAwait(false);
                 lines.Add($"Active Kits: {activeKits}");
             }
 
@@ -298,12 +307,14 @@ namespace InventoryManagementApp.Services.Items
             await Task.WhenAll(kitsTask, totalActiveKitsTask).ConfigureAwait(false);
             var kits = await kitsTask.ConfigureAwait(false);
             var totalActiveKits = await totalActiveKitsTask.ConfigureAwait(false);
+            var itemCounts = await _kitService.CountKitItemsByKitIdsAsync(kits.Select(kit => kit.KitID)).ConfigureAwait(false);
             var lines = new List<string>();
 
             foreach (var kit in kits)
             {
-                var items = await _kitService.GetKitItemsAsync(kit.KitID).ConfigureAwait(false);
-                var itemCount = FormatLimitedCount(items.Count);
+                var itemCount = itemCounts.TryGetValue(kit.KitID, out var count)
+                    ? FormatLimitedCount(count)
+                    : "0";
                 lines.Add($"Kit Number: {kit.KitNumber} | Kit Name: {kit.Name} | Category: {kit.Category} | Item Count: {itemCount} | Status: {(kit.IsActive ? "Active" : "Inactive")}");
             }
 
@@ -336,6 +347,12 @@ namespace InventoryManagementApp.Services.Items
 
         private static string FormatLimitedCount(int count) =>
             count >= DetailedReportResultLimit ? $"{DetailedReportResultLimit}+" : count.ToString();
+
+        private static void AddIfNotNull(List<Task> tasks, Task? task)
+        {
+            if (task != null)
+                tasks.Add(task);
+        }
 
         private static IEnumerable<string> AddExactReportLimitNotice(IEnumerable<string> lines, int displayedCount, int totalCount, string recordLabel)
         {

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -68,12 +68,16 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<FlowDocument> GenerateRentalReport(bool activeOnly = true)
         {
-            var rentals = activeOnly
-                ? await _rentalService.GetActiveRentalsAsync().ConfigureAwait(false)
-                : await _rentalService.GetAllRentalsAsync().ConfigureAwait(false);
-            var totalRentals = activeOnly
-                ? await _rentalService.CountActiveRentalsAsync().ConfigureAwait(false)
-                : await _rentalService.CountRentalsAsync().ConfigureAwait(false);
+            var rentalsTask = activeOnly
+                ? _rentalService.GetActiveRentalsAsync()
+                : _rentalService.GetAllRentalsAsync();
+            var totalRentalsTask = activeOnly
+                ? _rentalService.CountActiveRentalsAsync()
+                : _rentalService.CountRentalsAsync();
+
+            await Task.WhenAll(rentalsTask, totalRentalsTask).ConfigureAwait(false);
+            var rentals = await rentalsTask.ConfigureAwait(false);
+            var totalRentals = await totalRentalsTask.ConfigureAwait(false);
 
             var title = activeOnly ? "Active Rental Report" : "Full Rental History Report";
 
@@ -127,8 +131,13 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<FlowDocument> GenerateUserReport()
         {
-            var users = await _userService.GetAllUsersAsync(CancellationToken.None).ConfigureAwait(false);
-            var totalUsers = await _userService.CountUsersAsync(CancellationToken.None).ConfigureAwait(false);
+            var usersTask = _userService.GetAllUsersAsync(CancellationToken.None);
+            var totalUsersTask = _userService.CountUsersAsync(CancellationToken.None);
+
+            await Task.WhenAll(usersTask, totalUsersTask).ConfigureAwait(false);
+            var users = await usersTask.ConfigureAwait(false);
+            var totalUsers = await totalUsersTask.ConfigureAwait(false);
+
             var lines = users.Select(u =>
                 $"User ID: {u.UserID} | User Name: {u.UserName} | Admin: {u.IsAdmin}");
             return BuildReport("User Report", AddExactReportLimitNotice(lines, users.Count, totalUsers, "users"));
@@ -211,12 +220,16 @@ namespace InventoryManagementApp.Services.Items
             if (_maintenanceService == null)
                 return BuildReport("Maintenance Report", new[] { "Maintenance service not available" });
 
-            var records = overdueOnly
-                ? await _maintenanceService.GetOverdueMaintenanceAsync().ConfigureAwait(false)
-                : await _maintenanceService.GetAllMaintenanceRecordsAsync().ConfigureAwait(false);
-            var totalRecords = overdueOnly
-                ? await _maintenanceService.CountOverdueMaintenanceAsync().ConfigureAwait(false)
-                : await _maintenanceService.CountMaintenanceRecordsAsync().ConfigureAwait(false);
+            var recordsTask = overdueOnly
+                ? _maintenanceService.GetOverdueMaintenanceAsync()
+                : _maintenanceService.GetAllMaintenanceRecordsAsync();
+            var totalRecordsTask = overdueOnly
+                ? _maintenanceService.CountOverdueMaintenanceAsync()
+                : _maintenanceService.CountMaintenanceRecordsAsync();
+
+            await Task.WhenAll(recordsTask, totalRecordsTask).ConfigureAwait(false);
+            var records = await recordsTask.ConfigureAwait(false);
+            var totalRecords = await totalRecordsTask.ConfigureAwait(false);
 
             var title = overdueOnly ? "Overdue Maintenance Report" : "Maintenance Schedule Report";
 
@@ -231,12 +244,16 @@ namespace InventoryManagementApp.Services.Items
             if (_calibrationService == null)
                 return BuildReport("Calibration Report", new[] { "Calibration service not available" });
 
-            var records = overdueOnly
-                ? await _calibrationService.GetOverdueCalibrationAsync().ConfigureAwait(false)
-                : await _calibrationService.GetAllCalibrationRecordsAsync().ConfigureAwait(false);
-            var totalRecords = overdueOnly
-                ? await _calibrationService.CountOverdueCalibrationAsync().ConfigureAwait(false)
-                : await _calibrationService.CountCalibrationRecordsAsync().ConfigureAwait(false);
+            var recordsTask = overdueOnly
+                ? _calibrationService.GetOverdueCalibrationAsync()
+                : _calibrationService.GetAllCalibrationRecordsAsync();
+            var totalRecordsTask = overdueOnly
+                ? _calibrationService.CountOverdueCalibrationAsync()
+                : _calibrationService.CountCalibrationRecordsAsync();
+
+            await Task.WhenAll(recordsTask, totalRecordsTask).ConfigureAwait(false);
+            var records = await recordsTask.ConfigureAwait(false);
+            var totalRecords = await totalRecordsTask.ConfigureAwait(false);
 
             var title = overdueOnly ? "Overdue Calibration Report" : "Calibration Records Report";
 
@@ -251,12 +268,16 @@ namespace InventoryManagementApp.Services.Items
             if (_reservationService == null)
                 return BuildReport("Reservation Report", new[] { "Reservation service not available" });
 
-            var reservations = activeOnly
-                ? await _reservationService.GetActiveReservationsAsync().ConfigureAwait(false)
-                : await _reservationService.GetAllReservationsAsync().ConfigureAwait(false);
-            var totalReservations = activeOnly
-                ? await _reservationService.CountActiveReservationsAsync().ConfigureAwait(false)
-                : await _reservationService.CountReservationsAsync().ConfigureAwait(false);
+            var reservationsTask = activeOnly
+                ? _reservationService.GetActiveReservationsAsync()
+                : _reservationService.GetAllReservationsAsync();
+            var totalReservationsTask = activeOnly
+                ? _reservationService.CountActiveReservationsAsync()
+                : _reservationService.CountReservationsAsync();
+
+            await Task.WhenAll(reservationsTask, totalReservationsTask).ConfigureAwait(false);
+            var reservations = await reservationsTask.ConfigureAwait(false);
+            var totalReservations = await totalReservationsTask.ConfigureAwait(false);
 
             var title = activeOnly ? "Active Reservations Report" : "All Reservations Report";
 
@@ -271,8 +292,12 @@ namespace InventoryManagementApp.Services.Items
             if (_kitService == null)
                 return BuildReport("Kit Report", new[] { "Kit service not available" });
 
-            var kits = await _kitService.GetActiveKitsAsync().ConfigureAwait(false);
-            var totalActiveKits = await _kitService.CountActiveKitsAsync().ConfigureAwait(false);
+            var kitsTask = _kitService.GetActiveKitsAsync();
+            var totalActiveKitsTask = _kitService.CountActiveKitsAsync();
+
+            await Task.WhenAll(kitsTask, totalActiveKitsTask).ConfigureAwait(false);
+            var kits = await kitsTask.ConfigureAwait(false);
+            var totalActiveKits = await totalActiveKitsTask.ConfigureAwait(false);
             var lines = new List<string>();
 
             foreach (var kit in kits)

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -210,19 +210,16 @@ namespace InventoryManagementApp.Services.Items
             var records = overdueOnly
                 ? await _maintenanceService.GetOverdueMaintenanceAsync().ConfigureAwait(false)
                 : await _maintenanceService.GetAllMaintenanceRecordsAsync().ConfigureAwait(false);
+            var totalRecords = overdueOnly
+                ? await _maintenanceService.CountOverdueMaintenanceAsync().ConfigureAwait(false)
+                : await _maintenanceService.CountMaintenanceRecordsAsync().ConfigureAwait(false);
 
             var title = overdueOnly ? "Overdue Maintenance Report" : "Maintenance Schedule Report";
 
             var lines = records.Select(m =>
                 $"Maintenance ID: {m.MaintenanceID} | Item: {m.ItemNumber} - {m.ItemName} | Type: {m.MaintenanceType} | Scheduled: {m.ScheduledDate:yyyy-MM-dd} | Status: {m.StatusDisplay} | Cost: ${m.Cost:F2}");
 
-            if (overdueOnly)
-            {
-                var totalOverdueMaintenance = await _maintenanceService.CountOverdueMaintenanceAsync().ConfigureAwait(false);
-                return BuildReport(title, AddExactReportLimitNotice(lines, records.Count, totalOverdueMaintenance, "maintenance records"));
-            }
-
-            return BuildReport(title, AddReportLimitNotice(lines, records.Count, "maintenance records"));
+            return BuildReport(title, AddExactReportLimitNotice(lines, records.Count, totalRecords, "maintenance records"));
         }
 
         public async Task<FlowDocument> GenerateCalibrationReport(bool overdueOnly = false)
@@ -233,19 +230,16 @@ namespace InventoryManagementApp.Services.Items
             var records = overdueOnly
                 ? await _calibrationService.GetOverdueCalibrationAsync().ConfigureAwait(false)
                 : await _calibrationService.GetAllCalibrationRecordsAsync().ConfigureAwait(false);
+            var totalRecords = overdueOnly
+                ? await _calibrationService.CountOverdueCalibrationAsync().ConfigureAwait(false)
+                : await _calibrationService.CountCalibrationRecordsAsync().ConfigureAwait(false);
 
             var title = overdueOnly ? "Overdue Calibration Report" : "Calibration Records Report";
 
             var lines = records.Select(c =>
                 $"Calibration ID: {c.CalibrationID} | Item: {c.ItemNumber} - {c.ItemName} | Date: {c.CalibrationDate:yyyy-MM-dd} | Next Due: {c.NextCalibrationDue:yyyy-MM-dd} | Status: {c.StatusDisplay} | Certificate Number: {c.CertificateNumber}");
 
-            if (overdueOnly)
-            {
-                var totalOverdueCalibration = await _calibrationService.CountOverdueCalibrationAsync().ConfigureAwait(false);
-                return BuildReport(title, AddExactReportLimitNotice(lines, records.Count, totalOverdueCalibration, "calibration records"));
-            }
-
-            return BuildReport(title, AddReportLimitNotice(lines, records.Count, "calibration records"));
+            return BuildReport(title, AddExactReportLimitNotice(lines, records.Count, totalRecords, "calibration records"));
         }
 
         public async Task<FlowDocument> GenerateReservationReport(bool activeOnly = true)
@@ -256,19 +250,16 @@ namespace InventoryManagementApp.Services.Items
             var reservations = activeOnly
                 ? await _reservationService.GetActiveReservationsAsync().ConfigureAwait(false)
                 : await _reservationService.GetAllReservationsAsync().ConfigureAwait(false);
+            var totalReservations = activeOnly
+                ? await _reservationService.CountActiveReservationsAsync().ConfigureAwait(false)
+                : await _reservationService.CountReservationsAsync().ConfigureAwait(false);
 
             var title = activeOnly ? "Active Reservations Report" : "All Reservations Report";
 
             var lines = reservations.Select(r =>
                 $"Reservation ID: {r.ReservationID} | Item: {r.ItemNumber} - {r.ItemName} | Customer: {r.CustomerName} | Start: {r.StartDate:yyyy-MM-dd} | End: {r.EndDate:yyyy-MM-dd} | Quantity: {r.Quantity} | Status: {r.StatusDisplay}");
 
-            if (activeOnly)
-            {
-                var totalActiveReservations = await _reservationService.CountActiveReservationsAsync().ConfigureAwait(false);
-                return BuildReport(title, AddExactReportLimitNotice(lines, reservations.Count, totalActiveReservations, "reservations"));
-            }
-
-            return BuildReport(title, AddReportLimitNotice(lines, reservations.Count, "reservations"));
+            return BuildReport(title, AddExactReportLimitNotice(lines, reservations.Count, totalReservations, "reservations"));
         }
 
         public async Task<FlowDocument> GenerateKitReport()
@@ -316,15 +307,6 @@ namespace InventoryManagementApp.Services.Items
 
         private static string FormatLimitedCount(int count) =>
             count >= DetailedReportResultLimit ? $"{DetailedReportResultLimit}+" : count.ToString();
-
-        private static IEnumerable<string> AddReportLimitNotice(IEnumerable<string> lines, int recordCount, string recordLabel)
-        {
-            foreach (var line in lines)
-                yield return line;
-
-            if (recordCount >= DetailedReportResultLimit)
-                yield return $"Note: This report shows the first {DetailedReportResultLimit} {recordLabel}. Additional records may exist. Use filters or exports for a narrower full-detail review.";
-        }
 
         private static IEnumerable<string> AddExactReportLimitNotice(IEnumerable<string> lines, int displayedCount, int totalCount, string recordLabel)
         {

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -129,7 +129,7 @@ namespace InventoryManagementApp.Services.Kits
                 while (reader.Read())
                 {
                     var kitId = reader.GetInt32(reader.GetOrdinal("KitID"));
-                    counts[kitId] = reader.GetInt32(reader.GetOrdinal("ItemCount"));
+                    counts[kitId] = Convert.ToInt32(reader["ItemCount"] ?? 0);
                 }
 
                 return counts;

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using InventoryManagementApp.Models.Domain;
@@ -93,7 +94,45 @@ namespace InventoryManagementApp.Services.Kits
                     FROM Kits
                     WHERE IsActive = 1";
                 using var cmd = new SqliteCommand(sql, conn);
-                return Convert.ToInt32(cmd.ExecuteScalar());
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
+            });
+        }
+
+        public async Task<Dictionary<int, int>> CountKitItemsByKitIdsAsync(IEnumerable<int> kitIds)
+        {
+            if (kitIds == null)
+                throw new ArgumentNullException(nameof(kitIds));
+
+            var distinctKitIds = kitIds.Distinct().ToList();
+            if (distinctKitIds.Any(id => id < 1))
+                throw new ArgumentOutOfRangeException(nameof(kitIds), "Kit IDs must be greater than 0.");
+            if (distinctKitIds.Count == 0)
+                return new Dictionary<int, int>();
+
+            return await Task.Run(() =>
+            {
+                var counts = distinctKitIds.ToDictionary(id => id, _ => 0);
+                using var conn = _databaseService.CreateConnection();
+                var parameterNames = distinctKitIds
+                    .Select((_, index) => $"@KitID{index}")
+                    .ToList();
+                var sql = $@"
+                    SELECT KitID, COUNT(KitItemID) AS ItemCount
+                    FROM KitItems
+                    WHERE KitID IN ({string.Join(", ", parameterNames)})
+                    GROUP BY KitID";
+                using var cmd = new SqliteCommand(sql, conn);
+                for (var index = 0; index < distinctKitIds.Count; index++)
+                    cmd.Parameters.AddWithValue(parameterNames[index], distinctKitIds[index]);
+
+                using var reader = cmd.ExecuteReader();
+                while (reader.Read())
+                {
+                    var kitId = reader.GetInt32(reader.GetOrdinal("KitID"));
+                    counts[kitId] = reader.GetInt32(reader.GetOrdinal("ItemCount"));
+                }
+
+                return counts;
             });
         }
 
@@ -363,7 +402,7 @@ namespace InventoryManagementApp.Services.Kits
                     AND (i.ItemID IS NULL OR i.AvailableQuantity < ki.Quantity)";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@KitID", kitID);
-                var missingItems = Convert.ToInt32(cmd.ExecuteScalar());
+                var missingItems = Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
                 return missingItems == 0;
             });
         }
@@ -472,7 +511,7 @@ namespace InventoryManagementApp.Services.Kits
         {
             using var cmd = new SqliteCommand(sql, conn);
             cmd.Parameters.AddWithValue("@ID", id);
-            return Convert.ToInt32(cmd.ExecuteScalar()) > 0;
+            return Convert.ToInt32(cmd.ExecuteScalar() ?? 0) > 0;
         }
 
         private static object ToDbNullableText(string? value)

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -58,6 +58,20 @@ namespace InventoryManagementApp.Services.Maintenance
             });
         }
 
+        public async Task<int> CountMaintenanceRecordsAsync()
+        {
+            return await Task.Run(() =>
+            {
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(m.MaintenanceID)
+                    FROM MaintenanceRecords m
+                    JOIN Items i ON m.ItemID = i.ItemID";
+                using var cmd = new SqliteCommand(sql, conn);
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
+            });
+        }
+
         /// <summary>
         /// Retrieves all maintenance records for a specific item.
         /// </summary>

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -59,6 +59,21 @@ namespace InventoryManagementApp.Services.Reservations
             });
         }
 
+        public async Task<int> CountReservationsAsync()
+        {
+            return await Task.Run(() =>
+            {
+                using var conn = _databaseService.CreateConnection();
+                var sql = @"
+                    SELECT COUNT(r.ReservationID)
+                    FROM Reservations r
+                    JOIN Items i ON r.ItemID = i.ItemID
+                    JOIN Customers c ON r.CustomerID = c.CustomerID";
+                using var cmd = new SqliteCommand(sql, conn);
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
+            });
+        }
+
         /// <summary>
         /// Retrieves all active reservations (pending or confirmed status), ordered by start date.
         /// </summary>
@@ -195,7 +210,7 @@ namespace InventoryManagementApp.Services.Reservations
                     JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.Status IN ('Pending', 'Confirmed')";
                 using var cmd = new SqliteCommand(sql, conn);
-                return Convert.ToInt32(cmd.ExecuteScalar());
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
             });
         }
 
@@ -216,7 +231,7 @@ namespace InventoryManagementApp.Services.Reservations
                     AND r.StartDate <= @FutureDate";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@FutureDate", DateTime.Now.AddDays(days));
-                return Convert.ToInt32(cmd.ExecuteScalar());
+                return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
             });
         }
 


### PR DESCRIPTION
## What changed

- Bounded the customer detail report at the data-access source by using the existing 500-row customer search path instead of loading every customer and trimming after materialization.
- Started independent detailed-report row reads and exact-count reads together before rendering for rentals, customers, users, maintenance, calibration, reservations, and active kits.
- Added exact-count truncation notices for detailed reports with reliable total counters: rentals, customers, users, maintenance, calibration, reservations, and active kits.
- Added exact all-record count APIs for maintenance records, calibration records, and reservations so full-detail maintenance, calibration, and reservation reports no longer need vague capped-output fallback notices.
- Started optional application-summary counts for maintenance, calibration, reservations, and kits before the single summary await so summary preview does not wait through each optional section in sequence.
- Replaced active-kit report per-kit item-list loading with one grouped kit-item count query.
- Added grouped kit item count validation for null, duplicate, empty, and invalid kit-ID inputs, preserving zero-count rows for kits with no items.
- Hardened SQLite aggregate conversions on kit count paths with `Convert.ToInt32(... ?? 0)` instead of direct reader casts.
- Removed the remaining generic detailed-report fallback notice helper from `ReportService`; detailed report truncation notices now use exact "first N of total" wording where the app caps printable output.
- Updated report source-contract tests so bounded customer output, deterministic customer ordering, parallel row/count reads, summary count concurrency, grouped kit item counts, safe aggregate conversion, exact detailed-report notice wiring, and no-limit count query contracts stay covered.
- Updated the progress note for future scheduled runs.

## Why this was the highest-value next step

Recent merged work made summary report totals exact, and this PR is the active follow-on reporting slice. The current branch had already made detailed report truncation more honest, but connector readback showed two remaining workflow risks in the same report-preview path: optional summary counts still ran in section order, and active kit reports still loaded each kit's item list just to print an item count.

## Why the scope is real progress

This is a workflow-level reporting slice across printable report generation, service query APIs, source-contract coverage, and progress notes. It includes more than 10 focused improvements spanning data-access bounding, exact counters, report preview responsiveness, visible truncation messaging, grouped kit item counts, safer SQLite aggregate conversion, and test coverage. It improves operator-facing reports and persistence-query behavior instead of making an isolated wording or guard change.

## Validation

- GitHub connector readback confirms the PR is open, draft, and mergeable at head `7fc9a8ff7aa0a5ea7cd6a2aafd9f25229658b1d4`.
- Connector compare readback shows the branch is `ahead_by: 21` and `behind_by: 2` against current `master`; it should be updated from `master` before final validation/merge.
- Connector changed-file readback confirms the branch is limited to reporting services, kit/maintenance/calibration/reservation services, report source-contract tests, and one progress note.
- Connector source readback confirmed `GenerateCustomerReport` uses the bounded customer search path plus exact customer count wiring instead of `_customerService.GetAllCustomersAsync()`.
- Connector source readback confirmed rental, customer, user, maintenance, calibration, reservation, and active-kit detail reports start row and exact-count reads together before rendering notices.
- Connector source readback confirmed `GenerateSummaryReport` starts base and optional maintenance/calibration/reservation/kit count tasks before a single `Task.WhenAll(summaryTasks)` await.
- Connector source readback confirmed `GenerateKitReport` uses `CountKitItemsByKitIdsAsync(kits.Select(kit => kit.KitID))` and no longer calls `GetKitItemsAsync` per displayed kit.
- Connector source readback confirmed `KitService.CountKitItemsByKitIdsAsync` validates input, de-duplicates IDs, returns zero-filled counts, uses one grouped `KitItems` count query without `LIMIT @KitItemListLimit`, parameterizes the `IN` list, and converts aggregate values safely.
- Connector source readback confirmed the new `ReportServiceSummaryAndKitContractTests` cover summary concurrency, grouped kit report counts, grouped count query contracts, and the nullable-task helper.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the latest head SHA.

## Could not be checked

- Local checkout is blocked in this scheduled environment by `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
- This environment cannot update the branch from latest `master` without a checkout or GitHub CLI.

## Known follow-up work

- Update PR #1458 from current `master`, then run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Keep this PR as draft until local build/test/print-preview validation or CI coverage is available.
- Consider a dedicated customer report page API if future reports need filters beyond the current deterministic first-page customer listing.
- Consider true streaming/export-specific workflows for very large detailed report review if operators need full-row output beyond printable capped previews.