### PR TITLE
[codex] Normalize rental configuration text

### DIFF
--- a/InventoryManagementApp.Tests/RentalConfigurationNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalConfigurationNormalizationContractTests.cs
@@ -132,8 +132,12 @@ namespace InventoryManagementApp.Tests
             Assert.True(start >= 0, $"Could not find start marker: {startMarker}");
 
             var end = source.IndexOf(endMarker, start + startMarker.Length, StringComparison.Ordinal);
-            Assert.True(end > start, $"Could not find end marker after: {startMarker}");
+            if (end < 0)
+            {
+                end = source.IndexOf("\n        private static", start + startMarker.Length, StringComparison.Ordinal);
+            }
 
+            Assert.True(end > start, $"Could not find end marker after: {startMarker}");
             return source[start..end];
         }
 

--- a/InventoryManagementApp.Tests/RentalConfigurationNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalConfigurationNormalizationContractTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalConfigurationNormalizationContractTests
+    {
+        [Fact]
+        public void SingleLineEmailCompanyAndSmsSettingsNormalizeOnSaveAndRead()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "RentalConfigurationService.cs");
+
+            AssertSetterNormalizes(source, "SetSmtpHostAsync", "SmtpHostKey");
+            AssertSetterNormalizes(source, "SetSmtpUsernameAsync", "SmtpUsernameKey");
+            AssertSetterNormalizes(source, "SetFromEmailAsync", "FromEmailKey");
+            AssertSetterNormalizes(source, "SetFromNameAsync", "FromNameKey");
+            AssertSetterNormalizes(source, "SetContactInfoAsync", "ContactInfoKey");
+            AssertSetterNormalizes(source, "SetCompanyNameAsync", "CompanyNameKey");
+            AssertSetterNormalizes(source, "SetCompanyAddressAsync", "CompanyAddressKey");
+            AssertSetterNormalizes(source, "SetCompanyPhoneAsync", "CompanyPhoneKey");
+            AssertSetterNormalizes(source, "SetBackupDirectoryAsync", "BackupDirectoryKey");
+            AssertSetterNormalizes(source, "SetSmsProviderAsync", "SmsProviderKey");
+            AssertSetterNormalizes(source, "SetSmsSenderAsync", "SmsSenderKey");
+
+            AssertGetterUsesDefaultBoundary(source, "GetSmtpHostAsync", "SmtpHostKey", "smtp.example.com");
+            AssertGetterUsesDefaultBoundary(source, "GetSmtpUsernameAsync", "SmtpUsernameKey", "string.Empty");
+            AssertGetterUsesDefaultBoundary(source, "GetFromEmailAsync", "FromEmailKey", "rentals@example.com");
+            AssertGetterUsesDefaultBoundary(source, "GetFromNameAsync", "FromNameKey", "Equipment Rentals");
+            AssertGetterUsesDefaultBoundary(source, "GetContactInfoAsync", "ContactInfoKey", "Contact us for more information");
+            AssertGetterUsesDefaultBoundary(source, "GetCompanyNameAsync", "CompanyNameKey", "Equipment Rentals");
+            AssertGetterUsesDefaultBoundary(source, "GetCompanyAddressAsync", "CompanyAddressKey", "string.Empty");
+            AssertGetterUsesDefaultBoundary(source, "GetCompanyPhoneAsync", "CompanyPhoneKey", "string.Empty");
+            AssertGetterUsesDefaultBoundary(source, "GetBackupDirectoryAsync", "BackupDirectoryKey", "Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)");
+            AssertGetterUsesDefaultBoundary(source, "GetSmsProviderAsync", "SmsProviderKey", "None");
+            AssertGetterUsesDefaultBoundary(source, "GetSmsSenderAsync", "SmsSenderKey", "string.Empty");
+        }
+
+        [Fact]
+        public void ReminderAndOverdueTemplatesNormalizeEdgesAndFallbackWhenBlank()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "RentalConfigurationService.cs");
+
+            AssertSetterNormalizes(source, "SetEmailSignatureAsync", "EmailSignatureKey", "NormalizeMultilineSetting");
+            AssertSetterNormalizes(source, "SetReminderSubjectTemplateAsync", "ReminderSubjectTemplateKey");
+            AssertSetterNormalizes(source, "SetReminderBodyTemplateAsync", "ReminderBodyTemplateKey", "NormalizeMultilineSetting");
+            AssertSetterNormalizes(source, "SetOverdueSubjectTemplateAsync", "OverdueSubjectTemplateKey");
+            AssertSetterNormalizes(source, "SetOverdueBodyTemplateAsync", "OverdueBodyTemplateKey", "NormalizeMultilineSetting");
+
+            AssertGetterUsesDefaultBoundary(source, "GetEmailSignatureAsync", "EmailSignatureKey", "DefaultEmailSignature", "GetMultilineSettingOrDefault");
+            AssertGetterUsesDefaultBoundary(source, "GetReminderSubjectTemplateAsync", "ReminderSubjectTemplateKey", "DefaultReminderSubjectTemplate");
+            AssertGetterUsesDefaultBoundary(source, "GetReminderBodyTemplateAsync", "ReminderBodyTemplateKey", "DefaultReminderBodyTemplate", "GetMultilineSettingOrDefault");
+            AssertGetterUsesDefaultBoundary(source, "GetOverdueSubjectTemplateAsync", "OverdueSubjectTemplateKey", "DefaultOverdueSubjectTemplate");
+            AssertGetterUsesDefaultBoundary(source, "GetOverdueBodyTemplateAsync", "OverdueBodyTemplateKey", "DefaultOverdueBodyTemplate", "GetMultilineSettingOrDefault");
+        }
+
+        [Fact]
+        public void FromEmailOptionsAreNullSafeTrimmedAndDeduplicated()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "RentalConfigurationService.cs");
+            var setter = ExtractMember(source, "public async Task SetFromEmailOptionsAsync", "public async Task<string> GetEmailSignatureAsync");
+            var getter = ExtractMember(source, "public async Task<IReadOnlyList<string>> GetFromEmailOptionsAsync", "public async Task SetFromEmailOptionsAsync");
+
+            Assert.Contains("var normalized = (options ?? Enumerable.Empty<string>())", setter, StringComparison.Ordinal);
+            Assert.Contains(".Where(email => !string.IsNullOrWhiteSpace(email))", setter, StringComparison.Ordinal);
+            Assert.Contains(".Select(email => email.Trim())", setter, StringComparison.Ordinal);
+            Assert.Contains(".Distinct(StringComparer.OrdinalIgnoreCase)", setter, StringComparison.Ordinal);
+            Assert.Contains("JsonSerializer.Serialize(normalized)", setter, StringComparison.Ordinal);
+
+            Assert.Contains("options.Insert(0, currentFromEmail);", getter, StringComparison.Ordinal);
+            Assert.Contains(".Select(email => email.Trim())", getter, StringComparison.Ordinal);
+            Assert.Contains(".Distinct(StringComparer.OrdinalIgnoreCase)", getter, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PasswordAndApiKeyValuesRemainUntrimmedButNullSafe()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "RentalConfigurationService.cs");
+            var passwordSetter = ExtractMember(source, "public async Task SetSmtpPasswordAsync", "public async Task<string> GetFromEmailAsync");
+            var apiKeySetter = ExtractMember(source, "public async Task SetSmsApiKeyAsync", "public async Task<string> GetSmsSenderAsync");
+
+            Assert.Contains("SaveSettingAsync(SmtpPasswordKey, password ?? string.Empty", passwordSetter, StringComparison.Ordinal);
+            Assert.Contains("SaveSettingAsync(SmsApiKey, apiKey ?? string.Empty", apiKeySetter, StringComparison.Ordinal);
+            Assert.DoesNotContain("NormalizeSingleLineSetting(password)", passwordSetter, StringComparison.Ordinal);
+            Assert.DoesNotContain("NormalizeSingleLineSetting(apiKey)", apiKeySetter, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ConfigurationNormalizationHelpersTrimEdgesAndFallbackOnBlankValues()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "RentalConfigurationService.cs");
+            var helpers = ExtractMember(source, "private static string GetSingleLineSettingOrDefault", "    }\n}");
+
+            Assert.Contains("private static string GetSingleLineSettingOrDefault(string? value, string defaultValue)", helpers, StringComparison.Ordinal);
+            Assert.Contains("var normalized = NormalizeSingleLineSetting(value);", helpers, StringComparison.Ordinal);
+            Assert.Contains("return string.IsNullOrWhiteSpace(normalized) ? defaultValue : normalized;", helpers, StringComparison.Ordinal);
+            Assert.Contains("private static string GetMultilineSettingOrDefault(string? value, string defaultValue)", helpers, StringComparison.Ordinal);
+            Assert.Contains("var normalized = NormalizeMultilineSetting(value);", helpers, StringComparison.Ordinal);
+            Assert.Contains("private static string NormalizeSingleLineSetting(string? value) => value?.Trim() ?? string.Empty;", helpers, StringComparison.Ordinal);
+            Assert.Contains("private static string NormalizeMultilineSetting(string? value) => value?.Trim() ?? string.Empty;", helpers, StringComparison.Ordinal);
+        }
+
+        private static void AssertSetterNormalizes(string source, string methodName, string settingKey, string normalizer = "NormalizeSingleLineSetting")
+        {
+            var method = ExtractMember(source, $"public async Task {methodName}", "public async Task");
+            Assert.Contains($"SaveSettingAsync({settingKey}, {normalizer}(", method, StringComparison.Ordinal);
+        }
+
+        private static void AssertGetterUsesDefaultBoundary(
+            string source,
+            string methodName,
+            string settingKey,
+            string defaultValue,
+            string helper = "GetSingleLineSettingOrDefault")
+        {
+            var method = ExtractMember(source, $"public async Task<string> {methodName}", "public async Task");
+            Assert.Contains($"GetSettingAsync({settingKey}", method, StringComparison.Ordinal);
+            Assert.Contains($"return {helper}(value, {FormatExpectedDefault(defaultValue)});", method, StringComparison.Ordinal);
+        }
+
+        private static string FormatExpectedDefault(string expected) => expected switch
+        {
+            "string.Empty" => "string.Empty",
+            "Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)" => "Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)",
+            var value when value.StartsWith("Default", StringComparison.Ordinal) => value,
+            _ => $"\"{expected}\""
+        };
+
+        private static string ExtractMember(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start + startMarker.Length, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find end marker after: {startMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-rental-configuration-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-rental-configuration-normalization.md
@@ -1,0 +1,34 @@
+# Rental Configuration Text Normalization
+
+Date: 2026-07-02
+
+## Summary
+
+Normalized rental/email/company configuration text at the configuration workflow boundary so reminder, document, backup, and SMS settings no longer persist or return accidental leading/trailing whitespace.
+
+## Completed Work
+
+- Trimmed SMTP host values before saving and before returning stored settings, with blank stored values falling back to the default host.
+- Trimmed SMTP username values while preserving SMTP password contents as an untrimmed secret.
+- Trimmed from-email and from-name settings before persistence and defaulted whitespace-only stored values to the expected rental email defaults.
+- Made from-email option saves null-safe, while preserving trimming, blank filtering, and case-insensitive de-duplication.
+- Trimmed email signatures and reminder/overdue templates at their outer edges, while preserving internal multiline template content.
+- Defaulted whitespace-only stored email signatures and templates back to the built-in reminder/overdue defaults instead of returning blank email content.
+- Trimmed company contact info, company name, address, phone, and backup directory settings before persistence and on readback.
+- Defaulted whitespace-only company contact/name/backup settings to their existing user-facing defaults.
+- Trimmed SMS provider and sender settings while preserving SMS API keys as untrimmed secret values.
+- Added source-contract coverage for save normalization, read fallback behavior, email option null-safety, template handling, helper behavior, and untrimmed secret handling.
+
+## Why This Matters
+
+These settings feed reminder emails, printed/customer-facing documents, backup paths, SMS sender identity, and visible company/contact labels. Persisting padded or whitespace-only configuration values can make reminders fail, produce unprofessional output, or hide defaults behind blank stored settings.
+
+## Validation
+
+- Source inspection confirmed the configuration service now routes display/configuration text through shared single-line and multiline normalization helpers.
+- Source inspection confirmed SMTP passwords and SMS API keys are still stored without trimming, while null values are converted to empty strings.
+- Added `RentalConfigurationNormalizationContractTests` to guard the workflow boundary and readback/default contracts.
+
+## Validation Not Run
+
+This scheduled Linux environment still cannot clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, PowerShell/`pwsh`, GitHub CLI, or a WPF runtime. Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout before release.

--- a/InventoryManagementApp/Services/Settings/RentalConfigurationService.cs
+++ b/InventoryManagementApp/Services/Settings/RentalConfigurationService.cs
@@ -156,13 +156,13 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task<string> GetSmtpHostAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(SmtpHostKey, cancellationToken).ConfigureAwait(false) 
-                ?? "smtp.example.com";
+            var value = await _settingsService.GetSettingAsync(SmtpHostKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, "smtp.example.com");
         }
 
         public async Task SetSmtpHostAsync(string host, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(SmtpHostKey, host, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(SmtpHostKey, NormalizeSingleLineSetting(host), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<int> GetSmtpPortAsync(CancellationToken cancellationToken = default)
@@ -178,12 +178,13 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task<string> GetSmtpUsernameAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(SmtpUsernameKey, cancellationToken).ConfigureAwait(false) ?? string.Empty;
+            var value = await _settingsService.GetSettingAsync(SmtpUsernameKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, string.Empty);
         }
 
         public async Task SetSmtpUsernameAsync(string username, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(SmtpUsernameKey, username, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(SmtpUsernameKey, NormalizeSingleLineSetting(username), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetSmtpPasswordAsync(CancellationToken cancellationToken = default)
@@ -193,29 +194,29 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task SetSmtpPasswordAsync(string password, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(SmtpPasswordKey, password, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(SmtpPasswordKey, password ?? string.Empty, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetFromEmailAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(FromEmailKey, cancellationToken).ConfigureAwait(false) 
-                ?? "rentals@example.com";
+            var value = await _settingsService.GetSettingAsync(FromEmailKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, "rentals@example.com");
         }
 
         public async Task SetFromEmailAsync(string email, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(FromEmailKey, email, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(FromEmailKey, NormalizeSingleLineSetting(email), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetFromNameAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(FromNameKey, cancellationToken).ConfigureAwait(false) 
-                ?? "Equipment Rentals";
+            var value = await _settingsService.GetSettingAsync(FromNameKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, "Equipment Rentals");
         }
 
         public async Task SetFromNameAsync(string name, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(FromNameKey, name, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(FromNameKey, NormalizeSingleLineSetting(name), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<bool> GetEnableSslAsync(CancellationToken cancellationToken = default)
@@ -264,7 +265,7 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task SetFromEmailOptionsAsync(IEnumerable<string> options, CancellationToken cancellationToken = default)
         {
-            var normalized = options
+            var normalized = (options ?? Enumerable.Empty<string>())
                 .Where(email => !string.IsNullOrWhiteSpace(email))
                 .Select(email => email.Trim())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -275,57 +276,57 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task<string> GetEmailSignatureAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(EmailSignatureKey, cancellationToken).ConfigureAwait(false)
-                ?? DefaultEmailSignature;
+            var value = await _settingsService.GetSettingAsync(EmailSignatureKey, cancellationToken).ConfigureAwait(false);
+            return GetMultilineSettingOrDefault(value, DefaultEmailSignature);
         }
 
         public async Task SetEmailSignatureAsync(string signature, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(EmailSignatureKey, signature ?? string.Empty, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(EmailSignatureKey, NormalizeMultilineSetting(signature), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetReminderSubjectTemplateAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(ReminderSubjectTemplateKey, cancellationToken).ConfigureAwait(false)
-                ?? DefaultReminderSubjectTemplate;
+            var value = await _settingsService.GetSettingAsync(ReminderSubjectTemplateKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, DefaultReminderSubjectTemplate);
         }
 
         public async Task SetReminderSubjectTemplateAsync(string template, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(ReminderSubjectTemplateKey, template ?? string.Empty, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(ReminderSubjectTemplateKey, NormalizeSingleLineSetting(template), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetReminderBodyTemplateAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(ReminderBodyTemplateKey, cancellationToken).ConfigureAwait(false)
-                ?? DefaultReminderBodyTemplate;
+            var value = await _settingsService.GetSettingAsync(ReminderBodyTemplateKey, cancellationToken).ConfigureAwait(false);
+            return GetMultilineSettingOrDefault(value, DefaultReminderBodyTemplate);
         }
 
         public async Task SetReminderBodyTemplateAsync(string template, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(ReminderBodyTemplateKey, template ?? string.Empty, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(ReminderBodyTemplateKey, NormalizeMultilineSetting(template), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetOverdueSubjectTemplateAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(OverdueSubjectTemplateKey, cancellationToken).ConfigureAwait(false)
-                ?? DefaultOverdueSubjectTemplate;
+            var value = await _settingsService.GetSettingAsync(OverdueSubjectTemplateKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, DefaultOverdueSubjectTemplate);
         }
 
         public async Task SetOverdueSubjectTemplateAsync(string template, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(OverdueSubjectTemplateKey, template ?? string.Empty, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(OverdueSubjectTemplateKey, NormalizeSingleLineSetting(template), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetOverdueBodyTemplateAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(OverdueBodyTemplateKey, cancellationToken).ConfigureAwait(false)
-                ?? DefaultOverdueBodyTemplate;
+            var value = await _settingsService.GetSettingAsync(OverdueBodyTemplateKey, cancellationToken).ConfigureAwait(false);
+            return GetMultilineSettingOrDefault(value, DefaultOverdueBodyTemplate);
         }
 
         public async Task SetOverdueBodyTemplateAsync(string template, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(OverdueBodyTemplateKey, template ?? string.Empty, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(OverdueBodyTemplateKey, NormalizeMultilineSetting(template), cancellationToken).ConfigureAwait(false);
         }
 
         public const string DefaultEmailSignature = "Best regards,\nThe Equipment Rental Team";
@@ -357,68 +358,68 @@ If you have already returned this item or need to extend your rental, please con
 
         public async Task<string> GetContactInfoAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(ContactInfoKey, cancellationToken).ConfigureAwait(false) 
-                ?? "Contact us for more information";
+            var value = await _settingsService.GetSettingAsync(ContactInfoKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, "Contact us for more information");
         }
 
         public async Task SetContactInfoAsync(string info, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(ContactInfoKey, info, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(ContactInfoKey, NormalizeSingleLineSetting(info), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetCompanyNameAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(CompanyNameKey, cancellationToken).ConfigureAwait(false) 
-                ?? "Equipment Rentals";
+            var value = await _settingsService.GetSettingAsync(CompanyNameKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, "Equipment Rentals");
         }
 
         public async Task SetCompanyNameAsync(string name, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(CompanyNameKey, name, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(CompanyNameKey, NormalizeSingleLineSetting(name), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetCompanyAddressAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(CompanyAddressKey, cancellationToken).ConfigureAwait(false) 
-                ?? string.Empty;
+            var value = await _settingsService.GetSettingAsync(CompanyAddressKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, string.Empty);
         }
 
         public async Task SetCompanyAddressAsync(string address, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(CompanyAddressKey, address, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(CompanyAddressKey, NormalizeSingleLineSetting(address), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetCompanyPhoneAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(CompanyPhoneKey, cancellationToken).ConfigureAwait(false) 
-                ?? string.Empty;
+            var value = await _settingsService.GetSettingAsync(CompanyPhoneKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, string.Empty);
         }
 
         public async Task SetCompanyPhoneAsync(string phone, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(CompanyPhoneKey, phone, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(CompanyPhoneKey, NormalizeSingleLineSetting(phone), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetBackupDirectoryAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(BackupDirectoryKey, cancellationToken).ConfigureAwait(false)
-                ?? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            var value = await _settingsService.GetSettingAsync(BackupDirectoryKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
         }
 
         public async Task SetBackupDirectoryAsync(string directory, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(BackupDirectoryKey, directory, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(BackupDirectoryKey, NormalizeSingleLineSetting(directory), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetSmsProviderAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(SmsProviderKey, cancellationToken).ConfigureAwait(false)
-                ?? "None";
+            var value = await _settingsService.GetSettingAsync(SmsProviderKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, "None");
         }
 
         public async Task SetSmsProviderAsync(string provider, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(SmsProviderKey, provider, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(SmsProviderKey, NormalizeSingleLineSetting(provider), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetSmsApiKeyAsync(CancellationToken cancellationToken = default)
@@ -429,18 +430,34 @@ If you have already returned this item or need to extend your rental, please con
 
         public async Task SetSmsApiKeyAsync(string apiKey, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(SmsApiKey, apiKey, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(SmsApiKey, apiKey ?? string.Empty, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetSmsSenderAsync(CancellationToken cancellationToken = default)
         {
-            return await _settingsService.GetSettingAsync(SmsSenderKey, cancellationToken).ConfigureAwait(false)
-                ?? string.Empty;
+            var value = await _settingsService.GetSettingAsync(SmsSenderKey, cancellationToken).ConfigureAwait(false);
+            return GetSingleLineSettingOrDefault(value, string.Empty);
         }
 
         public async Task SetSmsSenderAsync(string sender, CancellationToken cancellationToken = default)
         {
-            await _settingsService.SaveSettingAsync(SmsSenderKey, sender, cancellationToken).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync(SmsSenderKey, NormalizeSingleLineSetting(sender), cancellationToken).ConfigureAwait(false);
         }
+
+        private static string GetSingleLineSettingOrDefault(string? value, string defaultValue)
+        {
+            var normalized = NormalizeSingleLineSetting(value);
+            return string.IsNullOrWhiteSpace(normalized) ? defaultValue : normalized;
+        }
+
+        private static string GetMultilineSettingOrDefault(string? value, string defaultValue)
+        {
+            var normalized = NormalizeMultilineSetting(value);
+            return string.IsNullOrWhiteSpace(normalized) ? defaultValue : normalized;
+        }
+
+        private static string NormalizeSingleLineSetting(string? value) => value?.Trim() ?? string.Empty;
+
+        private static string NormalizeMultilineSetting(string? value) => value?.Trim() ?? string.Empty;
     }
 }

--- a/ToDo.md
+++ b/ToDo.md
@@ -17,6 +17,7 @@ Current repository evidence:
 - Maintenance and calibration create/update workflows now normalize operational record text before persistence, and maintenance completion trims performer and notes before marking a record completed.
 - Reservation create/update and kit create/update workflows now normalize persisted workflow text before reference checks and database writes.
 - User create/update workflows now normalize profile and access text before first-user/existing-user checks and database writes, including canonicalized permission keys and nullable optional profile fields.
+- Rental/email/company configuration text now normalizes user-entered display and delivery settings before persistence and readback while preserving password/API-key secret values.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -67,6 +68,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Reservation create/update paths now normalize status and notes before reference checks, filter-facing status persistence, and database writes.
 - Kit create/update paths now normalize kit number, name, description, and category before insert/update persistence.
 - User create/update paths now normalize username, photo path, contact fields, role, and permissions before workflow checks and persistence, with blank optional profile/access fields stored as database null values.
+- Rental configuration paths now trim email delivery, company/contact, backup, SMS provider/sender, and reminder template settings at the configuration boundary, defaulting whitespace-only display values while preserving untrimmed secret settings.
 
 ## Highest-Value Next Work
 
@@ -77,7 +79,7 @@ Prioritize the following before adding unrelated new features:
 3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, and theme-customized popup surfaces.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
 5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
-6. Keep tightening import/export, save-path, and operational-record data-quality behavior only where current evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, search/report consistency, permission consistency, or professional output expectations.
+6. Keep tightening import/export, save-path, operational-record, configuration, and document-output data-quality behavior only where current evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, search/report consistency, permission consistency, delivery reliability, or professional output expectations.
 
 ## App Completion Status
 
@@ -91,7 +93,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, and operational-record normalization changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, and user/profile normalization changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Normalized SMTP host, SMTP username, from-email, and from-name settings before save and on readback.
- Preserved SMTP password values as untrimmed secrets while making null password saves persist as empty text.
- Made from-email option saves null-safe while preserving blank filtering, trimming, and case-insensitive de-duplication.
- Normalized email signatures, reminder subject/body templates, and overdue subject/body templates at their outer edges while preserving internal multiline template content.
- Defaulted whitespace-only stored signature/template values back to the built-in reminder and overdue defaults.
- Normalized company contact info, company name, address, phone, and backup directory settings before save and on readback.
- Defaulted whitespace-only company/contact/backup display settings back to existing user-facing defaults.
- Normalized SMS provider and SMS sender settings while preserving SMS API key values as untrimmed secrets.
- Added shared single-line and multiline configuration helpers for consistent read fallback and save normalization behavior.
- Added source-contract coverage for configuration save normalization, read default boundaries, email option null safety, template handling, helper behavior, and secret preservation.
- Added a focused progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this completed configuration slice without fresh evidence.

## Why this was the highest-value next step

Current repo evidence shows recent runs completed item, customer, operational-record, reservation, kit, and user text normalization. The next distinct persistence-facing gap was rental/email/company configuration text: these settings feed reminder delivery, printed/customer-facing documents, backup paths, SMS sender identity, and company/contact labels. Padded or whitespace-only values could hide defaults, make emails look unprofessional, or persist fragile delivery settings.

## Why the scope is large enough

This is a complete configuration workflow slice spanning email delivery settings, company/document settings, reminder/overdue templates, SMS sender settings, secret handling, readback defaults, source-contract coverage, progress notes, and the durable work queue. It includes more than ten focused improvements without adding unrelated modules or repeating recently merged service-normalization work.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 focused commits, and limited to:
  - `InventoryManagementApp/Services/Settings/RentalConfigurationService.cs`
  - `InventoryManagementApp.Tests/RentalConfigurationNormalizationContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-rental-configuration-normalization.md`
  - `ToDo.md`
- Connector source readback confirmed configuration setters route display/delivery text through `NormalizeSingleLineSetting(...)` or `NormalizeMultilineSetting(...)`.
- Connector source readback confirmed getters route display/delivery settings through `GetSingleLineSettingOrDefault(...)` or `GetMultilineSettingOrDefault(...)` so whitespace-only stored values fall back to defaults.
- Connector source readback confirmed SMTP passwords and SMS API keys are not trimmed, but null saves become empty text.
- Connector source readback confirmed `SetFromEmailOptionsAsync` is null-safe and still trims, filters blanks, and de-duplicates case-insensitively.
- Connector source readback confirmed `RentalConfigurationNormalizationContractTests` guards the new contracts.
- Connector status readback found no attached commit statuses on branch head `c5e2d7a2106d262671e1cb152bfdc9cafde2cdf8` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test reminder email configuration and document/company branding settings in the WPF app once a Windows runtime is available.
- Continue data-quality hardening only where current source evidence shows another concrete user-entered or file-imported value can bypass validation, duplicate detection, delivery reliability, or professional output expectations.