### PR TITLE
[codex] Improve customers workbench responsive layout

### DIFF
--- a/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomersPageResponsiveContractTests
+    {
+        [Fact]
+        public void CustomersPage_KeepsCustomerSummaryCardsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"160\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"250\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("CustomerStatValueText", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Grid Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"1.35*\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomersPage_AvoidsLargeFixedMinimumsInMainCustomerSplit()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.65*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\" Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2.1*\" MinWidth=\"560\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"1.05*\" MinWidth=\"360\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomersPage_EnablesDirectoryGridVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
+
+            Assert.Contains("x:Name=\"CustomerDataGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomersPage_BoundsSearchEmptyStateAndHandoffScrolling()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
+
+            Assert.Contains("<pages:SearchBar Width=\"300\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"310\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomersPage_PreservesPrimaryCustomerActionsAndRowHandoff()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
+
+            Assert.Contains("AddCustomerCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenCustomerDetailsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("EditCustomerCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedCustomerCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintSelectedCustomerCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintCustomerDirectoryCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("DeleteCustomerCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CustomerRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("CustomerRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-customers-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-customers-responsive-workbench.md
@@ -1,0 +1,35 @@
+# Customers Responsive Workbench
+
+Date: 2026-07-02
+
+## Completed
+
+- Reworked the Customers Workbench summary strip from four fixed grid columns into wrapping bounded customer metric cards.
+- Added bounded customer metric value styling so long search, contact, and selected-customer text trims inside each card instead of forcing horizontal overflow.
+- Bounded the page header copy so toolbar actions can wrap beside the title area at scaled desktop widths.
+- Reduced the main customer directory / advisor handoff split from large fixed minimums to a flexible star split with a practical 300px handoff minimum.
+- Added shrinkable pane shells with `MinWidth="0"` so WPF can contract both the directory and handoff panes instead of pushing the screen wider.
+- Narrowed the split handle to match the newer responsive workbench pattern.
+- Reduced customer search width while preserving a useful minimum.
+- Enabled explicit row and column virtualization on the customer directory grid.
+- Enabled automatic horizontal and vertical customer-grid scrollbars plus content scrolling for wide contact/address rows.
+- Switched the customer directory grid to single full-row selection for clearer double-click and context-menu actions.
+- Reduced oversized customer grid column minimums so directory rows remain useful on smaller scaled desktops.
+- Replaced the fixed-width empty state with a bounded, margin-protected empty state.
+- Changed advisor handoff scrolling from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
+- Wrapped handoff and footer actions so primary customer actions stay reachable at scaled desktop widths.
+- Added `CustomersPageResponsiveContractTests` to guard the responsive layout contracts and preserved customer commands/row handlers.
+
+## Why This Matters
+
+The Customers page is a dense advisor workflow with search, directory triage, selected-customer handoff, contact copying, customer sheets, directory printing, details, edit, and delete actions. Before this pass it still had the fixed summary strip, high split minimums, hidden handoff scrolling, and implicit grid scrolling risks already removed from nearby workbenches.
+
+## Validation
+
+- Source-contract coverage was added for the responsive summary strip, main split sizing, grid virtualization/scrolling, bounded search/empty/handoff areas, and preserved customer actions.
+- Connector source readback and compare were used because the scheduled Linux environment cannot clone the repository directly and does not provide `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, print-preview checks, or the full validation runner.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test Customers on Windows at 1366 x 768 and higher DPI scales, including search, clear search, row double-click, context-menu actions, selected-customer handoff scrolling, copy contact, customer sheet printing, directory printing, edit, delete, and details.

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml
@@ -8,11 +8,18 @@
         <Style x:Key="CustomerStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="MinHeight" Value="74"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="MinWidth" Value="160"/>
+            <Setter Property="MaxWidth" Value="250"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
         </Style>
         <Style x:Key="CustomerDetailText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="Margin" Value="0,2,0,0"/>
+        </Style>
+        <Style x:Key="CustomerStatValueText" TargetType="TextBlock" BasedOn="{StaticResource HeadingTextBlock}">
+            <Setter Property="TextWrapping" Value="NoWrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="MinHeight" Value="24"/>
         </Style>
     </Page.Resources>
 
@@ -24,13 +31,13 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
+        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="14,12">
             <DockPanel LastChildFill="False">
-                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <TextBlock Text="Customers" Style="{StaticResource PageTitleTextBlock}"/>
-                    <TextBlock Text="Find customer records, verify contact details, and prepare advisor handoffs before rentals or service follow-up." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,18,0" MinWidth="220" MaxWidth="460">
+                    <TextBlock Text="Customers" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Find customer records, verify contact details, and prepare advisor handoffs before rentals or service follow-up." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                 </StackPanel>
-                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="16,0,0,0">
+                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right">
                     <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCustomerCommand}" Margin="0,0,6,6"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" Margin="0,0,6,6"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}" Margin="0,0,6,6"/>
@@ -42,52 +49,46 @@
             </DockPanel>
         </Border>
 
-        <Grid Grid.Row="1" Margin="0,0,0,6">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="1.2*"/>
-                <ColumnDefinition Width="1.2*"/>
-                <ColumnDefinition Width="1.35*"/>
-            </Grid.ColumnDefinitions>
-            <Border Grid.Column="0" Style="{StaticResource CustomerStatCard}">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
+            <Border Style="{StaticResource CustomerStatCard}">
                 <StackPanel>
                     <TextBlock Text="Visible Customers" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding Customers.Count}" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="{Binding Customers.Count}" Style="{StaticResource CustomerStatValueText}"/>
                     <TextBlock Text="Directory rows matching the current search" Style="{StaticResource CustomerDetailText}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Column="1" Style="{StaticResource CustomerStatCard}">
+            <Border Style="{StaticResource CustomerStatCard}">
                 <StackPanel>
                     <TextBlock Text="Search State" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding CustomerResultsSummary}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding CustomerResultsSummary}" Style="{StaticResource CustomerStatValueText}"/>
                     <TextBlock Text="Use the directory filters before printing or copying handoffs" Style="{StaticResource CustomerDetailText}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Column="2" Style="{StaticResource CustomerStatCard}">
+            <Border Style="{StaticResource CustomerStatCard}">
                 <StackPanel>
                     <TextBlock Text="Contact Path" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding CustomerContactSummary}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding CustomerContactSummary}" Style="{StaticResource CustomerStatValueText}"/>
                     <TextBlock Text="Phone, mobile, and email context for the selected customer" Style="{StaticResource CustomerDetailText}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Column="3" Style="{StaticResource CustomerStatCard}" Margin="0">
+            <Border Style="{StaticResource CustomerStatCard}" Margin="0,0,0,8">
                 <StackPanel>
                     <TextBlock Text="Selected Customer" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding SelectedCustomer.Company, TargetNullValue=No customer selected}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding SelectedCustomer.Company, TargetNullValue=No customer selected}" Style="{StaticResource CustomerStatValueText}"/>
                     <TextBlock Text="{Binding CustomerOperationsSummary}" Style="{StaticResource CustomerDetailText}"/>
                 </StackPanel>
             </Border>
-        </Grid>
+        </WrapPanel>
 
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.1*" MinWidth="560"/>
-                <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="1.05*" MinWidth="360"/>
+                <ColumnDefinition Width="1.65*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="0.95*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
-                <Grid>
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                <Grid MinWidth="0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -99,14 +100,15 @@
                                 <TextBlock Text="Customer Directory" Style="{StaticResource SectionHeader}" Margin="0"/>
                                 <TextBlock Text="Select the exact company or contact before copying, printing, editing, or opening details." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
-                            <TextBlock DockPanel.Dock="Right" Text="{Binding CustomerResultsSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="12,0,0,0"/>
+                            <TextBlock DockPanel.Dock="Right" Text="{Binding CustomerResultsSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="12,0,0,0"/>
                         </DockPanel>
                     </Border>
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
-                        <DockPanel LastChildFill="False">
+                        <DockPanel LastChildFill="True">
                             <WrapPanel DockPanel.Dock="Left" VerticalAlignment="Center">
                                 <TextBlock Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,6"/>
-                                <pages:SearchBar Width="340"
+                                <pages:SearchBar Width="300"
+                                                 MinWidth="220"
                                                  Text="{Binding CustomerSearchTerm, UpdateSourceTrigger=PropertyChanged}"
                                                  SearchCommand="{Binding SearchCustomersCommand}"
                                                  ClearCommand="{Binding ClearCustomerSearchCommand}"
@@ -120,12 +122,20 @@
                             </WrapPanel>
                         </DockPanel>
                     </Border>
-                    <DataGrid Grid.Row="2"
+                    <DataGrid x:Name="CustomerDataGrid"
+                              Grid.Row="2"
                               ItemsSource="{Binding Customers}"
                               SelectedItem="{Binding SelectedCustomer}"
                               IsReadOnly="True"
                               AutoGenerateColumns="False"
                               SelectionMode="Single"
+                              SelectionUnit="FullRow"
+                              CanUserAddRows="False"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
@@ -134,7 +144,7 @@
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>
-                            <DataGridTemplateColumn Header="Company" Width="2.2*" MinWidth="190">
+                            <DataGridTemplateColumn Header="Company" Width="2.2*" MinWidth="170">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="0,3">
@@ -144,7 +154,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Contact" Width="1.7*" MinWidth="165">
+                            <DataGridTemplateColumn Header="Contact" Width="1.7*" MinWidth="150">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="0,3">
@@ -164,7 +174,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Address" Binding="{Binding Address}" Width="1.8*" MinWidth="155"/>
+                            <DataGridTextColumn Header="Address" Binding="{Binding Address}" Width="1.8*" MinWidth="150"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
@@ -178,7 +188,7 @@
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>
-                    <Border Grid.Row="2" Width="310" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Border Grid.Row="2" MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -197,10 +207,10 @@
                 </Grid>
             </Border>
 
-            <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
-                <Grid>
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                <Grid MinWidth="0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
@@ -214,7 +224,7 @@
                             </StackPanel>
                         </DockPanel>
                     </Border>
-                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Hidden">
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <StackPanel Margin="14">
                             <TextBlock Text="{Binding SelectedCustomer.Company, TargetNullValue='No customer selected', FallbackValue='No customer selected'}"
                                        FontSize="18"
@@ -261,8 +271,8 @@
                     </ScrollViewer>
                     <Border Grid.Row="2" Style="{StaticResource DesktopSectionActionStrip}">
                         <WrapPanel HorizontalAlignment="Right">
-                            <Button Style="{StaticResource PrimaryButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" Margin="0,0,6,0"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Command="{Binding PrintSelectedCustomerCommand}"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" Margin="0,0,6,6"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Command="{Binding PrintSelectedCustomerCommand}" Margin="0,0,0,6"/>
                         </WrapPanel>
                     </Border>
                 </Grid>
@@ -271,9 +281,9 @@
 
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,6,0,0">
             <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <Button Style="{StaticResource GhostButton}" Content="Clear Search" Command="{Binding ClearCustomerSearchCommand}"/>
-                </StackPanel>
+                <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource GhostButton}" Content="Clear Search" Command="{Binding ClearCustomerSearchCommand}" Margin="0,0,0,6"/>
+                </WrapPanel>
                 <TextBlock Text="{Binding SelectedCustomerSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>


### PR DESCRIPTION
## What changed

- Reworked the Customers Workbench summary metrics from a fixed four-column grid into wrapping bounded cards.
- Added bounded customer metric value styling so long search, contact, and selected-customer text trims inside each card instead of forcing horizontal overflow.
- Bounded the header title/copy area so toolbar actions can wrap beside the page heading at scaled desktop widths.
- Changed the main customer-directory / advisor-handoff split from 560px plus 360px fixed minimum pressure to a flexible star split with a practical 300px handoff minimum.
- Added `MinWidth="0"` pane shells so WPF can shrink both customer panes instead of pushing the page wider.
- Narrowed the split handle to match the newer responsive workbench pattern.
- Reduced the customer search width while preserving a useful minimum.
- Enabled explicit row and column virtualization on the customer directory grid.
- Enabled automatic horizontal and vertical directory-grid scrollbars plus content scrolling for wide customer/contact/address rows.
- Switched the customer directory grid to full-row single selection for clearer row-level double-click and context-menu actions.
- Reduced oversized customer grid column minimums so the directory remains useful on smaller scaled desktops.
- Replaced the fixed-width empty state with a bounded, margin-protected empty state.
- Changed advisor handoff scrolling from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
- Wrapped selected-customer handoff actions and the footer clear-search action so primary actions stay reachable at scaled desktop widths.
- Added `CustomersPageResponsiveContractTests` to guard the responsive summary, split sizing, grid virtualization/scrolling, bounded search/empty/handoff areas, and preserved customer commands/row handlers.
- Added a progress note for the completed Customers responsive workflow slice.

## Why this was the highest-value next step

Current repo evidence still lists Windows visual QA and scaled desktop usability as release risks. Recent merged runs completed the adjacent Activity Logs, Users, Reports, Maintenance, and Calibration responsive slices. Source readback showed Customers still had the same concrete risks: fixed four-card metrics, large directory/handoff split minimums, no explicit customer-grid scrollbar/virtualization contract, hidden handoff scrolling, and fixed-width empty-state behavior. Customers is a complete advisor workflow with search, directory triage, selected-customer handoff, details, edit/delete, copy contact, customer sheet printing, and directory printing, so tightening it improves a real workflow rather than isolated styling.

## Why this is large enough to count as real progress

This covers more than ten focused workflow-level improvements across summary layout, card sizing, metric value behavior, header sizing, split sizing, splitter sizing, WPF shrink behavior, search sizing, grid virtualization, grid scrolling, selection behavior, column sizing, empty-state sizing, handoff scrolling, action wrapping, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/CustomersPage.xaml`
  - `InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-customers-responsive-workbench.md`
- Connector source readback confirmed the Customers page now uses wrapping bounded metric cards, lower split minimums, shrinkable pane shells, explicit customer-grid virtualization/scrollbars, full-row selection, bounded empty state, automatic handoff scrolling, and wrapping actions.
- Connector source readback confirmed `CustomersPageResponsiveContractTests` covers the responsive layout contracts and preserved customer commands/row handlers.
- Connector status readback found no attached commit statuses on branch head `10f09f36644f0b4389a197dfb05ac157c87effca` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Customers on Windows at 1366 x 768 and higher DPI scales, including search, clear search, row double-click, context-menu actions, selected-customer handoff scrolling, copy contact, customer sheet printing, directory printing, details, edit, and delete.