### PR TITLE
Normalize item readback text projection

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryReadNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryReadNormalizationContractTests.cs
@@ -74,7 +74,7 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("Location, Brand, PartNumber, Supplier", projection, StringComparison.Ordinal);
             Assert.DoesNotContain("Notes, Keywords", projection, StringComparison.Ordinal);
             Assert.DoesNotContain("ImagePath, IsCheckedOut, CheckedOutBy", projection, StringComparison.Ordinal);
-            Assert.DoesNotContain("CheckedInBy, CheckedInTime", projection, StringComparison.Ordinal);
+            Assert.DoesNotContain("CheckedOutBy, CheckedOutTime, CheckedInBy", projection, StringComparison.Ordinal);
             Assert.DoesNotContain("IsIncomplete, MissingComponentsNotes, IssuesNotes", projection, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/ItemRepositoryReadNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryReadNormalizationContractTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemRepositoryReadNormalizationContractTests
+    {
+        [Fact]
+        public void ItemProjectionNormalizesAllReadbackTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+            var projection = ExtractProjection(source);
+
+            AssertContainsAll(
+                projection,
+                "TRIM(IFNULL(ItemNumber, '')) AS ItemNumber",
+                "TRIM(IFNULL(NameDescription, '')) AS Name",
+                "TRIM(IFNULL(Location, '')) AS Location",
+                "TRIM(IFNULL(Brand, '')) AS Brand",
+                "TRIM(IFNULL(PartNumber, '')) AS PartNumber",
+                "TRIM(IFNULL(Supplier, '')) AS Supplier",
+                "TRIM(IFNULL(Notes, '')) AS Notes",
+                "TRIM(IFNULL(Keywords, '')) AS Keywords",
+                "TRIM(IFNULL(ImagePath, '')) AS ImagePath",
+                "TRIM(IFNULL(CheckedOutBy, '')) AS CheckedOutBy",
+                "TRIM(IFNULL(CheckedInBy, '')) AS CheckedInBy",
+                "TRIM(IFNULL(MissingComponentsNotes, '')) AS MissingComponentsNotes",
+                "TRIM(IFNULL(IssuesNotes, '')) AS IssuesNotes");
+        }
+
+        [Fact]
+        public void ItemProjectionPreservesNonTextAndNullableTimestampReadbackContracts()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+            var projection = ExtractProjection(source);
+
+            AssertContainsAll(
+                projection,
+                "PurchasedDate",
+                "AvailableQuantity AS QuantityOnHand",
+                "RentedQuantity",
+                "IsRentalItem",
+                "Price",
+                "IsCheckedOut",
+                "CheckedOutTime",
+                "CheckedInTime",
+                "IsPowered",
+                "NULLIF(TRIM(UpdatedAt), '') AS UpdatedAt",
+                "IsIncomplete",
+                "CheckoutCount");
+        }
+
+        [Fact]
+        public void AllItemReadModelsUseTheSharedNormalizedProjection()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+
+            AssertMethodUsesProjection(source, "public async IAsyncEnumerable<Item> GetPageAsync", "public async Task<int> CountAsync");
+            AssertMethodUsesProjection(source, "public async Task<Item?> GetByIdAsync", "public async Task SaveChangesAsync");
+            AssertMethodUsesProjection(source, "public async Task<List<Item>> GetItemsCheckedOutByAsync", "public async Task<List<Item>> GetCheckedOutItemsAsync");
+            AssertMethodUsesProjection(source, "public async Task<List<Item>> GetCheckedOutItemsAsync", "public async Task UpdateItemImageAsync");
+            AssertMethodUsesProjection(source, "public async Task<List<Item>> GetMostCommonlyUsedItemsAsync", "public async Task<List<Item>> GetIncompleteItemsAsync");
+            AssertMethodUsesProjection(source, "public async Task<List<Item>> GetIncompleteItemsAsync", "private static (string WhereClause, DynamicParameters Parameters) BuildFilter");
+        }
+
+        [Fact]
+        public void ItemReadbackNoLongerProjectsRawUserTextColumns()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+            var projection = ExtractProjection(source);
+
+            Assert.DoesNotContain("ItemNumber, NameDescription AS Name", projection, StringComparison.Ordinal);
+            Assert.DoesNotContain("Location, Brand, PartNumber, Supplier", projection, StringComparison.Ordinal);
+            Assert.DoesNotContain("Notes, Keywords", projection, StringComparison.Ordinal);
+            Assert.DoesNotContain("ImagePath, IsCheckedOut, CheckedOutBy", projection, StringComparison.Ordinal);
+            Assert.DoesNotContain("CheckedInBy, CheckedInTime", projection, StringComparison.Ordinal);
+            Assert.DoesNotContain("IsIncomplete, MissingComponentsNotes, IssuesNotes", projection, StringComparison.Ordinal);
+        }
+
+        private static string ExtractProjection(string source)
+        {
+            const string marker = "private const string ItemProjection = \"";
+            var start = source.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(start >= 0, "Could not find ItemProjection constant.");
+            start += marker.Length;
+
+            var end = source.IndexOf("\";", start, StringComparison.Ordinal);
+            Assert.True(end > start, "Could not find ItemProjection constant terminator.");
+
+            return source[start..end];
+        }
+
+        private static void AssertMethodUsesProjection(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+            Assert.Contains("{ItemProjection}", method, StringComparison.Ordinal);
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -12,7 +12,7 @@ namespace InventoryManagementApp.Data;
 public sealed class ItemRepository : IItemRepository
 {
     private readonly SqliteConnectionFactory _factory;
-    private const string ItemProjection = "ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, CheckedInBy, CheckedInTime, IsPowered, NULLIF(TRIM(UpdatedAt), '') AS UpdatedAt, IsIncomplete, MissingComponentsNotes, IssuesNotes, CheckoutCount";
+    private const string ItemProjection = "ItemID, TRIM(IFNULL(ItemNumber, '')) AS ItemNumber, TRIM(IFNULL(NameDescription, '')) AS Name, TRIM(IFNULL(Location, '')) AS Location, TRIM(IFNULL(Brand, '')) AS Brand, TRIM(IFNULL(PartNumber, '')) AS PartNumber, TRIM(IFNULL(Supplier, '')) AS Supplier, PurchasedDate, TRIM(IFNULL(Notes, '')) AS Notes, TRIM(IFNULL(Keywords, '')) AS Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, TRIM(IFNULL(ImagePath, '')) AS ImagePath, IsCheckedOut, TRIM(IFNULL(CheckedOutBy, '')) AS CheckedOutBy, CheckedOutTime, TRIM(IFNULL(CheckedInBy, '')) AS CheckedInBy, CheckedInTime, IsPowered, NULLIF(TRIM(UpdatedAt), '') AS UpdatedAt, IsIncomplete, TRIM(IFNULL(MissingComponentsNotes, '')) AS MissingComponentsNotes, TRIM(IFNULL(IssuesNotes, '')) AS IssuesNotes, CheckoutCount";
 
     public ItemRepository(SqliteConnectionFactory factory)
         => _factory = factory;

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-item-readback-text-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-item-readback-text-normalization.md
@@ -1,0 +1,23 @@
+# Item Readback Text Normalization
+
+Date: 2026-07-02
+
+## Completed
+
+- Normalized the shared `ItemRepository.ItemProjection` text fields so legacy stored whitespace is trimmed before item models reach the UI, exports, reports, image import matching, dashboard summaries, and checkout workflows.
+- Covered item identity fields: item number, name, location, brand, part number, and supplier.
+- Covered item detail and search/export fields: notes, keywords, and image path.
+- Covered checkout attribution fields: checked-out-by and checked-in-by.
+- Covered incomplete/problem note fields: missing-components notes and issue notes.
+- Preserved non-text read contracts for purchased date, quantities, rental flags, price, checkout status/times, powered/incomplete flags, checkout counts, and nullable trimmed `UpdatedAt`.
+- Added source-contract coverage that all item read-model entry points continue to use the shared projection: paged item reads, item detail lookup, checked-out-by lists, all checked-out lists, most-common items, and incomplete items.
+
+## Why This Mattered
+
+Recent save and import work normalized user-entered item text before persistence, but older database rows could still contain padded item text. Because the repository projection feeds multiple user-facing workflows, normalizing at this shared read boundary keeps existing data professional and consistent without requiring a migration or touching unrelated workflows.
+
+## Validation
+
+- Source inspection confirmed the projection now trims the intended item text columns at the SQLite read boundary.
+- Added `ItemRepositoryReadNormalizationContractTests` to pin field coverage, non-text preservation, and use of the shared projection by all item read-model methods.
+- Local `dotnet` tests, PowerShell validation, WPF runtime checks, screenshots, and `pwsh -File scripts/run-full-validation.ps1` could not be run in this scheduled Linux environment because direct checkout is blocked and the required Windows/.NET tooling is unavailable.

--- a/ToDo.md
+++ b/ToDo.md
@@ -21,6 +21,7 @@ Current repository evidence:
 - Category/inventory linking now sends domain refresh messages when a new association is created, and inventory ensure/update now refreshes dependent item/report/category views when a normalized location label changes.
 - Settings readback now normalizes setting keys consistently with save/delete paths, item label settings trim/default display text, and item-detail visibility saves persist and broadcast a complete field map.
 - Rental list, history, and frequency readback now trims legacy item/customer/display text before screens, reports, reminders, and printable rental documents consume it.
+- Item repository readback now trims legacy item identity, detail, checkout attribution, image path, and incomplete/problem-note text through the shared item projection before grids, exports, dashboards, image import matching, reports, and item detail views consume it.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -75,6 +76,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Category/inventory association changes now refresh dependent category, item, and report views when new links are created; inventory location ensures now update stale labels and refresh only when a row actually changes.
 - Settings key readback now matches normalized write/delete behavior, all-settings readback normalizes keys, item label settings trim/default display text, and item-detail visibility saves canonical full field maps.
 - Rental row mapping and rental frequency summaries now trim legacy joined item/customer/display text before returning models to rental grids, dashboard/report summaries, reminders, and printable documents.
+- Item repository projection now trims item number, name, location, brand, part number, supplier, notes, keywords, image path, checkout user names, missing-components notes, and issue notes before item read models reach search grids, details, dashboards, exports, image import matching, checked-out lists, incomplete lists, and reports.
 
 ## Highest-Value Next Work
 
@@ -99,7 +101,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, and rental readback normalization changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, and item readback normalization changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Normalized item readback text in the shared `ItemRepository.ItemProjection` instead of only normalizing item save/import inputs.
- Trimmed legacy stored whitespace for item number, name, location, brand, part number, supplier, notes, keywords, image path, checkout user names, missing-components notes, and issue notes.
- Preserved non-text projection behavior for dates, quantities, rental flags, price, checkout status/times, powered/incomplete flags, checkout counts, and nullable trimmed `UpdatedAt`.
- Added source-contract coverage for the normalized field set and for every item read-model path that relies on the shared projection: paged reads, item detail lookup, checked-out-by reads, checked-out reads, most-common items, and incomplete items.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this slice.

## Why this was the highest-value next step

Recent work normalized item imports and item save paths, but current source evidence showed older database rows could still return padded item text through the repository projection. That projection feeds core item workflows, so normalizing there improves search grids, detail views, exports, dashboards, image import matching, checked-out lists, incomplete lists, and reports without a data migration.

## Why this is real progress

This is a shared read-boundary fix rather than a small visual tweak. One repository projection now consistently cleans thirteen item text fields across multiple workflows, and the tests guard both field coverage and method coverage so later changes do not silently bypass it.

## Validation

- GitHub connector compare confirmed the branch is current with `master` and focused on `ItemRepository`, one source-contract test file, one progress note, and `ToDo.md`.
- Connector readback confirmed the shared item projection trims the intended fields with `TRIM(IFNULL(..., ''))` while preserving the nullable trimmed `UpdatedAt` contract.
- Connector status/workflow readback found no attached commit statuses or workflow runs for the branch head.

## Could not check

- Local `dotnet restore`, build, test, and `pwsh -File scripts/run-full-validation.ps1` could not be run because this scheduled Linux environment cannot clone the repo directly and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
- WPF runtime screenshots, print-preview checks, and local banned-word scans could not be run for the same environment reason.

## Follow-up work

- Run the full Windows/.NET validation runner on a capable checkout.
- Smoke test item search, item detail, checked-out lists, exports, dashboards, image import matching, and reports with legacy whitespace-padded item rows.
- Continue data-quality hardening only where current source evidence shows another concrete read/write/import/export boundary gap.