### PR TITLE
Normalize operational record readback text

### DIFF
--- a/InventoryManagementApp.Tests/OperationalRecordReadNormalizationContractTests.cs
+++ b/InventoryManagementApp.Tests/OperationalRecordReadNormalizationContractTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class OperationalRecordReadNormalizationContractTests
+    {
+        [Fact]
+        public void MaintenanceMapperNormalizesAllReadbackTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+            var mapper = ExtractMethod(source, "private MaintenanceRecord MapMaintenanceRecord(SqliteDataReader reader)", "private static string NormalizeMaintenanceReadText");
+
+            AssertContainsAll(
+                mapper,
+                "ItemNumber = NormalizeMaintenanceReadText(reader, \"ItemNumber\")",
+                "ItemName = NormalizeMaintenanceReadText(reader, \"ItemName\")",
+                "MaintenanceType = NormalizeMaintenanceReadText(reader, \"MaintenanceType\")",
+                "Description = NormalizeMaintenanceReadText(reader, \"Description\")",
+                "PerformedBy = NormalizeMaintenanceReadText(reader, \"PerformedBy\")",
+                "Status = NormalizeMaintenanceReadText(reader, \"Status\")",
+                "Notes = NormalizeMaintenanceReadText(reader, \"Notes\")");
+
+            Assert.DoesNotContain("reader.GetString(reader.GetOrdinal(\"ItemNumber\"))", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("reader.GetString(reader.GetOrdinal(\"ItemName\"))", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("reader.GetString(reader.GetOrdinal(\"MaintenanceType\"))", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("Description = reader.IsDBNull", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("PerformedBy = reader.IsDBNull", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("Status = reader.GetString", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("Notes = reader.IsDBNull", mapper, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenanceReadNormalizerTrimsValuesAndPreservesEmptyFallback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+            var normalizer = ExtractMethod(source, "private static string NormalizeMaintenanceReadText(SqliteDataReader reader, string columnName)", "private static void NormalizeMaintenanceRecordForSave");
+
+            AssertContainsAll(
+                normalizer,
+                "var ordinal = reader.GetOrdinal(columnName);",
+                "return reader.IsDBNull(ordinal) ? string.Empty : reader.GetString(ordinal).Trim();");
+        }
+
+        [Fact]
+        public void MaintenanceReadMethodsShareTheNormalizedMapper()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+
+            AssertReadMethodUsesMapper(source, "public async Task<List<MaintenanceRecord>> GetAllMaintenanceRecordsAsync()", "public async Task<int> CountMaintenanceRecordsAsync()");
+            AssertReadMethodUsesMapper(source, "public async Task<List<MaintenanceRecord>> GetMaintenanceRecordsByItemAsync(int itemID)", "public async Task<List<MaintenanceRecord>> GetOverdueMaintenanceAsync()");
+            AssertReadMethodUsesMapper(source, "public async Task<List<MaintenanceRecord>> GetOverdueMaintenanceAsync()", "public async Task<int> CountOverdueMaintenanceAsync()");
+            AssertReadMethodUsesMapper(source, "public async Task<List<MaintenanceRecord>> GetUpcomingMaintenanceAsync(int days = 30)", "public async Task<int> CountUpcomingMaintenanceAsync(int days = 30)");
+            AssertReadMethodUsesMapper(source, "public async Task<MaintenanceRecord?> GetMaintenanceRecordByIdAsync(int maintenanceID)", "public async Task<int> CreateMaintenanceRecordAsync(MaintenanceRecord record)");
+        }
+
+        [Fact]
+        public void MaintenanceScheduledFiltersNormalizeLegacyPaddedStatusText()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+
+            AssertScheduledFilterNormalizesStatus(source, "public async Task<List<MaintenanceRecord>> GetOverdueMaintenanceAsync()", "public async Task<int> CountOverdueMaintenanceAsync()");
+            AssertScheduledFilterNormalizesStatus(source, "public async Task<int> CountOverdueMaintenanceAsync()", "public async Task<List<MaintenanceRecord>> GetUpcomingMaintenanceAsync(int days = 30)");
+            AssertScheduledFilterNormalizesStatus(source, "public async Task<List<MaintenanceRecord>> GetUpcomingMaintenanceAsync(int days = 30)", "public async Task<int> CountUpcomingMaintenanceAsync(int days = 30)");
+            AssertScheduledFilterNormalizesStatus(source, "public async Task<int> CountUpcomingMaintenanceAsync(int days = 30)", "public async Task<MaintenanceRecord?> GetMaintenanceRecordByIdAsync(int maintenanceID)");
+        }
+
+        [Fact]
+        public void CalibrationMapperNormalizesAllReadbackTextFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+            var mapper = ExtractMethod(source, "private CalibrationRecord MapCalibrationRecord(SqliteDataReader reader)", "private static string NormalizeCalibrationReadText");
+
+            AssertContainsAll(
+                mapper,
+                "ItemNumber = NormalizeCalibrationReadText(reader, \"ItemNumber\")",
+                "ItemName = NormalizeCalibrationReadText(reader, \"ItemName\")",
+                "CalibratedBy = NormalizeCalibrationReadText(reader, \"CalibratedBy\")",
+                "CertificateNumber = NormalizeCalibrationReadText(reader, \"CertificateNumber\")",
+                "Standard = NormalizeCalibrationReadText(reader, \"Standard\")",
+                "Result = NormalizeCalibrationReadText(reader, \"Result\")",
+                "Notes = NormalizeCalibrationReadText(reader, \"Notes\")");
+
+            Assert.DoesNotContain("reader.GetString(reader.GetOrdinal(\"ItemNumber\"))", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("reader.GetString(reader.GetOrdinal(\"ItemName\"))", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("CalibratedBy = reader.IsDBNull", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("CertificateNumber = reader.IsDBNull", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("Standard = reader.IsDBNull", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("Result = reader.IsDBNull", mapper, StringComparison.Ordinal);
+            Assert.DoesNotContain("Notes = reader.IsDBNull", mapper, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationReadNormalizerTrimsValuesAndPreservesEmptyFallback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+            var normalizer = ExtractMethod(source, "private static string NormalizeCalibrationReadText(SqliteDataReader reader, string columnName)", "private static void NormalizeCalibrationRecordForSave");
+
+            AssertContainsAll(
+                normalizer,
+                "var ordinal = reader.GetOrdinal(columnName);",
+                "return reader.IsDBNull(ordinal) ? string.Empty : reader.GetString(ordinal).Trim();");
+        }
+
+        [Fact]
+        public void CalibrationReadMethodsShareTheNormalizedMapper()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+
+            AssertReadMethodUsesMapper(source, "public async Task<List<CalibrationRecord>> GetAllCalibrationRecordsAsync()", "public async Task<int> CountCalibrationRecordsAsync()");
+            AssertReadMethodUsesMapper(source, "public async Task<List<CalibrationRecord>> GetCalibrationRecordsByItemAsync(int itemID)", "public async Task<List<CalibrationRecord>> GetOverdueCalibrationAsync()");
+            AssertReadMethodUsesMapper(source, "public async Task<List<CalibrationRecord>> GetOverdueCalibrationAsync()", "public async Task<int> CountOverdueCalibrationAsync()");
+            AssertReadMethodUsesMapper(source, "public async Task<List<CalibrationRecord>> GetUpcomingCalibrationAsync(int days = 30)", "public async Task<int> CountUpcomingCalibrationAsync(int days = 30)");
+            AssertReadMethodUsesMapper(source, "public async Task<CalibrationRecord?> GetLatestCalibrationForItemAsync(int itemID)", "public async Task<CalibrationRecord?> GetCalibrationRecordByIdAsync(int calibrationID)");
+            AssertReadMethodUsesMapper(source, "public async Task<CalibrationRecord?> GetCalibrationRecordByIdAsync(int calibrationID)", "public async Task<int> CreateCalibrationRecordAsync(CalibrationRecord record)");
+        }
+
+        private static void AssertScheduledFilterNormalizesStatus(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+            Assert.Contains("TRIM(IFNULL(m.Status, '')) = 'Scheduled'", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("m.Status = 'Scheduled'", method, StringComparison.Ordinal);
+        }
+
+        private static void AssertReadMethodUsesMapper(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+            Assert.Contains("Map", method, StringComparison.Ordinal);
+            Assert.Matches(@"Map(?:Maintenance|Calibration)Record\(reader\)", method);
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-operational-record-readback-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-operational-record-readback-normalization.md
@@ -1,0 +1,23 @@
+# Operational Record Readback Normalization
+
+Date: 2026-07-02
+
+## Completed
+
+- Normalized maintenance readback text through a shared `NormalizeMaintenanceReadText(...)` mapper helper.
+- Trimmed legacy maintenance item number, item name, maintenance type, description, performer, status, and notes before grids, detail views, reports, and printable operational output consume those models.
+- Made overdue and upcoming maintenance list/count queries compare `Scheduled` status through `TRIM(IFNULL(...))` so legacy padded scheduled statuses still appear in scheduled maintenance workflows.
+- Normalized calibration readback text through a shared `NormalizeCalibrationReadText(...)` mapper helper.
+- Trimmed legacy calibration item number, item name, technician, certificate number, standard, result, and notes before calibration grids, latest-calibration details, reports, and printable operational output consume those models.
+- Added `OperationalRecordReadNormalizationContractTests` to guard maintenance mapper fields, helper trim/null fallback behavior, maintenance scheduled-filter SQL, calibration mapper fields, helper trim/null fallback behavior, and every maintenance/calibration read method that should use the normalized mapper.
+
+## Validation
+
+- GitHub connector source readback and compare were used to verify the branch scope and implementation shape.
+- Local restore/build/test/full validation could not be run in the scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and WPF runtime tooling are unavailable here.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test maintenance and calibration grids, overdue/upcoming maintenance views, latest calibration details, operational reports, and print/preview output with legacy rows containing padded operational-record text.
+- Do not repeat operational-record readback normalization unless fresh source or runtime evidence shows a regression.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -374,19 +374,25 @@ namespace InventoryManagementApp.Services.Calibration
             {
                 CalibrationID = reader.GetInt32(reader.GetOrdinal("CalibrationID")),
                 ItemID = reader.GetInt32(reader.GetOrdinal("ItemID")),
-                ItemNumber = reader.IsDBNull(reader.GetOrdinal("ItemNumber")) ? "" : reader.GetString(reader.GetOrdinal("ItemNumber")),
-                ItemName = reader.IsDBNull(reader.GetOrdinal("ItemName")) ? "" : reader.GetString(reader.GetOrdinal("ItemName")),
+                ItemNumber = NormalizeCalibrationReadText(reader, "ItemNumber"),
+                ItemName = NormalizeCalibrationReadText(reader, "ItemName"),
                 CalibrationDate = reader.GetDateTime(reader.GetOrdinal("CalibrationDate")),
                 NextCalibrationDue = reader.GetDateTime(reader.GetOrdinal("NextCalibrationDue")),
-                CalibratedBy = reader.IsDBNull(reader.GetOrdinal("CalibratedBy")) ? "" : reader.GetString(reader.GetOrdinal("CalibratedBy")),
-                CertificateNumber = reader.IsDBNull(reader.GetOrdinal("CertificateNumber")) ? "" : reader.GetString(reader.GetOrdinal("CertificateNumber")),
-                Standard = reader.IsDBNull(reader.GetOrdinal("Standard")) ? "" : reader.GetString(reader.GetOrdinal("Standard")),
-                Result = reader.IsDBNull(reader.GetOrdinal("Result")) ? "" : reader.GetString(reader.GetOrdinal("Result")),
+                CalibratedBy = NormalizeCalibrationReadText(reader, "CalibratedBy"),
+                CertificateNumber = NormalizeCalibrationReadText(reader, "CertificateNumber"),
+                Standard = NormalizeCalibrationReadText(reader, "Standard"),
+                Result = NormalizeCalibrationReadText(reader, "Result"),
                 Cost = reader.GetDecimal(reader.GetOrdinal("Cost")),
-                Notes = reader.IsDBNull(reader.GetOrdinal("Notes")) ? "" : reader.GetString(reader.GetOrdinal("Notes")),
+                Notes = NormalizeCalibrationReadText(reader, "Notes"),
                 UserID = reader.IsDBNull(reader.GetOrdinal("UserID")) ? 0 : reader.GetInt32(reader.GetOrdinal("UserID")),
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt"))
             };
+        }
+
+        private static string NormalizeCalibrationReadText(SqliteDataReader reader, string columnName)
+        {
+            var ordinal = reader.GetOrdinal(columnName);
+            return reader.IsDBNull(ordinal) ? string.Empty : reader.GetString(ordinal).Trim();
         }
 
         private static void NormalizeCalibrationRecordForSave(CalibrationRecord record)

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -120,7 +120,7 @@ namespace InventoryManagementApp.Services.Maintenance
                     SELECT m.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM MaintenanceRecords m
                     JOIN Items i ON m.ItemID = i.ItemID
-                    WHERE m.Status = 'Scheduled' AND m.ScheduledDate < @Now
+                    WHERE TRIM(IFNULL(m.Status, '')) = 'Scheduled' AND m.ScheduledDate < @Now
                     ORDER BY m.ScheduledDate ASC
                     LIMIT @MaintenanceListLimit";
                 using var cmd = new SqliteCommand(sql, conn);
@@ -144,7 +144,7 @@ namespace InventoryManagementApp.Services.Maintenance
                     SELECT COUNT(m.MaintenanceID)
                     FROM MaintenanceRecords m
                     JOIN Items i ON m.ItemID = i.ItemID
-                    WHERE m.Status = 'Scheduled' AND m.ScheduledDate < @Now";
+                    WHERE TRIM(IFNULL(m.Status, '')) = 'Scheduled' AND m.ScheduledDate < @Now";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@Now", DateTime.Now);
                 return Convert.ToInt32(cmd.ExecuteScalar() ?? 0);
@@ -164,7 +164,7 @@ namespace InventoryManagementApp.Services.Maintenance
                     SELECT m.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM MaintenanceRecords m
                     JOIN Items i ON m.ItemID = i.ItemID
-                    WHERE m.Status = 'Scheduled' 
+                    WHERE TRIM(IFNULL(m.Status, '')) = 'Scheduled'
                     AND m.ScheduledDate >= @Now 
                     AND m.ScheduledDate <= @FutureDate
                     ORDER BY m.ScheduledDate ASC
@@ -195,7 +195,7 @@ namespace InventoryManagementApp.Services.Maintenance
                     SELECT COUNT(m.MaintenanceID)
                     FROM MaintenanceRecords m
                     JOIN Items i ON m.ItemID = i.ItemID
-                    WHERE m.Status = 'Scheduled'
+                    WHERE TRIM(IFNULL(m.Status, '')) = 'Scheduled'
                     AND m.ScheduledDate >= @Now
                     AND m.ScheduledDate <= @FutureDate";
                 using var cmd = new SqliteCommand(sql, conn);
@@ -387,19 +387,25 @@ namespace InventoryManagementApp.Services.Maintenance
             {
                 MaintenanceID = reader.GetInt32(reader.GetOrdinal("MaintenanceID")),
                 ItemID = reader.GetInt32(reader.GetOrdinal("ItemID")),
-                ItemNumber = reader.IsDBNull(reader.GetOrdinal("ItemNumber")) ? "" : reader.GetString(reader.GetOrdinal("ItemNumber")),
-                ItemName = reader.IsDBNull(reader.GetOrdinal("ItemName")) ? "" : reader.GetString(reader.GetOrdinal("ItemName")),
+                ItemNumber = NormalizeMaintenanceReadText(reader, "ItemNumber"),
+                ItemName = NormalizeMaintenanceReadText(reader, "ItemName"),
                 ScheduledDate = reader.GetDateTime(reader.GetOrdinal("ScheduledDate")),
                 CompletedDate = reader.IsDBNull(reader.GetOrdinal("CompletedDate")) ? null : reader.GetDateTime(reader.GetOrdinal("CompletedDate")),
-                MaintenanceType = reader.GetString(reader.GetOrdinal("MaintenanceType")),
-                Description = reader.IsDBNull(reader.GetOrdinal("Description")) ? "" : reader.GetString(reader.GetOrdinal("Description")),
-                PerformedBy = reader.IsDBNull(reader.GetOrdinal("PerformedBy")) ? "" : reader.GetString(reader.GetOrdinal("PerformedBy")),
+                MaintenanceType = NormalizeMaintenanceReadText(reader, "MaintenanceType"),
+                Description = NormalizeMaintenanceReadText(reader, "Description"),
+                PerformedBy = NormalizeMaintenanceReadText(reader, "PerformedBy"),
                 Cost = reader.GetDecimal(reader.GetOrdinal("Cost")),
-                Status = reader.GetString(reader.GetOrdinal("Status")),
-                Notes = reader.IsDBNull(reader.GetOrdinal("Notes")) ? "" : reader.GetString(reader.GetOrdinal("Notes")),
+                Status = NormalizeMaintenanceReadText(reader, "Status"),
+                Notes = NormalizeMaintenanceReadText(reader, "Notes"),
                 UserID = reader.IsDBNull(reader.GetOrdinal("UserID")) ? 0 : reader.GetInt32(reader.GetOrdinal("UserID")),
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt"))
             };
+        }
+
+        private static string NormalizeMaintenanceReadText(SqliteDataReader reader, string columnName)
+        {
+            var ordinal = reader.GetOrdinal(columnName);
+            return reader.IsDBNull(ordinal) ? string.Empty : reader.GetString(ordinal).Trim();
         }
 
         private static void NormalizeMaintenanceRecordForSave(MaintenanceRecord record)

--- a/ToDo.md
+++ b/ToDo.md
@@ -24,6 +24,7 @@ Current repository evidence:
 - Item repository readback now trims legacy item identity, detail, checkout attribution, image path, and incomplete/problem-note text through the shared item projection before grids, exports, dashboards, image import matching, reports, and item detail views consume it.
 - Reservation list and detail readback now trims legacy item number, item name, customer name, image path, status, and notes through the shared reservation mapper before reservation grids, upcoming views, detail views, reports, previews, and printable reservation-related output consume it.
 - Customer list, detail, search, and export readback now trims legacy company, email, contact, phone, mobile, and address text through the shared customer mapper before customer directory screens, handoff views, reports, printable output, and CSV/generic exports consume it.
+- Maintenance and calibration readback now trims legacy operational-record and joined item text before list/detail/report/print consumers receive those models, and maintenance overdue/upcoming filters now match legacy padded `Scheduled` statuses.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -81,6 +82,9 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Item repository projection now trims item number, name, location, brand, part number, supplier, notes, keywords, image path, checkout user names, missing-components notes, and issue notes before item read models reach search grids, details, dashboards, exports, image import matching, checked-out lists, incomplete lists, and reports.
 - Reservation row mapping now trims item number, item name, customer name, image path, status, and notes before reservation models reach all-reservation lists, active/upcoming lists, item/customer reservation histories, detail views, reports, previews, and printable reservation-related output.
 - Customer service mapping now trims company, email, contact, phone, mobile, and address before customer list, detail, search, paged export, report, print, rental handoff, and reservation handoff consumers receive customer read models.
+- Maintenance row mapping now trims item number, item name, maintenance type, description, performer, status, and notes before maintenance grids, detail views, reports, and printable operational output consume those models.
+- Maintenance overdue/upcoming list and count filters now compare scheduled status through trimmed null-safe SQL so legacy padded `Scheduled` statuses remain visible in scheduled-work workflows.
+- Calibration row mapping now trims item number, item name, technician, certificate number, standard, result, and notes before calibration grids, latest-calibration details, reports, and printable operational output consume those models.
 
 ## Highest-Value Next Work
 
@@ -91,7 +95,7 @@ Prioritize the following before adding unrelated new features:
 3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, and theme-customized popup surfaces.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
 5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
-6. Keep tightening import/export, save-path, operational-record, configuration, and document-output data-quality behavior only where current evidence shows another concrete user-entered, file-imported, or legacy stored value can bypass validation, duplicate detection, search/report consistency, permission consistency, delivery reliability, or professional output expectations.
+6. Keep tightening import/export, save-path, configuration, and document-output data-quality behavior only where current evidence shows another concrete user-entered, file-imported, or legacy stored value can bypass validation, duplicate detection, search/report consistency, permission consistency, delivery reliability, or professional output expectations.
 
 ## App Completion Status
 
@@ -105,7 +109,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, reservation readback normalization, and customer readback normalization changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, reservation readback normalization, customer readback normalization, and operational-record readback normalization changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Added `NormalizeMaintenanceReadText(...)` and routed maintenance readback display fields through it.
- Trimmed legacy maintenance item number, item name, maintenance type, description, performer, status, and notes before grids, detail views, reports, and printable operational output consume those models.
- Updated overdue and upcoming maintenance list/count queries to compare scheduled status through `TRIM(IFNULL(m.Status, ''))`, so legacy padded `Scheduled` values remain visible in scheduled-maintenance workflows.
- Added `NormalizeCalibrationReadText(...)` and routed calibration readback display fields through it.
- Trimmed legacy calibration item number, item name, technician, certificate number, standard, result, and notes before calibration grids, latest-calibration details, reports, and printable operational output consume those models.
- Added `OperationalRecordReadNormalizationContractTests` for maintenance mapper coverage, read helper behavior, scheduled-filter SQL, calibration mapper coverage, calibration helper behavior, and every operational-record read method using the shared mapper.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this completed slice without fresh evidence.

## Why this was the highest-value next step

Current `master` already normalized maintenance and calibration create/update persistence, but source readback showed their mappers still returned raw stored text. That left older padded rows leaking into operational grids, detail views, reports, and print/preview output. Maintenance overdue/upcoming filters also still matched only exact `Scheduled`, so padded legacy scheduled rows could be hidden from the workflows that need them most.

## Why this is large enough to count as real progress

This is a complete operational-record readback slice across maintenance lists, maintenance detail, overdue/upcoming maintenance list and count workflows, calibration lists, calibration detail/latest reads, shared service mapping, source-contract coverage, progress notes, and the durable work queue. It includes more than ten focused workflow-level improvements without adding unrelated features or reopening recently completed item/customer/rental/reservation normalization work.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 focused commits, and limited to:
  - `InventoryManagementApp/Services/Maintenance/MaintenanceService.cs`
  - `InventoryManagementApp/Services/Calibration/CalibrationService.cs`
  - `InventoryManagementApp.Tests/OperationalRecordReadNormalizationContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-operational-record-readback-normalization.md`
  - `ToDo.md`
- Connector source readback confirmed maintenance readback fields route through `NormalizeMaintenanceReadText(...)` and the helper trims non-null text while preserving empty-string fallback for database nulls.
- Connector source readback confirmed maintenance overdue/upcoming list and count queries use trimmed null-safe scheduled-status matching.
- Connector source readback confirmed calibration readback fields route through `NormalizeCalibrationReadText(...)` and the helper trims non-null text while preserving empty-string fallback for database nulls.
- Connector source readback confirmed `OperationalRecordReadNormalizationContractTests` covers mapper fields, helper behavior, scheduled filter SQL, and read-method mapper use.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `7cd9d5d8fd1658ca0d4e05f33802d5284175d19d` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test maintenance and calibration grids, overdue/upcoming maintenance views, latest calibration detail, operational reports, and print/preview output with legacy rows containing padded operational-record text.