### PR TITLE
[codex] Improve dashboard responsive workbench layout

### DIFF
--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class DashboardPageResponsiveContractTests
+    {
+        [Fact]
+        public void DashboardPage_KeepsOperationalMetricsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("DashboardMetricCard", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"230\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("DashboardMetricValueText", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Columns=\"4\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_AvoidsLargeFixedMinimumsInMainWorkloadSplit()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.65*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"6\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Row=\"0\" Grid.RowSpan=\"2\" Grid.Column=\"1\" Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"0\" Grid.RowSpan=\"2\" Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"1\" Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"520\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"*\" MinWidth=\"360\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_EnablesEveryDashboardGridVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");
+            var gridNames = new[]
+            {
+                "RentedItemsGrid",
+                "CheckedOutItemsGrid",
+                "RecentActivityGrid",
+                "IncompleteItemsGrid",
+                "CommonItemsGrid"
+            };
+
+            foreach (var gridName in gridNames)
+                Assert.Contains($"x:Name=\"{gridName}\"", xaml, StringComparison.Ordinal);
+
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "EnableRowVirtualization=\"True\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "EnableColumnVirtualization=\"True\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "SelectionUnit=\"FullRow\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "ScrollViewer.CanContentScroll=\"True\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "ScrollViewer.HorizontalScrollBarVisibility=\"Auto\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "ScrollViewer.VerticalScrollBarVisibility=\"Auto\""));
+        }
+
+        [Fact]
+        public void DashboardPage_WrapsHeaderAndPaneActionsForScaledDesktopWidths()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");
+
+            Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" MinWidth=\"210\" MaxWidth=\"320\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Style=\"{StaticResource DesktopSummaryCard}\" MinWidth=\"92\" MaxWidth=\"160\"", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">") >= 3);
+            Assert.DoesNotContain("<StackPanel Orientation=\"Horizontal\" DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_PreservesPrimaryDashboardActionsAndRowHandoff()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("NewItemCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenItemsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenRentalsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintDashboardSnapshotCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintCheckedOutItemsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenActivityDestinationCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenSelectedIncompleteItemCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenSelectedCommonItemCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("DashboardGrid_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("OpenFocusedRow", codeBehind, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-dashboard-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-dashboard-responsive-workbench.md
@@ -1,0 +1,27 @@
+# Dashboard Responsive Workbench
+
+Date: 2026-07-02
+
+## Completed
+
+- Replaced the fixed four-column dashboard operational summary with wrapping bounded metric cards.
+- Added local dashboard metric card/value styles so counts and labels stay inside their cards at scaled desktop widths.
+- Reduced the header title footprint and bounded top stat cards so toolbar actions and stat cards can wrap cleanly.
+- Changed the main dashboard workload split from fixed 520px plus 360px minimum pressure to a flexible split with a visible splitter and a practical 300px right-pane minimum.
+- Added shrinkable `MinWidth="0"` pane shells for checked-out items, active rentals, and the tabbed activity/issues/common item pane.
+- Wrapped active-rental, checked-out-item, and common-item header actions so primary dashboard actions remain reachable at 1366 x 768 and higher DPI scales.
+- Enabled explicit row and column virtualization on all five dashboard grids.
+- Enabled automatic horizontal and vertical dashboard-grid scrollbars plus content scrolling for wide item, rental, activity, and issue rows.
+- Switched all dashboard grids to full-row single selection for clearer double-click, keyboard, and context-menu actions.
+- Reduced several oversized dashboard grid columns so the most important workflow columns stay visible before horizontal scrolling is needed.
+- Added source-contract coverage in `DashboardPageResponsiveContractTests` for responsive metrics, split sizing, grid virtualization/scrolling, wrapped actions, and preserved dashboard commands/row handoff.
+
+## Validation Notes
+
+- Source readback/compare validation should confirm the branch is limited to Dashboard XAML, responsive source-contract coverage, this progress note, and the current work queue update.
+- Local `pwsh -File scripts/run-full-validation.ps1`, WPF screenshots, print-preview/layout checks, and .NET tests still need a Windows/.NET-capable checkout because the scheduled Linux environment cannot clone the repository and lacks `dotnet`, `pwsh`, `gh`, and WPF runtime tooling.
+
+## Follow-up
+
+- Run full Windows/.NET validation and visually smoke test Dashboard at 1366 x 768 plus 125%, 150%, and 200% scaling.
+- Exercise dashboard row actions for checked-out items, active rentals, recent activity, incomplete items, commonly used items, checked-out printing, and dashboard snapshot printing.

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -5,6 +5,21 @@
       xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
       Background="{DynamicResource MainContentBackgroundBrush}"
       Focusable="True">
+    <Page.Resources>
+        <Style x:Key="DashboardMetricCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
+            <Setter Property="MinWidth" Value="150"/>
+            <Setter Property="MaxWidth" Value="230"/>
+            <Setter Property="MinHeight" Value="72"/>
+            <Setter Property="Padding" Value="10,7"/>
+            <Setter Property="Margin" Value="0,0,6,6"/>
+        </Style>
+        <Style x:Key="DashboardMetricValueText" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        </Style>
+    </Page.Resources>
+
     <Grid Margin="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -15,7 +30,7 @@
 
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="10,6" Margin="0,0,0,6">
             <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Left" MinWidth="250" Margin="0,0,14,0" VerticalAlignment="Center">
+                <StackPanel DockPanel.Dock="Left" MinWidth="210" MaxWidth="320" Margin="0,0,14,0" VerticalAlignment="Center">
                     <TextBlock Text="Dashboard Command Center" Style="{StaticResource PageTitleTextBlock}" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Live workload, demand, and exception signals for the next counter action."
                                Style="{StaticResource CaptionTextBlock}"
@@ -25,12 +40,12 @@
                 </StackPanel>
 
                 <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="12,0,0,0">
-                    <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="New Item" Command="{Binding NewItemCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Open Items" Command="{Binding OpenItemsCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Open Rentals" Command="{Binding OpenRentalsCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Print Snapshot" Command="{Binding PrintDashboardSnapshotCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Import / Export" Command="{Binding OpenImportExportCommand}"/>
+                    <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="New Item" Command="{Binding NewItemCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Open Items" Command="{Binding OpenItemsCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Open Rentals" Command="{Binding OpenRentalsCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Snapshot" Command="{Binding PrintDashboardSnapshotCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Import / Export" Command="{Binding OpenImportExportCommand}" Margin="0,0,0,4"/>
                 </WrapPanel>
 
                 <ItemsControl ItemsSource="{Binding StatCards}" Margin="0,0,8,0" VerticalAlignment="Center">
@@ -41,7 +56,7 @@
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="92" Margin="0,0,6,4" Padding="9,5">
+                            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="92" MaxWidth="160" Margin="0,0,6,4" Padding="9,5">
                                 <StackPanel>
                                     <TextBlock Text="{Binding Value}"
                                                FontSize="18"
@@ -60,53 +75,60 @@
             </DockPanel>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource DesktopNoteCard}" Padding="8,5" Margin="0,0,0,6">
-            <UniformGrid Columns="4">
-                <StackPanel Margin="0,0,10,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
+            <Border Style="{StaticResource DashboardMetricCard}">
+                <StackPanel>
                     <TextBlock Text="Checked out" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding CheckedOutItems.Count}" FontSize="15" FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}"/>
