### PR TITLE
[codex] Improve categories workbench responsive layout

### DIFF
--- a/InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CategoriesPageResponsiveContractTests
+    {
+        [Fact]
+        public void CategoriesPage_KeepsCategorySummaryCardsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("CategoryStatValueText", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"520\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_AvoidsLargeFixedMinimumsInMainCategorySplit()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.55*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\" Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2.35*\" MinWidth=\"620\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"430\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_EnablesDirectoryGridVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
+
+            Assert.Contains("x:Name=\"CategoryGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_BoundsInputsEmptyStateAndHandoffScrolling()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
+
+            Assert.Contains("<TextBox x:Name=\"CategoryNameBox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Width=\"250\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"190\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"340\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_PreservesPrimaryCategoryActionsAndRowHandoff()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
+
+            Assert.Contains("AddCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("SaveCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("DeleteCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ClearSearchCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("RefreshCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenCategoryDetail_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("CopyCategory_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintSelectedCategory_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintCategories_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("CategoryRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("CategoryRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-categories-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-categories-responsive-workbench.md
@@ -1,0 +1,29 @@
+# Categories Responsive Workbench
+
+Date: 2026-07-02
+
+## Completed
+
+- Replaced the fixed four-column category summary strip with wrapping bounded metric cards.
+- Added local category metric card/value styles so directory, filter, selected-category, and setup text stays inside each card at scaled desktop widths.
+- Reduced the header title/stat area from large fixed minimum columns to shrinkable star columns.
+- Reduced category create/filter input widths while preserving practical minimums for keyboard-driven admin work.
+- Changed the main category-directory / setup-handoff split from fixed 620px plus 380px minimum pressure to a flexible split with a practical 300px handoff minimum.
+- Narrowed the splitter and added shrinkable `MinWidth="0"` pane shells so WPF can reduce both panes instead of pushing the page wider.
+- Enabled explicit row and column virtualization on the category directory grid.
+- Enabled automatic horizontal and vertical directory-grid scrollbars plus content scrolling for category rows.
+- Switched the category grid to full-row single selection for clearer row-level double-click and context-menu actions.
+- Reduced oversized category grid column minimums so the directory stays useful before horizontal scrolling is needed.
+- Replaced the fixed-width empty state with a bounded, margin-protected empty state.
+- Changed the setup handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
+- Added `CategoriesPageResponsiveContractTests` to guard the responsive summary, main split sizing, grid virtualization/scrolling, bounded inputs/empty/handoff areas, and preserved category commands/row handlers.
+
+## Validation Notes
+
+- Source readback/compare validation should confirm the branch is limited to Categories XAML, responsive source-contract coverage, and this progress note.
+- Local `pwsh -File scripts/run-full-validation.ps1`, WPF screenshots, print-preview/layout checks, and .NET tests still need a Windows/.NET-capable checkout because the scheduled Linux environment cannot clone the repository and lacks `dotnet`, `pwsh`, `gh`, and WPF runtime tooling.
+
+## Follow-up
+
+- Run full Windows/.NET validation and visually smoke test Categories at 1366 x 768 plus 125%, 150%, and 200% scaling.
+- Exercise category search, create, save, row double-click, row context menu, copy handoff, print sheet, print directory, delete, refresh, and setup handoff scrolling.

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
@@ -8,7 +8,16 @@
         <Style x:Key="CategoryStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="MinWidth" Value="150"/>
+            <Setter Property="MaxWidth" Value="235"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+        <Style x:Key="CategoryStatValueText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="Margin" Value="0,3,0,0"/>
         </Style>
         <Style x:Key="CategoryDetailCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
@@ -32,43 +41,43 @@
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" MinWidth="380"/>
+                    <ColumnDefinition Width="1.15*" MinWidth="0"/>
                     <ColumnDefinition Width="14"/>
-                    <ColumnDefinition Width="3*" MinWidth="520"/>
+                    <ColumnDefinition Width="1.65*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center">
+                <StackPanel VerticalAlignment="Center" MinWidth="0">
                     <TextBlock Text="Category Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
                     <TextBlock Text="Shape the category language staff use for item setup, advisor search, printed directories, and clean handoffs between inventory areas."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <UniformGrid Grid.Column="2" Columns="4">
+                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
                     <Border Style="{StaticResource CategoryStatCard}">
                         <StackPanel>
                             <TextBlock Text="DIRECTORY" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding CategoryResultsSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding CategoryResultsSummary}" Style="{StaticResource CategoryStatValueText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource CategoryStatCard}">
                         <StackPanel>
                             <TextBlock Text="FILTER" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding CategoryFilterSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding CategoryFilterSummary}" Style="{StaticResource CategoryStatValueText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource CategoryStatCard}">
                         <StackPanel>
                             <TextBlock Text="SELECTED" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedCategoryTitle}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding SelectedCategoryTitle}" Style="{StaticResource CategoryStatValueText}"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}" Padding="12,10" MinHeight="76">
+                    <Border Style="{StaticResource CategoryStatCard}">
                         <StackPanel>
                             <TextBlock Text="SETUP" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding CategoryNameStatus}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding CategoryNameStatus}" Style="{StaticResource CategoryStatValueText}"/>
                         </StackPanel>
                     </Border>
-                </UniformGrid>
+                </WrapPanel>
             </Grid>
         </Border>
 
@@ -94,13 +103,13 @@
                     <TextBlock Text="Create and filter" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
                         <TextBox x:Name="CategoryNameBox"
-                                 Width="260"
+                                 Width="250"
                                  MinWidth="190"
                                  Text="{Binding CategoryName, UpdateSourceTrigger=PropertyChanged}"
                                  ToolTip="Category name"
                                  Margin="0,0,6,4"/>
                         <TextBox x:Name="FindBox"
-                                 Width="260"
+                                 Width="250"
                                  MinWidth="190"
                                  Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                                  ToolTip="Filter categories by ID or name"
@@ -114,12 +123,12 @@
 
         <Grid Grid.Row="2" Margin="0,6,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.35*" MinWidth="620"/>
-                <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="430" MinWidth="380"/>
+                <ColumnDefinition Width="1.55*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="0.95*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -130,7 +139,7 @@
 
                     <Border Style="{StaticResource DesktopPaneHeader}">
                         <DockPanel>
-                            <StackPanel DockPanel.Dock="Left">
+                            <StackPanel DockPanel.Dock="Left" MinWidth="0">
                                 <TextBlock Text="01 Category Directory" Style="{StaticResource SectionHeader}" Margin="0"/>
                                 <TextBlock Text="Review the controlled category vocabulary before renaming, printing, or assigning matching inventory records." Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
@@ -151,7 +160,13 @@
                               SelectedItem="{Binding SelectedCategory, Mode=TwoWay}"
                               IsReadOnly="True"
                               AutoGenerateColumns="False"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
                               SelectionMode="Single"
+                              SelectionUnit="FullRow"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
@@ -175,7 +190,7 @@
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                         <DataGrid.Columns>
-                            <DataGridTemplateColumn Header="Category" Width="2.4*" MinWidth="240">
+                            <DataGridTemplateColumn Header="Category" Width="2.4*" MinWidth="200">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -185,7 +200,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Directory Label" Width="2.2*" MinWidth="220">
+                            <DataGridTemplateColumn Header="Directory Label" Width="2.2*" MinWidth="190">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -195,11 +210,11 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="ID" Binding="{Binding CategoryID}" Width="90" MinWidth="76"/>
+                            <DataGridTextColumn Header="ID" Binding="{Binding CategoryID}" Width="78" MinWidth="68"/>
                         </DataGrid.Columns>
                     </DataGrid>
 
-                    <Border Grid.Row="2" Width="340" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Border Grid.Row="2" MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -225,9 +240,9 @@
                 </Grid>
             </Border>
 
-            <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -239,7 +254,7 @@
                             <TextBlock Text="Use the selected category card to guide rename, print, and item-assignment decisions." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                         </StackPanel>
                     </Border>
-                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Hidden">
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <StackPanel Margin="8">
                             <Border Style="{StaticResource CategoryDetailCard}">
                                 <StackPanel>
@@ -306,7 +321,7 @@
                     <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Clear Filter" Command="{Binding ClearSearchCommand}" Margin="0,0,0,4"/>
                 </WrapPanel>
-                <StackPanel>
+                <StackPanel MinWidth="0">
                     <TextBlock Text="{Binding SelectedCategorySummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="2,0,10,0"/>
                     <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="2,2,10,0"/>
                 </StackPanel>


### PR DESCRIPTION
## What changed

- Reworked the Categories Workbench summary metrics from a fixed four-column strip into wrapping bounded cards.
- Added local category metric card/value styles so directory, filter, selected-category, and setup text stays inside cards at scaled desktop widths.
- Reduced the header title/stat area from large fixed minimum columns to shrinkable star columns.
- Reduced category create/filter input widths while preserving useful minimums for keyboard-driven admin work.
- Changed the main category-directory / setup-handoff split from fixed 620px plus 380px minimum pressure to a flexible star split with a practical 300px handoff minimum.
- Narrowed the splitter and added `MinWidth="0"` pane shells so WPF can shrink the directory and handoff panes instead of forcing horizontal overflow.
- Enabled explicit row and column virtualization on the category directory grid.
- Enabled automatic horizontal and vertical directory-grid scrollbars plus content scrolling for category rows.
- Switched the category grid to full-row single selection for clearer row-level double-click and context-menu actions.
- Reduced oversized category grid column minimums so the directory remains useful on smaller scaled desktops.
- Replaced the fixed-width empty state with a bounded, margin-protected empty state.
- Changed the setup handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
- Added `CategoriesPageResponsiveContractTests` to guard responsive metrics, main split sizing, grid virtualization/scrolling, bounded input/empty/handoff areas, and preserved category command/row-handler behavior.
- Added a progress note for the completed Categories responsive workflow slice.

## Why this was the highest-value next step

Current repo evidence still lists Windows visual QA and scaled desktop usability as release risks. Recent merged runs completed adjacent dense workbenches for Activity Logs, Users, Reports, Maintenance, Calibration, Customers, and Dashboard. Source readback showed Categories still had the same concrete risks: a fixed four-column summary strip, large directory/handoff split minimums, hidden handoff scrolling, a fixed-width empty state, and no explicit category-grid scrollbar/virtualization/full-row-selection contract. Categories is an admin workflow with search, create/save/delete, row drilldown, row-correct context menus, copy handoff, print sheet, and print directory actions, so tightening it improves a complete workflow.

## Why this is large enough to count as real progress

This covers more than ten focused workflow-level improvements across summary layout, card sizing, metric value behavior, header sizing, input sizing, split sizing, splitter sizing, WPF shrink behavior, grid virtualization, grid scrolling, selection behavior, column sizing, empty-state sizing, handoff scrolling, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/CategoriesPage.xaml`
  - `InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-categories-responsive-workbench.md`
- Connector source readback confirmed Categories now uses wrapping bounded metric cards, lower header pressure, lower split minimums, shrinkable pane shells, a narrower splitter, explicit category-grid virtualization/scrollbars, full-row selection, reduced column minimums, bounded empty state, and automatic handoff scrolling.
- Connector source readback confirmed `CategoriesPageResponsiveContractTests` covers the responsive layout contracts and preserved category commands/context-menu row handoff.
- Connector status readback found no attached commit statuses on branch head `f17a34540e64c11f9e709116882adc4d61657f78` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Categories on Windows at 1366 x 768 and higher DPI scales, including category search, create, save, row double-click, context-menu actions, copy handoff, print sheet, print directory, delete, refresh, and setup handoff scrolling.