### PR TITLE
[codex] Improve kits workbench responsive layout

### DIFF
--- a/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class KitManagementPageResponsiveContractTests
+    {
+        [Fact]
+        public void KitManagementPage_KeepsKitSummaryCardsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("KitStatValueText", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"520\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitManagementPage_AvoidsLargeFixedMinimumsInMainKitSplit()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.65*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Row=\"0\" Grid.RowSpan=\"3\" Grid.Column=\"1\" Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"0\" Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"0\" Grid.RowSpan=\"3\" Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2.05*\" MinWidth=\"620\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"440\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitManagementPage_EnablesKitGridsVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml");
+            var gridNames = new[] { "KitsGrid", "KitItemsGrid" };
+
+            foreach (var gridName in gridNames)
+                Assert.Contains($"x:Name=\"{gridName}\"", xaml, StringComparison.Ordinal);
+
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "EnableRowVirtualization=\"True\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "EnableColumnVirtualization=\"True\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "SelectionUnit=\"FullRow\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "ScrollViewer.CanContentScroll=\"True\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "ScrollViewer.HorizontalScrollBarVisibility=\"Auto\""));
+            Assert.Equal(gridNames.Length, CountOccurrences(xaml, "ScrollViewer.VerticalScrollBarVisibility=\"Auto\""));
+        }
+
+        [Fact]
+        public void KitManagementPage_BoundsInputsEmptyStatesAndHandoffScrolling()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml");
+
+            Assert.Contains("<TextBox Width=\"240\" MinWidth=\"190\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ComboBox Width=\"140\" MinWidth=\"120\"", xaml, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(xaml, "MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\""));
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\" Padding=\"12\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"320\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Width=\"320\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel DockPanel.Dock=\"Right\" Orientation=\"Horizontal\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitManagementPage_PreservesPrimaryKitActionsAndRowHandoff()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml");
+
+            Assert.Contains("AddKitCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenKitDetailsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("EditKitCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CheckAvailabilityCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedKitCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintSelectedKitCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintKitListCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("DeleteKitCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("AddKitItemCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("EditKitItemCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("RemoveKitItemCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ViewKitItemsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("KitRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("KitItemRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("DataGridRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-kits-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-kits-responsive-workbench.md
@@ -1,0 +1,30 @@
+# Kits Responsive Workbench
+
+Date: 2026-07-02
+
+## Completed
+
+- Replaced the fixed four-column kit summary strip with wrapping bounded metric cards.
+- Added local kit metric card/value styles so directory, membership, selected-kit, and availability text stays inside each card at scaled desktop widths.
+- Reduced the header title/stat area from large fixed minimum columns to shrinkable star columns.
+- Reduced kit search and filter input widths while preserving useful keyboard-driven minimums.
+- Changed the main kit-directory / selected-handoff split from fixed 620px plus 380px minimum pressure to a flexible split with a practical 300px handoff minimum.
+- Narrowed the splitter and added shrinkable `MinWidth="0"` pane shells so WPF can reduce the directory, membership, and handoff panes instead of pushing the page wider.
+- Enabled explicit row and column virtualization on both the kit directory grid and the kit item membership grid.
+- Enabled automatic horizontal and vertical grid scrollbars plus content scrolling for both kit grids.
+- Switched both kit grids to full-row single selection for clearer row-level double-click and context-menu actions.
+- Reduced oversized kit directory and membership grid column minimums so both tables stay useful before horizontal scrolling is needed.
+- Replaced fixed-width empty states with bounded, margin-protected empty states for the kit directory and kit membership lists.
+- Changed the selected-kit handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
+- Wrapped footer actions so Add Item and Print Directory remain reachable at scaled desktop widths.
+- Added `KitManagementPageResponsiveContractTests` to guard the responsive summary, main split sizing, grid virtualization/scrolling, bounded input/empty/handoff areas, wrapped footer actions, and preserved kit commands/row handlers.
+
+## Validation Notes
+
+- Source readback/compare validation should confirm the branch is limited to KitManagement XAML, responsive source-contract coverage, and this progress note.
+- Local `pwsh -File scripts/run-full-validation.ps1`, WPF screenshots, print-preview/layout checks, and .NET tests still need a Windows/.NET-capable checkout because the scheduled Linux environment cannot clone the repository and lacks `dotnet`, `pwsh`, `gh`, and WPF runtime tooling.
+
+## Follow-up
+
+- Run full Windows/.NET validation and visually smoke test Kits at 1366 x 768 plus 125%, 150%, and 200% scaling.
+- Exercise kit search/filter, add/edit/delete kit, row double-click, row context menu, availability check, membership add/edit/remove/reload, selected-kit handoff scrolling, copy, print kit, print directory, and footer actions.

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
@@ -6,7 +6,16 @@
         <Style x:Key="KitStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="MinWidth" Value="150"/>
+            <Setter Property="MaxWidth" Value="235"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+        <Style x:Key="KitStatValueText" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="Margin" Value="0,3,0,0"/>
         </Style>
     </Page.Resources>
 
@@ -21,41 +30,41 @@
         <Border Style="{StaticResource ToolbarCard}" Padding="12,10">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" MinWidth="380"/>
-                    <ColumnDefinition Width="14"/>
-                    <ColumnDefinition Width="3*" MinWidth="520"/>
+                    <ColumnDefinition Width="1.15*" MinWidth="0"/>
+                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="1.35*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center">
+                <StackPanel VerticalAlignment="Center" MinWidth="220" MaxWidth="520">
                     <TextBlock Text="Kit Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
                     <TextBlock Text="Build reusable item sets, maintain membership, confirm availability, and print kit handoffs from one operations surface."
                                Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                 </StackPanel>
-                <UniformGrid Grid.Column="2" Columns="4">
+                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
                     <Border Style="{StaticResource KitStatCard}">
                         <StackPanel>
                             <TextBlock Text="DIRECTORY" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding KitResultsSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding KitResultsSummary}" Style="{StaticResource KitStatValueText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource KitStatCard}">
                         <StackPanel>
                             <TextBlock Text="MEMBERSHIP" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding KitItemsSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding KitItemsSummary}" Style="{StaticResource KitStatValueText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource KitStatCard}">
                         <StackPanel>
                             <TextBlock Text="SELECTED" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedKit.KitNumber, TargetNullValue='No kit selected', FallbackValue='No kit selected'}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding SelectedKit.KitNumber, TargetNullValue='No kit selected', FallbackValue='No kit selected'}" Style="{StaticResource KitStatValueText}"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}" Padding="12,10" MinHeight="76">
+                    <Border Style="{StaticResource KitStatCard}">
                         <StackPanel>
                             <TextBlock Text="AVAILABILITY" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Check before promise" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="Check before promise" Style="{StaticResource KitStatValueText}"/>
                         </StackPanel>
                     </Border>
-                </UniformGrid>
+                </WrapPanel>
             </Grid>
         </Border>
 
@@ -81,8 +90,8 @@
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
                     <TextBlock Text="Find and filter" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <TextBox Width="260" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,4" ToolTip="Search kit number, name, category, or description"/>
-                        <ComboBox Width="150" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}" Margin="0,0,6,4"/>
+                        <TextBox Width="240" MinWidth="190" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,4" ToolTip="Search kit number, name, category, or description"/>
+                        <ComboBox Width="140" MinWidth="120" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}" Margin="0,0,6,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearSearchCommand}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
@@ -92,17 +101,17 @@
 
         <Grid Grid.Row="2" Margin="0,0,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.05*" MinWidth="620"/>
