### PR TITLE
[codex] Normalize item import text before duplicate checks

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceImportNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceImportNormalizationContractTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemServiceImportNormalizationContractTests
+    {
+        [Fact]
+        public void CsvItemImportNormalizesMappedTextBeforeValidationDuplicatesAndInsert()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "private async Task<List<int>> ImportItemsFromCsvInternalAsync",
+                "protected virtual async Task<int> InsertItemAsync");
+
+            Assert.Contains("var itemNumber = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"ItemNumber\"));", method, StringComparison.Ordinal);
+            Assert.Contains("var name = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, nameof(ItemImportDto.Name)));", method, StringComparison.Ordinal);
+            Assert.Contains("var location = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"Location\"));", method, StringComparison.Ordinal);
+            Assert.Contains("var brand = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"Brand\"));", method, StringComparison.Ordinal);
+            Assert.Contains("var partNumber = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"PartNumber\"));", method, StringComparison.Ordinal);
+            Assert.Contains("var supplier = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"Supplier\"));", method, StringComparison.Ordinal);
+            Assert.Contains("var purchased = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"PurchasedDate\"));", method, StringComparison.Ordinal);
+            Assert.Contains("var notes = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"Notes\"));", method, StringComparison.Ordinal);
+            Assert.Contains("var keywords = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)));", method, StringComparison.Ordinal);
+            Assert.Contains("var quantity = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"AvailableQuantity\"));", method, StringComparison.Ordinal);
+            Assert.Contains("var powered = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"IsPowered\"));", method, StringComparison.Ordinal);
+            Assert.Contains("var rental = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, \"IsRentalItem\"));", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("var itemNumber = NormalizeImportedText", StringComparison.Ordinal) < method.IndexOf("string.IsNullOrWhiteSpace(itemNumber)", StringComparison.Ordinal),
+                "CSV item import should trim item numbers before missing-number validation.");
+            Assert.True(
+                method.IndexOf("var itemNumber = NormalizeImportedText", StringComparison.Ordinal) < method.IndexOf("existingNumbers.Contains(itemNumber)", StringComparison.Ordinal),
+                "CSV item import should trim item numbers before duplicate checks.");
+            Assert.True(
+                method.IndexOf("var name = NormalizeImportedText", StringComparison.Ordinal) < method.IndexOf("Name = name ?? string.Empty", StringComparison.Ordinal),
+                "CSV item import should trim names before insert model construction.");
+            Assert.True(
+                method.IndexOf("var quantity = NormalizeImportedText", StringComparison.Ordinal) < method.IndexOf("var parsedQuantity = TryParseInt(quantity);", StringComparison.Ordinal),
+                "CSV item import should trim quantity text before parsing.");
+        }
+
+        [Fact]
+        public void GenericItemImportNormalizesItemsBeforeGeneratedNumbersDuplicatesValidationAndInsert()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<List<int>> ImportItemsAsync",
+                "private static void NormalizeImportedItem");
+
+            Assert.Contains("NormalizeImportedItem(item);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeImportedItem(item);", StringComparison.Ordinal) < method.IndexOf("string.IsNullOrWhiteSpace(item.ItemNumber)", StringComparison.Ordinal),
+                "Generic item import should trim imported fields before deciding whether to generate an item number.");
+            Assert.True(
+                method.IndexOf("NormalizeImportedItem(item);", StringComparison.Ordinal) < method.IndexOf("existingNumbers.Contains(item.ItemNumber)", StringComparison.Ordinal),
+                "Generic item import should trim item numbers before duplicate checks.");
+            Assert.True(
+                method.IndexOf("NormalizeImportedItem(item);", StringComparison.Ordinal) < method.IndexOf("ValidateQuantity(item.QuantityOnHand);", StringComparison.Ordinal),
+                "Generic item import should normalize rows before validation and insert work.");
+            Assert.True(
+                method.IndexOf("NormalizeImportedItem(item);", StringComparison.Ordinal) < method.IndexOf("InsertItemAsync(conn, transaction, item", StringComparison.Ordinal),
+                "Generic item import should only insert normalized item text.");
+        }
+
+        [Fact]
+        public void ItemImportExistingNumberSetsUseTrimmedDatabaseValues()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var csvMethod = ExtractMethod(
+                source,
+                "private async Task<List<int>> ImportItemsFromCsvInternalAsync",
+                "protected virtual async Task<int> InsertItemAsync");
+            var genericMethod = ExtractMethod(
+                source,
+                "public async Task<List<int>> ImportItemsAsync",
+                "private static void NormalizeImportedItem");
+
+            Assert.Contains("r => r.GetString(0).Trim()", csvMethod, StringComparison.Ordinal);
+            Assert.Contains("r => r.GetString(0).Trim()", genericMethod, StringComparison.Ordinal);
+            Assert.True(
+                csvMethod.IndexOf("r => r.GetString(0).Trim()", StringComparison.Ordinal) < csvMethod.IndexOf("existingNumbers.Contains(itemNumber)", StringComparison.Ordinal),
+                "CSV item imports should compare normalized imported numbers against trimmed persisted numbers.");
+            Assert.True(
+                genericMethod.IndexOf("r => r.GetString(0).Trim()", StringComparison.Ordinal) < genericMethod.IndexOf("existingNumbers.Contains(item.ItemNumber)", StringComparison.Ordinal),
+                "Generic item imports should compare normalized imported numbers against trimmed persisted numbers.");
+        }
+
+        [Fact]
+        public void ImportedItemNormalizerCoversIdentityDetailAndOperationalTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var normalizer = ExtractMethod(
+                source,
+                "private static void NormalizeImportedItem",
+                "private static string? NormalizeImportedText");
+
+            Assert.Contains("item.ItemNumber = NormalizeImportedText(item.ItemNumber) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Name = NormalizeImportedText(item.Name) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Location = NormalizeImportedText(item.Location) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Brand = NormalizeImportedText(item.Brand) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.PartNumber = NormalizeImportedText(item.PartNumber) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Supplier = NormalizeImportedText(item.Supplier) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Notes = NormalizeImportedText(item.Notes) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Keywords = NormalizeImportedText(item.Keywords) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.ImagePath = NormalizeImportedText(item.ImagePath) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.CheckedOutBy = NormalizeImportedText(item.CheckedOutBy) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.CheckedInBy = NormalizeImportedText(item.CheckedInBy) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.MissingComponentsNotes = NormalizeImportedText(item.MissingComponentsNotes) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("item.IssuesNotes = NormalizeImportedText(item.IssuesNotes) ?? string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("private static string? NormalizeImportedText(string? value) => value?.Trim();", source, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-item-import-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-item-import-normalization.md
@@ -1,0 +1,19 @@
+# Item Import Normalization
+
+Date: 2026-07-02
+
+## Completed
+
+- Normalized CSV item import text immediately after mapped field extraction so item numbers, names, locations, brands, part numbers, suppliers, purchase-date text, notes, keywords, quantity text, and boolean text are trimmed before row validation.
+- Compared normalized CSV item numbers against trimmed persisted item numbers before duplicate decisions, preventing whitespace variants from bypassing duplicate checks.
+- Built CSV import `ItemModel` rows from normalized text so stored item identity and detail fields do not retain accidental leading or trailing spaces from import files.
+- Normalized generic importer `ItemModel` rows before generated-number decisions, duplicate checks, quantity validation, and insert work.
+- Trimmed persisted item numbers when hydrating duplicate-check sets for both CSV and generic item imports.
+- Added a shared imported-item normalizer covering identity, descriptive, image, holder, and incomplete/issue note text fields on generic import models.
+- Added source-contract coverage for CSV normalization order, generic normalization order, trimmed persisted duplicate sets, and the imported-item normalizer field list.
+
+## Validation
+
+- GitHub connector readback should confirm `ItemService` normalizes CSV mapped values and generic importer models before duplicate checks and inserts.
+- GitHub connector readback should confirm `ItemServiceImportNormalizationContractTests` covers the normalization order and trimmed persisted-number lookup shape.
+- Local .NET validation still needs a Windows/.NET-capable checkout because this scheduled environment cannot clone the repository and does not provide `dotnet`, `pwsh`, `gh`, or WPF runtime support.

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -468,7 +468,7 @@ namespace InventoryManagementApp.Services.Items
             var existingNumbers = new HashSet<string>(
                 await SqliteHelper.ExecuteReaderAsync(conn,
                     "SELECT ItemNumber FROM Items",
-                    r => r.GetString(0),
+                    r => r.GetString(0).Trim(),
                     null, cancellationToken),
                 StringComparer.OrdinalIgnoreCase);
             using var transaction = conn.BeginTransaction();
@@ -487,18 +487,18 @@ namespace InventoryManagementApp.Services.Items
                         invalidRows.Add(row);
                         continue;
                     }
-                    var itemNumber = CsvHelperUtil.GetMapped(cols, headers, map, "ItemNumber");
-                    var name = CsvHelperUtil.GetMapped(cols, headers, map, nameof(ItemImportDto.Name));
-                    var location = CsvHelperUtil.GetMapped(cols, headers, map, "Location");
-                    var brand = CsvHelperUtil.GetMapped(cols, headers, map, "Brand");
-                    var partNumber = CsvHelperUtil.GetMapped(cols, headers, map, "PartNumber");
-                    var supplier = CsvHelperUtil.GetMapped(cols, headers, map, "Supplier");
-                    var purchased = CsvHelperUtil.GetMapped(cols, headers, map, "PurchasedDate");
-                    var notes = CsvHelperUtil.GetMapped(cols, headers, map, "Notes");
-                    var keywords = CsvHelperUtil.GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords));
-                    var quantity = CsvHelperUtil.GetMapped(cols, headers, map, "AvailableQuantity");
-                    var powered = CsvHelperUtil.GetMapped(cols, headers, map, "IsPowered");
-                    var rental = CsvHelperUtil.GetMapped(cols, headers, map, "IsRentalItem");
+                    var itemNumber = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "ItemNumber"));
+                    var name = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, nameof(ItemImportDto.Name)));
+                    var location = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "Location"));
+                    var brand = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "Brand"));
+                    var partNumber = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "PartNumber"));
+                    var supplier = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "Supplier"));
+                    var purchased = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "PurchasedDate"));
+                    var notes = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "Notes"));
+                    var keywords = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)));
+                    var quantity = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "AvailableQuantity"));
+                    var powered = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "IsPowered"));
+                    var rental = NormalizeImportedText(CsvHelperUtil.GetMapped(cols, headers, map, "IsRentalItem"));
 
                     bool skip = false;
                     if (string.IsNullOrWhiteSpace(itemNumber))
