### PR TITLE
[codex] Improve calibration workbench responsive layout

### DIFF
--- a/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CalibrationPageResponsiveContractTests
+    {
+        [Fact]
+        public void CalibrationPage_KeepsCalibrationSummaryCardsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"CalibrationMetricCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"520\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPage_AvoidsLargeFixedMinimumsInMainCalibrationSplit()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.55*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"630\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"440\" MinWidth=\"390\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPage_EnablesRegisterGridVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml");
+
+            Assert.Contains("x:Name=\"CalibrationGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPage_BoundsFiltersEmptyStateAndHandoffScrolling()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml");
+
+            Assert.Contains("<TextBox Width=\"250\" MinWidth=\"190\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ComboBox Width=\"175\" MinWidth=\"145\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"360\" MinHeight=\"130\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Grid.Row=\"2\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Center\" MaxWidth=\"380\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPage_PreservesPrimaryCalibrationActionsAndContextMenuHandoff()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml");
+
+            Assert.Contains("AddCalibrationCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenCalibrationDetailsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("EditCalibrationCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedCalibrationCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintSelectedCalibrationCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintCalibrationListCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ShowOverdueCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ShowDueSoonCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ShowCurrentCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CalibrationRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("CalibrationRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-calibration-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-calibration-responsive-workbench.md
@@ -1,0 +1,32 @@
+# Calibration Responsive Workbench
+
+Date: 2026-07-02
+
+## Completed
+
+- Reworked the Calibration Workbench summary metrics from a fixed four-column `UniformGrid` into wrapping bounded cards.
+- Reduced the header title area from large fixed minimum columns to a shrinkable star column so the title and certificate metrics can share scaled desktop widths more safely.
+- Bounded each calibration metric card with minimum and maximum widths to keep register, due-state, selected-certificate, and release text wrapping inside cards.
+- Added practical minimums to the calibration search and filter controls so they remain usable while still allowing the toolbar to wrap.
+- Changed the main calibration-register / certificate-handoff split from a 630px plus 390px minimum layout to a flexible star split with a practical 300px handoff minimum.
+- Added a visible splitter and `MinWidth="0"` pane shells so WPF can shrink the register and handoff panes instead of forcing horizontal overflow.
+- Enabled explicit row and column virtualization on the calibration register grid.
+- Enabled automatic horizontal and vertical calibration-grid scrollbars with content scrolling for wide certificate item, due-window, certificate, owner, and result columns.
+- Switched the calibration grid to full-row single selection for clearer context-menu and double-click certificate actions.
+- Reduced oversized calibration grid column minimums so the register remains useful on smaller scaled desktops.
+- Replaced the fixed-position empty state with a bounded, margin-protected empty state that keeps the register pane from being forced wider.
+- Changed the certificate handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
+- Changed the bottom action area from a fixed horizontal stack to a wrapping action group so primary calibration actions remain reachable at scaled desktop widths.
+- Added source-contract coverage for the responsive summary, main split, grid virtualization/scrolling, bounded filter/empty/handoff areas, and preserved calibration actions.
+
+## Validation
+
+- GitHub connector source readback confirmed the XAML uses wrapping bounded calibration metric cards, lower split minimums, shrinkable pane shells, explicit calibration-grid virtualization/scrollbars, full-row selection, bounded empty state, and reachable handoff scrolling.
+- GitHub connector source readback confirmed `CalibrationPageResponsiveContractTests` covers the responsive layout contracts and preserved calibration commands/row handlers.
+- GitHub connector compare/readback confirmed this branch is scoped to Calibration XAML, one source-contract test, and this progress note.
+- Local `dotnet`/PowerShell/WPF validation could not be run in the scheduled Linux environment because direct checkout is blocked and the required Windows/.NET tooling is unavailable.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test Calibration at 1366 x 768 and higher DPI scales, including search, filters, overdue/due-soon/current views, row double-click, context-menu actions, copy handoff, print record, print due report, edit/delete, and handoff scrolling.

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
@@ -2,6 +2,16 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{DynamicResource MainContentBackgroundBrush}">
+    <Page.Resources>
+        <Style x:Key="CalibrationMetricCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
+            <Setter Property="Padding" Value="12,10"/>
+            <Setter Property="MinHeight" Value="76"/>
+            <Setter Property="MinWidth" Value="150"/>
+            <Setter Property="MaxWidth" Value="235"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+    </Page.Resources>
+
     <Grid Margin="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -13,9 +23,9 @@
         <Border Style="{StaticResource ToolbarCard}" Padding="12,10">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" MinWidth="380"/>
-                    <ColumnDefinition Width="14"/>
-                    <ColumnDefinition Width="3*" MinWidth="520"/>
+                    <ColumnDefinition Width="1.15*" MinWidth="0"/>
+                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="2.85*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
 
                 <StackPanel VerticalAlignment="Center">
@@ -26,32 +36,32 @@
                                Margin="0,3,0,0"/>
                 </StackPanel>
 
-                <UniformGrid Grid.Column="2" Columns="4">
-                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                    <Border Style="{StaticResource CalibrationMetricCard}">
                         <StackPanel>
                             <TextBlock Text="REGISTER" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="{Binding CalibrationResultsSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+                    <Border Style="{StaticResource CalibrationMetricCard}">
                         <StackPanel>
                             <TextBlock Text="DUE STATE" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="{Binding CalibrationBacklogSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+                    <Border Style="{StaticResource CalibrationMetricCard}">
                         <StackPanel>
                             <TextBlock Text="SELECTED" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="{Binding SelectedRecord.StatusDisplay, TargetNullValue='No certificate selected', FallbackValue='No certificate selected'}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}">
+                    <Border Style="{StaticResource CalibrationMetricCard}">
                         <StackPanel>
                             <TextBlock Text="RELEASE" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="Verify before issue" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
-                </UniformGrid>
+                </WrapPanel>
             </Grid>
         </Border>
 
@@ -75,8 +85,8 @@
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
                     <TextBlock Text="Find and filter" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <TextBox Width="250" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,4" ToolTip="Search item number, name, certificate, calibrated by, standard, result, or notes"/>
-                        <ComboBox Width="175" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}" Margin="0,0,6,4"/>
+                        <TextBox Width="250" MinWidth="190" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,4" ToolTip="Search item number, name, certificate, calibrated by, standard, result, or notes"/>
+                        <ComboBox Width="175" MinWidth="145" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}" Margin="0,0,6,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Overdue" Command="{Binding ShowOverdueCommand}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Due Soon" Command="{Binding ShowDueSoonCommand}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Current" Command="{Binding ShowCurrentCommand}" Margin="0,0,4,4"/>
@@ -90,12 +100,12 @@
 
         <Grid Grid.Row="2" Margin="0,6,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*" MinWidth="630"/>