-                <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="440" MinWidth="380"/>
+                <ColumnDefinition Width="1.65*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="0.95*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="1.05*"/>
-                <RowDefinition Height="8"/>
+                <RowDefinition Height="6"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Border Grid.Row="0" Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Row="0" Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -111,17 +120,17 @@
                     </Grid.RowDefinitions>
                     <Border Style="{StaticResource DesktopPaneHeader}">
                         <DockPanel>
-                            <StackPanel DockPanel.Dock="Left">
+                            <StackPanel DockPanel.Dock="Left" MinWidth="210" MaxWidth="420">
                                 <TextBlock Text="01 Kit Directory" Style="{StaticResource SectionHeader}" Margin="0"/>
-                                <TextBlock Text="Search the reusable kit catalog before editing membership or promising availability." Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0"/>
+                                <TextBlock Text="Search the reusable kit catalog before editing membership or promising availability." Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
-                            <TextBlock Text="{Binding KitResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding KitResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap" Margin="12,0,0,0"/>
                         </DockPanel>
                     </Border>
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
                         <TextBlock Text="Select a kit to load required and optional item lines, then check availability or print a handoff sheet." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                     </Border>
-                    <DataGrid x:Name="KitsGrid" Grid.Row="2" ItemsSource="{Binding FilteredKits}" SelectedItem="{Binding SelectedKit}" AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single" Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid x:Name="KitsGrid" Grid.Row="2" ItemsSource="{Binding FilteredKits}" SelectedItem="{Binding SelectedKit}" AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single" SelectionUnit="FullRow" EnableRowVirtualization="True" EnableColumnVirtualization="True" ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
                                 <EventSetter Event="MouseDoubleClick" Handler="KitRow_MouseDoubleClick"/>
