### PR TITLE
[codex] Improve users workbench responsive layout

### DIFF
--- a/InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UsersPageResponsiveContractTests
+    {
+        [Fact]
+        public void UsersPage_KeepsAccountSummaryCardsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"160\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"250\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Grid Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"1.35*\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersPage_AvoidsLargeFixedMinimumsInMainAccountSplit()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.65*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\" Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2.15*\" MinWidth=\"620\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"1.05*\" MinWidth=\"360\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersPage_EnablesDirectoryGridVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
+
+            Assert.Contains("x:Name=\"UsersDataGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersPage_BoundsSearchEmptyStateAndHandoffScrolling()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
+
+            Assert.Contains("<pages:SearchBar Width=\"300\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"330\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersPage_PreservesPrimaryAccountActionsAndRowHandoff()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
+
+            Assert.Contains("AddUserCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("EditUserCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ResetSelectedUser_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("UploadUserPhotoCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedUser_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintUsers_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenSelectedUser_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("UserRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-users-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-users-responsive-workbench.md
@@ -1,0 +1,27 @@
+# Users Responsive Workbench
+
+Date: 2026-07-02
+
+## Completed
+
+- Reworked the Users Workbench account summary strip from four fixed grid columns into wrapping bounded cards.
+- Bounded user summary cards with minimum and maximum widths so long filter, access, and lockout text wraps without forcing the page wider.
+- Added a bounded header title area so toolbar actions keep wrapping beside the page heading instead of competing with unbounded title text.
+- Reduced the main directory/detail split from large fixed minimums to a flexible grid where the directory can shrink to available space and the handoff pane keeps a practical minimum.
+- Narrowed the split handle to match the more responsive audit workbench pattern.
+- Added `MinWidth="0"` to the directory and handoff card shells so WPF can actually shrink their content columns at scaled desktop sizes.
+- Reduced the account search box width while preserving a usable minimum.
+- Enabled explicit row and column virtualization on the user directory grid.
+- Enabled automatic horizontal and vertical grid scrollbars plus content scrolling for wide account/security/contact columns.
+- Switched the directory grid to full-row single selection for clearer row-level account actions.
+- Replaced the fixed-width empty state with a bounded, margin-protected empty state.
+- Changed the access/security handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
+- Added `UsersPageResponsiveContractTests` to guard the responsive summary cards, lower split pressure, directory grid scrolling/virtualization, bounded empty state, handoff scrolling, and preserved account actions.
+
+## Why
+
+Recent repository evidence identifies Windows visual QA and scaled desktop usability as remaining release risks. The Users Workbench is a dense administrative workflow with account search, security/access columns, row-level context actions, password reset, photo upload, copy/print output, and a selected-account handoff pane. Source inspection showed fixed summary columns, large split minimums, hidden detail scrolling, and a user grid without explicit scroll/virtualization contracts, making this a concrete workflow-level layout risk.
+
+## Validation
+
+Could not run local validation in this scheduled Linux environment because direct repository clone is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, PowerShell/`pwsh`, `gh`, and the WPF runtime are unavailable. Use GitHub connector compare/source readback and status/workflow readback for this run, then run `pwsh -File scripts/run-full-validation.ps1` plus a Windows WPF visual smoke test from a capable checkout.

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -9,7 +9,9 @@
         <Style x:Key="UserStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="MinWidth" Value="160"/>
+            <Setter Property="MaxWidth" Value="250"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
         </Style>
         <Style x:Key="UserDetailText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
             <Setter Property="TextWrapping" Value="Wrap"/>
@@ -32,8 +34,8 @@
 
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="14,12">
             <DockPanel LastChildFill="False">
-                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,18,0">
-                    <TextBlock Text="Users Workbench" Style="{StaticResource PageTitleTextBlock}"/>
+                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,18,0" MinWidth="220" MaxWidth="460">
+                    <TextBlock Text="Users Workbench" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Manage account access, password recovery, profile photos, and audit-ready user directory output from one admin desk."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
@@ -50,52 +52,46 @@
             </DockPanel>
         </Border>
 
-        <Grid Grid.Row="1" Margin="0,0,0,6">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="1.2*"/>
-                <ColumnDefinition Width="1.2*"/>
-                <ColumnDefinition Width="1.35*"/>
-            </Grid.ColumnDefinitions>
-            <Border Grid.Column="0" Style="{StaticResource UserStatCard}">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
+            <Border Style="{StaticResource UserStatCard}">
                 <StackPanel>
                     <TextBlock Text="Visible Users" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding Users.Count}" Style="{StaticResource UserStatValueText}"/>
                     <TextBlock Text="Rows matching the current account search" Style="{StaticResource UserDetailText}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Column="1" Style="{StaticResource UserStatCard}">
+            <Border Style="{StaticResource UserStatCard}">
                 <StackPanel>
                     <TextBlock Text="Directory Filter" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding UserSearchText, TargetNullValue=All accounts}" Style="{StaticResource UserStatValueText}"/>
                     <TextBlock Text="Search by user, role, contact, or access summary before printing" Style="{StaticResource UserDetailText}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Column="2" Style="{StaticResource UserStatCard}">
+            <Border Style="{StaticResource UserStatCard}">
                 <StackPanel>
                     <TextBlock Text="Selected Access" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding SelectedUser.AccessSummary, TargetNullValue=No account selected}" Style="{StaticResource UserStatValueText}"/>
                     <TextBlock Text="Review allowed app areas before editing permissions" Style="{StaticResource UserDetailText}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Column="3" Style="{StaticResource UserStatCard}" Margin="0">
+            <Border Style="{StaticResource UserStatCard}" Margin="0,0,0,8">
                 <StackPanel>
                     <TextBlock Text="Security State" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding SelectedUser.LockoutStatus, TargetNullValue=Select a user}" Style="{StaticResource UserStatValueText}"/>
                     <TextBlock Text="Password reset, lockout, and active-status context" Style="{StaticResource UserDetailText}"/>
                 </StackPanel>
             </Border>
-        </Grid>
+        </WrapPanel>
 
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.15*" MinWidth="620"/>
-                <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="1.05*" MinWidth="360"/>
+                <ColumnDefinition Width="1.65*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="0.95*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
-                <Grid>
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                <Grid MinWidth="0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -103,7 +99,7 @@
                     </Grid.RowDefinitions>
 
                     <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
-                        <DockPanel LastChildFill="False">
+                        <DockPanel>
                             <StackPanel DockPanel.Dock="Left">
                                 <TextBlock Text="Account Directory" Style="{StaticResource SectionHeader}" Margin="0"/>
                                 <TextBlock Text="Select the exact account before editing access, resetting a password, uploading a photo, or printing directory evidence."
@@ -114,15 +110,17 @@
                                        Text="{Binding Users.Count, StringFormat='Visible: {0}'}"
                                        Style="{StaticResource CaptionTextBlock}"
                                        VerticalAlignment="Center"
+                                       TextWrapping="Wrap"
                                        Margin="12,0,0,0"/>
                         </DockPanel>
                     </Border>
 
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
-                        <DockPanel LastChildFill="False">
+                        <DockPanel LastChildFill="True">
                             <WrapPanel DockPanel.Dock="Left" VerticalAlignment="Center">
                                 <TextBlock Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,6"/>
-                                <pages:SearchBar Width="340"
+                                <pages:SearchBar Width="300"
+                                                 MinWidth="220"
                                                  SearchLabel="Search"
                                                  Text="{Binding UserSearchText, UpdateSourceTrigger=PropertyChanged}"
                                                  SearchCommand="{Binding SearchUsersCommand}"
@@ -144,7 +142,13 @@
                               IsReadOnly="True"
                               AutoGenerateColumns="False"
                               SelectionMode="Single"
+                              SelectionUnit="FullRow"
                               CanUserAddRows="False"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               RowHeight="48"
                               Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.RowStyle>
@@ -220,7 +224,7 @@
                         </DataGrid.ContextMenu>
                     </DataGrid>
 
-                    <Border Grid.Row="2" Width="330" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Border Grid.Row="2" MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -239,10 +243,10 @@
                 </Grid>
             </Border>
 
-            <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
-                <Grid>
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                <Grid MinWidth="0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
@@ -265,8 +269,8 @@
                         </DockPanel>
                     </Border>
 
-                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Hidden">
-                        <StackPanel Margin="14">
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                        <StackPanel Margin="12">
                             <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,8">
                                 <StackPanel>
                                     <TextBlock Text="Selected Account" Style="{StaticResource SectionHeader}"/>

--- a/ToDo.md
+++ b/ToDo.md
@@ -25,6 +25,8 @@ Current repository evidence:
 - Reservation list and detail readback now trims legacy item number, item name, customer name, image path, status, and notes through the shared reservation mapper before reservation grids, upcoming views, detail views, reports, previews, and printable reservation-related output consume it.
 - Customer list, detail, search, and export readback now trims legacy company, email, contact, phone, mobile, and address text through the shared customer mapper before customer directory screens, handoff views, reports, printable output, and CSV/generic exports consume it.
 - Maintenance and calibration readback now trims legacy operational-record and joined item text before list/detail/report/print consumers receive those models, and maintenance overdue/upcoming filters now match legacy padded `Scheduled` statuses.
+- Activity Audit Workbench layout now uses wrapping bounded metrics, lower split minimums, explicit grid virtualization/scrollbars, and bounded handoff/empty-state areas for scaled desktop reliability.
+- Users Workbench layout now uses wrapping bounded account summary cards, lower directory/detail split pressure, explicit user-grid virtualization/scrollbars, bounded empty state, and reachable access/security handoff scrolling.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -85,6 +87,8 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Maintenance row mapping now trims item number, item name, maintenance type, description, performer, status, and notes before maintenance grids, detail views, reports, and printable operational output consume those models.
 - Maintenance overdue/upcoming list and count filters now compare scheduled status through trimmed null-safe SQL so legacy padded `Scheduled` statuses remain visible in scheduled-work workflows.
 - Calibration row mapping now trims item number, item name, technician, certificate number, standard, result, and notes before calibration grids, latest-calibration details, reports, and printable operational output consume those models.
+- Activity Audit Workbench now has source-backed responsive layout contracts for wrapping audit metrics, reduced fixed split pressure, grid virtualization/scrolling, bounded empty state, bounded selected-log handoff, and preserved audit actions.
+- Users Workbench now has source-backed responsive layout contracts for wrapping account metrics, reduced fixed split pressure, directory grid virtualization/scrolling, bounded empty state, reachable handoff scrolling, and preserved account actions.
 
 ## Highest-Value Next Work
 
@@ -92,7 +96,7 @@ Prioritize the following before adding unrelated new features:
 
 1. Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout and capture the actual restore, audit, build, test, publish, banned-word, and artifact-manifest results.
 2. Review the dedicated vulnerable-package audit output plus any NU190x warnings from repository-level NuGet auditing, then update affected packages or document intentional risk decisions.
-3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, and theme-customized popup surfaces.
+3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, Users, Activity Logs, and theme-customized popup surfaces.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
 5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
 6. Keep tightening import/export, save-path, configuration, and document-output data-quality behavior only where current evidence shows another concrete user-entered, file-imported, or legacy stored value can bypass validation, duplicate detection, search/report consistency, permission consistency, delivery reliability, or professional output expectations.
@@ -109,7 +113,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, reservation readback normalization, customer readback normalization, and operational-record readback normalization changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, reservation readback normalization, customer readback normalization, operational-record readback normalization, Activity Logs responsive layout, and Users responsive layout changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Reworked the Users Workbench account summary strip from four fixed grid columns into wrapping bounded cards.
- Bounded user summary cards with minimum and maximum widths so long filter, access, and lockout text wraps without forcing the page wider.
- Added a bounded header title area so toolbar actions keep wrapping beside the page heading instead of competing with unbounded title text.
- Reduced the main directory/detail split from large fixed minimums to a flexible grid where the directory can shrink to available space and the handoff pane keeps a practical minimum.
- Narrowed the split handle to match the more responsive Activity Audit Workbench pattern.
- Added `MinWidth="0"` to the directory and handoff card shells so WPF can actually shrink their content columns at scaled desktop sizes.
- Reduced the account search box width while preserving a usable minimum.
- Enabled explicit row and column virtualization on the user directory grid.
- Enabled automatic horizontal and vertical grid scrollbars plus content scrolling for wide account/security/contact columns.
- Switched the directory grid to full-row single selection for clearer row-level account actions.
- Replaced the fixed-width empty state with a bounded, margin-protected empty state.
- Changed the access/security handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
- Added `UsersPageResponsiveContractTests` to guard the responsive summary cards, lower split pressure, directory grid scrolling/virtualization, bounded empty state, handoff scrolling, and preserved account actions.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this slice without fresh evidence.

## Why this was the highest-value next step

Current repo evidence still identifies Windows visual QA and scaled desktop usability as release risks, while recent scheduled runs already completed the adjacent data normalization and Activity Audit responsive slice. Source inspection showed the Users Workbench still had fixed summary columns, a high directory/detail split minimum, hidden detail overflow, and no explicit user-grid scrollbar/virtualization contract. This page is a dense admin workflow with search, account security/access columns, row-level context actions, password reset, photo upload, copy/print output, and selected-account handoff, so tightening it improves a real workflow rather than isolated styling.

## Why this is large enough to count as real progress

This covers more than ten focused workflow-level improvements across summary layout, card sizing, header sizing, split sizing, splitter sizing, WPF shrink behavior, search sizing, grid virtualization, grid scrollbars, selection behavior, empty-state sizing, handoff scrolling, source-contract coverage, and repo progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/UsersPage.xaml`
  - `InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-users-responsive-workbench.md`
  - `ToDo.md`
- Connector source readback confirmed the Users page now uses wrapping bounded account summary cards, lower directory/detail split minimums, `MinWidth="0"` shrinkable pane shells, reduced search width with a useful minimum, explicit user-grid virtualization/scrollbars, full-row selection, bounded empty state, and automatic handoff scrolling.
- Connector source readback confirmed `UsersPageResponsiveContractTests` covers the responsive layout contracts and preserved account actions.
- Connector compare/status/workflow readback found no attached commit statuses or workflow runs on branch head `720fe4732dde317a4d89f0e8ce1a57b3c7279daa` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Users on Windows at 1366 x 768 and higher DPI scales, including account search, row context actions, password reset, photo upload, copy/print output, and handoff scrolling.
