### PR TITLE
[codex] Normalize maintenance and calibration record text

### DIFF
--- a/InventoryManagementApp.Tests/OperationalRecordNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/OperationalRecordNormalizationContractTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class OperationalRecordNormalizationContractTests
+    {
+        [Fact]
+        public void MaintenanceCreateNormalizesTextBeforeReferenceChecksAndInsert()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<int> CreateMaintenanceRecordAsync",
+                "public async Task<bool> UpdateMaintenanceRecordAsync");
+
+            Assert.Contains("NormalizeMaintenanceRecordForSave(record);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeMaintenanceRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("EnsureItemExists(conn, record.ItemID);", StringComparison.Ordinal),
+                "Maintenance creation should normalize user-entered text before reference checks and insert work.");
+            Assert.True(
+                method.IndexOf("NormalizeMaintenanceRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("cmd.Parameters.AddWithValue(\"@MaintenanceType\", record.MaintenanceType);", StringComparison.Ordinal),
+                "Maintenance creation should only persist normalized maintenance type text.");
+            Assert.True(
+                method.IndexOf("NormalizeMaintenanceRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("cmd.Parameters.AddWithValue(\"@Status\", record.Status);", StringComparison.Ordinal),
+                "Maintenance creation should only persist normalized status text.");
+        }
+
+        [Fact]
+        public void MaintenanceUpdateNormalizesTextBeforeReferenceChecksAndUpdate()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<bool> UpdateMaintenanceRecordAsync",
+                "public async Task<bool> CompleteMaintenanceAsync");
+
+            Assert.Contains("NormalizeMaintenanceRecordForSave(record);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeMaintenanceRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("EnsureMaintenanceRecordExists(conn, record.MaintenanceID);", StringComparison.Ordinal),
+                "Maintenance updates should normalize user-entered text before existing-row checks.");
+            Assert.True(
+                method.IndexOf("NormalizeMaintenanceRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("cmd.Parameters.AddWithValue(\"@Description\", record.Description);", StringComparison.Ordinal),
+                "Maintenance updates should only persist normalized description text.");
+            Assert.True(
+                method.IndexOf("NormalizeMaintenanceRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("cmd.Parameters.AddWithValue(\"@Notes\", record.Notes);", StringComparison.Ordinal),
+                "Maintenance updates should only persist normalized notes text.");
+        }
+
+        [Fact]
+        public void MaintenanceCompletionNormalizesPerformerAndNotesBeforeUpdate()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<bool> CompleteMaintenanceAsync",
+                "public async Task<bool> DeleteMaintenanceRecordAsync");
+
+            Assert.Contains("var normalizedPerformedBy = NormalizeOptionalText(performedBy);", method, StringComparison.Ordinal);
+            Assert.Contains("var normalizedNotes = NormalizeOptionalText(notes);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("var normalizedPerformedBy = NormalizeOptionalText(performedBy);", StringComparison.Ordinal) < method.IndexOf("EnsureMaintenanceRecordExists(conn, maintenanceID);", StringComparison.Ordinal),
+                "Maintenance completion should trim performer text before persistence work starts.");
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@PerformedBy\", normalizedPerformedBy);", method, StringComparison.Ordinal);
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@Notes\", normalizedNotes);", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenanceNormalizerCoversPersistedWorkflowTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+            var normalizer = ExtractMethod(
+                source,
+                "private static void NormalizeMaintenanceRecordForSave",
+                "private static void EnsureMaintenanceCreateSucceeded");
+
+            Assert.Contains("record.MaintenanceType = NormalizeOptionalText(record.MaintenanceType);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("record.Description = NormalizeOptionalText(record.Description);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("record.PerformedBy = NormalizeOptionalText(record.PerformedBy);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("record.Status = NormalizeMaintenanceStatus(record.Status);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("record.Notes = NormalizeOptionalText(record.Notes);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("return string.IsNullOrEmpty(normalizedStatus) ? \"Scheduled\" : normalizedStatus;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;", normalizer, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationCreateNormalizesTextBeforeReferenceChecksAndInsert()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<int> CreateCalibrationRecordAsync",
+                "public async Task<bool> UpdateCalibrationRecordAsync");
+
+            Assert.Contains("NormalizeCalibrationRecordForSave(record);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeCalibrationRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("EnsureItemExists(conn, record.ItemID);", StringComparison.Ordinal),
+                "Calibration creation should normalize user-entered text before reference checks and insert work.");
+            Assert.True(
+                method.IndexOf("NormalizeCalibrationRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("cmd.Parameters.AddWithValue(\"@CalibratedBy\", record.CalibratedBy);", StringComparison.Ordinal),
+                "Calibration creation should only persist normalized technician text.");
+            Assert.True(
+                method.IndexOf("NormalizeCalibrationRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("cmd.Parameters.AddWithValue(\"@CertificateNumber\", record.CertificateNumber);", StringComparison.Ordinal),
+                "Calibration creation should only persist normalized certificate text.");
+        }
+
+        [Fact]
+        public void CalibrationUpdateNormalizesTextBeforeReferenceChecksAndUpdate()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<bool> UpdateCalibrationRecordAsync",
+                "public async Task<bool> DeleteCalibrationRecordAsync");
+
+            Assert.Contains("NormalizeCalibrationRecordForSave(record);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeCalibrationRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("EnsureCalibrationRecordExists(conn, record.CalibrationID);", StringComparison.Ordinal),
+                "Calibration updates should normalize user-entered text before existing-row checks.");
+            Assert.True(
+                method.IndexOf("NormalizeCalibrationRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("cmd.Parameters.AddWithValue(\"@Standard\", record.Standard);", StringComparison.Ordinal),
+                "Calibration updates should only persist normalized standard text.");
+            Assert.True(
+                method.IndexOf("NormalizeCalibrationRecordForSave(record);", StringComparison.Ordinal) < method.IndexOf("cmd.Parameters.AddWithValue(\"@Notes\", record.Notes);", StringComparison.Ordinal),
+                "Calibration updates should only persist normalized notes text.");
+        }
+
+        [Fact]
+        public void CalibrationNormalizerCoversPersistedWorkflowTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+            var normalizer = ExtractMethod(
+                source,
+                "private static void NormalizeCalibrationRecordForSave",
+                "private static void EnsureCalibrationCreateSucceeded");
+
+            Assert.Contains("record.CalibratedBy = NormalizeOptionalText(record.CalibratedBy);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("record.CertificateNumber = NormalizeOptionalText(record.CertificateNumber);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("record.Standard = NormalizeOptionalText(record.Standard);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("record.Result = NormalizeOptionalText(record.Result);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("record.Notes = NormalizeOptionalText(record.Notes);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;", normalizer, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-operational-record-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-operational-record-normalization.md
@@ -1,0 +1,26 @@
+# Operational Record Text Normalization
+
+Date: 2026-07-02
+
+## Completed
+
+- Normalized maintenance record text before create and update persistence work.
+- Normalized maintenance completion performer and notes text before the completed-record update.
+- Defaulted whitespace-only maintenance statuses back to `Scheduled` so overdue/upcoming filters keep seeing the expected status value.
+- Normalized calibration record text before create and update persistence work.
+- Added source-contract coverage for maintenance create/update/completion normalization ordering and persisted field coverage.
+- Added source-contract coverage for calibration create/update normalization ordering and persisted field coverage.
+
+## Why It Matters
+
+Maintenance and calibration records are operational history. Before this change, those workflows could persist leading/trailing spaces in technician names, status values, certificates, standards, results, descriptions, and notes even though adjacent item and customer workflows now normalize persistence-facing text. This makes reporting, filtering, printed output, and future duplicate or search behavior more predictable without changing database schema or adding unrelated features.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused maintenance service, calibration service, contract test, and progress note changes.
+- Local restore/build/test/full validation was not available in the scheduled Linux environment because direct checkout is blocked and `dotnet`, PowerShell/`pwsh`, `gh`, and the WPF runtime are unavailable here.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Continue workflow data-quality hardening only where current source evidence shows another concrete validation, persistence, duplicate-detection, search, report, or professional-output risk.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -257,6 +257,8 @@ namespace InventoryManagementApp.Services.Calibration
             if (record.ItemID < 1)
                 throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
 
+            NormalizeCalibrationRecordForSave(record);
+
             var id = await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -303,6 +305,8 @@ namespace InventoryManagementApp.Services.Calibration
                 throw new ArgumentOutOfRangeException(nameof(record.CalibrationID), "Calibration ID must be greater than 0.");
             if (record.ItemID < 1)
                 throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
+
+            NormalizeCalibrationRecordForSave(record);
 
             var updated = await Task.Run(() =>
             {
@@ -384,6 +388,17 @@ namespace InventoryManagementApp.Services.Calibration
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt"))
             };
         }
+
+        private static void NormalizeCalibrationRecordForSave(CalibrationRecord record)
+        {
+            record.CalibratedBy = NormalizeOptionalText(record.CalibratedBy);
+            record.CertificateNumber = NormalizeOptionalText(record.CertificateNumber);
+            record.Standard = NormalizeOptionalText(record.Standard);
+            record.Result = NormalizeOptionalText(record.Result);
+            record.Notes = NormalizeOptionalText(record.Notes);
+        }
+
+        private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;
 
         private static void EnsureCalibrationCreateSucceeded(int affectedRows)
         {

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -236,6 +236,8 @@ namespace InventoryManagementApp.Services.Maintenance
             if (record.ItemID < 1)
                 throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
 
+            NormalizeMaintenanceRecordForSave(record);
+
             var id = await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -283,6 +285,8 @@ namespace InventoryManagementApp.Services.Maintenance
             if (record.ItemID < 1)
                 throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
 
+            NormalizeMaintenanceRecordForSave(record);
+
             var updated = await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -326,6 +330,9 @@ namespace InventoryManagementApp.Services.Maintenance
             if (maintenanceID < 1)
                 throw new ArgumentOutOfRangeException(nameof(maintenanceID), "Maintenance ID must be greater than 0.");
 
+            var normalizedPerformedBy = NormalizeOptionalText(performedBy);
+            var normalizedNotes = NormalizeOptionalText(notes);
+
             var completed = await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -341,8 +348,8 @@ namespace InventoryManagementApp.Services.Maintenance
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@MaintenanceID", maintenanceID);
                 cmd.Parameters.AddWithValue("@CompletedDate", DateTime.Now);
-                cmd.Parameters.AddWithValue("@PerformedBy", performedBy);
-                cmd.Parameters.AddWithValue("@Notes", notes);
+                cmd.Parameters.AddWithValue("@PerformedBy", normalizedPerformedBy);
+                cmd.Parameters.AddWithValue("@Notes", normalizedNotes);
                 if (cmd.ExecuteNonQuery() == 0)
                     throw new InvalidOperationException("Maintenance record not found.");
 
@@ -394,6 +401,23 @@ namespace InventoryManagementApp.Services.Maintenance
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt"))
             };
         }
+
+        private static void NormalizeMaintenanceRecordForSave(MaintenanceRecord record)
+        {
+            record.MaintenanceType = NormalizeOptionalText(record.MaintenanceType);
+            record.Description = NormalizeOptionalText(record.Description);
+            record.PerformedBy = NormalizeOptionalText(record.PerformedBy);
+            record.Status = NormalizeMaintenanceStatus(record.Status);
+            record.Notes = NormalizeOptionalText(record.Notes);
+        }
+
+        private static string NormalizeMaintenanceStatus(string? status)
+        {
+            var normalizedStatus = NormalizeOptionalText(status);
+            return string.IsNullOrEmpty(normalizedStatus) ? "Scheduled" : normalizedStatus;
+        }
+
+        private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;
 
         private static void EnsureMaintenanceCreateSucceeded(int affectedRows)
         {

--- a/ToDo.md
+++ b/ToDo.md
@@ -14,6 +14,7 @@ Current repository evidence:
 - Recent merged work completed the detailed-report truncation/count behavior in PR #1458 and paged customer export row collection through deterministic 500-row batches for both CSV and generic customer export workflows.
 - Item and customer import rows now normalize imported text before required-field validation, duplicate checks, in-file duplicate reservation, and insert work.
 - Normal item add/update/bulk-save paths now normalize user-entered item text before duplicate checks and repository persistence, sharing the import trimming rules for item identity/detail fields.
+- Maintenance and calibration create/update workflows now normalize operational record text before persistence, and maintenance completion trims performer and notes before marking a record completed.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -59,6 +60,8 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Item imports now normalize imported identity/detail text before duplicate checks and inserts across CSV and generic importer paths.
 - Customer imports now normalize imported company, email, contact, phone, mobile, and address text before validation, persisted duplicate checks, in-file duplicate reservation, and inserts across CSV and generic importer paths.
 - Normal item add/update/bulk-save paths now normalize user-entered item text before duplicate checks, repository persistence, and activity-log messages.
+- Maintenance create/update and completion paths now normalize persisted operational record text before reference checks and database writes.
+- Calibration create/update paths now normalize persisted operational record text before reference checks and database writes.
 
 ## Highest-Value Next Work
 
@@ -69,7 +72,7 @@ Prioritize the following before adding unrelated new features:
 3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, and theme-customized popup surfaces.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
 5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
-6. Keep tightening import/export and save-path data-quality behavior only where current evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, or professional output expectations.
+6. Keep tightening import/export, save-path, and operational-record data-quality behavior only where current evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, search/report consistency, or professional output expectations.
 
 ## App Completion Status
 
@@ -83,7 +86,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, and validation-runner changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, and operational-record normalization changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Normalized maintenance create/update text before reference checks and database writes.
- Normalized maintenance completion performer and notes before marking a record completed.
- Defaulted whitespace-only maintenance statuses back to `Scheduled` so scheduled/upcoming/overdue filters keep matching the expected status value.
- Normalized calibration create/update technician, certificate, standard, result, and notes text before reference checks and database writes.
- Added source-contract coverage for maintenance create/update/completion normalization ordering and field coverage.
- Added source-contract coverage for calibration create/update normalization ordering and field coverage.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this slice without fresh evidence.

## Why this was the highest-value next step

Current repo notes show recent work has already hardened item and customer import/save text normalization. Inspection found the next persistence-facing gap in existing operational record workflows: maintenance and calibration records could still store leading/trailing whitespace in technician, status, certificate, standard, result, description, and notes fields. These values feed filters, search/report consistency, printed output, and durable operational history.

## Why the scope is large enough

This is a complete workflow-level data-quality slice across maintenance and calibration services, completion handling, source-contract coverage, and durable notes. It covers more than ten persisted text-field improvements without adding unrelated features or reopening already-completed item/customer import work.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 commits, and limited to:
  - `InventoryManagementApp/Services/Maintenance/MaintenanceService.cs`
  - `InventoryManagementApp/Services/Calibration/CalibrationService.cs`
  - `InventoryManagementApp.Tests/OperationalRecordNormalizationContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-operational-record-normalization.md`
  - `ToDo.md`
- Connector readback confirmed maintenance create/update now call `NormalizeMaintenanceRecordForSave(record)` before reference checks and persisted parameter values.
- Connector readback confirmed maintenance completion now trims `performedBy` and `notes` into normalized local values before the update.
- Connector readback confirmed calibration create/update now call `NormalizeCalibrationRecordForSave(record)` before reference checks and persisted parameter values.
- Connector readback confirmed the new source-contract tests cover maintenance and calibration normalization ordering and field coverage.

## Could not be checked

- Local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, and WPF runtime tooling are unavailable here.
- Because of those environment limits, I could not run `pwsh -File scripts/run-full-validation.ps1`, local .NET tests, WPF screenshots, print-preview/layout checks, or banned-word scans.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout and review the generated validation artifacts.
- Continue data-quality hardening only where current source evidence shows another concrete validation, persistence, duplicate-detection, search/report consistency, or professional-output risk.