### PR TITLE
[codex] Normalize item save text before duplicate checks

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceSaveNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceSaveNormalizationContractTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemServiceSaveNormalizationContractTests
+    {
+        [Fact]
+        public void AddItemNormalizesTextBeforeAuthorizationDuplicateChecksInsertAndActivityLog()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var publicMethod = ExtractMethod(
+                source,
+                "public async Task AddItemAsync",
+                "        /// <summary>\n        /// Updates an existing item");
+            var internalMethod = ExtractMethod(
+                source,
+                "private async Task AddItemInternalAsync",
+                "private async Task UpdateItemInternalAsync");
+
+            Assert.Contains("NormalizeItemForSave(item);", publicMethod, StringComparison.Ordinal);
+            Assert.True(
+                publicMethod.IndexOf("NormalizeItemForSave(item);", StringComparison.Ordinal) < publicMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Add-item saves should normalize user-entered text before permission-gated persistence work starts.");
+            Assert.True(
+                publicMethod.IndexOf("NormalizeItemForSave(item);", StringComparison.Ordinal) < publicMethod.IndexOf("AddItemInternalAsync(item", StringComparison.Ordinal),
+                "Add-item saves should normalize the model before duplicate checks and inserts.");
+            Assert.True(
+                publicMethod.IndexOf("NormalizeItemForSave(item);", StringComparison.Ordinal) < publicMethod.IndexOf("Added item {item.ItemNumber}", StringComparison.Ordinal),
+                "Activity log messages should use the normalized item number.");
+
+            Assert.Contains("ItemExistsAsync(itemNumber: item.ItemNumber", internalMethod, StringComparison.Ordinal);
+            Assert.Contains("_repository.InsertAsync(item", internalMethod, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UpdateItemNormalizesTextBeforeAuthorizationDuplicateChecksUpdateAndActivityLog()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var publicMethod = ExtractMethod(
+                source,
+                "public async Task UpdateItemAsync",
+                "        /// <summary>\n        /// Deletes an item");
+            var internalMethod = ExtractMethod(
+                source,
+                "private async Task UpdateItemInternalAsync",
+                "private async Task DeleteItemInternalAsync");
+
+            Assert.Contains("NormalizeItemForSave(item);", publicMethod, StringComparison.Ordinal);
+            Assert.True(
+                publicMethod.IndexOf("NormalizeItemForSave(item);", StringComparison.Ordinal) < publicMethod.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Update-item saves should normalize user-entered text before permission-gated persistence work starts.");
+            Assert.True(
+                publicMethod.IndexOf("NormalizeItemForSave(item);", StringComparison.Ordinal) < publicMethod.IndexOf("UpdateItemInternalAsync(item", StringComparison.Ordinal),
+                "Update-item saves should normalize the model before duplicate checks and repository updates.");
+            Assert.True(
+                publicMethod.IndexOf("NormalizeItemForSave(item);", StringComparison.Ordinal) < publicMethod.IndexOf("Updated item {item.ItemNumber}", StringComparison.Ordinal),
+                "Activity log messages should use the normalized item number.");
+
+            Assert.Contains("ItemExistsAsync(itemNumber: item.ItemNumber", internalMethod, StringComparison.Ordinal);
+            Assert.Contains("_repository.UpdateAsync(item", internalMethod, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void BulkSaveChangesNormalizesEveryChangedItemBeforeRepositoryHandoff()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task SaveChangesAsync",
+                "public Task<List<ItemModel>> GetMostCommonlyUsedItemsAsync");
+
+            Assert.Contains("var changedItems = changes?.ToList() ?? new List<ItemModel>();", method, StringComparison.Ordinal);
+            Assert.Contains("foreach (var item in changedItems)", method, StringComparison.Ordinal);
+            Assert.Contains("ArgumentNullException.ThrowIfNull(item);", method, StringComparison.Ordinal);
+            Assert.Contains("NormalizeItemForSave(item);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeItemForSave(item);", StringComparison.Ordinal) < method.IndexOf("_repository.SaveChangesAsync(changedItems", StringComparison.Ordinal),
+                "Bulk item saves should normalize each model before repository persistence.");
+        }
+
+        [Fact]
+        public void ItemSaveAndImportPathsShareTheSameTextNormalizationRules()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var saveNormalizer = ExtractMethod(
+                source,
+                "private static void NormalizeItemForSave",
+                "private static void NormalizeImportedItem");
+            var importedNormalizer = ExtractMethod(
+                source,
+                "private static void NormalizeImportedItem",
+                "private static string? NormalizeImportedText");
+
+            Assert.Contains("NormalizeImportedItem(item);", saveNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.ItemNumber = NormalizeImportedText(item.ItemNumber) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Name = NormalizeImportedText(item.Name) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Location = NormalizeImportedText(item.Location) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Brand = NormalizeImportedText(item.Brand) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.PartNumber = NormalizeImportedText(item.PartNumber) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Supplier = NormalizeImportedText(item.Supplier) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Notes = NormalizeImportedText(item.Notes) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.Keywords = NormalizeImportedText(item.Keywords) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.ImagePath = NormalizeImportedText(item.ImagePath) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.CheckedOutBy = NormalizeImportedText(item.CheckedOutBy) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.CheckedInBy = NormalizeImportedText(item.CheckedInBy) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.MissingComponentsNotes = NormalizeImportedText(item.MissingComponentsNotes) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+            Assert.Contains("item.IssuesNotes = NormalizeImportedText(item.IssuesNotes) ?? string.Empty;", importedNormalizer, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-item-save-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-item-save-normalization.md
@@ -1,0 +1,21 @@
+# Item Save Normalization
+
+Date: 2026-07-02
+
+## Completed
+
+- Normal item add saves now trim item text before authorization, duplicate checks, repository insert work, activity-log messages, and change notifications.
+- Normal item update saves now trim item text before authorization, duplicate checks, repository update work, activity-log messages, and change notifications.
+- Bulk item save changes now normalize every changed item before handing the list to the repository.
+- The normal item save path now shares the same text normalization rules as item imports, covering item number, name, location, brand, part number, supplier, notes, keywords, image path, checkout names, missing-component notes, and issue notes.
+- Added source-contract coverage for add, update, bulk save, shared normalization, duplicate-check ordering, repository handoff ordering, and activity-log ordering.
+
+## Why This Mattered
+
+Recent work normalized item and customer import rows before validation, duplicate detection, and persistence. The adjacent normal item save path still accepted user-entered whitespace as-is, which could let duplicate checks compare padded item numbers and persist avoidable whitespace in item identity/detail fields. This closes that data-quality gap without changing unrelated workflows.
+
+## Validation
+
+- GitHub connector source readback should confirm `AddItemAsync`, `UpdateItemAsync`, and `SaveChangesAsync` call `NormalizeItemForSave(...)` before persistence handoff.
+- GitHub connector source readback should confirm `NormalizeItemForSave(...)` delegates to `NormalizeImportedItem(...)`, keeping save and import trimming rules aligned.
+- Local .NET validation still needs to run from a Windows/.NET-capable checkout because this scheduled environment cannot clone the repo directly and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -82,7 +82,8 @@ namespace InventoryManagementApp.Services.Items
         {
             if (item is null)
                 throw new ArgumentNullException(nameof(item));
-            
+
+            NormalizeItemForSave(item);
             _auth.EnsurePermission(User.PermissionManageItems);
             await AddItemInternalAsync(item, cancellationToken).ConfigureAwait(false);
             if (_activityLog != null)
@@ -104,7 +105,8 @@ namespace InventoryManagementApp.Services.Items
         {
             if (item is null)
                 throw new ArgumentNullException(nameof(item));
-            
+
+            NormalizeItemForSave(item);
             _auth.EnsurePermission(User.PermissionManageItems);
             await UpdateItemInternalAsync(item, cancellationToken).ConfigureAwait(false);
             if (_activityLog != null)
@@ -711,6 +713,12 @@ namespace InventoryManagementApp.Services.Items
         {
             _auth.EnsurePermission(User.PermissionManageItems);
             var changedItems = changes?.ToList() ?? new List<ItemModel>();
+            foreach (var item in changedItems)
+            {
+                ArgumentNullException.ThrowIfNull(item);
+                NormalizeItemForSave(item);
+            }
+
             await _repository.SaveChangesAsync(changedItems, ct).ConfigureAwait(false);
             NotifyChanged(DomainDataScope.Items | DomainDataScope.Reports, changedItems.FirstOrDefault()?.ItemID);
         }
@@ -775,6 +783,11 @@ namespace InventoryManagementApp.Services.Items
                 transaction.Rollback();
                 throw;
             }
+        }
+
+        private static void NormalizeItemForSave(ItemModel item)
+        {
+            NormalizeImportedItem(item);
         }
 
         private static void NormalizeImportedItem(ItemModel item)

--- a/ToDo.md
+++ b/ToDo.md
@@ -13,6 +13,7 @@ Current repository evidence:
 - Recent scheduled work has focused on release safety: validation diagnostics, dependency-audit visibility, bounded list/report/export reads, import/export setup guards, stale-write guards, and more honest printable report output.
 - Recent merged work completed the detailed-report truncation/count behavior in PR #1458 and paged customer export row collection through deterministic 500-row batches for both CSV and generic customer export workflows.
 - Item and customer import rows now normalize imported text before required-field validation, duplicate checks, in-file duplicate reservation, and insert work.
+- Normal item add/update/bulk-save paths now normalize user-entered item text before duplicate checks and repository persistence, sharing the import trimming rules for item identity/detail fields.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -57,6 +58,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Customer exports now collect rows through a deterministic paged collector rather than loading the full directory in one database read.
 - Item imports now normalize imported identity/detail text before duplicate checks and inserts across CSV and generic importer paths.
 - Customer imports now normalize imported company, email, contact, phone, mobile, and address text before validation, persisted duplicate checks, in-file duplicate reservation, and inserts across CSV and generic importer paths.
+- Normal item add/update/bulk-save paths now normalize user-entered item text before duplicate checks, repository persistence, and activity-log messages.
 
 ## Highest-Value Next Work
 
@@ -67,7 +69,7 @@ Prioritize the following before adding unrelated new features:
 3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, and theme-customized popup surfaces.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
 5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
-6. Keep tightening import/export data-quality behavior only where current evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, or professional output expectations.
+6. Keep tightening import/export and save-path data-quality behavior only where current evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, or professional output expectations.
 
 ## App Completion Status
 


### PR DESCRIPTION
## What changed

- Normal item add saves now call `NormalizeItemForSave(...)` before authorization, duplicate checks, repository insert work, activity-log messages, and change notifications.
- Normal item update saves now call `NormalizeItemForSave(...)` before authorization, duplicate checks, repository update work, activity-log messages, and change notifications.
- Bulk item save changes now normalize every changed item before repository handoff.
- Bulk item save changes now reject null entries explicitly before repository handoff instead of failing deeper in persistence.
- Normal save paths now share the same trimming rules as item imports by delegating `NormalizeItemForSave(...)` to `NormalizeImportedItem(...)`.
- The shared item normalizer covers item number, name, location, brand, part number, supplier, notes, keywords, image path, checkout names, missing-component notes, and issue notes.
- Add/update activity-log messages now use normalized item numbers.
- Duplicate checks now receive normalized item numbers on normal add and update paths.
- Repository insert/update/save handoffs now receive normalized item text.
- Added `ItemServiceSaveNormalizationContractTests` for add, update, bulk save, shared normalization, duplicate-check ordering, repository handoff ordering, and activity-log ordering.
- Added a focused progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this save-path normalization slice.

## Why this was the highest-value next step

Recent repo evidence showed item and customer import normalization had just been completed, while the current queue still called out concrete user-entered or file-imported text paths that can bypass validation, duplicate detection, or persistence quality. `ItemService` still normalized imported items but not normal item add/update/bulk-save paths, leaving an adjacent data-quality risk where padded item numbers could evade duplicate checks and be persisted as distinct values.

## Why this is large enough to count as real progress

This is a complete item save workflow hardening slice across normal add, normal update, bulk save, duplicate checks, repository handoff, activity logging, shared normalization behavior, source-contract coverage, progress notes, and the durable work queue. It is more than 10 focused improvements in one existing workflow rather than a tiny isolated guard.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 commits, and limited to `ItemService`, one new source-contract test file, one progress note, and `ToDo.md`.
- Connector source readback confirmed `AddItemAsync` and `UpdateItemAsync` call `NormalizeItemForSave(item)` before authorization, internal duplicate-check/persistence calls, and activity-log messages.
- Connector source readback confirmed `SaveChangesAsync` normalizes every changed item before `_repository.SaveChangesAsync(changedItems, ct)`.
- Connector source readback confirmed `NormalizeItemForSave(...)` delegates to `NormalizeImportedItem(...)`, which covers item identity/detail/operational text fields.
- Connector source readback confirmed `ItemServiceSaveNormalizationContractTests` guards add, update, bulk save, shared normalization, and ordering contracts.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `8250c779a890f92203b1dc4301dd7c3ef60fc20d` before PR creation.

## Could not be checked

- Direct local checkout is blocked in this scheduled environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue data-quality hardening only when current source evidence shows another concrete validation, duplicate-detection, or persistence gap.