### PR TITLE
Page customer export row collection

### DIFF
--- a/InventoryManagementApp.Tests/CustomerImportExportEntrypointContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerImportExportEntrypointContractTests.cs
@@ -44,11 +44,49 @@ namespace InventoryManagementApp.Tests
                 exportMethod.IndexOf("if (exporter is null)", StringComparison.Ordinal) < exportMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
                 "Generic customer exports should reject a missing exporter before authorization or row collection.");
             Assert.True(
-                exportMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal) < exportMethod.IndexOf("GetAllCustomersAsync", StringComparison.Ordinal),
+                exportMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal) < exportMethod.IndexOf("CollectCustomersForExportAsync", StringComparison.Ordinal),
                 "Generic customer exports should still authorize before collecting customer rows.");
             Assert.True(
-                exportMethod.IndexOf("GetAllCustomersAsync", StringComparison.Ordinal) < exportMethod.IndexOf("exporter.ExportAsync", StringComparison.Ordinal),
+                exportMethod.IndexOf("CollectCustomersForExportAsync", StringComparison.Ordinal) < exportMethod.IndexOf("exporter.ExportAsync", StringComparison.Ordinal),
                 "Generic customer exports should collect rows before exporter handoff.");
+        }
+
+        [Fact]
+        public void CustomerExportsCollectRowsWithBoundedPagesBeforeWriterWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var csvExportMethod = ExtractMethod(
+                source,
+                "async Task ExportCustomersToCsvInternalAsync",
+                "async Task<List<CustomerModel>> CollectCustomersForExportAsync");
+            var collectorMethod = ExtractMethod(
+                source,
+                "async Task<List<CustomerModel>> CollectCustomersForExportAsync",
+                "async Task InsertCustomerAsync");
+            var genericExportMethod = ExtractMethod(
+                source,
+                "public async Task ExportCustomersAsync",
+                "static void NotifyChanged");
+
+            Assert.Contains("private const int CustomerExportPageSize = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("var offset = 0;", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("while (true)", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("LIMIT @CustomerExportPageSize OFFSET @CustomerExportOffset", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("ORDER BY Company ASC, Contact ASC, CustomerID ASC", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@CustomerExportPageSize\", CustomerExportPageSize)", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@CustomerExportOffset\", offset)", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("customers.AddRange(page);", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("if (page.Count < CustomerExportPageSize)", collectorMethod, StringComparison.Ordinal);
+            Assert.Contains("offset += CustomerExportPageSize;", collectorMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetAllCustomersInternalAsync", csvExportMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetAllCustomersAsync", genericExportMethod, StringComparison.Ordinal);
+
+            Assert.True(
+                csvExportMethod.IndexOf("var all = await CollectCustomersForExportAsync(cancellationToken)", StringComparison.Ordinal) < csvExportMethod.IndexOf("CsvHelperUtil.ExportCustomersToCsv", StringComparison.Ordinal),
+                "CSV customer exports should finish bounded collection before handing rows to the CSV writer.");
+            Assert.True(
+                genericExportMethod.IndexOf("var all = await CollectCustomersForExportAsync(cancellationToken)", StringComparison.Ordinal) < genericExportMethod.IndexOf("exporter.ExportAsync", StringComparison.Ordinal),
+                "Generic customer exports should finish bounded collection before handing rows to the exporter.");
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-07-01-customer-export-paged-collection.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-01-customer-export-paged-collection.md
@@ -1,0 +1,16 @@
+# Customer Export Paged Collection
+
+Date: 2026-07-01
+
+## Completed
+
+- Replaced customer export workflows' direct all-customer collection with a shared bounded page collector using `CustomerExportPageSize`.
+- Applied the paged collection path to both CSV customer export and generic customer exporter handoff while preserving full-directory export behavior.
+- Added deterministic export ordering by company, contact, and customer ID so paged exports stay stable across batches.
+- Preserved cancellation checks before collection, during each page pass, and immediately before writer/exporter handoff.
+- Added source-contract coverage so customer exports keep using the bounded page loop and do not regress to `GetAllCustomersAsync()` or `GetAllCustomersInternalAsync()` in export paths.
+
+## Validation
+
+- Connector readback should confirm the service now pages customer export collection and the source-contract test covers both CSV and generic export paths.
+- Local .NET validation still needs a Windows/.NET-capable checkout because this scheduled environment cannot clone the repository and does not provide `dotnet`, `pwsh`, or `gh`.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -25,6 +25,7 @@ namespace InventoryManagementApp.Services.Customers
     public class CustomerService : ICustomerService
     {
         private const int MaxCustomerSearchResults = 500;
+        private const int CustomerExportPageSize = 500;
 
         private readonly DatabaseService _dbService;
         private readonly ILogger<CustomerService> _logger;
@@ -395,13 +396,53 @@ namespace InventoryManagementApp.Services.Customers
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var all = await GetAllCustomersInternalAsync(cancellationToken);
+            var all = await CollectCustomersForExportAsync(cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             await Task.Run(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 CsvHelperUtil.ExportCustomersToCsv(filePath, all);
             }, cancellationToken);
+        }
+
+        async Task<List<CustomerModel>> CollectCustomersForExportAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            const string sql = @"
+                SELECT * FROM Customers
+                ORDER BY Company ASC, Contact ASC, CustomerID ASC
+                LIMIT @CustomerExportPageSize OFFSET @CustomerExportOffset";
+            var customers = new List<CustomerModel>();
+            var offset = 0;
+            using var conn = _dbService.CreateConnection();
+
+            try
+            {
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var p = new[]
+                    {
+                        new SqliteParameter("@CustomerExportPageSize", CustomerExportPageSize),
+                        new SqliteParameter("@CustomerExportOffset", offset)
+                    };
+                    var page = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapCustomer, p, cancellationToken).ConfigureAwait(false);
+                    customers.AddRange(page);
+
+                    if (page.Count < CustomerExportPageSize)
+                        break;
+
+                    offset += CustomerExportPageSize;
+                }
+
+                return customers;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to collect customers for export");
+                throw;
+            }
         }
 
         async Task InsertCustomerAsync(SqliteConnection conn, SqliteTransaction? tran, CustomerModel customer, CancellationToken cancellationToken)