+                    <TextBlock Text="{Binding CheckedOutItems.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Return or inspect before shift end." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
-                <StackPanel Margin="0,0,10,0">
+            </Border>
+            <Border Style="{StaticResource DashboardMetricCard}">
+                <StackPanel>
                     <TextBlock Text="Active rentals" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding RentedItems.Count}" FontSize="15" FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}"/>
+                    <TextBlock Text="{Binding RentedItems.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Review due dates." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
-                <StackPanel Margin="0,0,10,0">
+            </Border>
+            <Border Style="{StaticResource DashboardMetricCard}">
+                <StackPanel>
                     <TextBlock Text="Items with issues" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding IncompleteItems.Count}" FontSize="15" FontWeight="SemiBold" Foreground="{DynamicResource WarningBrush}"/>
+                    <TextBlock Text="{Binding IncompleteItems.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource WarningBrush}"/>
                     <TextBlock Text="Prioritize missing parts." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
+            </Border>
+            <Border Style="{StaticResource DashboardMetricCard}">
                 <StackPanel>
                     <TextBlock Text="Activity rows" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding RecentActivity.Count}" FontSize="15" FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}"/>
+                    <TextBlock Text="{Binding RecentActivity.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Open latest audit rows." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
-            </UniformGrid>
-        </Border>
+            </Border>
+        </WrapPanel>
 
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*" MinWidth="520"/>
-                <ColumnDefinition Width="*" MinWidth="360"/>
+                <ColumnDefinition Width="1.65*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="0.95*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Border Grid.Row="0" Grid.Column="1" Style="{StaticResource Card}" Padding="0" Margin="0,0,0,6">
+            <Border Grid.Row="0" Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0" Margin="0,0,0,6">
                 <DockPanel>
                     <Border DockPanel.Dock="Top" Style="{StaticResource DesktopPaneHeader}" Margin="0">
                         <DockPanel LastChildFill="False">
