### PR TITLE
Normalize rental readback display text

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceReadNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceReadNormalizationContractTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalServiceReadNormalizationContractTests
+    {
+        [Fact]
+        public void RentalMapperNormalizesAllDisplayTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+            var mapRental = ExtractMethod(source, "Rental? MapRental(IDataRecord r)", "DateTime ParseDateOrDefault");
+
+            AssertContainsAll(
+                mapRental,
+                "Status = ValidateString(r[\"Status\"], \"Status\")",
+                "ItemNumber = ValidateString(r[\"ItemNumber\"], \"ItemNumber\")",
+                "CustomerName = ValidateString(r[\"Company\"], \"Company\")",
+                "CustomerContact = ValidateString(r[\"Contact\"], \"Contact\")",
+                "CustomerEmail = ValidateString(r[\"Email\"], \"Email\")",
+                "CustomerPhone = ValidateString(r[\"Phone\"], \"Phone\")",
+                "CustomerMobile = ValidateString(r[\"Mobile\"], \"Mobile\")",
+                "CustomerAddress = ValidateString(r[\"Address\"], \"Address\")",
+                "ImagePath = ValidateString(r[\"ImagePath\"], \"ImagePath\")",
+                "ItemLocation = ValidateString(r[\"ItemLocation\"], \"ItemLocation\")");
+
+            var validateString = ExtractMethod(source, "string ValidateString(object? value, string field)", "private static string NormalizeRentalReadText");
+            AssertContainsAll(
+                validateString,
+                "var text = NormalizeRentalReadText(value);",
+                "if (string.IsNullOrEmpty(text))",
+                "return text;");
+
+            var normalizer = ExtractMethod(source, "private static string NormalizeRentalReadText(object? value)", "public async Task RentItemAsync");
+            AssertContainsAll(
+                normalizer,
+                "value?.ToString()?.Trim() ?? string.Empty");
+        }
+
+        [Fact]
+        public void RentalFrequencyNormalizesItemSummaryText()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+            var frequencyMethod = ExtractMethod(source, "public async Task<List<ItemRentalFrequency>> GetRentalFrequencyAsync", "private static async Task<int> GetAvailableQuantityForExistingItemAsync");
+
+            AssertContainsAll(
+                frequencyMethod,
+                "ItemNumber = NormalizeRentalReadText(reader[\"ItemNumber\"])",
+                "ItemName = NormalizeRentalReadText(reader[\"NameDescription\"])");
+
+            Assert.DoesNotContain("ItemNumber = reader[\"ItemNumber\"]?.ToString() ?? string.Empty", frequencyMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("ItemName = reader[\"NameDescription\"]?.ToString() ?? string.Empty", frequencyMethod, StringComparison.Ordinal);
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-rental-read-text-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-rental-read-text-normalization.md
@@ -1,0 +1,34 @@
+# Rental Read Text Normalization
+
+Date: 2026-07-02
+
+## Completed
+
+- Normalized rental display text when mapping joined rental rows back from SQLite.
+- Trimmed rental status readback before list/history consumers see it.
+- Trimmed item number, item location, and image path readback for active, overdue, all-rental, and rental-history screens.
+- Trimmed customer company, contact, email, phone, mobile, and address readback for rental screens, reports, reminders, and printable documents.
+- Preserved existing empty-string fallback and warning behavior for missing rental display fields.
+- Added a shared `NormalizeRentalReadText(...)` helper so rental row mapping and rental frequency summaries share the same readback rule.
+- Normalized rental frequency item number and item name output before returning dashboard/report summary models.
+- Added source-contract coverage that keeps every rental row display field routed through the readback normalizer.
+- Added source-contract coverage that prevents rental frequency summaries from returning raw item text again.
+- Kept the change scoped to rental readback/display data quality without changing rental write semantics or query caps.
+
+## Why
+
+Recent scheduled work normalized many save/import/configuration boundaries, but current `RentalService` evidence still showed rental list/history/frequency outputs returning raw item and customer text from joined rows. Legacy padded values could therefore leak into rental grids, overdue views, customer handoff details, reminders, reports, and printable rental documents even after newer save paths were hardened.
+
+## Validation
+
+- GitHub connector source readback should confirm `ValidateString(...)` routes through `NormalizeRentalReadText(...)`, and that rental frequency item number/name values use the same helper.
+- Full local validation still requires a Windows/.NET-capable checkout with:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```
+
+## Follow-up
+
+- Run the full Windows/.NET validation runner when available.
+- Smoke test rental screens, rental history, overdue rentals, rental frequency dashboard/report surfaces, and printable rental documents against legacy rows with padded item/customer text.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -147,13 +147,18 @@ namespace InventoryManagementApp.Services.Rentals
 
         string ValidateString(object? value, string field)
         {
-            var text = value?.ToString();
-            if (string.IsNullOrWhiteSpace(text))
+            var text = NormalizeRentalReadText(value);
+            if (string.IsNullOrEmpty(text))
             {
                 _logger.LogWarning("{Field} was null or empty while mapping rental", field);
                 return string.Empty;
             }
             return text;
+        }
+
+        private static string NormalizeRentalReadText(object? value)
+        {
+            return value?.ToString()?.Trim() ?? string.Empty;
         }
 
         /// <summary>
@@ -510,8 +515,8 @@ namespace InventoryManagementApp.Services.Rentals
                 frequencies.Add(new ItemRentalFrequency
                 {
                     ItemID = Convert.ToInt32(reader["ItemID"]),
-                    ItemNumber = reader["ItemNumber"]?.ToString() ?? string.Empty,
-                    ItemName = reader["NameDescription"]?.ToString() ?? string.Empty,
+                    ItemNumber = NormalizeRentalReadText(reader["ItemNumber"]),
+                    ItemName = NormalizeRentalReadText(reader["NameDescription"]),
                     RentalCount = Convert.ToInt32(reader["RentalCount"])
                 });
             }

--- a/ToDo.md
+++ b/ToDo.md
@@ -20,6 +20,7 @@ Current repository evidence:
 - Rental/email/company configuration text now normalizes user-entered display and delivery settings before persistence and readback while preserving password/API-key secret values.
 - Category/inventory linking now sends domain refresh messages when a new association is created, and inventory ensure/update now refreshes dependent item/report/category views when a normalized location label changes.
 - Settings readback now normalizes setting keys consistently with save/delete paths, item label settings trim/default display text, and item-detail visibility saves persist and broadcast a complete field map.
+- Rental list, history, and frequency readback now trims legacy item/customer/display text before screens, reports, reminders, and printable rental documents consume it.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -73,6 +74,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Rental configuration paths now trim email delivery, company/contact, backup, SMS provider/sender, and reminder template settings at the configuration boundary, defaulting whitespace-only display values while preserving untrimmed secret settings.
 - Category/inventory association changes now refresh dependent category, item, and report views when new links are created; inventory location ensures now update stale labels and refresh only when a row actually changes.
 - Settings key readback now matches normalized write/delete behavior, all-settings readback normalizes keys, item label settings trim/default display text, and item-detail visibility saves canonical full field maps.
+- Rental row mapping and rental frequency summaries now trim legacy joined item/customer/display text before returning models to rental grids, dashboard/report summaries, reminders, and printable documents.
 
 ## Highest-Value Next Work
 
@@ -83,7 +85,7 @@ Prioritize the following before adding unrelated new features:
 3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, and theme-customized popup surfaces.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
 5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
-6. Keep tightening import/export, save-path, operational-record, configuration, and document-output data-quality behavior only where current evidence shows another concrete user-entered or file-imported text path can bypass validation, duplicate detection, search/report consistency, permission consistency, delivery reliability, or professional output expectations.
+6. Keep tightening import/export, save-path, operational-record, configuration, and document-output data-quality behavior only where current evidence shows another concrete user-entered, file-imported, or legacy stored value can bypass validation, duplicate detection, search/report consistency, permission consistency, delivery reliability, or professional output expectations.
 
 ## App Completion Status
 
@@ -97,7 +99,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, and settings normalization changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, and rental readback normalization changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Normalized rental row display text through a shared `NormalizeRentalReadText(...)` helper when mapping joined rental rows from SQLite.
- Trimmed rental status readback before active, overdue, all-rental, and history consumers see it.
- Trimmed item number, item location, and image path readback for rental grids, rental history, reports, reminders, and printable rental documents.
- Trimmed customer company, contact, email, phone, mobile, and address readback for rental-facing workflows.
- Preserved the existing empty-string fallback and warning behavior for missing rental display fields.
- Routed rental frequency item number and item name summaries through the same readback normalizer.
- Added source-contract coverage for every rental mapper display field.
- Added source-contract coverage preventing rental frequency summaries from returning raw item text again.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this slice without fresh evidence.

## Why this was the highest-value next step

Recent repository evidence shows save/import/configuration normalization work is already merged across items, customers, operational records, reservations, kits, users, rental configuration, categories, and settings. Current `RentalService` still returned raw joined item/customer text when reading rental rows and rental frequency summaries. Legacy padded values could leak into rental screens, overdue views, customer handoff details, reports, reminders, and printable rental documents even after newer save paths were hardened.

## Why this is large enough to count as real progress

This is a complete rental readback/display workflow slice across active rentals, overdue rentals, all rentals, item/customer rental histories, rental frequency summaries, source-contract coverage, progress notes, and the current work queue. It improves existing workflow output quality without adding unrelated features or repeating recently completed normalization paths.

## Validation

- Connector compare confirmed the branch is current with `master`, ahead by 4 commits, and limited to:
  - `InventoryManagementApp/Services/Rentals/RentalService.cs`
  - `InventoryManagementApp.Tests/RentalServiceReadNormalizationContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-rental-read-text-normalization.md`
  - `ToDo.md`
- Connector source readback confirmed `ValidateString(...)` now routes through `NormalizeRentalReadText(...)`, which trims readback text and preserves empty-string fallback.
- Connector source readback confirmed rental row mapping covers status, item number, customer company/contact/email/phone/mobile/address, image path, and item location through `ValidateString(...)`.
- Connector source readback confirmed `GetRentalFrequencyAsync(...)` now normalizes item number and item name with `NormalizeRentalReadText(...)`.
- Connector source readback confirmed `RentalServiceReadNormalizationContractTests` guards mapper field coverage and rental frequency summary normalization.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `daa64406790eb9efe4ce4835dd58465c131216a9`.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test rental screens, rental history, overdue rentals, rental frequency dashboard/report surfaces, reminders, and printable rental documents against legacy rows with padded item/customer text.