@@ -129,7 +138,7 @@
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>
-                            <DataGridTemplateColumn Header="Kit" Width="2*" MinWidth="210">
+                            <DataGridTemplateColumn Header="Kit" Width="2*" MinWidth="180">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -139,7 +148,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Category" Width="1.2*" MinWidth="150">
+                            <DataGridTemplateColumn Header="Category" Width="1.2*" MinWidth="125">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -149,8 +158,8 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" MinWidth="210"/>
-                            <DataGridTextColumn Header="Updated" Binding="{Binding UpdatedAt, StringFormat={}{0:yyyy-MM-dd}}" Width="118" MinWidth="96"/>
+                            <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" MinWidth="160"/>
+                            <DataGridTextColumn Header="Updated" Binding="{Binding UpdatedAt, StringFormat={}{0:yyyy-MM-dd}}" Width="108" MinWidth="90"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
@@ -164,7 +173,7 @@
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>
-                    <Border Grid.Row="2" Width="320" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Border Grid.Row="2" MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -181,9 +190,9 @@
                 </Grid>
             </Border>
 
-            <GridSplitter Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="8" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+            <GridSplitter Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-            <Border Grid.Row="2" Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Row="2" Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -192,11 +201,11 @@
                     </Grid.RowDefinitions>
                     <Border Style="{StaticResource DesktopPaneHeader}">
                         <DockPanel>
-                            <StackPanel DockPanel.Dock="Left">
+                            <StackPanel DockPanel.Dock="Left" MinWidth="210" MaxWidth="420">
                                 <TextBlock Text="02 Kit Item Membership" Style="{StaticResource SectionHeader}" Margin="0"/>
-                                <TextBlock Text="Maintain required quantities and optional lines for the selected kit." Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0"/>
+                                <TextBlock Text="Maintain required quantities and optional lines for the selected kit." Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
-                            <TextBlock Text="{Binding KitItemsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding KitItemsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap" Margin="12,0,0,0"/>
                         </DockPanel>
                     </Border>
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
@@ -208,7 +217,7 @@
                         </WrapPanel>
                     </Border>
                     <Grid Grid.Row="2">
-                        <DataGrid x:Name="KitItemsGrid" ItemsSource="{Binding KitItems}" SelectedItem="{Binding SelectedKitItem}" AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single" Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid x:Name="KitItemsGrid" ItemsSource="{Binding KitItems}" SelectedItem="{Binding SelectedKitItem}" AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single" SelectionUnit="FullRow" EnableRowVirtualization="True" EnableColumnVirtualization="True" ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" Style="{StaticResource VirtualizedDataGridStyle}">
                             <DataGrid.RowStyle>
                                 <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
                                     <EventSetter Event="MouseDoubleClick" Handler="KitItemRow_MouseDoubleClick"/>
@@ -216,7 +225,7 @@
                                 </Style>
                             </DataGrid.RowStyle>
                             <DataGrid.Columns>
-                                <DataGridTemplateColumn Header="Item" Width="2*" MinWidth="230">
+                                <DataGridTemplateColumn Header="Item" Width="2*" MinWidth="190">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Margin="2,3">
@@ -226,7 +235,7 @@
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
-                                <DataGridTemplateColumn Header="Quantity" Width="140" MinWidth="110">
+                                <DataGridTemplateColumn Header="Quantity" Width="120" MinWidth="96">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Margin="2,3">
@@ -246,7 +255,7 @@
                                 </ContextMenu>
                             </DataGrid.ContextMenu>
                         </DataGrid>
-                        <Border Width="320" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Border MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                             <Border.Style>
                                 <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -264,7 +273,7 @@
                 </Grid>
             </Border>
 
-            <Border Grid.Row="0" Grid.RowSpan="3" Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Row="0" Grid.RowSpan="3" Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -277,7 +286,7 @@
                             <TextBlock Text="Availability, membership, and print actions for the selected kit." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                         </StackPanel>
                     </Border>