-                            <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
-                                <TextBlock Text="Active Rentals" Style="{StaticResource SubheadingTextBlock}"/>
-                                <TextBlock Text="Due dates needing follow-up." Style="{StaticResource CaptionTextBlock}"/>
+                            <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="0">
+                                <TextBlock Text="Active Rentals" Style="{StaticResource SubheadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                <TextBlock Text="Due dates needing follow-up." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedRentalCommand}" Margin="0,0,4,0"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Return" Command="{Binding ReturnSelectedRentalCommand}"/>
-                            </StackPanel>
+                            <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
+                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedRentalCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Return" Command="{Binding ReturnSelectedRentalCommand}" Margin="0,0,0,4"/>
+                            </WrapPanel>
                         </DockPanel>
                     </Border>
                     <DataGrid x:Name="RentedItemsGrid"
@@ -115,7 +137,13 @@
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
                               CanUserAddRows="False"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
                               SelectionMode="Single"
+                              SelectionUnit="FullRow"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               Style="{StaticResource VirtualizedDataGridStyle}"
                               RowHeight="44"
                               MouseDoubleClick="RentedItemsGrid_MouseDoubleClick"
@@ -136,9 +164,9 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="76"/>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="72"/>
                             <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="*"/>
-                            <DataGridTextColumn Header="Due" Binding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd}}" Width="88"/>
+                            <DataGridTextColumn Header="Due" Binding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd}}" Width="84"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
@@ -151,19 +179,21 @@
                 </DockPanel>
             </Border>
 
-            <Border Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" Style="{StaticResource Card}" Padding="0" Margin="0,0,6,0">
+            <GridSplitter Grid.Row="0" Grid.RowSpan="2" Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+
+            <Border Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0" Margin="0,0,6,0">
                 <DockPanel>
                     <Border DockPanel.Dock="Top" Style="{StaticResource DesktopPaneHeader}" Margin="0">
                         <DockPanel LastChildFill="False">
-                            <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
-                                <TextBlock Text="Checked-Out Items" Style="{StaticResource SubheadingTextBlock}"/>
-                                <TextBlock Text="Away from shelf with holder context." Style="{StaticResource CaptionTextBlock}"/>
+                            <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="0">
+                                <TextBlock Text="Checked-Out Items" Style="{StaticResource SubheadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                <TextBlock Text="Away from shelf with holder context." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCheckedOutItemCommand}" Margin="0,0,4,0"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Check In" Command="{Binding CheckInSelectedItemCommand}" Margin="0,0,4,0"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintCheckedOutItemsCommand}"/>
-                            </StackPanel>
+                            <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
+                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCheckedOutItemCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Check In" Command="{Binding CheckInSelectedItemCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintCheckedOutItemsCommand}" Margin="0,0,0,4"/>
+                            </WrapPanel>
                         </DockPanel>
                     </Border>
                     <DataGrid x:Name="CheckedOutItemsGrid"
