### PR TITLE
[codex] Improve reports workbench responsive layout

### DIFF
--- a/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReportsPageResponsiveContractTests
+    {
+        [Fact]
+        public void ReportsPage_KeepsReportSummaryCardsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"240\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"390\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"540\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReportsPage_AvoidsLargeFixedMinimumsInMainReportSplit()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.55*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\" Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2.55*\" MinWidth=\"620\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"430\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReportsPage_EnablesResultsGridVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
+
+            Assert.Contains("x:Name=\"ReportGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReportsPage_BoundsEmptyStateHandoffPaneAndHandoffText()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
+
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"360\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"130\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxHeight=\"260\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"360\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinHeight=\"150\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReportsPage_PreservesReportActionsAndContextMenuHandoff()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
+
+            Assert.Contains("RunReportCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenSourcePage_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintReport_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedRow_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("ClearReportCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ReportGrid_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("ReportGrid_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectedLineHandoff", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-reports-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-reports-responsive-workbench.md
@@ -1,0 +1,30 @@
+# Reports Responsive Workbench
+
+Date: 2026-07-02
+
+## Completed
+
+- Reworked the Reports Workbench summary metrics from a fixed four-column `UniformGrid` into wrapping bounded cards.
+- Reduced the header title column from large fixed minimums to a shrinkable star column so report metrics and title text can share scaled desktop widths.
+- Bounded each report metric card with minimum and maximum widths to keep long report, destination, and last-run values wrapping inside cards.
+- Reduced the report selector combo width while preserving a usable minimum.
+- Changed the main report results / row handoff split from a 620px plus 380px minimum layout to a flexible star split with a practical 300px handoff minimum.
+- Narrowed the splitter and added `MinWidth="0"` to both report pane cards so WPF can shrink columns instead of forcing horizontal overflow.
+- Enabled explicit row and column virtualization on the report results grid.
+- Enabled automatic horizontal and vertical report-grid scrollbars with content scrolling for wide report detail and destination columns.
+- Switched report results selection to full-row single selection for clearer row-level context-menu and double-click behavior.
+- Reduced oversized result-column minimum widths so the grid can remain useful on smaller scaled desktops.
+- Replaced the fixed-width empty state with a bounded, margin-protected empty state.
+- Disabled horizontal scrolling in the row handoff pane and bounded the handoff text box height so long handoff content scrolls inside the pane without pushing actions away.
+- Added source-contract coverage for the responsive summary, main split, grid virtualization/scrolling, bounded empty/handoff areas, and preserved report actions.
+
+## Validation
+
+- GitHub connector source readback confirmed the XAML uses wrapping bounded report metric cards, lower split minimums, shrinkable pane shells, explicit result-grid virtualization/scrollbars, full-row selection, bounded empty state, and bounded row-handoff scrolling.
+- GitHub connector source readback confirmed `ReportsPageResponsiveContractTests` covers the responsive layout contracts and preserved report actions.
+- Local `dotnet`/PowerShell/WPF validation could not be run in the scheduled Linux environment because direct checkout is blocked and the required Windows/.NET tooling is unavailable.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test Reports at 1366 x 768 and higher DPI scales, including report selection, report generation, result row double-click, context-menu actions, copy handoff, print report, and row handoff scrolling.

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml
@@ -7,7 +7,9 @@
         <Style x:Key="ReportsStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="MinHeight" Value="78"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="MinWidth" Value="150"/>
+            <Setter Property="MaxWidth" Value="240"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
         </Style>
         <Style x:Key="ReportsDetailCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
@@ -30,18 +32,18 @@
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" MinWidth="390"/>
-                    <ColumnDefinition Width="14"/>
-                    <ColumnDefinition Width="3*" MinWidth="540"/>
+                    <ColumnDefinition Width="1.15*" MinWidth="0"/>
+                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center">
+                <StackPanel VerticalAlignment="Center" MinWidth="0">
                     <TextBlock Text="Reports Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
                     <TextBlock Text="Run operational reports, inspect the highest-priority rows, then jump to the exact source page for follow-up."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <UniformGrid Grid.Column="2" Columns="4">
+                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
                     <Border Style="{StaticResource ReportsStatCard}">
                         <StackPanel>
                             <TextBlock Text="REPORT" Style="{StaticResource LabelTextBlock}"/>
@@ -72,7 +74,7 @@
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}" Padding="12,10" MinHeight="78">
+                    <Border Style="{StaticResource ReportsStatCard}">
                         <StackPanel>
                             <TextBlock Text="LAST RUN" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="{Binding LastRunText}"
@@ -82,7 +84,7 @@
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
-                </UniformGrid>
+                </WrapPanel>
             </Grid>
         </Border>
 
@@ -95,8 +97,8 @@
                 <DockPanel LastChildFill="True">
                     <TextBlock Text="Report selector" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <ComboBox Width="270"
-                                  MinWidth="210"
+                        <ComboBox Width="250"
+                                  MinWidth="200"
                                   ItemsSource="{Binding ReportTypes}"
                                   SelectedItem="{Binding SelectedReport}"
                                   ItemContainerStyle="{StaticResource DropdownItemStyle}"
@@ -120,12 +122,12 @@
 
         <Grid Grid.Row="2" Margin="0,6,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.55*" MinWidth="620"/>
-                <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="430" MinWidth="380"/>
+                <ColumnDefinition Width="1.55*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="0.95*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -136,7 +138,7 @@
 
                     <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
                         <DockPanel>
-                            <StackPanel DockPanel.Dock="Left">
+                            <StackPanel DockPanel.Dock="Left" MinWidth="0">
                                 <TextBlock Text="01 Report Results" Style="{StaticResource SectionHeader}" Margin="0"/>
                                 <TextBlock Text="Review generated report lines, priority wording, destination, and next action before opening the source workflow." Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
@@ -159,6 +161,12 @@
                               AutoGenerateColumns="False"
                               CanUserAddRows="False"
                               SelectionMode="Single"
+                              SelectionUnit="FullRow"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               MouseDoubleClick="ReportGrid_MouseDoubleClick"
                               PreviewMouseRightButtonDown="ReportGrid_PreviewMouseRightButtonDown"
                               Style="{StaticResource VirtualizedDataGridStyle}">
@@ -171,7 +179,7 @@
                         </DataGrid.ContextMenu>
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="#" Binding="{Binding Number}" Width="48" MinWidth="44"/>
-                            <DataGridTemplateColumn Header="Type / Destination" Width="1.05*" MinWidth="170">
+                            <DataGridTemplateColumn Header="Type / Destination" Width="1.05*" MinWidth="150">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -181,7 +189,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Report Detail" Width="2.15*" MinWidth="300">
+                            <DataGridTemplateColumn Header="Report Detail" Width="2.15*" MinWidth="240">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -191,11 +199,11 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Destination" Binding="{Binding DestinationName}" Width="135" MinWidth="120"/>
+                            <DataGridTextColumn Header="Destination" Binding="{Binding DestinationName}" Width="120" MinWidth="110"/>
                         </DataGrid.Columns>
                     </DataGrid>
 
-                    <Border Grid.Row="2" Width="360" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Border Grid.Row="2" MaxWidth="360" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -221,9 +229,9 @@
                 </Grid>
             </Border>
 
-            <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -235,7 +243,7 @@
                             <TextBlock Text="Keep the report context, source page, and next action visible while triaging generated rows." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                         </StackPanel>
                     </Border>
-                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <StackPanel Margin="8">
                             <Border Style="{StaticResource ReportsDetailCard}">
                                 <StackPanel>
@@ -266,8 +274,10 @@
                                              IsReadOnly="True"
                                              TextWrapping="Wrap"
                                              AcceptsReturn="True"
-                                             MinHeight="150"
+                                             MinHeight="130"
+                                             MaxHeight="260"
                                              VerticalScrollBarVisibility="Auto"
+                                             HorizontalScrollBarVisibility="Disabled"
                                              Margin="0,5,0,0"/>
                                 </StackPanel>
                             </Border>
@@ -290,7 +300,7 @@
                 Margin="0,6,0,0"
                 Padding="8,5">
             <DockPanel LastChildFill="True">
-                <ProgressBar Width="150"
+                <ProgressBar Width="140"
                              Height="14"
                              DockPanel.Dock="Right"
                              IsIndeterminate="True"

--- a/ToDo.md
+++ b/ToDo.md
@@ -27,6 +27,7 @@ Current repository evidence:
 - Maintenance and calibration readback now trims legacy operational-record and joined item text before list/detail/report/print consumers receive those models, and maintenance overdue/upcoming filters now match legacy padded `Scheduled` statuses.
 - Activity Audit Workbench layout now uses wrapping bounded metrics, lower split minimums, explicit grid virtualization/scrollbars, and bounded handoff/empty-state areas for scaled desktop reliability.
 - Users Workbench layout now uses wrapping bounded account summary cards, lower directory/detail split pressure, explicit user-grid virtualization/scrollbars, bounded empty state, and reachable access/security handoff scrolling.
+- Reports Workbench layout now uses wrapping bounded report metrics, lower report-results/handoff split pressure, explicit result-grid virtualization/scrollbars, bounded empty state, and bounded row-handoff scrolling.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -89,6 +90,7 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Calibration row mapping now trims item number, item name, technician, certificate number, standard, result, and notes before calibration grids, latest-calibration details, reports, and printable operational output consume those models.
 - Activity Audit Workbench now has source-backed responsive layout contracts for wrapping audit metrics, reduced fixed split pressure, grid virtualization/scrolling, bounded empty state, bounded selected-log handoff, and preserved audit actions.
 - Users Workbench now has source-backed responsive layout contracts for wrapping account metrics, reduced fixed split pressure, directory grid virtualization/scrolling, bounded empty state, reachable handoff scrolling, and preserved account actions.
+- Reports Workbench now has source-backed responsive layout contracts for wrapping report metrics, reduced fixed split pressure, result grid virtualization/scrolling, bounded empty state, bounded row-handoff scrolling, and preserved report actions.
 
 ## Highest-Value Next Work
 
@@ -96,7 +98,7 @@ Prioritize the following before adding unrelated new features:
 
 1. Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout and capture the actual restore, audit, build, test, publish, banned-word, and artifact-manifest results.
 2. Review the dedicated vulnerable-package audit output plus any NU190x warnings from repository-level NuGet auditing, then update affected packages or document intentional risk decisions.
-3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, Users, Activity Logs, and theme-customized popup surfaces.
+3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, Activity Logs, Users, Reports, and theme-customized popup surfaces.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
 5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
 6. Keep tightening import/export, save-path, configuration, and document-output data-quality behavior only where current evidence shows another concrete user-entered, file-imported, or legacy stored value can bypass validation, duplicate detection, search/report consistency, permission consistency, delivery reliability, or professional output expectations.
@@ -113,7 +115,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, reservation readback normalization, customer readback normalization, operational-record readback normalization, Activity Logs responsive layout, and Users responsive layout changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, reservation readback normalization, customer readback normalization, operational-record readback normalization, Activity Logs responsive layout, Users responsive layout, and Reports responsive layout changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Reworked the Reports Workbench summary metrics from a fixed four-column `UniformGrid` into wrapping bounded cards.
- Bounded report metric cards with minimum and maximum widths so long report, destination, and last-run text wraps inside cards.
- Reduced the header title area from large fixed minimum columns to a shrinkable star column.
- Reduced the report selector combo width while preserving a usable minimum.
- Changed the main results / row handoff split from fixed 620px + 380px minimum pressure to a flexible star split with a practical 300px handoff minimum.
- Narrowed the split handle and added `MinWidth="0"` to both report pane shells so WPF can shrink them at scaled desktop sizes.
- Enabled explicit row and column virtualization on the report results grid.
- Enabled automatic horizontal and vertical result-grid scrollbars plus content scrolling for wide report detail and destination columns.
- Switched report results to full-row single selection for clearer row-level actions.
- Reduced oversized result-column minimums so the grid remains useful on smaller scaled desktops.
- Replaced the fixed-width empty state with a bounded, margin-protected empty state.
- Disabled horizontal overflow in the row handoff pane and bounded the handoff text box height so long handoff text scrolls inside the pane.
- Added `ReportsPageResponsiveContractTests` to guard responsive summary cards, split sizing, grid virtualization/scrolling, bounded empty/handoff areas, and preserved report actions.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this slice without fresh evidence.

## Why this was the highest-value next step

Current repo evidence still lists scaled desktop visual QA as a release risk. Recent runs already completed the Activity Audit and Users workbench responsive slices, while source inspection showed Reports still had a fixed four-card header, high report-results/handoff split minimums, no explicit result-grid scrollbar/virtualization contract, and a fixed-width empty state. Reports is a complete workflow with report selection, result triage, source-page handoff, context-menu actions, copy handoff, and print output, so tightening it improves a real workflow rather than isolated styling.

## Why this is large enough to count as real progress

This covers more than ten focused workflow-level improvements across summary layout, card sizing, header sizing, selector sizing, split sizing, splitter sizing, shrink behavior, grid virtualization, grid scrolling, selection behavior, column sizing, empty-state sizing, handoff scrolling, source-contract coverage, and repo progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ReportsPage.xaml`
  - `InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-reports-responsive-workbench.md`
  - `ToDo.md`
- Connector source readback confirmed the Reports page now uses wrapping bounded metric cards, lower split minimums, shrinkable pane shells, explicit result-grid virtualization/scrollbars, full-row selection, bounded empty state, and bounded handoff scrolling.
- Connector source readback confirmed `ReportsPageResponsiveContractTests` covers the responsive layout contracts and preserved report actions.
- Connector compare/status/workflow readback found no attached commit statuses or workflow runs on branch head `576929b4e4d5da62615d2009ffb196bd68c23ac2` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Reports on Windows at 1366 x 768 and higher DPI scales, including report selection, report generation, result row double-click, context-menu actions, copy handoff, print report, and row handoff scrolling.