-                <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="440" MinWidth="390"/>
+                <ColumnDefinition Width="1.55*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="0.95*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -116,12 +126,19 @@
                             <TextBlock Text="{Binding CalibrationBacklogSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,10,0"/>
                         </DockPanel>
                     </Border>
-                    <DataGrid Grid.Row="2"
+                    <DataGrid x:Name="CalibrationGrid"
+                              Grid.Row="2"
                               ItemsSource="{Binding FilteredCalibrationRecords}"
                               SelectedItem="{Binding SelectedRecord}"
                               SelectionMode="Single"
+                              SelectionUnit="FullRow"
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
@@ -130,7 +147,7 @@
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>
-                            <DataGridTemplateColumn Header="Certificate item" Width="2.1*" MinWidth="220">
+                            <DataGridTemplateColumn Header="Certificate item" Width="2.1*" MinWidth="190">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -140,7 +157,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Due window" Width="170">
+                            <DataGridTemplateColumn Header="Due window" Width="155" MinWidth="145">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -150,7 +167,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Certificate" Width="2*" MinWidth="210">
+                            <DataGridTemplateColumn Header="Certificate" Width="2*" MinWidth="185">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -160,7 +177,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Last calibration" Width="170">
+                            <DataGridTemplateColumn Header="Last calibration" Width="160" MinWidth="150">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -170,7 +187,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Result" Binding="{Binding Result}" Width="90"/>
+                            <DataGridTextColumn Header="Result" Binding="{Binding Result}" Width="90" MinWidth="84"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
@@ -185,7 +202,7 @@
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>
-                    <Border Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="380" Padding="16">
+                    <Border Grid.Row="2" MaxWidth="360" MinHeight="130" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="16">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -208,7 +225,13 @@
                 </Grid>
             </Border>
 
-            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+            <GridSplitter Grid.Column="1"
+                          Width="6"
+                          HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          Background="{DynamicResource BorderBrushBase}"/>
+
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -224,7 +247,7 @@
                             <TextBlock Text="Issue-ready check" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
                         </DockPanel>
                     </Border>