@@ -172,7 +202,13 @@
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
                               CanUserAddRows="False"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
                               SelectionMode="Single"
+                              SelectionUnit="FullRow"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               Style="{StaticResource VirtualizedDataGridStyle}"
                               RowHeight="44"
                               MouseDoubleClick="CheckedOutItemsGrid_MouseDoubleClick"
@@ -193,11 +229,11 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="92"/>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="86"/>
                             <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*"/>
-                            <DataGridTextColumn Header="Holder" Binding="{Binding CheckedOutBy}" Width="112"/>
-                            <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="104"/>
-                            <DataGridTextColumn Header="Out Since" Binding="{Binding CheckedOutTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="118"/>
+                            <DataGridTextColumn Header="Holder" Binding="{Binding CheckedOutBy}" Width="102"/>
+                            <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="92"/>
+                            <DataGridTextColumn Header="Out Since" Binding="{Binding CheckedOutTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="108"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
@@ -211,15 +247,15 @@
                 </DockPanel>
             </Border>
 
-            <Border Grid.Row="1" Grid.Column="1" Style="{StaticResource Card}" Padding="0">
-                <TabControl>
+            <Border Grid.Row="1" Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                <TabControl MinWidth="0">
                     <TabItem Header="Recent Activity">
                         <DockPanel>
                             <Border DockPanel.Dock="Top" Style="{StaticResource DesktopPaneHeader}" Margin="0">
                                 <DockPanel LastChildFill="False">
-                                    <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
-                                        <TextBlock Text="Audit Trail" Style="{StaticResource SubheadingTextBlock}"/>
-                                        <TextBlock Text="Open the selected activity workflow." Style="{StaticResource CaptionTextBlock}"/>
+                                    <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="0">
+                                        <TextBlock Text="Audit Trail" Style="{StaticResource SubheadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="Open the selected activity workflow." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                                     </StackPanel>
                                     <Button Style="{StaticResource GhostButton}" Content="Open Related" Command="{Binding OpenActivityDestinationCommand}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                                 </DockPanel>
@@ -233,13 +269,19 @@
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True"
                                       CanUserAddRows="False"
+                                      EnableRowVirtualization="True"
+                                      EnableColumnVirtualization="True"
                                       SelectionMode="Single"
+                                      SelectionUnit="FullRow"
+                                      ScrollViewer.CanContentScroll="True"
+                                      ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                      ScrollViewer.VerticalScrollBarVisibility="Auto"
                                       Style="{StaticResource VirtualizedDataGridStyle}"
                                       MouseDoubleClick="RecentActivityGrid_MouseDoubleClick"
                                       PreviewMouseRightButtonDown="DashboardGrid_PreviewMouseRightButtonDown">
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Header="When" Binding="{Binding Timestamp, StringFormat={}{0:HH:mm}}" Width="70"/>
-                                    <DataGridTextColumn Header="User" Binding="{Binding UserName}" Width="95"/>
+                                    <DataGridTextColumn Header="When" Binding="{Binding Timestamp, StringFormat={}{0:HH:mm}}" Width="64"/>
+                                    <DataGridTextColumn Header="User" Binding="{Binding UserName}" Width="90"/>
                                     <DataGridTextColumn Header="Action" Binding="{Binding Action}" Width="*"/>
                                 </DataGrid.Columns>
                                 <DataGrid.ContextMenu>
@@ -255,9 +297,9 @@
                         <DockPanel>
                             <Border DockPanel.Dock="Top" Style="{StaticResource DesktopPaneHeader}" Margin="0">
                                 <DockPanel LastChildFill="False">
