### PR TITLE
Harden category inventory refresh workflow

### DIFF
--- a/InventoryManagementApp.Tests/CategoriesServiceTests.cs
+++ b/InventoryManagementApp.Tests/CategoriesServiceTests.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
 using Dapper;
+using InventoryManagementApp.Messages;
 using InventoryManagementApp.Services.Categories;
 using InventoryManagementApp.Services.Core;
 using Xunit;
@@ -38,6 +41,31 @@ public class CategoriesServiceTests
     }
 
     [Fact]
+    public async Task LinkCategoryToInventory_NotifiesWhenNewAssociationIsCreatedOnly()
+    {
+        await using var db = new DatabaseService(":memory:");
+        var svc = new CategoriesService(db);
+        await svc.EnsureSchemaAsync();
+        await svc.EnsureInventoryAsync(1, "Main");
+        var categoryId = await svc.EnsureCategoryAsync("Tools");
+
+        using var recorder = new DomainMessageRecorder();
+
+        await svc.LinkCategoryToInventoryAsync(categoryId, 1);
+
+        var message = Assert.Single(recorder.Messages);
+        Assert.True(message.Includes(DomainDataScope.Categories));
+        Assert.True(message.Includes(DomainDataScope.Items));
+        Assert.True(message.Includes(DomainDataScope.Reports));
+        Assert.Equal(categoryId, message.EntityId);
+
+        recorder.Messages.Clear();
+        await svc.LinkCategoryToInventoryAsync(categoryId, 1);
+
+        Assert.Empty(recorder.Messages);
+    }
+
+    [Fact]
     public async Task EnsureInventoryAsync_CreatesMissingInventoryRow()
     {
         await using var db = new DatabaseService(":memory:");
@@ -50,6 +78,35 @@ public class CategoriesServiceTests
         var location = await conn.ExecuteScalarAsync<string>(
             "SELECT Location FROM Inventories WHERE InventoryID=1");
         Assert.Equal("Main", location);
+    }
+
+    [Fact]
+    public async Task EnsureInventoryAsync_UpdatesExistingInventoryLocationAndNotifiesOnChangeOnly()
+    {
+        await using var db = new DatabaseService(":memory:");
+        var svc = new CategoriesService(db);
+        await svc.EnsureSchemaAsync();
+        await svc.EnsureInventoryAsync(1, "Main");
+
+        using var recorder = new DomainMessageRecorder();
+
+        await svc.EnsureInventoryAsync(1, "  Warehouse  ");
+
+        await using var conn = db.CreateConnection();
+        var location = await conn.ExecuteScalarAsync<string>(
+            "SELECT Location FROM Inventories WHERE InventoryID=1");
+        Assert.Equal("Warehouse", location);
+
+        var message = Assert.Single(recorder.Messages);
+        Assert.True(message.Includes(DomainDataScope.Categories));
+        Assert.True(message.Includes(DomainDataScope.Items));
+        Assert.True(message.Includes(DomainDataScope.Reports));
+        Assert.Equal(1, message.EntityId);
+
+        recorder.Messages.Clear();
+        await svc.EnsureInventoryAsync(1, "Warehouse");
+
+        Assert.Empty(recorder.Messages);
     }
 
     [Fact]
@@ -78,6 +135,22 @@ public class CategoriesServiceTests
 
         await using var conn = db.CreateConnection();
         var count = await conn.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM Categories");
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task EnsureInventoryAsync_HonorsCancellationBeforeCreatingInventory()
+    {
+        await using var db = new DatabaseService(":memory:");
+        var svc = new CategoriesService(db);
+        await svc.EnsureSchemaAsync();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => svc.EnsureInventoryAsync(1, "Main", cts.Token));
+
+        await using var conn = db.CreateConnection();
+        var count = await conn.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM Inventories");
         Assert.Equal(0, count);
     }
 
@@ -112,6 +185,51 @@ public class CategoriesServiceTests
     }
 
     [Fact]
