### PR TITLE
Harden settings normalization workflow

### DIFF
--- a/InventoryManagementApp.Tests/SettingsServiceTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Services.Core;
 using InventoryManagementApp.Services.Settings;
 using Xunit;
@@ -20,6 +23,18 @@ public class SettingsServiceTests
     }
 
     [Fact]
+    public async Task GetSettingAsync_ReturnsNull_WhenKeyIsWhitespace()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new SettingsService(db);
+
+        var value = await service.GetSettingAsync("   ");
+
+        Assert.Null(value);
+    }
+
+    [Fact]
     public async Task SaveAndGetThemeAsync_RoundTrip()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
@@ -30,6 +45,23 @@ public class SettingsServiceTests
         var value = await service.GetThemeAsync();
 
         Assert.Equal("Dark", value);
+    }
+
+    [Fact]
+    public async Task SaveAndGetSettingAsync_NormalizesKeysForRoundTripAndAllSettings()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new SettingsService(db);
+
+        await service.SaveSettingAsync("  Theme  ", "Dark");
+
+        Assert.Equal("Dark", await service.GetSettingAsync("Theme"));
+        Assert.Equal("Dark", await service.GetSettingAsync("  Theme  "));
+
+        var settings = await service.GetAllSettingsAsync();
+        Assert.True(settings.ContainsKey("Theme"));
+        Assert.False(settings.ContainsKey("  Theme  "));
     }
 
     [Fact]
@@ -55,5 +87,52 @@ public class SettingsServiceTests
         var value = await service.GetItemCardSizeAsync();
 
         Assert.Equal(1.2, value);
+    }
+
+    [Fact]
+    public async Task SaveAndGetItemLabelsAsync_NormalizesWhitespaceAndDefaultsBlankLabels()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new SettingsService(db);
+
+        await service.SaveItemLabelSingularAsync("  Tool  ");
+        await service.SaveItemLabelPluralAsync("  Tools  ");
+
+        Assert.Equal("Tool", await service.GetItemLabelSingularAsync());
+        Assert.Equal("Tools", await service.GetItemLabelPluralAsync());
+
+        await service.SaveItemLabelSingularAsync("   ");
+        await service.SaveItemLabelPluralAsync("\t");
+
+        Assert.Equal("Item", await service.GetItemLabelSingularAsync());
+        Assert.Equal("Items", await service.GetItemLabelPluralAsync());
+    }
+
+    [Fact]
+    public async Task SaveItemDetailVisibilityAsync_CanonicalizesMissingFieldsAndEventPayload()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new SettingsService(db);
+        var firstField = Enum.GetValues<ItemDetailField>().First();
+        IDictionary<ItemDetailField, bool>? eventPayload = null;
+        service.ItemDetailVisibilityChanged += (_, visibility) => eventPayload = visibility;
+
+        await service.SaveItemDetailVisibilityAsync(new Dictionary<ItemDetailField, bool>
+        {
+            [firstField] = false
+        });
+
+        var savedVisibility = await service.GetItemDetailVisibilityAsync();
+        var allFields = Enum.GetValues<ItemDetailField>();
+        Assert.All(allFields, field => Assert.True(savedVisibility.ContainsKey(field)));
+        Assert.False(savedVisibility[firstField]);
+        Assert.All(allFields.Where(field => field != firstField), field => Assert.True(savedVisibility[field]));
+
+        Assert.NotNull(eventPayload);
+        Assert.All(allFields, field => Assert.True(eventPayload!.ContainsKey(field)));
+        Assert.False(eventPayload![firstField]);
+        Assert.All(allFields.Where(field => field != firstField), field => Assert.True(eventPayload![field]));
     }
 }

--- a/InventoryManagementApp.Tests/SettingsServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceWriteGuardContractTests.cs
@@ -15,19 +15,60 @@ namespace InventoryManagementApp.Tests
                 "public async Task SaveSettingAsync",
                 "        /// <summary>\n        /// Retrieves a setting value from the database.");
 