-                                    <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
-                                        <TextBlock Text="Needs Attention" Style="{StaticResource SubheadingTextBlock}"/>
-                                        <TextBlock Text="Incomplete records and missing-component notes for follow-up." Style="{StaticResource CaptionTextBlock}"/>
+                                    <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="0">
+                                        <TextBlock Text="Needs Attention" Style="{StaticResource SubheadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="Incomplete records and missing-component notes for follow-up." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                                     </StackPanel>
                                     <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedIncompleteItemCommand}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                                 </DockPanel>
@@ -268,14 +310,20 @@
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True"
                                       CanUserAddRows="False"
+                                      EnableRowVirtualization="True"
+                                      EnableColumnVirtualization="True"
                                       SelectionMode="Single"
+                                      SelectionUnit="FullRow"
+                                      ScrollViewer.CanContentScroll="True"
+                                      ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                      ScrollViewer.VerticalScrollBarVisibility="Auto"
                                       Style="{StaticResource VirtualizedDataGridStyle}"
                                       MouseDoubleClick="IncompleteItemsGrid_MouseDoubleClick"
                                       PreviewMouseRightButtonDown="DashboardGrid_PreviewMouseRightButtonDown">
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="90"/>
+                                    <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="82"/>
                                     <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
-                                    <DataGridTextColumn Header="Notes" Binding="{Binding MissingComponentsNotes}" Width="160"/>
+                                    <DataGridTextColumn Header="Notes" Binding="{Binding MissingComponentsNotes}" Width="130"/>
                                 </DataGrid.Columns>
                                 <DataGrid.ContextMenu>
                                     <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
@@ -290,14 +338,14 @@
                         <DockPanel>
                             <Border DockPanel.Dock="Top" Style="{StaticResource DesktopPaneHeader}" Margin="0">
                                 <DockPanel LastChildFill="False">
-                                    <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
-                                        <TextBlock Text="Commonly Used Items" Style="{StaticResource SubheadingTextBlock}"/>
-                                        <TextBlock Text="High-frequency counter items." Style="{StaticResource CaptionTextBlock}"/>
+                                    <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="0">
+                                        <TextBlock Text="Commonly Used Items" Style="{StaticResource SubheadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="High-frequency counter items." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                                     </StackPanel>
-                                    <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                                        <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCommonItemCommand}" Margin="0,0,4,0"/>
-                                        <Button Style="{StaticResource GhostButton}" Content="Check Out / In" Command="{Binding ToggleSelectedCommonItemCommand}"/>
-                                    </StackPanel>
+                                    <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
+                                        <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCommonItemCommand}" Margin="0,0,4,4"/>
+                                        <Button Style="{StaticResource GhostButton}" Content="Check Out / In" Command="{Binding ToggleSelectedCommonItemCommand}" Margin="0,0,0,4"/>
+                                    </WrapPanel>
                                 </DockPanel>
                             </Border>
                             <DataGrid x:Name="CommonItemsGrid"
@@ -306,7 +354,13 @@
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True"
                                       CanUserAddRows="False"
+                                      EnableRowVirtualization="True"
+                                      EnableColumnVirtualization="True"
                                       SelectionMode="Single"
+                                      SelectionUnit="FullRow"
+                                      ScrollViewer.CanContentScroll="True"
+                                      ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                      ScrollViewer.VerticalScrollBarVisibility="Auto"
                                       Style="{StaticResource VirtualizedDataGridStyle}"
                                       RowHeight="44"
                                       MouseDoubleClick="CommonItemsGrid_MouseDoubleClick"
@@ -327,11 +381,11 @@
                                             </DataTemplate>
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>
-                                    <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="82"/>
+                                    <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="76"/>
                                     <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