-                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Hidden" Padding="12">
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="12">
                         <StackPanel>
                             <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10"><StackPanel><TextBlock Text="Selected kit" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/><TextBlock Text="{Binding SelectedKitSummary}" FontWeight="SemiBold" TextWrapping="Wrap"/></StackPanel></Border>
                             <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10"><StackPanel><TextBlock Text="Kit detail" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/><TextBlock Text="{Binding SelectedKitDetail}" TextWrapping="Wrap"/></StackPanel></Border>
@@ -301,10 +310,10 @@
 
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
             <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}"/>
-                </StackPanel>
+                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" Margin="0,0,0,4"/>
+                </WrapPanel>
                 <TextBlock Text="{Binding SelectedKitSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>


### PR DESCRIPTION
## What changed

- Reworked the Kits Workbench summary metrics from a fixed four-column strip into wrapping bounded cards.
- Added local kit metric card/value styles so directory, membership, selected-kit, and availability text stays inside cards at scaled desktop widths.
- Reduced the header title/stat area from large fixed minimum columns to shrinkable star columns.
- Reduced kit search and filter input widths while preserving useful keyboard-driven minimums.
- Changed the main kit-directory / selected-handoff split from fixed 620px plus 380px minimum pressure to a flexible star split with a practical 300px handoff minimum.
- Narrowed the splitter and added `MinWidth="0"` pane shells so WPF can shrink the directory, membership, and handoff panes instead of forcing horizontal overflow.
- Enabled explicit row and column virtualization on both the kit directory grid and the kit item membership grid.
- Enabled automatic horizontal and vertical grid scrollbars plus content scrolling for both kit grids.
- Switched both kit grids to full-row single selection for clearer row-level double-click and context-menu actions.
- Reduced oversized kit directory and membership grid column minimums so both tables remain useful on smaller scaled desktops.
- Replaced fixed-width empty states with bounded, margin-protected empty states for the kit directory and kit membership lists.
- Changed the selected-kit handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
- Wrapped footer actions so Add Item and Print Directory remain reachable at scaled desktop widths.
- Added `KitManagementPageResponsiveContractTests` to guard responsive metrics, split sizing, grid virtualization/scrolling, bounded input/empty/handoff areas, wrapped footer actions, and preserved kit command/row-handler behavior.
- Added a progress note for the completed Kits responsive workflow slice.

## Why this was the highest-value next step

Current repo notes still list scaled Windows visual QA and dense workbench usability as release risks. Recent merged runs completed adjacent responsive slices for Activity Logs, Users, Reports, Maintenance, Calibration, Customers, Dashboard, and Categories. Source readback showed Kits still had the same concrete risks: a fixed four-column summary strip, large directory/handoff split minimums, hidden handoff scrolling, fixed-width empty states, fixed footer actions, and no explicit kit-grid scrollbar/virtualization/full-row-selection contract. Kits is a complete operational workflow covering kit search/filter, kit details, availability checks, item membership, selected handoff, copy, print kit, print directory, and row-correct actions, so tightening it improves a real vertical slice.

## Why this is large enough to count as real progress

This covers more than ten focused workflow-level improvements across summary layout, card sizing, metric value behavior, header sizing, search/filter sizing, main split sizing, splitter sizing, WPF shrink behavior, directory-grid virtualization, membership-grid virtualization, grid scrolling, row selection, column sizing, empty-state sizing, handoff scrolling, footer action wrapping, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/KitManagementPage.xaml`
  - `InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-kits-responsive-workbench.md`
- Connector source readback confirmed Kits now uses wrapping bounded metric cards, lower header pressure, lower split minimums, shrinkable pane shells, a narrower splitter, explicit virtualization/scrollbars on both kit grids, full-row selection, reduced grid column minimums, bounded empty states, automatic handoff scrolling, and wrapped footer actions.
- Connector source readback confirmed `KitManagementPageResponsiveContractTests` covers the responsive layout contracts and preserved kit commands/context-menu row handoff.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `ebbdd48a9c97238af78b09f2d36f9149961702c8` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Kits on Windows at 1366 x 768 and higher DPI scales, including kit search/filter, add/edit/delete kit, row double-click, context-menu actions, availability check, membership add/edit/remove/reload, selected-kit handoff scrolling, copy, print kit, print directory, and footer actions.