### PR TITLE
Normalize reservation readback display text

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceReadNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceReadNormalizationContractTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReservationServiceReadNormalizationContractTests
+    {
+        [Fact]
+        public void ReservationMapperNormalizesAllDisplayTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+            var mapReservation = ExtractMethod(source, "private Reservation MapReservation(SqliteDataReader reader)", "private static string NormalizeReservationReadText");
+
+            AssertContainsAll(
+                mapReservation,
+                "ItemNumber = NormalizeReservationReadText(reader, \"ItemNumber\")",
+                "ItemName = NormalizeReservationReadText(reader, \"ItemName\")",
+                "CustomerName = NormalizeReservationReadText(reader, \"CustomerName\")",
+                "ImagePath = NormalizeReservationReadText(reader, \"ImagePath\")",
+                "Status = NormalizeReservationReadText(reader, \"Status\")",
+                "Notes = NormalizeReservationReadText(reader, \"Notes\")");
+
+            Assert.DoesNotContain("reader.GetString(reader.GetOrdinal(\"ItemNumber\"))", mapReservation, StringComparison.Ordinal);
+            Assert.DoesNotContain("reader.GetString(reader.GetOrdinal(\"ItemName\"))", mapReservation, StringComparison.Ordinal);
+            Assert.DoesNotContain("reader.GetString(reader.GetOrdinal(\"CustomerName\"))", mapReservation, StringComparison.Ordinal);
+            Assert.DoesNotContain("reader.GetString(reader.GetOrdinal(\"ImagePath\"))", mapReservation, StringComparison.Ordinal);
+            Assert.DoesNotContain("Status = reader.GetString", mapReservation, StringComparison.Ordinal);
+            Assert.DoesNotContain("Notes = reader.IsDBNull", mapReservation, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationReadNormalizerTrimsValuesAndPreservesEmptyFallback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+            var normalizer = ExtractMethod(source, "private static string NormalizeReservationReadText(SqliteDataReader reader, string columnName)", "private static void ValidateReservation");
+
+            AssertContainsAll(
+                normalizer,
+                "var ordinal = reader.GetOrdinal(columnName);",
+                "return reader.IsDBNull(ordinal) ? string.Empty : reader.GetString(ordinal).Trim();");
+        }
+
+        [Fact]
+        public void ReservationReadMethodsShareTheNormalizedMapper()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+
+            AssertReadMethodUsesMapper(source, "public async Task<List<Reservation>> GetAllReservationsAsync()", "public async Task<int> CountReservationsAsync()");
+            AssertReadMethodUsesMapper(source, "public async Task<List<Reservation>> GetActiveReservationsAsync()", "public async Task<List<Reservation>> GetReservationsByItemAsync(int itemID)");
+            AssertReadMethodUsesMapper(source, "public async Task<List<Reservation>> GetReservationsByItemAsync(int itemID)", "public async Task<List<Reservation>> GetReservationsByCustomerAsync(int customerID)");
+            AssertReadMethodUsesMapper(source, "public async Task<List<Reservation>> GetReservationsByCustomerAsync(int customerID)", "public async Task<List<Reservation>> GetUpcomingReservationsAsync(int days = 7)");
+            AssertReadMethodUsesMapper(source, "public async Task<List<Reservation>> GetUpcomingReservationsAsync(int days = 7)", "public async Task<int> CountActiveReservationsAsync()");
+            AssertReadMethodUsesMapper(source, "public async Task<Reservation?> GetReservationByIdAsync(int reservationID)", "public async Task<int> CreateReservationAsync(Reservation reservation)");
+        }
+
+        private static void AssertReadMethodUsesMapper(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+            Assert.Contains("MapReservation(reader)", method, StringComparison.Ordinal);
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-reservation-read-text-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-reservation-read-text-normalization.md
@@ -1,0 +1,35 @@
+# Reservation Read Text Normalization
+
+Date: 2026-07-02
+
+## Completed
+
+- Normalized reservation display text when mapping joined reservation rows back from SQLite.
+- Trimmed item number, item name, customer name, and item image path before reservation grids, previews, reports, and detail surfaces consume them.
+- Trimmed reservation status and notes readback so legacy padded reservation rows render consistently with newer save-path normalization.
+- Preserved the existing empty-string fallback for nullable joined display columns.
+- Added a shared `NormalizeReservationReadText(...)` helper so reservation list/detail read methods use one readback rule.
+- Kept reservation date, quantity, IDs, rental references, and create/update write semantics unchanged.
+- Added source-contract coverage for every reservation mapper display field.
+- Added source-contract coverage for the trim/null fallback helper behavior.
+- Added source-contract coverage that all reservation read methods continue to route through the shared mapper: all reservations, active reservations, item reservations, customer reservations, upcoming reservations, and single-reservation detail lookup.
+- Kept the change scoped to reservation readback/display data quality without adding unrelated features.
+
+## Why
+
+Recent save-path work normalized reservation status and notes before persistence, and recent rental/item readback work trimmed legacy display text before those workflows reached screens, reports, reminders, and documents. Current reservation source evidence still returned raw joined item/customer/image text plus raw reservation status/notes from the mapper. Legacy padded values could therefore leak into reservation screens and report/preview surfaces even after newer save paths were hardened.
+
+## Validation
+
+- GitHub connector readback should confirm `MapReservation(...)` routes item number, item name, customer name, image path, status, and notes through `NormalizeReservationReadText(...)`.
+- Source-contract coverage was added in `ReservationServiceReadNormalizationContractTests`.
+- Full local validation still requires a Windows/.NET-capable checkout with:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```
+
+## Follow-up
+
+- Run the full Windows/.NET validation runner when available.
+- Smoke test reservation grids, upcoming reservations, reservation details, report/preview surfaces, and printable reservation-related output against legacy rows with padded item/customer/status/note text.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -477,20 +477,26 @@ namespace InventoryManagementApp.Services.Reservations
                 ReservationID = reader.GetInt32(reader.GetOrdinal("ReservationID")),
                 ItemID = reader.GetInt32(reader.GetOrdinal("ItemID")),
                 CustomerID = reader.GetInt32(reader.GetOrdinal("CustomerID")),
-                ItemNumber = reader.IsDBNull(reader.GetOrdinal("ItemNumber")) ? "" : reader.GetString(reader.GetOrdinal("ItemNumber")),
-                ItemName = reader.IsDBNull(reader.GetOrdinal("ItemName")) ? "" : reader.GetString(reader.GetOrdinal("ItemName")),
-                CustomerName = reader.IsDBNull(reader.GetOrdinal("CustomerName")) ? "" : reader.GetString(reader.GetOrdinal("CustomerName")),
-                ImagePath = reader.IsDBNull(reader.GetOrdinal("ImagePath")) ? "" : reader.GetString(reader.GetOrdinal("ImagePath")),
+                ItemNumber = NormalizeReservationReadText(reader, "ItemNumber"),
+                ItemName = NormalizeReservationReadText(reader, "ItemName"),
+                CustomerName = NormalizeReservationReadText(reader, "CustomerName"),
+                ImagePath = NormalizeReservationReadText(reader, "ImagePath"),
                 ReservationDate = reader.GetDateTime(reader.GetOrdinal("ReservationDate")),
                 StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
                 EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
                 Quantity = reader.GetInt32(reader.GetOrdinal("Quantity")),
-                Status = reader.GetString(reader.GetOrdinal("Status")),
-                Notes = reader.IsDBNull(reader.GetOrdinal("Notes")) ? "" : reader.GetString(reader.GetOrdinal("Notes")),
+                Status = NormalizeReservationReadText(reader, "Status"),
+                Notes = NormalizeReservationReadText(reader, "Notes"),
                 CreatedByUserID = reader.GetInt32(reader.GetOrdinal("CreatedByUserID")),
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt")),
                 RentalID = reader.IsDBNull(reader.GetOrdinal("RentalID")) ? null : reader.GetInt32(reader.GetOrdinal("RentalID"))
             };
+        }
+
+        private static string NormalizeReservationReadText(SqliteDataReader reader, string columnName)
+        {
+            var ordinal = reader.GetOrdinal(columnName);
+            return reader.IsDBNull(ordinal) ? string.Empty : reader.GetString(ordinal).Trim();
         }
 
         private static void ValidateReservation(Reservation reservation, bool requireExistingId)

--- a/ToDo.md
+++ b/ToDo.md
@@ -22,6 +22,7 @@ Current repository evidence:
 - Settings readback now normalizes setting keys consistently with save/delete paths, item label settings trim/default display text, and item-detail visibility saves persist and broadcast a complete field map.
 - Rental list, history, and frequency readback now trims legacy item/customer/display text before screens, reports, reminders, and printable rental documents consume it.
 - Item repository readback now trims legacy item identity, detail, checkout attribution, image path, and incomplete/problem-note text through the shared item projection before grids, exports, dashboards, image import matching, reports, and item detail views consume it.
+- Reservation list and detail readback now trims legacy item number, item name, customer name, image path, status, and notes through the shared reservation mapper before reservation grids, upcoming views, detail views, reports, previews, and printable reservation-related output consume it.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -77,6 +78,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Settings key readback now matches normalized write/delete behavior, all-settings readback normalizes keys, item label settings trim/default display text, and item-detail visibility saves canonical full field maps.
 - Rental row mapping and rental frequency summaries now trim legacy joined item/customer/display text before returning models to rental grids, dashboard/report summaries, reminders, and printable documents.
 - Item repository projection now trims item number, name, location, brand, part number, supplier, notes, keywords, image path, checkout user names, missing-components notes, and issue notes before item read models reach search grids, details, dashboards, exports, image import matching, checked-out lists, incomplete lists, and reports.
+- Reservation row mapping now trims item number, item name, customer name, image path, status, and notes before reservation models reach all-reservation lists, active/upcoming lists, item/customer reservation histories, detail views, reports, previews, and printable reservation-related output.
 
 ## Highest-Value Next Work
 
@@ -101,7 +103,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, and item readback normalization changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, and reservation readback normalization changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Normalized reservation readback display text through a shared `NormalizeReservationReadText(...)` helper.
- Trimmed joined item number, item name, customer name, and image path before reservation models reach grids, detail views, reports, previews, and printable reservation-related output.
- Trimmed reservation status and notes on readback so legacy padded reservation rows render consistently with newer save-path normalization.
- Preserved empty-string fallback for nullable joined display columns.
- Preserved existing ID, date, quantity, rental-reference, create/update, confirm/cancel/fulfill, and query-cap behavior.
- Added source-contract coverage for every mapper display field.
- Added source-contract coverage for helper trim/null fallback behavior.
- Added source-contract coverage that all reservation read methods keep using the shared mapper: all, active, by item, by customer, upcoming, and detail lookup.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this completed slice without fresh evidence.

## Why this was the highest-value next step

Current repo evidence shows many save/import/readback normalization slices are already complete, including item and rental readback. Reservation create/update now normalizes status and notes before persistence, but `ReservationService.MapReservation(...)` still returned raw joined item/customer/image text and raw reservation status/notes. Legacy padded values could still leak into reservation screens, report/preview surfaces, and printable reservation-related output.

## Why this is large enough to count as real progress

This is a complete reservation readback workflow slice across list reads, active/upcoming reads, item/customer history reads, detail lookup, shared service mapping, source-contract coverage, progress notes, and the durable work queue. It closes an adjacent display/data-quality gap without inventing a new feature or reopening recently completed rental/item normalization work.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 commits, and limited to:
  - `InventoryManagementApp/Services/Reservations/ReservationService.cs`
  - `InventoryManagementApp.Tests/ReservationServiceReadNormalizationContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-reservation-read-text-normalization.md`
  - `ToDo.md`
- Connector readback confirmed `MapReservation(...)` routes item number, item name, customer name, image path, status, and notes through `NormalizeReservationReadText(...)`.
- Connector readback confirmed the helper trims non-null text and returns `string.Empty` for database nulls.
- Connector readback confirmed the new source-contract tests guard mapper fields, helper behavior, and all reservation read methods using the shared mapper.
- Connector status readback found no attached commit statuses on branch head `966eb46bd5c8331cf46ab532088af107de98109a` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test reservation grids, upcoming reservations, reservation detail views, report/preview surfaces, and printable reservation-related output with legacy rows containing padded item/customer/status/note text.