@@ -742,7 +742,7 @@ namespace InventoryManagementApp.Services.Items
             var existingNumbers = new HashSet<string>(
                 await SqliteHelper.ExecuteReaderAsync(conn,
                     "SELECT ItemNumber FROM Items",
-                    r => r.GetString(0),
+                    r => r.GetString(0).Trim(),
                     null, cancellationToken),
                 StringComparer.OrdinalIgnoreCase);
             using var transaction = conn.BeginTransaction();
@@ -752,6 +752,7 @@ namespace InventoryManagementApp.Services.Items
                 foreach (var item in items)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+                    NormalizeImportedItem(item);
 
                     if (string.IsNullOrWhiteSpace(item.ItemNumber))
                         item.ItemNumber = GenerateNextImportedItemNumber(existingNumbers);
@@ -775,6 +776,25 @@ namespace InventoryManagementApp.Services.Items
                 throw;
             }
         }
+
+        private static void NormalizeImportedItem(ItemModel item)
+        {
+            item.ItemNumber = NormalizeImportedText(item.ItemNumber) ?? string.Empty;
+            item.Name = NormalizeImportedText(item.Name) ?? string.Empty;
+            item.Location = NormalizeImportedText(item.Location) ?? string.Empty;
+            item.Brand = NormalizeImportedText(item.Brand) ?? string.Empty;
+            item.PartNumber = NormalizeImportedText(item.PartNumber) ?? string.Empty;
+            item.Supplier = NormalizeImportedText(item.Supplier) ?? string.Empty;
+            item.Notes = NormalizeImportedText(item.Notes) ?? string.Empty;
+            item.Keywords = NormalizeImportedText(item.Keywords) ?? string.Empty;
+            item.ImagePath = NormalizeImportedText(item.ImagePath) ?? string.Empty;
+            item.CheckedOutBy = NormalizeImportedText(item.CheckedOutBy) ?? string.Empty;
+            item.CheckedInBy = NormalizeImportedText(item.CheckedInBy) ?? string.Empty;
+            item.MissingComponentsNotes = NormalizeImportedText(item.MissingComponentsNotes) ?? string.Empty;
+            item.IssuesNotes = NormalizeImportedText(item.IssuesNotes) ?? string.Empty;
+        }
+
+        private static string? NormalizeImportedText(string? value) => value?.Trim();
 
         private static string GenerateNextImportedItemNumber(ISet<string> existingNumbers)
         {

--- a/ToDo.md
+++ b/ToDo.md
@@ -11,8 +11,7 @@ Current repository evidence:
 - The active application remains `InventoryManagementApp`, a WPF desktop app targeting `net10.0-windows` with SQLite persistence through `DatabaseService`.
 - The repository default branch is `master`.
 - Recent scheduled work has focused on release safety: validation diagnostics, dependency-audit visibility, bounded list/report/export reads, import/export setup guards, stale-write guards, and more honest printable report output.
-- The latest completed merged work before this note paged customer export row collection through deterministic 500-row batches for both CSV and generic customer export workflows.
-- Draft PR #1458 remains open for detailed-report truncation/count behavior and should not be merged until real Windows/.NET validation is available.
+- Recent merged work completed the detailed-report truncation/count behavior in PR #1458 and paged customer export row collection through deterministic 500-row batches for both CSV and generic customer export workflows.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -53,20 +52,20 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Local and CI validation paths now clean stale validation artifacts and publish output before producing fresh manifests.
 - Item, customer, rental, reservation, maintenance, calibration, kit, activity-log, user, report, and export workflows have been progressively bounded or routed through count APIs where large reads were risky.
 - Item and customer import/export entry points now reject missing setup before authorization or expensive work in the recently touched paths.
-- Generated reports now have stronger document layout, visible empty states, readable labels, honest capped-result notices, and exact summary counts for the completed report paths.
+- Generated reports now have stronger document layout, visible empty states, readable labels, honest capped-result notices, exact summary counts, and exact detailed-report truncation counts for the completed report paths.
 - Customer exports now collect rows through a deterministic paged collector rather than loading the full directory in one database read.
+- Item imports now normalize imported identity/detail text before duplicate checks and inserts across CSV and generic importer paths.
 
 ## Highest-Value Next Work
 
 Prioritize the following before adding unrelated new features:
 
 1. Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout and capture the actual restore, audit, build, test, publish, banned-word, and artifact-manifest results.
-2. Validate draft PR #1458 with the full runner before deciding whether to mark it ready, update it, or close it.
-3. Review the dedicated vulnerable-package audit output plus any NU190x warnings from repository-level NuGet auditing, then update affected packages or document intentional risk decisions.
-4. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, and theme-customized popup surfaces.
-5. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
-6. Harden item import data normalization so CSV and generic item imports trim item identity/detail fields before duplicate checks and inserts, matching the data-quality direction already applied to customer and activity-log workflows.
-7. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
+2. Review the dedicated vulnerable-package audit output plus any NU190x warnings from repository-level NuGet auditing, then update affected packages or document intentional risk decisions.
+3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, and theme-customized popup surfaces.
+4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
+5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
+6. Keep tightening import/export data-quality behavior where current evidence shows user-entered or file-imported text can bypass validation, duplicate detection, or professional output expectations.
 
 ## App Completion Status
 


### PR DESCRIPTION
## What changed

- Normalized CSV item import mapped text immediately after extraction, covering item number, name, location, brand, part number, supplier, purchase-date text, notes, keywords, available quantity text, and boolean text.
- Compared normalized CSV item numbers against trimmed persisted item numbers before duplicate decisions.
- Built CSV import `ItemModel` rows from normalized identity/detail text so imported rows do not persist accidental leading or trailing spaces.
- Normalized generic importer `ItemModel` rows before generated-number decisions, duplicate checks, quantity validation, insert work, and duplicate-set updates.
- Trimmed persisted item numbers when hydrating duplicate-check sets for both CSV and generic item import paths.
- Added a shared imported-item normalizer for generic imports covering identity, descriptive, image, holder, incomplete-component, and issue-note text fields.
- Added source-contract coverage for CSV normalization order, generic normalization order, trimmed persisted-number lookups, and the imported-item normalizer field list.
- Added a progress note and refreshed `ToDo.md` so it no longer treats merged PR #1458 as an open draft and records item import normalization as completed on this branch.

## Why this was the highest-value next step

The current repository queue explicitly called out item import data normalization after the recent customer/activity-log data-quality work. This is a data-quality and duplicate-detection risk in a core import workflow: whitespace variants could be checked and stored inconsistently before this change.

## Why the scope is real progress

This is a complete import workflow hardening slice across CSV import parsing, generic importer model handling, persisted duplicate-set hydration, insert inputs, source-contract coverage, progress notes, and the durable work queue. It includes more than 10 focused improvements in one existing workflow rather than a tiny isolated guard or wording change.

## Validation

- GitHub connector compare readback confirms this branch is current with `master`, ahead by 4 commits, and limited to `ItemService`, one new item-import normalization test file, one progress note, and `ToDo.md`.
- Connector source readback confirmed CSV import now uses `NormalizeImportedText(CsvHelperUtil.GetMapped(...))` for item number, name, location, brand, part number, supplier, purchased date, notes, keywords, quantity, powered, and rental fields before validation, duplicate checks, parsing, and insert model construction.
- Connector source readback confirmed both CSV and generic item import duplicate sets read persisted item numbers with `r => r.GetString(0).Trim()`.
- Connector source readback confirmed generic item imports call `NormalizeImportedItem(item)` before generated-number decisions, duplicate checks, quantity validation, and `InsertItemAsync(...)`.
- Connector source readback confirmed `ItemServiceImportNormalizationContractTests` covers CSV normalization order, generic normalization order, trimmed persisted duplicate sets, and the normalizer field list.

## Could not be checked

- Local checkout is blocked in this scheduled environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue replacing source-contract tests with behavior-focused tests when a local .NET-capable environment is available for stronger execution coverage.
- Review current NuGet audit output once validation can run.