### PR TITLE
[codex] Normalize user profile save text

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceSaveNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceSaveNormalizationContractTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserServiceSaveNormalizationContractTests
+    {
+        [Fact]
+        public void AddUserNormalizesProfileAndPermissionTextBeforeFirstUserCheckAndInsert()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task AddUserAsync",
+                "public async Task UpdateUserAsync");
+
+            Assert.Contains("NormalizeUserForSave(user);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeUserForSave(user);", StringComparison.Ordinal) < method.IndexOf("GetAllUsersAsync(CancellationToken.None)", StringComparison.Ordinal),
+                "User creation should normalize profile/access text before first-user checks, authorization branching, and insert work.");
+            Assert.Contains("new SqliteParameter(\"@UserName\", user.UserName)", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Photo\",    ToDbNullableText(user.UserPhotoPath))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Email\",    ToDbNullableText(user.Email))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Phone\",    ToDbNullableText(user.Phone))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Mobile\",   ToDbNullableText(user.Mobile))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Address\",  ToDbNullableText(user.Address))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Role\",     ToDbNullableText(user.Role))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Permissions\", ToDbNullableText(user.Permissions))", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("(object)user.Email ?? DBNull.Value", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("(object)user.Permissions ?? DBNull.Value", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UpdateUserNormalizesProfileAndPermissionTextBeforeExistingUserReadAndUpdate()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateUserAsync",
+                "public async Task<bool> ChangeUserPasswordAsync");
+
+            Assert.Contains("NormalizeUserForSave(user);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("NormalizeUserForSave(user);", StringComparison.Ordinal) < method.IndexOf("GetUserByIDAsync(user.UserID, CancellationToken.None)", StringComparison.Ordinal),
+                "User updates should normalize profile/access text before existing-row reads and persisted update parameters.");
+            Assert.Contains("new SqliteParameter(\"@UserName\", user.UserName)", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Photo\",    ToDbNullableText(user.UserPhotoPath))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Email\",    ToDbNullableText(user.Email))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Phone\",    ToDbNullableText(user.Phone))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Mobile\",   ToDbNullableText(user.Mobile))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Address\",  ToDbNullableText(user.Address))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Role\",     ToDbNullableText(user.Role))", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Permissions\", ToDbNullableText(user.Permissions))", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("(object)user.UserPhotoPath ?? DBNull.Value", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("(object)user.Role ?? DBNull.Value", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UserSaveNormalizerCoversProfileAndAccessFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var normalizer = ExtractMethod(
+                source,
+                "private static void NormalizeUserForSave",
+                "private static string NormalizePermissionsForSave");
+
+            Assert.Contains("user.UserName = NormalizeRequiredText(user.UserName);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("user.UserPhotoPath = NormalizeOptionalText(user.UserPhotoPath);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("user.Email = NormalizeOptionalText(user.Email);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("user.Phone = NormalizeOptionalText(user.Phone);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("user.Mobile = NormalizeOptionalText(user.Mobile);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("user.Address = NormalizeOptionalText(user.Address);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("user.Role = NormalizeOptionalText(user.Role);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("user.Permissions = NormalizePermissionsForSave(user.Permissions);", normalizer, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UserPermissionNormalizerCanonicalizesPersistedAccessKeys()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var normalizer = ExtractMethod(
+                source,
+                "private static string NormalizePermissionsForSave",
+                "private static object ToDbNullableText");
+
+            Assert.Contains("var normalized = NormalizeOptionalText(value);", normalizer, StringComparison.Ordinal);
+            Assert.Contains("return string.Empty;", normalizer, StringComparison.Ordinal);
+            Assert.Contains("User.BuildPermissions(normalized.Split(new[] { ';', ',', '|', ' ' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))", normalizer, StringComparison.Ordinal);
+            Assert.DoesNotContain("return normalized;", normalizer, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UserSaveStoresBlankOptionalTextAsDatabaseNull()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var helper = ExtractMethod(
+                source,
+                "private static object ToDbNullableText",
+                "private static string NormalizeRequiredText");
+
+            Assert.Contains("var normalized = NormalizeOptionalText(value);", helper, StringComparison.Ordinal);
+            Assert.Contains("return string.IsNullOrEmpty(normalized) ? DBNull.Value : normalized;", helper, StringComparison.Ordinal);
+            Assert.Contains("private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;", source, StringComparison.Ordinal);
+            Assert.Contains("private static string NormalizeRequiredText(string? value) => value?.Trim() ?? string.Empty;", source, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-user-profile-save-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-user-profile-save-normalization.md
@@ -1,0 +1,34 @@
+# User Profile Save Normalization - 2026-07-02
+
+## Completed
+
+- Normalized user account profile/access text once at the save workflow boundary before create authorization branching, first-user checks, existing-user reads, and database writes.
+- Trimmed user names through a shared required-text helper while preserving the existing empty-username validation behavior.
+- Trimmed optional photo path, email, phone, mobile, address, and role values before create/update persistence.
+- Canonicalized persisted permission keys through `User.BuildPermissions(...)` so mixed delimiters, duplicate keys, and padded access values save consistently.
+- Preserved blank permission values as empty/default-access behavior while persisting blank optional profile/access fields as database null values.
+- Routed user create parameters through normalized model values and the shared nullable-text helper instead of casting raw optional strings directly.
+- Routed user update parameters through the same normalized model values and nullable-text helper.
+- Added source-contract coverage for add-user normalization ordering, update-user normalization ordering, field coverage, permission canonicalization, and nullable optional-text persistence.
+- Refreshed `ToDo.md` so future scheduled runs do not repeat this user profile/access text slice without fresh evidence.
+
+## Why This Was Next
+
+Recent repository work normalized item, customer, maintenance, calibration, reservation, and kit save/import text. Current source still showed user create/update workflows trimming only `UserName`, while profile and access fields could be persisted with accidental whitespace or mixed permission delimiters. Those values feed the user directory, permission summaries, reports, and access checks, so this was the next concrete data-quality risk supported by current source evidence.
+
+## Validation
+
+- Connector readback should confirm `AddUserAsync` and `UpdateUserAsync` call `NormalizeUserForSave(user)` before first-user/existing-user checks and before persistence parameters are bound.
+- Connector readback should confirm user photo, email, phone, mobile, address, role, and permissions create/update parameters call `ToDbNullableText(...)`.
+- Connector readback should confirm `NormalizeUserForSave(...)`, `NormalizePermissionsForSave(...)`, `NormalizeRequiredText(...)`, `NormalizeOptionalText(...)`, and `ToDbNullableText(...)` exist with the expected field coverage.
+- Connector readback should confirm `UserServiceSaveNormalizationContractTests` guards the new ordering and field coverage.
+
+## Could Not Be Checked Here
+
+- Direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Continue data-quality hardening only where current source evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, search/report consistency, permission consistency, or professional output expectations.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -289,7 +289,7 @@ namespace InventoryManagementApp.Services.Users
             if (user is null)
                 throw new ArgumentNullException(nameof(user));
 
-            user.UserName = (user.UserName ?? string.Empty).Trim();
+            NormalizeUserForSave(user);
             if (string.IsNullOrWhiteSpace(user.UserName))
                 throw new ArgumentException("Username cannot be empty.", nameof(user.UserName));
 
@@ -329,17 +329,17 @@ namespace InventoryManagementApp.Services.Users
                 new SqliteParameter("@UserName", user.UserName),
                 new SqliteParameter("@PasswordHash", hashed),
                 new SqliteParameter("@PasswordSalt",     salt),
-                new SqliteParameter("@Photo",    (object)user.UserPhotoPath ?? DBNull.Value),
+                new SqliteParameter("@Photo",    ToDbNullableText(user.UserPhotoPath)),
                 new SqliteParameter("@Admin",    user.IsAdmin ? 1 : 0),
-                new SqliteParameter("@Email",    (object)user.Email ?? DBNull.Value),
-                new SqliteParameter("@Phone",    (object)user.Phone ?? DBNull.Value),
-                new SqliteParameter("@Mobile",   (object)user.Mobile ?? DBNull.Value),
-                new SqliteParameter("@Address",  (object)user.Address ?? DBNull.Value),
-                new SqliteParameter("@Role",     (object)user.Role ?? DBNull.Value),
+                new SqliteParameter("@Email",    ToDbNullableText(user.Email)),
+                new SqliteParameter("@Phone",    ToDbNullableText(user.Phone)),
+                new SqliteParameter("@Mobile",   ToDbNullableText(user.Mobile)),
+                new SqliteParameter("@Address",  ToDbNullableText(user.Address)),
+                new SqliteParameter("@Role",     ToDbNullableText(user.Role)),
                 new SqliteParameter("@IsActive", user.IsActive ? 1 : 0),
                 new SqliteParameter("@CreatedAt", user.CreatedAt),
                 new SqliteParameter("@PasswordExpired", user.PasswordExpired ? 1 : 0),
-                new SqliteParameter("@Permissions", (object)user.Permissions ?? DBNull.Value)
+                new SqliteParameter("@Permissions", ToDbNullableText(user.Permissions))
             });
             try
             {
@@ -370,7 +370,7 @@ namespace InventoryManagementApp.Services.Users
             if (user.UserID < 1)
                 throw new ArgumentOutOfRangeException(nameof(user), "User ID must be greater than 0.");
 
-            user.UserName = (user.UserName ?? string.Empty).Trim();
+            NormalizeUserForSave(user);
             if (string.IsNullOrWhiteSpace(user.UserName))
                 throw new ArgumentException("Username cannot be empty.", nameof(user.UserName));
 
@@ -420,15 +420,15 @@ namespace InventoryManagementApp.Services.Users
                 new SqliteParameter("@UserName", user.UserName),
                 new SqliteParameter("@PasswordHash", hashed),
                 new SqliteParameter("@PasswordSalt",     salt),
-                new SqliteParameter("@Photo",    (object)user.UserPhotoPath ?? DBNull.Value),
+                new SqliteParameter("@Photo",    ToDbNullableText(user.UserPhotoPath)),
                 new SqliteParameter("@Admin",    user.IsAdmin ? 1 : 0),
-                new SqliteParameter("@Email",    (object)user.Email ?? DBNull.Value),
-                new SqliteParameter("@Phone",    (object)user.Phone ?? DBNull.Value),
-                new SqliteParameter("@Mobile",   (object)user.Mobile ?? DBNull.Value),
-                new SqliteParameter("@Address",  (object)user.Address ?? DBNull.Value),
-                new SqliteParameter("@Role",     (object)user.Role ?? DBNull.Value),
+                new SqliteParameter("@Email",    ToDbNullableText(user.Email)),
+                new SqliteParameter("@Phone",    ToDbNullableText(user.Phone)),
+                new SqliteParameter("@Mobile",   ToDbNullableText(user.Mobile)),
+                new SqliteParameter("@Address",  ToDbNullableText(user.Address)),
+                new SqliteParameter("@Role",     ToDbNullableText(user.Role)),
                 new SqliteParameter("@IsActive", user.IsActive ? 1 : 0),
-                new SqliteParameter("@Permissions", (object)user.Permissions ?? DBNull.Value)
+                new SqliteParameter("@Permissions", ToDbNullableText(user.Permissions))
             };
 
             try
@@ -522,6 +522,37 @@ namespace InventoryManagementApp.Services.Users
             }
             return await DeleteUserInternalAsync(userID);
         }
+
+        private static void NormalizeUserForSave(User user)
+        {
+            user.UserName = NormalizeRequiredText(user.UserName);
+            user.UserPhotoPath = NormalizeOptionalText(user.UserPhotoPath);
+            user.Email = NormalizeOptionalText(user.Email);
+            user.Phone = NormalizeOptionalText(user.Phone);
+            user.Mobile = NormalizeOptionalText(user.Mobile);
+            user.Address = NormalizeOptionalText(user.Address);
+            user.Role = NormalizeOptionalText(user.Role);
+            user.Permissions = NormalizePermissionsForSave(user.Permissions);
+        }
+
+        private static string NormalizePermissionsForSave(string? value)
+        {
+            var normalized = NormalizeOptionalText(value);
+            if (string.IsNullOrWhiteSpace(normalized))
+                return string.Empty;
+
+            return User.BuildPermissions(normalized.Split(new[] { ';', ',', '|', ' ' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        }
+
+        private static object ToDbNullableText(string? value)
+        {
+            var normalized = NormalizeOptionalText(value);
+            return string.IsNullOrEmpty(normalized) ? DBNull.Value : normalized;
+        }
+
+        private static string NormalizeRequiredText(string? value) => value?.Trim() ?? string.Empty;
+
+        private static string NormalizeOptionalText(string? value) => value?.Trim() ?? string.Empty;
 
         static void NotifyChanged(DomainDataScope scope, int? entityId = null)
         {

--- a/ToDo.md
+++ b/ToDo.md
@@ -16,6 +16,7 @@ Current repository evidence:
 - Normal item add/update/bulk-save paths now normalize user-entered item text before duplicate checks and repository persistence, sharing the import trimming rules for item identity/detail fields.
 - Maintenance and calibration create/update workflows now normalize operational record text before persistence, and maintenance completion trims performer and notes before marking a record completed.
 - Reservation create/update and kit create/update workflows now normalize persisted workflow text before reference checks and database writes.
+- User create/update workflows now normalize profile and access text before first-user/existing-user checks and database writes, including canonicalized permission keys and nullable optional profile fields.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -65,6 +66,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Calibration create/update paths now normalize persisted operational record text before reference checks and database writes.
 - Reservation create/update paths now normalize status and notes before reference checks, filter-facing status persistence, and database writes.
 - Kit create/update paths now normalize kit number, name, description, and category before insert/update persistence.
+- User create/update paths now normalize username, photo path, contact fields, role, and permissions before workflow checks and persistence, with blank optional profile/access fields stored as database null values.
 
 ## Highest-Value Next Work
 
@@ -75,7 +77,7 @@ Prioritize the following before adding unrelated new features:
 3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, and theme-customized popup surfaces.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
 5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
-6. Keep tightening import/export, save-path, and operational-record data-quality behavior only where current evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, search/report consistency, or professional output expectations.
+6. Keep tightening import/export, save-path, and operational-record data-quality behavior only where current evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, search/report consistency, permission consistency, or professional output expectations.
 
 ## App Completion Status
 


### PR DESCRIPTION
## What changed

- Normalized user create/update profile and access text once at the save workflow boundary.
- Trimmed usernames through a shared required-text helper before validation.
- Trimmed optional user photo path, email, phone, mobile, address, and role values before create/update persistence.
- Canonicalized persisted permission keys through `User.BuildPermissions(...)` so mixed delimiters, duplicate keys, and padded access values save consistently.
- Preserved blank permission values as empty/default-access behavior while persisting blank optional profile/access fields as database null values.
- Routed user create and update SQL parameters through normalized model values and a shared nullable-text helper.
- Added source-contract coverage for add-user ordering, update-user ordering, field coverage, permission canonicalization, and nullable optional text persistence.
- Added a focused progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this slice without fresh evidence.

## Why this was the highest-value next step

Recent merged work normalized item, customer, maintenance, calibration, reservation, and kit save/import text. Current source still showed user create/update workflows trimming only `UserName`, while profile and access fields could be persisted with accidental whitespace or mixed permission delimiters. Those values feed the user directory, permission summaries, reports, and access checks, so this was the next concrete data-quality risk supported by current repository evidence.

## Why the scope is large enough

This is a complete user account save workflow slice across service-layer create/update behavior, profile persistence, permission consistency, source-contract coverage, durable progress notes, and the current work queue. It includes more than ten focused improvements without adding unrelated features or reopening already-completed import/report/export work.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to:
  - `InventoryManagementApp/Services/Users/UserService.cs`
  - `InventoryManagementApp.Tests/UserServiceSaveNormalizationContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-user-profile-save-normalization.md`
  - `ToDo.md`
- Connector readback confirmed `AddUserAsync` and `UpdateUserAsync` call `NormalizeUserForSave(user)` before first-user/existing-user checks and before persistence parameters are bound.
- Connector readback confirmed user photo, email, phone, mobile, address, role, and permissions create/update parameters call `ToDbNullableText(...)`.
- Connector readback confirmed `NormalizeUserForSave(...)`, `NormalizePermissionsForSave(...)`, `NormalizeRequiredText(...)`, `NormalizeOptionalText(...)`, and `ToDbNullableText(...)` exist with the expected field coverage.
- Connector readback confirmed `UserServiceSaveNormalizationContractTests` guards the new ordering and field coverage.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `7fc0ca4fec1aeb4b3b168d8e409fb225542cd677`.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Continue data-quality hardening only where current source evidence shows another concrete validation, duplicate-detection, permission-consistency, search/report consistency, or professional-output risk.