-                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Hidden">
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <StackPanel Margin="14">
                             <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
                                 <StackPanel>
@@ -287,10 +310,10 @@
 
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
             <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Copy Handoff" Command="{Binding CopySelectedCalibrationCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Due" Command="{Binding PrintCalibrationListCommand}"/>
-                </StackPanel>
+                <WrapPanel DockPanel.Dock="Right">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Copy Handoff" Command="{Binding CopySelectedCalibrationCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Due" Command="{Binding PrintCalibrationListCommand}" Margin="0,0,0,4"/>
+                </WrapPanel>
                 <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>

--- a/ToDo.md
+++ b/ToDo.md
@@ -28,6 +28,8 @@ Current repository evidence:
 - Activity Audit Workbench layout now uses wrapping bounded metrics, lower split minimums, explicit grid virtualization/scrollbars, and bounded handoff/empty-state areas for scaled desktop reliability.
 - Users Workbench layout now uses wrapping bounded account summary cards, lower directory/detail split pressure, explicit user-grid virtualization/scrollbars, bounded empty state, and reachable access/security handoff scrolling.
 - Reports Workbench layout now uses wrapping bounded report metrics, lower report-results/handoff split pressure, explicit result-grid virtualization/scrollbars, bounded empty state, and bounded row-handoff scrolling.
+- Maintenance Workbench layout now uses wrapping bounded schedule metrics, lower schedule/handoff split pressure, explicit schedule-grid virtualization/scrollbars, bounded empty state, reachable technician handoff scrolling, and wrapping footer actions.
+- Calibration Workbench layout now uses wrapping bounded certificate metrics, lower register/handoff split pressure, explicit calibration-grid virtualization/scrollbars, bounded empty state, reachable certificate handoff scrolling, and wrapping footer actions.
 - This scheduled Linux environment cannot currently clone the repository directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
 
 ## Build And Validation
@@ -91,6 +93,8 @@ Recent completed slices that should not be repeated unless fresh evidence shows 
 - Activity Audit Workbench now has source-backed responsive layout contracts for wrapping audit metrics, reduced fixed split pressure, grid virtualization/scrolling, bounded empty state, bounded selected-log handoff, and preserved audit actions.
 - Users Workbench now has source-backed responsive layout contracts for wrapping account metrics, reduced fixed split pressure, directory grid virtualization/scrolling, bounded empty state, reachable handoff scrolling, and preserved account actions.
 - Reports Workbench now has source-backed responsive layout contracts for wrapping report metrics, reduced fixed split pressure, result grid virtualization/scrolling, bounded empty state, bounded row-handoff scrolling, and preserved report actions.
+- Maintenance Workbench now has source-backed responsive layout contracts for wrapping schedule metrics, reduced fixed split pressure, grid virtualization/scrolling, bounded empty state, reachable technician handoff scrolling, wrapping footer actions, and preserved maintenance actions.
+- Calibration Workbench now has source-backed responsive layout contracts for wrapping certificate metrics, reduced fixed split pressure, grid virtualization/scrolling, bounded empty state, reachable certificate handoff scrolling, wrapping footer actions, and preserved calibration actions.
 
 ## Highest-Value Next Work
 
@@ -98,7 +102,7 @@ Prioritize the following before adding unrelated new features:
 
 1. Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout and capture the actual restore, audit, build, test, publish, banned-word, and artifact-manifest results.
 2. Review the dedicated vulnerable-package audit output plus any NU190x warnings from repository-level NuGet auditing, then update affected packages or document intentional risk decisions.
-3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, Activity Logs, Users, Reports, and theme-customized popup surfaces.
+3. Smoke test the WPF app visually on Windows, especially dark-theme top navigation dropdowns, context menus, combo boxes, print preview, report preview, Activity Logs, Users, Reports, Maintenance, Calibration, and theme-customized popup surfaces.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical, especially when touching the same workflow for a real fix.
 5. Consider true streaming or exporter-specific flows for very large exports if future evidence shows the current paged-then-handoff export collectors still create unacceptable memory pressure.
 6. Keep tightening import/export, save-path, configuration, and document-output data-quality behavior only where current evidence shows another concrete user-entered, file-imported, or legacy stored value can bypass validation, duplicate detection, search/report consistency, permission consistency, delivery reliability, or professional output expectations.
@@ -115,7 +119,7 @@ Completed or substantially implemented:
 
 Still needing attention:
 
-- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, reservation readback normalization, customer readback normalization, operational-record readback normalization, Activity Logs responsive layout, Users responsive layout, and Reports responsive layout changes.
+- Full test suite green after the latest source-contract, dependency, reporting, export, import, validation-runner, operational-record, configuration, user/profile normalization, category/inventory refresh, settings normalization, rental readback normalization, item readback normalization, reservation readback normalization, customer readback normalization, operational-record readback normalization, Activity Logs responsive layout, Users responsive layout, Reports responsive layout, Maintenance responsive layout, and Calibration responsive layout changes.
 - Runtime WPF walkthrough of core workflows on Windows.
 - Visual QA in light/dark themes, including dropdowns, context menus, combo boxes, dialogs, and theme-customized popup surfaces.
 - Print and report preview QA for capped, empty, and large-data documents.


### PR DESCRIPTION
## What changed

- Reworked the Calibration Workbench summary metrics from a fixed four-column `UniformGrid` into wrapping bounded cards.
- Added a local `CalibrationMetricCard` style with practical minimum/maximum widths so register, due-state, selected-certificate, and release text wraps inside each card.
- Reduced the header title area from large fixed minimum columns to a shrinkable star column.
- Added practical minimums to the search and filter controls so the calibration toolbar can wrap while remaining usable.
- Changed the main calibration-register / certificate-handoff split from 630px plus 390px minimum pressure to a flexible star split with a practical 300px handoff minimum.
- Added a visible splitter and `MinWidth="0"` pane shells so WPF can shrink the register and handoff panes instead of forcing horizontal overflow.
- Enabled explicit row and column virtualization on the calibration register grid.
- Enabled automatic horizontal and vertical calibration-grid scrollbars plus content scrolling for wide certificate rows.
- Switched the calibration grid to full-row single selection for clearer row-level double-click and context-menu actions.
- Reduced oversized calibration grid column minimums so the register remains useful on smaller scaled desktops.
- Replaced the fixed-position empty state with a bounded, margin-protected empty state.
- Changed the certificate handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
- Changed the bottom action area from a fixed horizontal stack to a wrapping action group so primary calibration actions stay reachable at scaled desktop widths.
- Added `CalibrationPageResponsiveContractTests` to guard the responsive summary, main split, grid virtualization/scrolling, bounded filter/empty/handoff areas, and preserved calibration commands/row handlers.
- Added a progress note and refreshed `ToDo.md` so future scheduled runs do not repeat this slice without fresh evidence.

## Why this was the highest-value next step

Current repo evidence still lists Windows visual QA and scaled desktop usability as release risks. Recent merged runs completed adjacent responsive slices for Activity Logs, Users, Reports, and Maintenance. Source readback showed Calibration still had the same concrete risks: fixed four-card metrics, large register/handoff split minimums, no explicit calibration-grid scrollbar/virtualization contract, hidden handoff scrolling, and fixed horizontal footer actions. Calibration is a complete workflow with search, due-state filters, certificate triage, row actions, copy/print handoff, print due report, edit/delete, and selected-certificate handoff, so tightening it improves a real operations workflow rather than isolated styling.

## Why this is large enough to count as real progress

This covers more than ten focused workflow-level improvements across summary layout, card sizing, header sizing, filter sizing, split sizing, splitter behavior, WPF shrink behavior, grid virtualization, grid scrolling, selection behavior, column sizing, empty-state sizing, handoff scrolling, footer action reachability, source-contract coverage, progress notes, and the durable work queue.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/CalibrationPage.xaml`
  - `InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-calibration-responsive-workbench.md`
  - `ToDo.md`
- Connector source readback confirmed the Calibration page now uses wrapping bounded metric cards, lower split minimums, shrinkable pane shells, a visible splitter, explicit calibration-grid virtualization/scrollbars, full-row selection, bounded empty state, automatic handoff scrolling, and wrapping footer actions.
- Connector source readback confirmed `CalibrationPageResponsiveContractTests` covers the responsive layout contracts and preserved calibration commands/row handlers.
- Connector compare/status/workflow readback found no attached commit statuses or workflow runs on branch head `a6f23cb7d221996db3f0a81560b89457b6e7e68a` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Calibration on Windows at 1366 x 768 and higher DPI scales, including search, filters, overdue/due-soon/current views, row double-click, context-menu actions, copy handoff, print record, print due report, edit/delete, and handoff scrolling.