-            Assert.Contains("var normalizedKey = key.Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("var normalizedKey = NormalizeRequiredSettingKey(key, nameof(key));", method, StringComparison.Ordinal);
             Assert.Contains("new SqliteParameter(\"@Key\", normalizedKey)", method, StringComparison.Ordinal);
             Assert.Contains("var affectedRows = await SqliteHelper.ExecuteNonQueryAsync", method, StringComparison.Ordinal);
             Assert.Contains("EnsureSettingsWriteSucceeded(affectedRows, normalizedKey);", method, StringComparison.Ordinal);
             Assert.Contains("Failed to save setting '{normalizedKey}'.", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("new SqliteParameter(\"@Key\", key)", method, StringComparison.Ordinal);
             Assert.DoesNotContain("await SqliteHelper.ExecuteNonQueryAsync(conn, UpsertSql, p, cancellationToken).ConfigureAwait(false);", method, StringComparison.Ordinal);
 
             Assert.True(
-                method.IndexOf("var normalizedKey = key.Trim();", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Key\", normalizedKey)", StringComparison.Ordinal),
+                method.IndexOf("var normalizedKey = NormalizeRequiredSettingKey(key, nameof(key));", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Key\", normalizedKey)", StringComparison.Ordinal),
                 "Single setting writes should bind the normalized key.");
             Assert.True(
                 method.IndexOf("var affectedRows = await SqliteHelper.ExecuteNonQueryAsync", StringComparison.Ordinal) < method.IndexOf("EnsureSettingsWriteSucceeded(affectedRows, normalizedKey);", StringComparison.Ordinal),
                 "Single setting writes should capture affected rows before checking the upsert result.");
+        }
+
+        [Fact]
+        public void GetSettingNormalizesKeysAndRejectsBlankKeysBeforeConnectionWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "SettingsService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<string?> GetSettingAsync",
+                "public async Task<Dictionary<string, string>> GetAllSettingsAsync");
+
+            Assert.Contains("var normalizedKey = NormalizeOptionalSettingKey(key);", method, StringComparison.Ordinal);
+            Assert.Contains("if (normalizedKey is null)", method, StringComparison.Ordinal);
+            Assert.Contains("return null;", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Key\", normalizedKey)", method, StringComparison.Ordinal);
+            Assert.Contains("Retrieving setting {Key} canceled or timed out", method, StringComparison.Ordinal);
+            Assert.Contains("Failed to retrieve setting '{normalizedKey}'.", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("new SqliteParameter(\"@Key\", key)", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("if (normalizedKey is null)", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                "Blank read keys should return without opening a database connection.");
+            Assert.True(
+                method.IndexOf("var normalizedKey = NormalizeOptionalSettingKey(key);", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Key\", normalizedKey)", StringComparison.Ordinal),
+                "Setting reads should bind the normalized key.");
+        }
+
+        [Fact]
+        public void GetAllSettingsNormalizesReturnedKeysAndSkipsBlankStoredKeys()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "SettingsService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<Dictionary<string, string>> GetAllSettingsAsync",
+                "        /// <summary>\n        /// Updates or inserts multiple settings within a single transaction.");
+
+            Assert.Contains("var key = NormalizeOptionalSettingKey(rdr[\"Key\"]?.ToString());", method, StringComparison.Ordinal);
+            Assert.Contains("if (key != null && value != null)", method, StringComparison.Ordinal);
+            Assert.Contains("dict[key] = value;", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("dict[rdr[\"Key\"]", method, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -41,7 +82,7 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("var normalizedSettings = new List<KeyValuePair<string, string>>(settings.Count);", method, StringComparison.Ordinal);
             Assert.Contains("var normalizedKeys = new HashSet<string>(StringComparer.Ordinal);", method, StringComparison.Ordinal);
-            Assert.Contains("var normalizedKey = kv.Key.Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("var normalizedKey = NormalizeRequiredSettingKey(kv.Key, nameof(settings));", method, StringComparison.Ordinal);
             Assert.Contains("throw new ArgumentException(\"Duplicate setting keys are not allowed.\", nameof(settings));", method, StringComparison.Ordinal);
             Assert.Contains("normalizedSettings.Add(new KeyValuePair<string, string>(normalizedKey, kv.Value));", method, StringComparison.Ordinal);
             Assert.Contains("foreach (var kv in normalizedSettings)", method, StringComparison.Ordinal);
@@ -68,20 +109,66 @@ namespace InventoryManagementApp.Tests
             var method = ExtractMethod(
                 source,
                 "public async Task DeleteSettingAsync",
-                "static void EnsureSettingsWriteSucceeded");
+                "static string? NormalizeOptionalSettingKey");
 
-            Assert.Contains("if (string.IsNullOrWhiteSpace(key))", method, StringComparison.Ordinal);
-            Assert.Contains("throw new ArgumentException(\"Key cannot be null or empty.\", nameof(key));", method, StringComparison.Ordinal);
-            Assert.Contains("var normalizedKey = key.Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("var normalizedKey = NormalizeRequiredSettingKey(key, nameof(key));", method, StringComparison.Ordinal);
             Assert.Contains("new SqliteParameter(\"@Key\", normalizedKey)", method, StringComparison.Ordinal);
             Assert.Contains("No setting found for key {Key}", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("new SqliteParameter(\"@Key\", key)", method, StringComparison.Ordinal);
 
             Assert.True(
-                method.IndexOf("if (string.IsNullOrWhiteSpace(key))", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                method.IndexOf("var normalizedKey = NormalizeRequiredSettingKey(key, nameof(key));", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
                 "Invalid delete keys should fail before opening a database connection.");
             Assert.True(
-                method.IndexOf("var normalizedKey = key.Trim();", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Key\", normalizedKey)", StringComparison.Ordinal),
+                method.IndexOf("var normalizedKey = NormalizeRequiredSettingKey(key, nameof(key));", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Key\", normalizedKey)", StringComparison.Ordinal),
                 "Setting delete should bind the normalized key.");
+        }
+
+        [Fact]
+        public void SettingKeyNormalizationHelpersPreserveReadAndWriteContracts()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "SettingsService.cs");
+
+            Assert.Contains("static string? NormalizeOptionalSettingKey(string? key)", source, StringComparison.Ordinal);
+            Assert.Contains("string.IsNullOrWhiteSpace(key) ? null : key.Trim();", source, StringComparison.Ordinal);
+            Assert.Contains("static string NormalizeRequiredSettingKey(string key, string parameterName)", source, StringComparison.Ordinal);
+            Assert.Contains("var normalizedKey = NormalizeOptionalSettingKey(key);", source, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentException(\"Key cannot be null or empty.\", parameterName);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemDisplaySettingsNormalizeLabelsAndCanonicalizeVisibilitySaves()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Settings", "SettingsService.cs");
+            var singular = ExtractMethod(
+                source,
+                "public async Task SaveItemLabelSingularAsync",
+                "public async Task<string> GetItemLabelPluralAsync");
+            var plural = ExtractMethod(
+                source,
+                "public async Task SaveItemLabelPluralAsync",
+                "public async Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync");
+            var visibility = ExtractMethod(
+                source,
+                "public async Task SaveItemDetailVisibilityAsync",
+                "public async Task<double> GetItemCardSizeAsync");
+
+            Assert.Contains("return NormalizeDisplayLabel(value, \"Item\");", source, StringComparison.Ordinal);
+            Assert.Contains("return NormalizeDisplayLabel(value, \"Items\");", source, StringComparison.Ordinal);
+            Assert.Contains("var normalizedLabel = NormalizeDisplayLabel(label, \"Item\");", singular, StringComparison.Ordinal);
+            Assert.Contains("await SaveSettingAsync(ItemLabelSingularKey, normalizedLabel, cancellationToken).ConfigureAwait(false);", singular, StringComparison.Ordinal);
+            Assert.Contains("var normalizedLabel = NormalizeDisplayLabel(label, \"Items\");", plural, StringComparison.Ordinal);
+            Assert.Contains("await SaveSettingAsync(ItemLabelPluralKey, normalizedLabel, cancellationToken).ConfigureAwait(false);", plural, StringComparison.Ordinal);
+            Assert.Contains("static string NormalizeDisplayLabel(string? label, string defaultLabel)", source, StringComparison.Ordinal);
+            Assert.Contains("string.IsNullOrWhiteSpace(label) ? defaultLabel : label.Trim();", source, StringComparison.Ordinal);
+
+            Assert.Contains("if (visibility is null)", visibility, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(visibility));", visibility, StringComparison.Ordinal);
+            Assert.Contains("var normalizedVisibility = Enum.GetValues<ItemDetailField>()", visibility, StringComparison.Ordinal);
+            Assert.Contains("visibility.TryGetValue(f, out var visible) ? visible : true", visibility, StringComparison.Ordinal);
+            Assert.Contains("var dict = normalizedVisibility.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);", visibility, StringComparison.Ordinal);
+            Assert.Contains("ItemDetailVisibilityChanged?.Invoke(this, normalizedVisibility);", visibility, StringComparison.Ordinal);
+            Assert.DoesNotContain("ItemDetailVisibilityChanged?.Invoke(this, new Dictionary<ItemDetailField, bool>(visibility));", visibility, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-settings-normalization-hardening.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-settings-normalization-hardening.md
@@ -1,0 +1,28 @@
+# Settings Normalization Hardening - 2026-07-02
+
+## Why
+
+The settings service already normalized keys on write and delete, but readback still accepted raw keys. That left settings workflows vulnerable to inconsistent lookup behavior when UI or maintenance code passed padded keys, and it meant `GetAllSettingsAsync` could surface stale padded keys from older data. Item display labels also preserved accidental whitespace, and partial item-detail visibility saves could notify listeners with only a partial field set.
+
+## Completed
+
+- Routed single-setting reads through the same normalized key boundary used by writes and deletes.
+- Returned `null` for blank setting read keys before opening a database connection.
+- Normalized keys returned by `GetAllSettingsAsync` and skipped blank stored keys.
+- Centralized optional and required setting key normalization helpers.
+- Preserved existing write/delete behavior while routing it through the shared required-key helper.
+- Trimmed item label singular/plural values before saving them.
+- Trimmed item label readback and defaulted blank labels to `Item` / `Items`.
+- Rejected null item-detail visibility saves with a clear `ArgumentNullException`.
+- Canonicalized item-detail visibility saves so every known `ItemDetailField` is persisted, defaulting missing fields to visible.
+- Raised item-detail visibility change events with the canonical full field map instead of the caller's partial dictionary.
+- Added runtime-style settings service coverage for blank read keys, padded-key round trips, normalized `GetAllSettingsAsync` output, item label normalization/defaults, and canonical visibility event/readback behavior.
+- Extended source-contract coverage for normalized read keys, normalized all-settings keys, shared key helpers, item label normalization, and canonical visibility persistence/events.
+
+## Validation
+
+Local validation could not be run in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and the environment does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime. Connector readback/compare should be used to confirm the branch scope before merge, and the next Windows-capable run should execute:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -61,10 +61,7 @@ namespace InventoryManagementApp.Services.Settings
         public async Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {
             _auth.EnsurePermission(User.PermissionSettings);
-            if (string.IsNullOrWhiteSpace(key))
-                throw new ArgumentException("Key cannot be null or empty.", nameof(key));
-
-            var normalizedKey = key.Trim();
+            var normalizedKey = NormalizeRequiredSettingKey(key, nameof(key));
 
             try
             {
@@ -106,31 +103,32 @@ namespace InventoryManagementApp.Services.Settings
         /// <returns>The setting value if found; otherwise, null.</returns>
         public async Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default)
         {
-            if (key is null)
+            var normalizedKey = NormalizeOptionalSettingKey(key);
+            if (normalizedKey is null)
                 return null;
 
             try
             {
                 const string sql = "SELECT Value FROM Settings WHERE Key = @Key";
                 using var conn = _dbService.CreateConnection();
-                var p = new[] { new SqliteParameter("@Key", key) };
+                var p = new[] { new SqliteParameter("@Key", normalizedKey) };
                 var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
                 return result?.ToString();
             }
             catch (OperationCanceledException ex)
             {
-                _logger.LogWarning(ex, "Retrieving setting {Key} canceled or timed out", key);
+                _logger.LogWarning(ex, "Retrieving setting {Key} canceled or timed out", normalizedKey);
                 throw;
             }
             catch (SqliteException ex) when (ex.SqliteErrorCode == SQLitePCL.raw.SQLITE_BUSY)
             {
-                _logger.LogWarning(ex, "Retrieving setting {Key} timed out", key);
+                _logger.LogWarning(ex, "Retrieving setting {Key} timed out", normalizedKey);
                 throw;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to retrieve setting {Key}", key);
-                throw new InvalidOperationException($"Failed to retrieve setting '{key}'.", ex);
+                _logger.LogError(ex, "Failed to retrieve setting {Key}", normalizedKey);
+                throw new InvalidOperationException($"Failed to retrieve setting '{normalizedKey}'.", ex);
             }
         }
 
@@ -145,7 +143,7 @@ namespace InventoryManagementApp.Services.Settings
                 using var rdr = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
                 while (await rdr.ReadAsync(cancellationToken).ConfigureAwait(false))
                 {
-                    var key = rdr["Key"]?.ToString();
+                    var key = NormalizeOptionalSettingKey(rdr["Key"]?.ToString());
                     var value = rdr["Value"]?.ToString();
                     if (key != null && value != null)
                         dict[key] = value;
@@ -189,10 +187,7 @@ namespace InventoryManagementApp.Services.Settings
             var normalizedKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (var kv in settings)
             {
-                if (string.IsNullOrWhiteSpace(kv.Key))
-                    throw new ArgumentException("Key cannot be null or empty.", nameof(settings));
-
-                var normalizedKey = kv.Key.Trim();
+                var normalizedKey = NormalizeRequiredSettingKey(kv.Key, nameof(settings));
                 if (!normalizedKeys.Add(normalizedKey))
                     throw new ArgumentException("Duplicate setting keys are not allowed.", nameof(settings));
 
@@ -238,10 +233,7 @@ namespace InventoryManagementApp.Services.Settings
         public async Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
         {
             _auth.EnsurePermission(User.PermissionSettings);
-            if (string.IsNullOrWhiteSpace(key))
-                throw new ArgumentException("Key cannot be null or empty.", nameof(key));
-
-            var normalizedKey = key.Trim();
+            var normalizedKey = NormalizeRequiredSettingKey(key, nameof(key));
 
             try
             {
@@ -267,6 +259,18 @@ namespace InventoryManagementApp.Services.Settings
                 _logger.LogError(ex, "Failed to delete setting {Key}", normalizedKey);
                 throw new InvalidOperationException($"Failed to delete setting '{normalizedKey}'.", ex);
             }
+        }
+
+        static string? NormalizeOptionalSettingKey(string? key) =>
+            string.IsNullOrWhiteSpace(key) ? null : key.Trim();
+
+        static string NormalizeRequiredSettingKey(string key, string parameterName)
+        {
+            var normalizedKey = NormalizeOptionalSettingKey(key);
+            if (normalizedKey is null)
+                throw new ArgumentException("Key cannot be null or empty.", parameterName);
+
+            return normalizedKey;
         }
 
         static void EnsureSettingsWriteSucceeded(int affectedRows, string key)
@@ -322,25 +326,27 @@ namespace InventoryManagementApp.Services.Settings
         public async Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default)
         {
             var value = await GetSettingAsync(ItemLabelSingularKey, cancellationToken).ConfigureAwait(false);
-            return string.IsNullOrWhiteSpace(value) ? "Item" : value;
+            return NormalizeDisplayLabel(value, "Item");
         }
 
         public async Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
         {
             _auth.EnsurePermission(User.PermissionSettings);
-            await SaveSettingAsync(ItemLabelSingularKey, label, cancellationToken).ConfigureAwait(false);
+            var normalizedLabel = NormalizeDisplayLabel(label, "Item");
+            await SaveSettingAsync(ItemLabelSingularKey, normalizedLabel, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default)
         {
             var value = await GetSettingAsync(ItemLabelPluralKey, cancellationToken).ConfigureAwait(false);
-            return string.IsNullOrWhiteSpace(value) ? "Items" : value;
+            return NormalizeDisplayLabel(value, "Items");
         }
 
         public async Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default)
         {
             _auth.EnsurePermission(User.PermissionSettings);
-            await SaveSettingAsync(ItemLabelPluralKey, label, cancellationToken).ConfigureAwait(false);
+            var normalizedLabel = NormalizeDisplayLabel(label, "Items");
+            await SaveSettingAsync(ItemLabelPluralKey, normalizedLabel, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
@@ -374,10 +380,15 @@ namespace InventoryManagementApp.Services.Settings
         public async Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
         {
             _auth.EnsurePermission(User.PermissionSettings);
-            var dict = visibility.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);
+            if (visibility is null)
+                throw new ArgumentNullException(nameof(visibility));
+
+            var normalizedVisibility = Enum.GetValues<ItemDetailField>()
+                .ToDictionary(f => f, f => visibility.TryGetValue(f, out var visible) ? visible : true);
+            var dict = normalizedVisibility.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);
             var json = JsonSerializer.Serialize(dict);
             await SaveSettingAsync(ItemDetailVisibilityKey, json, cancellationToken).ConfigureAwait(false);
-            ItemDetailVisibilityChanged?.Invoke(this, new Dictionary<ItemDetailField, bool>(visibility));
+            ItemDetailVisibilityChanged?.Invoke(this, normalizedVisibility);
         }
 
         public async Task<double> GetItemCardSizeAsync(CancellationToken cancellationToken = default)
@@ -401,5 +412,8 @@ namespace InventoryManagementApp.Services.Settings
             await SaveSettingAsync(ItemCardSizeKey, value, cancellationToken).ConfigureAwait(false);
             ItemCardSizeChanged?.Invoke(this, size);
         }
+
+        static string NormalizeDisplayLabel(string? label, string defaultLabel) =>
+            string.IsNullOrWhiteSpace(label) ? defaultLabel : label.Trim();
     }
 }

--- a/ToDo.md
+++ b/ToDo.md
@@ -19,6 +19,7 @@ Current repository evidence:
 - User create/update workflows now normalize profile and access text before first-user/existing-user checks and database writes, including canonicalized permission keys and nullable optional profile fields.
 - Rental/email/company configuration text now normalizes user-entered display and delivery settings before persistence and readback while preserving password/API-key secret values.
 - Category/inventory linking now sends domain refresh messages when a new association is created, and inventory ensure/update now refreshes dependent item/report/category views when a normalized location label changes.
+- Settings readback now normalizes setting keys consistently with save/delete paths, item label settings trim/default display text, and item-detail visibility saves persist and broadcast a complete field map.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -71,6 +72,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - User create/update paths now normalize username, photo path, contact fields, role, and permissions before workflow checks and persistence, with blank optional profile/access fields stored as database null values.
 - Rental configuration paths now trim email delivery, company/contact, backup, SMS provider/sender, and reminder template settings at the configuration boundary, defaulting whitespace-only display values while preserving untrimmed secret settings.
 - Category/inventory association changes now refresh dependent category, item, and report views when new links are created; inventory location ensures now update stale labels and refresh only when a row actually changes.
+- Settings key readback now matches normalized write/delete behavior, all-settings readback normalizes keys, item label settings trim/default display text, and item-detail visibility saves canonical full field maps.
 
 ## Highest-Value Next Work
 
@@ -95,7 +97,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, and category/inventory refresh changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, and settings normalization changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Normalized `GetSettingAsync` keys before database lookup and returned `null` for blank read keys before connection work.
- Normalized keys returned by `GetAllSettingsAsync` and skipped blank stored keys.
- Centralized optional/required setting key normalization and routed save/update/delete/read paths through it.
- Trimmed item label singular/plural settings on save and readback, defaulting blank values to `Item` / `Items`.
- Canonicalized item-detail visibility saves so every known `ItemDetailField` is persisted and emitted to listeners, defaulting omitted fields to visible.
- Added behavior coverage for padded-key round trips, blank read keys, normalized all-settings output, label trimming/defaulting, and canonical visibility readback/events.
- Expanded source-contract coverage so future edits cannot reintroduce raw setting-key reads or partial visibility event payloads.
- Added a progress note and refreshed `ToDo.md`.

## Why this was the highest-value next step

Current repo notes say to keep tightening configuration/data-quality behavior only where current evidence shows user-entered text can bypass validation or consistency. Settings writes/deletes normalized keys, but readback still bound raw keys. Item label settings also preserved accidental whitespace, and item-detail visibility saves could notify subscribers with partial maps. This is a real admin/settings workflow consistency issue without reopening already-completed import/export/report work.

## Why this is real progress

This is a complete settings workflow slice across persistence boundary behavior, user-facing display labels, visibility payload consistency, behavioral tests, source-contract coverage, and durable progress notes. It includes more than isolated cleanup and keeps the scope inside the active app.

## Validation

- Connector compare confirmed the branch is current with `master`, ahead by 5 commits, and limited to:
  - `InventoryManagementApp/Services/Settings/SettingsService.cs`
  - `InventoryManagementApp.Tests/SettingsServiceTests.cs`
  - `InventoryManagementApp.Tests/SettingsServiceWriteGuardContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-settings-normalization-hardening.md`
  - `ToDo.md`
- Connector readback confirmed `GetSettingAsync` now uses `NormalizeOptionalSettingKey`, returns before connection work for blank keys, and binds `normalizedKey`.
- Connector readback confirmed `GetAllSettingsAsync` normalizes stored keys before adding them to the dictionary.
- Connector readback confirmed item label save/read paths use `NormalizeDisplayLabel` and item-detail visibility saves canonicalize `Enum.GetValues<ItemDetailField>()` before JSON persistence and event notification.

## Could not be checked

Local validation could not be run in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and the environment does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime. Full Windows validation is still needed with:

```powershell
pwsh -File scripts/run-full-validation.ps1
```

## Known follow-up work

- Run the full Windows/.NET validation runner on a capable checkout.
- Continue the production dependency/security review after real package audit output is available.
- Smoke test settings/theme-customized popup surfaces in the WPF app on Windows.