-                                    <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="82"/>
-                                    <DataGridTextColumn Header="Use" Binding="{Binding CheckoutCount}" Width="54"/>
-                                    <DataGridTemplateColumn Header="Status" Width="90">
+                                    <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="78"/>
+                                    <DataGridTextColumn Header="Use" Binding="{Binding CheckoutCount}" Width="52"/>
+                                    <DataGridTemplateColumn Header="Status" Width="82">
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate>
                                                 <StackPanel Orientation="Horizontal">
@@ -358,7 +412,7 @@
 
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Padding="6,3" Margin="0,6,0,0">
             <DockPanel LastChildFill="True">
-                <TextBlock Text="{Binding OperationsSummary}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Text="{Binding OperationsSummary}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,12,0" TextWrapping="Wrap"/>
                 <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>


### PR DESCRIPTION
## What changed

- Reworked the Dashboard operational summary from a fixed four-column `UniformGrid` into wrapping bounded metric cards.
- Added local dashboard metric card/value styles so workload counts and labels stay inside their cards at scaled desktop widths.
- Bounded the header title area and top stat cards so the action toolbar and stat cards can wrap without forcing horizontal overflow.
- Changed the main dashboard split from fixed 520px plus 360px minimum pressure to a flexible split with a visible splitter and a practical 300px right-pane minimum.
- Added `MinWidth="0"` shrinkable pane shells for checked-out items, active rentals, and the tabbed activity/issues/common-items pane.
- Wrapped dashboard pane header actions for active rentals, checked-out items, and commonly used items so primary actions remain reachable at 1366 x 768 and higher DPI scales.
- Enabled explicit row and column virtualization on all five dashboard grids.
- Enabled automatic horizontal and vertical grid scrollbars plus content scrolling for wide item, rental, activity, issue, and common-item rows.
- Switched all dashboard grids to full-row single selection for clearer row-level double-click, keyboard, and context-menu actions.
- Reduced several oversized dashboard grid column widths so the most important operational fields stay visible before horizontal scrolling is needed.
- Added `DashboardPageResponsiveContractTests` to guard responsive metrics, main split sizing, grid virtualization/scrolling, wrapped actions, and preserved dashboard command/row-handoff behavior.
- Added a progress note for the completed Dashboard responsive workflow slice.

## Why this was the highest-value next step

Current repository notes still identify Windows visual QA and scaled desktop usability as release risks. Recent merged runs completed adjacent dense workbenches for Activity Logs, Users, Reports, Maintenance, Calibration, and Customers. Source readback showed Dashboard still had the same concrete risks: a fixed four-column operational summary, large main split minimums, unbounded pane shells, horizontal pane header actions, and no explicit scrollbar/virtualization/full-row-selection contracts on the five dashboard grids. Dashboard is the app's cross-workflow command center for checked-out items, active rentals, recent activity, incomplete items, commonly used items, printing, and navigation, so tightening it improves a complete core workflow.

## Why this is large enough to count as real progress

This covers more than ten focused workflow-level improvements across summary layout, card sizing, header sizing, stat-card bounding, split sizing, visible splitter behavior, WPF shrink behavior, action wrapping, grid virtualization, grid scrolling, row selection, column sizing, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/DashboardPage.xaml`
  - `InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-dashboard-responsive-workbench.md`
- Connector source readback confirmed Dashboard now uses wrapping bounded metric cards, bounded header/stat cards, lower main split minimums, a visible splitter, shrinkable pane shells, wrapped pane actions, explicit grid virtualization/scrollbars, full-row selection, and narrower dashboard grid columns.
- Connector source readback confirmed `DashboardPageResponsiveContractTests` covers the responsive layout contracts and preserved dashboard commands/context-menu row handoff.
- Connector status readback found no attached commit statuses on branch head `e8e7b78efb90676c5432d02b8a6797055efc449f` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Dashboard on Windows at 1366 x 768 and higher DPI scales, including checked-out item actions, active rental actions, recent activity navigation, incomplete/common item actions, checked-out printing, and dashboard snapshot printing.