@@ -635,7 +676,7 @@ namespace InventoryManagementApp.Services.Customers
             _auth.EnsurePermission(User.PermissionImportExport);
             cancellationToken.ThrowIfCancellationRequested();
 
-            var all = await GetAllCustomersAsync(cancellationToken).ConfigureAwait(false);
+            var all = await CollectCustomersForExportAsync(cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             await exporter.ExportAsync(filePath, all, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
## What changed

- Added a shared `CollectCustomersForExportAsync` helper that reads customer export rows in deterministic 500-row pages ordered by company, contact, and customer ID.
- Routed both CSV customer export and generic customer exporter handoff through the paged collector instead of calling the all-customers read directly from export paths.
- Preserved full-directory export behavior and cancellation checks before collection, during each page pass, and before writer/exporter handoff.
- Extended `CustomerImportExportEntrypointContractTests` so customer export paths stay bounded and do not regress to `GetAllCustomersAsync()` or `GetAllCustomersInternalAsync()`.
- Added a progress note for the completed customer export reliability slice.

## Why this was the highest-value next step

Recent merged work already paged item exports and capped several interactive list/report reads. Current source showed customer export still used the full customer directory read before writer/exporter work, which is the same large-dataset materialization risk the item export workflow recently removed. This improves an existing import/export workflow without reopening the active draft report PR #1458 or repeating completed report-count work.

## Why the scope is large enough to count as real progress

This is a complete workflow slice across CSV export, generic export, data-access collection behavior, cancellation preservation, source-contract coverage, and progress notes. It is not a narrow wording or guard-only edit: both user-facing customer export routes now share the safer collection path.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to `CustomerService`, `CustomerImportExportEntrypointContractTests`, and one progress note.
- Connector readback confirmed CSV and generic customer exports now call `CollectCustomersForExportAsync(...)` before writer/exporter handoff.
- Connector readback confirmed the collector uses `CustomerExportPageSize = 500`, deterministic ordering, `LIMIT @CustomerExportPageSize OFFSET @CustomerExportOffset`, cancellation checks, and page offset advancement.
- Connector readback confirmed source-contract coverage rejects `GetAllCustomersInternalAsync` in the CSV export path and `GetAllCustomersAsync` in the generic export path.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `9ed5b01ca1b9ab0c4a5da29f089950fbb4f8ff35`.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime, screenshots, print/layout checks, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Consider true streaming exporter contracts later if very large customer exports still need lower memory pressure at writer handoff.