### PR TITLE
Normalize customer readback display text

### DIFF
--- a/InventoryManagementApp.Tests/CustomerServiceReadNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceReadNormalizationContractTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomerServiceReadNormalizationContractTests
+    {
+        [Fact]
+        public void CustomerMapperNormalizesAllCustomerDisplayFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var mapper = ExtractMethod(
+                source,
+                "CustomerModel MapCustomer(IDataRecord r)",
+                "public async Task<int> ImportCustomersAsync");
+
+            Assert.Contains("CustomerID = Convert.ToInt32(r[\"CustomerID\"])", mapper, StringComparison.Ordinal);
+            Assert.Contains("Company = NormalizeCustomerReadText(r[\"Company\"]?.ToString())", mapper, StringComparison.Ordinal);
+            Assert.Contains("Email = NormalizeCustomerReadText(r[\"Email\"]?.ToString())", mapper, StringComparison.Ordinal);
+            Assert.Contains("Contact = NormalizeCustomerReadText(r[\"Contact\"]?.ToString())", mapper, StringComparison.Ordinal);
+            Assert.Contains("Phone = NormalizeCustomerReadText(r[\"Phone\"]?.ToString())", mapper, StringComparison.Ordinal);
+            Assert.Contains("Mobile = NormalizeCustomerReadText(r[\"Mobile\"]?.ToString())", mapper, StringComparison.Ordinal);
+            Assert.Contains("Address = NormalizeCustomerReadText(r[\"Address\"]?.ToString())", mapper, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("r[\"Company\"]?.ToString() ?? string.Empty", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("r[\"Email\"]?.ToString() ?? string.Empty", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("r[\"Contact\"]?.ToString() ?? string.Empty", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("r[\"Phone\"]?.ToString() ?? string.Empty", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("r[\"Mobile\"]?.ToString() ?? string.Empty", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("r[\"Address\"]?.ToString() ?? string.Empty", mapper, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerReadNormalizerTrimsLegacyTextAndPreservesEmptyFallback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+
+            Assert.Contains("static string NormalizeCustomerReadText(string? value) => value?.Trim() ?? string.Empty;", source, StringComparison.Ordinal);
+            Assert.Contains("static string? NormalizeImportedText(string? value) => value?.Trim();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerReadAndExportPathsUseSharedMapper()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+
+            AssertReaderUsesMapper(
+                source,
+                "async Task<CustomerModel?> GetCustomerByIDInternalAsync",
+                "async Task<List<CustomerModel>> GetAllCustomersInternalAsync");
+            AssertReaderUsesMapper(
+                source,
+                "async Task<List<CustomerModel>> GetAllCustomersInternalAsync",
+                "async Task<int> CountCustomersInternalAsync");
+            AssertReaderUsesMapper(
+                source,
+                "async Task<List<CustomerModel>> SearchCustomersInternalAsync",
+                "async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync");
+            AssertReaderUsesMapper(
+                source,
+                "async Task<List<CustomerModel>> CollectCustomersForExportAsync",
+                "async Task InsertCustomerAsync");
+        }
+
+        [Fact]
+        public void CustomerExportEntrypointsCollectNormalizedReadModels()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var csvExport = ExtractMethod(
+                source,
+                "async Task ExportCustomersToCsvInternalAsync",
+                "async Task<List<CustomerModel>> CollectCustomersForExportAsync");
+            var genericExport = ExtractMethod(
+                source,
+                "public async Task ExportCustomersAsync",
+                "static void NotifyChanged");
+
+            Assert.Contains("var all = await CollectCustomersForExportAsync(cancellationToken).ConfigureAwait(false);", csvExport, StringComparison.Ordinal);
+            Assert.Contains("CsvHelperUtil.ExportCustomersToCsv(filePath, all);", csvExport, StringComparison.Ordinal);
+            Assert.Contains("var all = await CollectCustomersForExportAsync(cancellationToken).ConfigureAwait(false);", genericExport, StringComparison.Ordinal);
+            Assert.Contains("await exporter.ExportAsync(filePath, all, cancellationToken).ConfigureAwait(false);", genericExport, StringComparison.Ordinal);
+        }
+
+        private static void AssertReaderUsesMapper(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+            Assert.Contains("MapCustomer", method, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-customer-readback-text-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-customer-readback-text-normalization.md
@@ -1,0 +1,35 @@
+# Customer Readback Text Normalization
+
+Date: 2026-07-02
+
+## Summary
+
+Normalized customer readback text at the shared `CustomerService.MapCustomer(...)` mapper so legacy padded customer rows are trimmed before they reach customer-facing workflows.
+
+## Completed Improvements
+
+- Added `NormalizeCustomerReadText(...)` as the read-boundary helper for customer display/contact text.
+- Trimmed `Company` readback before customer directory lists, search results, detail reads, reports, and exports consume it.
+- Trimmed `Email` readback before customer screens, handoff surfaces, and exports consume it.
+- Trimmed `Contact` readback before customer lists, duplicate-facing display, rental/reservation handoff, and exports consume it.
+- Trimmed `Phone` readback before customer lists, report/export output, and contact workflows consume it.
+- Trimmed `Mobile` readback before customer lists, report/export output, and contact workflows consume it.
+- Trimmed `Address` readback before detail views, reports, documents, and exports consume it.
+- Preserved the existing empty-string fallback for database null customer text values.
+- Left customer IDs, required-field validation, save/import normalization, duplicate checks, update/delete write guards, and export paging behavior unchanged.
+- Added source-contract coverage for every customer mapper display/contact field.
+- Added source-contract coverage for the read normalizer trim/null fallback contract.
+- Added source-contract coverage that detail lookup, all-customer reads, search reads, and paged export collection keep using the shared mapper.
+- Added source-contract coverage that CSV and generic export entry points continue using the paged collector, which now returns normalized read models.
+
+## Validation
+
+- GitHub connector source readback should confirm `MapCustomer(...)` routes `Company`, `Email`, `Contact`, `Phone`, `Mobile`, and `Address` through `NormalizeCustomerReadText(...)`.
+- GitHub connector source readback should confirm `CustomerServiceReadNormalizationContractTests` covers mapper fields, helper behavior, customer read methods, paged export collection, and CSV/generic export handoff.
+
+Local validation could not be run in this scheduled Linux environment because direct clone is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, PowerShell/`pwsh`, GitHub CLI, and WPF runtime tooling are unavailable here.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test customer directory, customer search, customer detail, customer exports, rental/customer handoff views, reservation/customer handoff views, and customer-facing report/print output with legacy rows containing padded customer text.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -571,6 +571,8 @@ namespace InventoryManagementApp.Services.Customers
 
         static string? NormalizeImportedText(string? value) => value?.Trim();
 
+        static string NormalizeCustomerReadText(string? value) => value?.Trim() ?? string.Empty;
+
         static void ValidateCustomerRequiredFields(CustomerModel customer)
         {
             var reason = GetSkipReason(customer);
@@ -617,12 +619,12 @@ namespace InventoryManagementApp.Services.Customers
         CustomerModel MapCustomer(IDataRecord r) => new()
         {
             CustomerID = Convert.ToInt32(r["CustomerID"]),
-            Company = r["Company"]?.ToString() ?? string.Empty,
-            Email = r["Email"]?.ToString() ?? string.Empty,
-            Contact = r["Contact"]?.ToString() ?? string.Empty,
-            Phone = r["Phone"]?.ToString() ?? string.Empty,
-            Mobile = r["Mobile"]?.ToString() ?? string.Empty,
-            Address = r["Address"]?.ToString() ?? string.Empty
+            Company = NormalizeCustomerReadText(r["Company"]?.ToString()),
+            Email = NormalizeCustomerReadText(r["Email"]?.ToString()),
+            Contact = NormalizeCustomerReadText(r["Contact"]?.ToString()),
+            Phone = NormalizeCustomerReadText(r["Phone"]?.ToString()),
+            Mobile = NormalizeCustomerReadText(r["Mobile"]?.ToString()),
+            Address = NormalizeCustomerReadText(r["Address"]?.ToString())
         };
 
         public async Task<int> ImportCustomersAsync(string filePath, IDataImporter<Customer> importer, CancellationToken cancellationToken = default)

--- a/ToDo.md
+++ b/ToDo.md
@@ -23,6 +23,7 @@ Current repository evidence:
 - Rental list, history, and frequency readback now trims legacy item/customer/display text before screens, reports, reminders, and printable rental documents consume it.
 - Item repository readback now trims legacy item identity, detail, checkout attribution, image path, and incomplete/problem-note text through the shared item projection before grids, exports, dashboards, image import matching, reports, and item detail views consume it.
 - Reservation list and detail readback now trims legacy item number, item name, customer name, image path, status, and notes through the shared reservation mapper before reservation grids, upcoming views, detail views, reports, previews, and printable reservation-related output consume it.
+- Customer list, detail, search, and export readback now trims legacy company, email, contact, phone, mobile, and address text through the shared customer mapper before customer directory screens, handoff views, reports, printable output, and CSV/generic exports consume it.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -79,6 +80,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Rental row mapping and rental frequency summaries now trim legacy joined item/customer/display text before returning models to rental grids, dashboard/report summaries, reminders, and printable documents.
 - Item repository projection now trims item number, name, location, brand, part number, supplier, notes, keywords, image path, checkout user names, missing-components notes, and issue notes before item read models reach search grids, details, dashboards, exports, image import matching, checked-out lists, incomplete lists, and reports.
 - Reservation row mapping now trims item number, item name, customer name, image path, status, and notes before reservation models reach all-reservation lists, active/upcoming lists, item/customer reservation histories, detail views, reports, previews, and printable reservation-related output.
+- Customer service mapping now trims company, email, contact, phone, mobile, and address before customer list, detail, search, paged export, report, print, rental handoff, and reservation handoff consumers receive customer read models.
 
 ## Highest-Value Next Work
 
@@ -103,7 +105,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, and reservation readback normalization changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, reservation readback normalization, and customer readback normalization changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Added `NormalizeCustomerReadText(...)` for customer readback/display values.
- Trimmed legacy stored `Company`, `Email`, `Contact`, `Phone`, `Mobile`, and `Address` text in the shared `CustomerService.MapCustomer(...)` mapper.
- Preserved customer ID handling and the existing empty-string fallback for database null text values.
- Left customer save/import normalization, required-field validation, duplicate checks, write guards, delete behavior, and paged export ordering unchanged.
- Kept customer detail lookup, all-customer reads, customer search, and paged export collection on the shared mapper so customer directory screens, handoff views, reports, printable output, and CSV/generic exports consume normalized read models.
- Added `CustomerServiceReadNormalizationContractTests` to guard mapper field coverage, helper behavior, read-method mapper use, paged export collection, and CSV/generic export handoff.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this completed slice without fresh evidence.

## Why this was the highest-value next step

Current `master` already normalized customer imports and direct customer saves, and recent PRs completed item, rental, and reservation readback normalization. Source evidence still showed `CustomerService.MapCustomer(...)` returning raw stored customer text. Legacy padded customer rows could therefore still leak into customer directory/search/detail views, rental/reservation handoff surfaces, reports, printable output, and customer exports.

## Why this is large enough to count as real progress

This is a complete customer readback workflow slice across detail reads, all-customer reads, search reads, paged export collection, CSV/generic export handoff, service-layer normalization, source-contract coverage, progress notes, and the durable work queue. It closes an adjacent display/data-quality gap without inventing unrelated features or reopening recently completed item/rental/reservation work.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 commits, and limited to:
  - `InventoryManagementApp/Services/Customers/CustomerService.cs`
  - `InventoryManagementApp.Tests/CustomerServiceReadNormalizationContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-customer-readback-text-normalization.md`
  - `ToDo.md`
- Connector source readback confirmed `MapCustomer(...)` routes `Company`, `Email`, `Contact`, `Phone`, `Mobile`, and `Address` through `NormalizeCustomerReadText(...)`.
- Connector source readback confirmed `NormalizeCustomerReadText(...)` trims non-null text and preserves empty-string fallback for database nulls.
- Connector source readback confirmed the new source-contract tests guard mapper fields, helper behavior, customer read paths, paged export collection, and CSV/generic export handoff.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test customer directory, customer search, customer detail, customer exports, rental/customer handoff views, reservation/customer handoff views, and customer-facing report/print output with legacy rows containing padded customer text.