+    public void LinkCategoryToInventoryNotifiesOnlyWhenANewAssociationIsInserted()
+    {
+        var source = ReadRepoFile("InventoryManagementApp", "Services", "Categories", "CategoriesService.cs");
+        var method = ExtractMethod(
+            source,
+            "public async Task LinkCategoryToInventoryAsync(int categoryId, int inventoryId, CancellationToken ct = default)",
+            "public async Task EnsureInventoryAsync");
+
+        Assert.Contains("var linkedRows = await conn.ExecuteAsync(", method, StringComparison.Ordinal);
+        Assert.Contains("INSERT OR IGNORE INTO InventoryCategories", method, StringComparison.Ordinal);
+        Assert.Contains("if (linkedRows > 0)", method, StringComparison.Ordinal);
+        Assert.Contains("NotifyChanged(DomainDataScope.Categories | DomainDataScope.Items | DomainDataScope.Reports, categoryId);", method, StringComparison.Ordinal);
+        Assert.True(
+            method.IndexOf("var linkedRows = await conn.ExecuteAsync(", StringComparison.Ordinal) <
+            method.IndexOf("if (linkedRows > 0)", StringComparison.Ordinal),
+            "Category/inventory linking should decide whether to refresh from the actual inserted-row result.");
+    }
+
+    [Fact]
+    public void EnsureInventoryAsyncUpsertsLocationAndNotifiesOnlyWhenRowsChange()
+    {
+        var source = ReadRepoFile("InventoryManagementApp", "Services", "Categories", "CategoriesService.cs");
+        var method = ExtractMethod(
+            source,
+            "public async Task EnsureInventoryAsync(int inventoryId, string location, CancellationToken ct = default)",
+            "public async Task<List<CategoryDto>> GetCategoriesForInventoryAsync");
+
+        Assert.Contains("location = string.IsNullOrWhiteSpace(location) ? \"Main\" : location.Trim();", method, StringComparison.Ordinal);
+        Assert.Contains("var changedRows = await conn.ExecuteAsync(", method, StringComparison.Ordinal);
+        Assert.Contains("ON CONFLICT(InventoryID) DO UPDATE SET Location = excluded.Location", method, StringComparison.Ordinal);
+        Assert.Contains("WHERE Inventories.Location <> excluded.Location;", method, StringComparison.Ordinal);
+        Assert.Contains("if (changedRows > 0)", method, StringComparison.Ordinal);
+        Assert.Contains("NotifyChanged(DomainDataScope.Categories | DomainDataScope.Items | DomainDataScope.Reports, inventoryId);", method, StringComparison.Ordinal);
+        Assert.DoesNotContain("INSERT OR IGNORE INTO Inventories", method, StringComparison.Ordinal);
+        Assert.True(
+            method.IndexOf("location = string.IsNullOrWhiteSpace(location) ? \"Main\" : location.Trim();", StringComparison.Ordinal) <
+            method.IndexOf("var changedRows = await conn.ExecuteAsync(", StringComparison.Ordinal),
+            "Inventory location text should be normalized before upsert parameters are bound.");
+        Assert.True(
+            method.IndexOf("if (changedRows > 0)", StringComparison.Ordinal) <
+            method.IndexOf("NotifyChanged(DomainDataScope.Categories | DomainDataScope.Items | DomainDataScope.Reports, inventoryId);", StringComparison.Ordinal),
+            "Inventory refresh messages should be sent only after the upsert reports a changed row.");
+    }
+
+    [Fact]
     public void CategoryServiceHonorsCancellationBeforeConnectionWork()
     {
         var source = ReadRepoFile("InventoryManagementApp", "Services", "Categories", "CategoriesService.cs");
@@ -130,6 +248,10 @@ public class CategoriesServiceTests
             "public async Task EnsureInventoryAsync");
         AssertCancellationGuardBeforeConnection(
             source,
+            "public async Task EnsureInventoryAsync(int inventoryId, string location, CancellationToken ct = default)",
+            "public async Task<List<CategoryDto>> GetCategoriesForInventoryAsync");
+        AssertCancellationGuardBeforeConnection(
+            source,
             "public async Task<List<CategoryDto>> GetCategoriesForInventoryAsync(int inventoryId, CancellationToken ct = default)",
             "public async Task<bool> RenameCategoryAsync");
         AssertCancellationGuardBeforeConnection(
@@ -140,6 +262,21 @@ public class CategoriesServiceTests
             source,
             "public async Task<bool> DeleteCategoryAsync(int categoryId, CancellationToken ct = default)",
             "private static async Task EnsureInventoryExistsAsync");
