### PR TITLE
[codex] Normalize reservation and kit workflow text

### DIFF
--- a/InventoryManagementApp.Tests/ReservationKitNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationKitNormalizationContractTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReservationKitNormalizationContractTests
+    {
+        [Fact]
+        public void ReservationCreateNormalizesTextBeforeReferenceChecksAndInsert()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<int> CreateReservationAsync",
+                "public async Task<bool> UpdateReservationAsync");
+
+            Assert.Contains("NormalizeReservationForSave(reservation);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeReservationForSave(reservation);", StringComparison.Ordinal) < method.IndexOf("EnsureReservationReferencesExist(conn, reservation);", StringComparison.Ordinal),
+                "Reservation creation should normalize user-entered status and notes before reference checks and insert work.");
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@Status\", reservation.Status);", method, StringComparison.Ordinal);
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@Notes\", ToDbNullableText(reservation.Notes));", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("cmd.Parameters.AddWithValue(\"@Status\", NormalizeStatus(reservation.Status));", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationUpdateNormalizesTextBeforeReferenceChecksAndUpdate()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<bool> UpdateReservationAsync",
+                "public async Task<bool> ConfirmReservationAsync");
+
+            Assert.Contains("NormalizeReservationForSave(reservation);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeReservationForSave(reservation);", StringComparison.Ordinal) < method.IndexOf("EnsureReservationExists(conn, reservation.ReservationID);", StringComparison.Ordinal),
+                "Reservation updates should normalize workflow text before existing-row and reference checks.");
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@Status\", reservation.Status);", method, StringComparison.Ordinal);
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@Notes\", ToDbNullableText(reservation.Notes));", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("cmd.Parameters.AddWithValue(\"@Status\", NormalizeStatus(reservation.Status));", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationNormalizerCoversPersistedWorkflowTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+            var normalizer = ExtractMethod(
+                source,
+                "private static void NormalizeReservationForSave",
+                "private static void EnsureReservationExists");
+
+            Assert.Contains("reservation.Status = NormalizeStatus(reservation.Status);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("reservation.Notes = NormalizeOptionalText(reservation.Notes);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;", source, StringComparison.Ordinal);
+            Assert.Contains("var normalizedStatus = string.IsNullOrWhiteSpace(status) ? \"Pending\" : status.Trim();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitCreateNormalizesTextBeforeInsert()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<int> CreateKitAsync",
+                "public async Task<bool> UpdateKitAsync");
+
+            Assert.Contains("NormalizeKitForSave(kit);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeKitForSave(kit);", StringComparison.Ordinal) < method.IndexOf("cmd.Parameters.AddWithValue(\"@KitNumber\", kit.KitNumber);", StringComparison.Ordinal),
+                "Kit creation should normalize kit text before insert parameters are bound.");
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@KitNumber\", kit.KitNumber);", method, StringComparison.Ordinal);
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@Name\", kit.Name);", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("cmd.Parameters.AddWithValue(\"@KitNumber\", kit.KitNumber.Trim());", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("cmd.Parameters.AddWithValue(\"@Name\", kit.Name.Trim());", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitUpdateNormalizesTextBeforeExistingRowCheckAndUpdate()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<bool> UpdateKitAsync",
+                "public async Task<bool> DeleteKitAsync");
+
+            Assert.Contains("NormalizeKitForSave(kit);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeKitForSave(kit);", StringComparison.Ordinal) < method.IndexOf("EnsureKitExists(conn, kit.KitID);", StringComparison.Ordinal),
+                "Kit updates should normalize user-entered kit text before existing-row checks and update work.");
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@KitNumber\", kit.KitNumber);", method, StringComparison.Ordinal);
+            Assert.Contains("cmd.Parameters.AddWithValue(\"@Name\", kit.Name);", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("cmd.Parameters.AddWithValue(\"@KitNumber\", kit.KitNumber.Trim());", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("cmd.Parameters.AddWithValue(\"@Name\", kit.Name.Trim());", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitNormalizerCoversPersistedWorkflowTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+            var normalizer = ExtractMethod(
+                source,
+                "private static void NormalizeKitForSave",
+                "private static void ValidateKitItem");
+
+            Assert.Contains("kit.KitNumber = NormalizeRequiredText(kit.KitNumber);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("kit.Name = NormalizeRequiredText(kit.Name);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("kit.Description = NormalizeOptionalText(kit.Description);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("kit.Category = NormalizeOptionalText(kit.Category);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("private static string NormalizeRequiredText(string? value) => value?.Trim() ?? string.Empty;", source, StringComparison.Ordinal);
+            Assert.Contains("private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;", source, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-reservation-kit-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-reservation-kit-normalization.md
@@ -1,0 +1,34 @@
+# Reservation And Kit Workflow Normalization - 2026-07-02
+
+## Completed
+
+- Normalized reservation create/update status and notes once at the workflow boundary after structural validation and before reference checks or database writes.
+- Persisted reservation status from the normalized model value instead of re-normalizing only at SQL parameter binding.
+- Kept whitespace-only reservation status defaulting to `Pending`, preserving active/upcoming reservation filters and report consistency.
+- Trimmed reservation notes before persistence and still stored blank notes as database null values.
+- Normalized kit create/update number, name, description, and category once at the workflow boundary before database work.
+- Persisted kit number and name from normalized model values instead of trimming only during SQL parameter binding.
+- Trimmed optional kit description/category before persistence and still stored blank optional values as database null values.
+- Added source-contract coverage for reservation create/update normalization ordering, persisted parameter usage, status defaulting, and normalized notes.
+- Added source-contract coverage for kit create/update normalization ordering, persisted parameter usage, and field coverage.
+- Refreshed `ToDo.md` so future scheduled runs do not repeat this data-quality slice without fresh evidence.
+
+## Why This Was Next
+
+Recent repository work normalized item, customer, maintenance, and calibration persistence paths. Current source still showed reservations and kits cleaning text at the final SQL parameter in some places instead of normalizing the workflow model before checks and writes. This made them the adjacent persistence-facing data-quality risk that matched the repo's current work queue.
+
+## Validation
+
+- Connector source readback should confirm `CreateReservationAsync` and `UpdateReservationAsync` call `NormalizeReservationForSave(reservation)` before reference checks and persist `reservation.Status` plus normalized nullable notes.
+- Connector source readback should confirm `CreateKitAsync` and `UpdateKitAsync` call `NormalizeKitForSave(kit)` before insert/update work and persist normalized kit text values.
+- Connector source readback should confirm `ReservationKitNormalizationContractTests` guards the new ordering and field coverage.
+
+## Could Not Be Checked Here
+
+- Direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Continue data-quality hardening only where current source evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, search/report consistency, or professional output expectations.

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -200,6 +200,7 @@ namespace InventoryManagementApp.Services.Kits
         public async Task<int> CreateKitAsync(Kit kit)
         {
             ValidateKit(kit, requireExistingId: false);
+            NormalizeKitForSave(kit);
 
             var id = await Task.Run(() =>
             {
@@ -210,8 +211,8 @@ namespace InventoryManagementApp.Services.Kits
                     VALUES 
                     (@KitNumber, @Name, @Description, @Category, @IsActive, @CreatedByUserID, @CreatedAt, @UpdatedAt)";
                 using var cmd = new SqliteCommand(sql, conn);
-                cmd.Parameters.AddWithValue("@KitNumber", kit.KitNumber.Trim());
-                cmd.Parameters.AddWithValue("@Name", kit.Name.Trim());
+                cmd.Parameters.AddWithValue("@KitNumber", kit.KitNumber);
+                cmd.Parameters.AddWithValue("@Name", kit.Name);
                 cmd.Parameters.AddWithValue("@Description", ToDbNullableText(kit.Description));
                 cmd.Parameters.AddWithValue("@Category", ToDbNullableText(kit.Category));
                 cmd.Parameters.AddWithValue("@IsActive", kit.IsActive ? 1 : 0);
@@ -234,6 +235,7 @@ namespace InventoryManagementApp.Services.Kits
         public async Task<bool> UpdateKitAsync(Kit kit)
         {
             ValidateKit(kit, requireExistingId: true);
+            NormalizeKitForSave(kit);
 
             var updated = await Task.Run(() =>
             {
@@ -251,8 +253,8 @@ namespace InventoryManagementApp.Services.Kits
                     WHERE KitID = @KitID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@KitID", kit.KitID);
-                cmd.Parameters.AddWithValue("@KitNumber", kit.KitNumber.Trim());
-                cmd.Parameters.AddWithValue("@Name", kit.Name.Trim());
+                cmd.Parameters.AddWithValue("@KitNumber", kit.KitNumber);
+                cmd.Parameters.AddWithValue("@Name", kit.Name);
                 cmd.Parameters.AddWithValue("@Description", ToDbNullableText(kit.Description));
                 cmd.Parameters.AddWithValue("@Category", ToDbNullableText(kit.Category));
                 cmd.Parameters.AddWithValue("@IsActive", kit.IsActive ? 1 : 0);
@@ -449,6 +451,14 @@ namespace InventoryManagementApp.Services.Kits
                 throw new ArgumentException("Kit name is required.", nameof(kit.Name));
         }
 
+        private static void NormalizeKitForSave(Kit kit)
+        {
+            kit.KitNumber = NormalizeRequiredText(kit.KitNumber);
+            kit.Name = NormalizeRequiredText(kit.Name);
+            kit.Description = NormalizeOptionalText(kit.Description);
+            kit.Category = NormalizeOptionalText(kit.Category);
+        }
+
         private static void ValidateKitItem(KitItem kitItem, bool requireExistingId)
         {
             if (kitItem == null)
@@ -516,8 +526,13 @@ namespace InventoryManagementApp.Services.Kits
 
         private static object ToDbNullableText(string? value)
         {
-            return string.IsNullOrWhiteSpace(value) ? DBNull.Value : value.Trim();
+            var normalized = NormalizeOptionalText(value);
+            return string.IsNullOrEmpty(normalized) ? DBNull.Value : normalized;
         }
+
+        private static string NormalizeRequiredText(string? value) => value?.Trim() ?? string.Empty;
+
+        private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;
 
         static void NotifyChanged(DomainDataScope scope, int? entityId = null)
         {

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -263,6 +263,7 @@ namespace InventoryManagementApp.Services.Reservations
         public async Task<int> CreateReservationAsync(Reservation reservation)
         {
             ValidateReservation(reservation, requireExistingId: false);
+            NormalizeReservationForSave(reservation);
 
             var id = await Task.Run(() =>
             {
@@ -283,7 +284,7 @@ namespace InventoryManagementApp.Services.Reservations
                 cmd.Parameters.AddWithValue("@StartDate", reservation.StartDate);
                 cmd.Parameters.AddWithValue("@EndDate", reservation.EndDate);
                 cmd.Parameters.AddWithValue("@Quantity", reservation.Quantity);
-                cmd.Parameters.AddWithValue("@Status", NormalizeStatus(reservation.Status));
+                cmd.Parameters.AddWithValue("@Status", reservation.Status);
                 cmd.Parameters.AddWithValue("@Notes", ToDbNullableText(reservation.Notes));
                 cmd.Parameters.AddWithValue("@CreatedByUserID", _userContext.CurrentUser?.UserID ?? 0);
                 cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
@@ -304,6 +305,7 @@ namespace InventoryManagementApp.Services.Reservations
         public async Task<bool> UpdateReservationAsync(Reservation reservation)
         {
             ValidateReservation(reservation, requireExistingId: true);
+            NormalizeReservationForSave(reservation);
 
             var updated = await Task.Run(() =>
             {
@@ -330,7 +332,7 @@ namespace InventoryManagementApp.Services.Reservations
                 cmd.Parameters.AddWithValue("@StartDate", reservation.StartDate);
                 cmd.Parameters.AddWithValue("@EndDate", reservation.EndDate);
                 cmd.Parameters.AddWithValue("@Quantity", reservation.Quantity);
-                cmd.Parameters.AddWithValue("@Status", NormalizeStatus(reservation.Status));
+                cmd.Parameters.AddWithValue("@Status", reservation.Status);
                 cmd.Parameters.AddWithValue("@Notes", ToDbNullableText(reservation.Notes));
                 cmd.Parameters.AddWithValue("@RentalID", reservation.RentalID.HasValue ? (object)reservation.RentalID.Value : DBNull.Value);
                 var updatedRows = cmd.ExecuteNonQuery();
@@ -507,6 +509,12 @@ namespace InventoryManagementApp.Services.Reservations
                 throw new ArgumentException("End date must be on or after start date.", nameof(reservation.EndDate));
         }
 
+        private static void NormalizeReservationForSave(Reservation reservation)
+        {
+            reservation.Status = NormalizeStatus(reservation.Status);
+            reservation.Notes = NormalizeOptionalText(reservation.Notes);
+        }
+
         private static void EnsureReservationExists(SqliteConnection conn, int reservationID)
         {
             if (!RecordExists(conn, "SELECT COUNT(*) FROM Reservations WHERE ReservationID = @ID", reservationID))
@@ -570,8 +578,11 @@ namespace InventoryManagementApp.Services.Reservations
 
         private static object ToDbNullableText(string? value)
         {
-            return string.IsNullOrWhiteSpace(value) ? DBNull.Value : value.Trim();
+            var normalized = NormalizeOptionalText(value);
+            return string.IsNullOrEmpty(normalized) ? DBNull.Value : normalized;
         }
+
+        private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;
 
         static void NotifyChanged(DomainDataScope scope, int? entityId = null)
         {

--- a/ToDo.md
+++ b/ToDo.md
@@ -15,6 +15,7 @@ Current repository evidence:
 - Item and customer import rows now normalize imported text before required-field validation, duplicate checks, in-file duplicate reservation, and insert work.
 - Normal item add/update/bulk-save paths now normalize user-entered item text before duplicate checks and repository persistence, sharing the import trimming rules for item identity/detail fields.
 - Maintenance and calibration create/update workflows now normalize operational record text before persistence, and maintenance completion trims performer and notes before marking a record completed.
+- Reservation create/update and kit create/update workflows now normalize persisted workflow text before reference checks and database writes.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -62,6 +63,8 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Normal item add/update/bulk-save paths now normalize user-entered item text before duplicate checks, repository persistence, and activity-log messages.
 - Maintenance create/update and completion paths now normalize persisted operational record text before reference checks and database writes.
 - Calibration create/update paths now normalize persisted operational record text before reference checks and database writes.
+- Reservation create/update paths now normalize status and notes before reference checks, filter-facing status persistence, and database writes.
+- Kit create/update paths now normalize kit number, name, description, and category before insert/update persistence.
 
 ## Highest-Value Next Work
 


### PR DESCRIPTION
## What changed

- Normalized reservation create/update status and notes once at the workflow boundary after structural validation.
- Ensured reservation reference checks and database writes use the normalized reservation model values.
- Preserved whitespace-only reservation status defaulting to `Pending` so active/upcoming filters and reports keep matching expected status values.
- Preserved nullable database storage for blank reservation notes after trimming.
- Normalized kit create/update kit number, name, description, and category once at the workflow boundary.
- Ensured kit insert/update persistence uses normalized kit model values instead of trimming only during SQL parameter binding.
- Preserved nullable database storage for blank kit description/category after trimming.
- Added source-contract coverage for reservation create/update normalization ordering, persisted parameter use, status defaulting, and notes handling.
- Added source-contract coverage for kit create/update normalization ordering, persisted parameter use, and field coverage.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this slice without fresh evidence.

## Why this was the highest-value next step

Recent repo evidence shows item, customer, maintenance, and calibration persistence paths were just normalized. The next adjacent persistence-facing gap in current source was reservation and kit workflow text: both had text cleaning at SQL parameter binding in places, but not the explicit workflow-boundary normalization pattern now used by the newer operational-record slices. This could leave reference checks, filter-facing status values, reports, and stored output depending on slightly different representations.

## Why the scope is large enough

This is a complete data-quality slice across two existing workflows, persisted service logic, source-contract coverage, progress notes, and the durable work queue. It includes more than ten focused improvements without adding unrelated features or reopening already-completed import/report/export work.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 focused commits, and limited to:
  - `InventoryManagementApp/Services/Reservations/ReservationService.cs`
  - `InventoryManagementApp/Services/Kits/KitService.cs`
  - `InventoryManagementApp.Tests/ReservationKitNormalizationContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-reservation-kit-normalization.md`
  - `ToDo.md`
- Connector readback confirmed `CreateReservationAsync` and `UpdateReservationAsync` call `NormalizeReservationForSave(reservation)` before reservation reference checks and persist `reservation.Status` plus normalized nullable notes.
- Connector readback confirmed `NormalizeReservationForSave` trims notes and routes status through the existing reservation status validation/defaulting behavior.
- Connector readback confirmed `CreateKitAsync` and `UpdateKitAsync` call `NormalizeKitForSave(kit)` before insert/update work and persist normalized kit number/name/detail values.
- Connector readback confirmed `ReservationKitNormalizationContractTests` covers reservation and kit normalization ordering plus field coverage.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `e8e50d8534515c1904b24fe72b4dcb3e3f75bc0e`.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue data-quality hardening only where current source evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, search/report consistency, or professional output expectations.