+    }
+
+    private sealed class DomainMessageRecorder : IDisposable
+    {
+        public DomainMessageRecorder()
+        {
+            WeakReferenceMessenger.Default.Register<DomainDataChangedMessage>(this, (_, message) => Messages.Add(message));
+        }
+
+        public List<DomainDataChangedMessage> Messages { get; } = new();
+
+        public void Dispose()
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(this);
+        }
     }
 
     private static void AssertCancellationGuardBeforeConnection(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-category-inventory-refresh-hardening.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-category-inventory-refresh-hardening.md
@@ -1,0 +1,24 @@
+# Category Inventory Refresh Hardening - 2026-07-02
+
+## Completed
+
+- Hardened `CategoriesService.LinkCategoryToInventoryAsync(...)` so a newly created category/inventory association sends the same domain refresh signal used by other category mutations.
+- Kept category/inventory linking idempotent by preserving `INSERT OR IGNORE`, while only notifying listeners when SQLite reports that a new association row was inserted.
+- Replaced `EnsureInventoryAsync(...)`'s stale `INSERT OR IGNORE` behavior with an upsert that updates an existing inventory location when the normalized label changes.
+- Kept inventory upserts quiet when the requested normalized location already matches the stored location, avoiding unnecessary UI/report refresh work.
+- Preserved the existing default `Main` location behavior for blank inventory location text and trimmed non-blank location text before persistence.
+- Added behavioral coverage for inventory location updates, idempotent unchanged inventory ensures, new category/inventory link refresh messages, and duplicate link no-refresh behavior.
+- Added behavioral coverage proving `EnsureInventoryAsync(...)` honors already-cancelled callers before creating an inventory row.
+- Expanded category service source-contract coverage so `EnsureInventoryAsync(...)` is included in the cancellation-before-connection guard.
+- Added source-contract coverage for category/inventory link refresh ordering and changed-row notification gating.
+- Added source-contract coverage for inventory upsert ordering, normalized location binding, changed-row notification gating, and the removal of stale `INSERT OR IGNORE` inventory behavior.
+
+## Why It Matters
+
+Inventory/category associations affect item lists, filters, and reports. Before this change, linking a category to an inventory location could succeed without telling dependent screens or reports to refresh, and ensuring an inventory row could leave an old location label in place forever. The workflow now behaves more consistently with category create, rename, and delete operations.
+
+## Validation
+
+- Source was updated through the GitHub connector because the scheduled Linux environment cannot clone the repository directly.
+- Connector readback should confirm the branch is focused on `CategoriesService`, `CategoriesServiceTests`, this progress note, and the current work queue.
+- Local `dotnet`/WPF validation could not be run in this environment because direct checkout is blocked and the required Windows/.NET tooling is unavailable.

--- a/InventoryManagementApp/Services/Categories/CategoriesService.cs
+++ b/InventoryManagementApp/Services/Categories/CategoriesService.cs
@@ -119,9 +119,11 @@ CREATE TABLE IF NOT EXISTS InventoryCategories (
             await using var conn = _db.CreateConnection();
             await EnsureInventoryExistsAsync(conn, inventoryId);
             await EnsureCategoryExistsAsync(conn, categoryId);
-            await conn.ExecuteAsync(
+            var linkedRows = await conn.ExecuteAsync(
                 "INSERT OR IGNORE INTO InventoryCategories(InventoryID,CategoryID) VALUES(@i,@c);",
                 new { i = inventoryId, c = categoryId });
+            if (linkedRows > 0)
+                NotifyChanged(DomainDataScope.Categories | DomainDataScope.Items | DomainDataScope.Reports, categoryId);
         }
 
         public async Task EnsureInventoryAsync(int inventoryId, string location, CancellationToken ct = default)
@@ -133,10 +135,14 @@ CREATE TABLE IF NOT EXISTS InventoryCategories (
             ct.ThrowIfCancellationRequested();
 
             await using var conn = _db.CreateConnection();
-            await conn.ExecuteAsync(
-                @"INSERT OR IGNORE INTO Inventories(InventoryID, Location)
-                  VALUES(@i, @location);",
+            var changedRows = await conn.ExecuteAsync(
+                @"INSERT INTO Inventories(InventoryID, Location)
+                  VALUES(@i, @location)
+                  ON CONFLICT(InventoryID) DO UPDATE SET Location = excluded.Location
+                  WHERE Inventories.Location <> excluded.Location;",
                 new { i = inventoryId, location });
+            if (changedRows > 0)
+                NotifyChanged(DomainDataScope.Categories | DomainDataScope.Items | DomainDataScope.Reports, inventoryId);
         }
 
         /// <summary>

--- a/ToDo.md
+++ b/ToDo.md
@@ -18,6 +18,7 @@ Current repository evidence:
 - Reservation create/update and kit create/update workflows now normalize persisted workflow text before reference checks and database writes.
 - User create/update workflows now normalize profile and access text before first-user/existing-user checks and database writes, including canonicalized permission keys and nullable optional profile fields.
 - Rental/email/company configuration text now normalizes user-entered display and delivery settings before persistence and readback while preserving password/API-key secret values.
+- Category/inventory linking now sends domain refresh messages when a new association is created, and inventory ensure/update now refreshes dependent item/report/category views when a normalized location label changes.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -69,6 +70,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Kit create/update paths now normalize kit number, name, description, and category before insert/update persistence.
 - User create/update paths now normalize username, photo path, contact fields, role, and permissions before workflow checks and persistence, with blank optional profile/access fields stored as database null values.
 - Rental configuration paths now trim email delivery, company/contact, backup, SMS provider/sender, and reminder template settings at the configuration boundary, defaulting whitespace-only display values while preserving untrimmed secret settings.
+- Category/inventory association changes now refresh dependent category, item, and report views when new links are created; inventory location ensures now update stale labels and refresh only when a row actually changes.
 
 ## Highest-Value Next Work
 
@@ -93,7 +95,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, and user/profile normalization changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, and category/inventory refresh changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Hardened `CategoriesService.LinkCategoryToInventoryAsync(...)` so newly inserted category/inventory associations send the same category/item/report domain refresh signal used by other category mutations.
- Kept duplicate category/inventory linking idempotent and quiet by gating the refresh message on the actual `INSERT OR IGNORE` affected-row result.
- Replaced stale `EnsureInventoryAsync(...)` `INSERT OR IGNORE` behavior with a normalized-location upsert so existing inventory location labels can be corrected instead of staying stale.
- Gated inventory refresh messages on changed rows so unchanged inventory ensures do not trigger unnecessary UI/report reloads.
- Preserved blank-location fallback to `Main` and trimming of non-blank inventory location text before persistence.
- Added behavioral tests for inventory location updates, changed-row notifications, unchanged-row quiet behavior, new category/inventory link notifications, duplicate link quiet behavior, and cancelled inventory ensures.
- Expanded source-contract coverage for `EnsureInventoryAsync(...)` cancellation-before-connection ordering.
- Added source-contract coverage for category/inventory link inserted-row refresh gating.
- Added source-contract coverage for inventory upsert ordering, normalized location binding, changed-row notification gating, and removal of stale `INSERT OR IGNORE` inventory behavior.
- Updated progress notes and the current work queue so this completed reliability slice is not repeated without new evidence.

## Why this was the highest-value next step

Current repo notes show the recent import/save/configuration normalization slices are already merged, and no open PRs or attached failing checks were present. The category/inventory workflow still had a concrete consistency gap: association and inventory-location changes could alter persisted data without refreshing dependent category, item, and report views, while inventory ensures could leave stale location labels in place.

## Why this is large enough to count as real progress

This is a complete vertical reliability slice across service behavior, persistence semantics, domain refresh behavior, behavioral tests, source-contract tests, progress notes, and the repo work queue. It improves an existing workflow rather than making an isolated one-line tweak.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 commits, and limited to `CategoriesService`, `CategoriesServiceTests`, one progress note, and `ToDo.md`.
- Connector readback confirmed `LinkCategoryToInventoryAsync(...)` captures `linkedRows`, preserves `INSERT OR IGNORE`, and sends category/item/report refresh only when `linkedRows > 0`.
- Connector readback confirmed `EnsureInventoryAsync(...)` normalizes location text, uses `ON CONFLICT(InventoryID) DO UPDATE`, limits updates to changed locations, and sends category/item/report refresh only when `changedRows > 0`.
- Connector status/workflow readback found no attached commit statuses or workflow runs on the branch head.

## Could not be checked

- Local clone still fails in this scheduled Linux environment with GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, print-preview checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so compile/test/runtime validation could not be run.

## Known follow-up work

- Run the full Windows/.NET validation runner on a capable checkout.
- Smoke test category/inventory UI refresh behavior in the WPF app once runtime validation is available.