### PR TITLE
[codex] Improve reservations workbench responsive layout

### DIFF
--- a/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReservationPageResponsiveContractTests
+    {
+        [Fact]
+        public void ReservationPage_KeepsReservationSummaryCardsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("ReservationStatValueText", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.85*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"540\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationPage_AvoidsLargeFixedMinimumsInMainHoldSplit()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.55*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\"\n                          Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2.45*\" MinWidth=\"620\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"430\" MinWidth=\"390\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationPage_EnablesHoldGridVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml");
+
+            Assert.Contains("x:Name=\"ReservationGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationPage_BoundsFiltersEmptyStateAndHandoffScrolling()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml");
+
+            Assert.Contains("<TextBox Width=\"230\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ComboBox Width=\"160\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Center\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\" Padding=\"16\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel Margin=\"12,12,12,4\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MaxWidth=\"370\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationPage_PreservesPrimaryReservationActionsAndRowHandoff()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml");
+            var requiredContracts = new[]
+            {
+                "AddReservationCommand",
+                "ConfirmReservationCommand",
+                "FulfillReservationCommand",
+                "OpenReservationDetailsCommand",
+                "EditReservationCommand",
+                "CancelReservationCommand",
+                "CopyReservationHandoffCommand",
+                "PrintReservationHandoffCommand",
+                "DeleteReservationCommand",
+                "ShowActiveReservationsCommand",
+                "ShowPendingReservationsCommand",
+                "ShowConfirmedReservationsCommand",
+                "ShowUpcomingReservationsCommand",
+                "ClearReservationSearchCommand",
+                "RefreshCommand",
+                "PrintReservationDirectoryCommand",
+                "ReservationRow_MouseDoubleClick",
+                "ReservationRow_PreviewMouseRightButtonDown"
+            };
+
+            foreach (var contract in requiredContracts)
+                Assert.Contains(contract, xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-reservations-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-reservations-responsive-workbench.md
@@ -1,0 +1,23 @@
+# 2026-07-02 Reservations responsive workbench
+
+## Completed
+
+- Reworked the Reservations Workbench summary metrics from a fixed four-column strip into wrapping bounded cards.
+- Added bounded reservation metric value styling so long directory, filter, selected-hold, and handoff text stays inside each card at scaled desktop widths.
+- Reduced the header title/stat area from large fixed minimum columns to shrinkable star columns.
+- Reduced reservation search and filter input widths while preserving useful minimums for keyboard-driven hold triage.
+- Changed the main hold-directory / pickup-handoff split from fixed 620px plus 390px minimum pressure to a flexible star split with a practical 300px handoff minimum.
+- Narrowed the splitter and added `MinWidth="0"` pane shells so WPF can shrink the directory and handoff panes instead of forcing horizontal overflow.
+- Enabled explicit row and column virtualization on the reservation grid.
+- Enabled automatic horizontal and vertical reservation-grid scrollbars plus content scrolling for wide hold, customer, item, date, rental, and notes rows.
+- Switched the reservation grid to full-row single selection for clearer row-level double-click and context-menu actions.
+- Reduced oversized reservation grid column minimums so the hold directory remains useful on smaller scaled desktops.
+- Replaced the wider fixed empty state with a bounded, margin-protected empty state.
+- Changed the pickup handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
+- Preserved the existing add, confirm, fulfill, details, edit, cancel, copy, print, delete, quick-filter, refresh, row double-click, and row-correct context-menu paths.
+- Added `ReservationPageResponsiveContractTests` to guard the responsive layout contracts and preserved reservation workflow bindings.
+
+## Validation
+
+- GitHub connector readback and compare should be used for this scheduled run because the environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
+- Full Windows validation still needs to run with `pwsh -File scripts/run-full-validation.ps1`.

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml
@@ -6,8 +6,18 @@
     <Page.Resources>
         <Style x:Key="ReservationStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
             <Setter Property="Padding" Value="12,10"/>
+            <Setter Property="MinWidth" Value="150"/>
+            <Setter Property="MaxWidth" Value="235"/>
             <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+        <Style x:Key="ReservationStatValueText" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="MaxHeight" Value="36"/>
+            <Setter Property="Margin" Value="0,3,0,0"/>
         </Style>
         <Style x:Key="ReservationDetailCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
@@ -30,43 +40,43 @@
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" MinWidth="380"/>
-                    <ColumnDefinition Width="14"/>
-                    <ColumnDefinition Width="3*" MinWidth="540"/>
+                    <ColumnDefinition Width="1.15*" MinWidth="0"/>
+                    <ColumnDefinition Width="8"/>
+                    <ColumnDefinition Width="1.85*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center">
+                <StackPanel VerticalAlignment="Center" MinWidth="0">
                     <TextBlock Text="Reservations Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
                     <TextBlock Text="Stage customer holds, confirm availability, prepare shelf pickup, and move ready reservations into rentals from one operations surface."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <UniformGrid Grid.Column="2" Columns="4">
+                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
                     <Border Style="{StaticResource ReservationStatCard}">
                         <StackPanel>
                             <TextBlock Text="DIRECTORY" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding ReservationResultsSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding ReservationResultsSummary}" Style="{StaticResource ReservationStatValueText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource ReservationStatCard}">
                         <StackPanel>
                             <TextBlock Text="FILTER" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedFilter}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding SelectedFilter}" Style="{StaticResource ReservationStatValueText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource ReservationStatCard}">
                         <StackPanel>
                             <TextBlock Text="SELECTED" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedReservation.ReservationID, StringFormat=Hold #{0}, TargetNullValue='No hold selected', FallbackValue='No hold selected'}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding SelectedReservation.ReservationID, StringFormat=Hold #{0}, TargetNullValue='No hold selected', FallbackValue='No hold selected'}" Style="{StaticResource ReservationStatValueText}"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}" Padding="12,10" MinHeight="76">
+                    <Border Style="{StaticResource ReservationStatCard}">
                         <StackPanel>
                             <TextBlock Text="HANDOFF" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Copy / print ready" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="Copy / print ready" Style="{StaticResource ReservationStatValueText}"/>
                         </StackPanel>
                     </Border>
-                </UniformGrid>
+                </WrapPanel>
             </Grid>
         </Border>
 
@@ -93,12 +103,12 @@
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
                     <TextBlock Text="Find and filter" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <TextBox Width="250"
+                        <TextBox Width="230"
                                  MinWidth="150"
                                  Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                                  ToolTip="Search reservation number, item, customer, status, or notes"
                                  Margin="0,0,6,4"/>
-                        <ComboBox Width="175"
+                        <ComboBox Width="160"
                                   MinWidth="130"
                                   ItemsSource="{Binding FilterOptions}"
                                   SelectedItem="{Binding SelectedFilter}"
@@ -117,12 +127,12 @@
 
         <Grid Grid.Row="2" Margin="0,6,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.45*" MinWidth="620"/>
-                <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="430" MinWidth="390"/>
+                <ColumnDefinition Width="1.55*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="0.95*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -132,9 +142,9 @@
 
                     <Border Style="{StaticResource DesktopPaneHeader}">
                         <DockPanel>
-                            <StackPanel DockPanel.Dock="Left">
+                            <StackPanel DockPanel.Dock="Left" MinWidth="0">
                                 <TextBlock Text="01 Hold Directory" Style="{StaticResource SectionHeader}" Margin="0"/>
-                                <TextBlock Text="Sorts staged holds by start date, then customer for pickup planning" Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0"/>
+                                <TextBlock Text="Sorts staged holds by start date, then customer for pickup planning" Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
                             <TextBlock Text="{Binding ReservationResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
                         </DockPanel>
@@ -153,6 +163,12 @@
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
                               SelectionMode="Single"
+                              SelectionUnit="FullRow"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
@@ -161,7 +177,7 @@
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>
-                            <DataGridTemplateColumn Header="Hold" Width="1.25*" MinWidth="155">
+                            <DataGridTemplateColumn Header="Hold" Width="1.25*" MinWidth="145">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -171,7 +187,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Customer" Width="1.7*" MinWidth="170">
+                            <DataGridTemplateColumn Header="Customer" Width="1.7*" MinWidth="155">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -181,7 +197,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Item" Width="2*" MinWidth="200">
+                            <DataGridTemplateColumn Header="Item" Width="2*" MinWidth="175">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -191,7 +207,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Window" Width="170" MinWidth="150">
+                            <DataGridTemplateColumn Header="Window" Width="160" MinWidth="140">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="2,3">
@@ -201,8 +217,8 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Rental ID" Binding="{Binding RentalID}" Width="92" MinWidth="76"/>
-                            <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="1.35*" MinWidth="160"/>
+                            <DataGridTextColumn Header="Rental ID" Binding="{Binding RentalID}" Width="86" MinWidth="72"/>
+                            <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="1.35*" MinWidth="140"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
@@ -223,7 +239,7 @@
                         </DataGrid.ContextMenu>
                     </DataGrid>
 
-                    <Border Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="370" Padding="16">
+                    <Border Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="330" MinHeight="120" Margin="12" Padding="16">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -247,12 +263,12 @@
             </Border>
 
             <GridSplitter Grid.Column="1"
-                          Width="8"
+                          Width="6"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
                           Background="{DynamicResource BorderBrushBase}"/>
 
-            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -261,16 +277,16 @@
                     </Grid.RowDefinitions>
                     <Border Style="{StaticResource DesktopPaneHeader}">
                         <DockPanel>
-                            <StackPanel DockPanel.Dock="Left">
+                            <StackPanel DockPanel.Dock="Left" MinWidth="0">
                                 <TextBlock Text="02 Pickup Handoff" Style="{StaticResource SectionHeader}" Margin="0"/>
-                                <TextBlock Text="Selected hold, dates, next action, and shelf checklist" Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0"/>
+                                <TextBlock Text="Selected hold, dates, next action, and shelf checklist" Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
-                            <TextBlock Text="Ready to copy" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            <TextBlock Text="Ready to copy" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
                         </DockPanel>
                     </Border>
 
-                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Hidden">
-                        <StackPanel Margin="12,12,12,4">
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                        <StackPanel Margin="12,12,12,4" MinWidth="0">
                             <Border Style="{StaticResource ReservationDetailCard}">
                                 <StackPanel>
                                     <TextBlock Text="Selected Hold" Style="{StaticResource LabelTextBlock}"/>


### PR DESCRIPTION
## What changed

- Reworked the Reservations Workbench summary metrics from a fixed four-column strip into wrapping bounded cards.
- Added bounded reservation metric value styling so long directory, filter, selected-hold, and handoff text stays inside each card at scaled desktop widths.
- Reduced the header title/stat area from large fixed minimum columns to shrinkable star columns.
- Reduced reservation search and filter input widths while preserving useful minimums for keyboard-driven hold triage.
- Changed the main hold-directory / pickup-handoff split from fixed 620px plus 390px minimum pressure to a flexible star split with a practical 300px handoff minimum.
- Narrowed the splitter and added `MinWidth="0"` pane shells so WPF can shrink the directory and handoff panes instead of forcing horizontal overflow.
- Enabled explicit row and column virtualization on the reservation grid.
- Enabled automatic horizontal and vertical reservation-grid scrollbars plus content scrolling for wide hold, customer, item, date, rental, and notes rows.
- Switched the reservation grid to full-row single selection for clearer row-level double-click and context-menu actions.
- Reduced oversized reservation grid column minimums so the hold directory remains useful on smaller scaled desktops.
- Replaced the wider fixed empty state with a bounded, margin-protected empty state.
- Changed the pickup handoff pane from hidden vertical overflow to automatic vertical scrolling with horizontal overflow disabled.
- Preserved the existing add, confirm, fulfill, details, edit, cancel, copy, print, delete, quick-filter, refresh, row double-click, and row-correct context-menu paths.
- Added `ReservationPageResponsiveContractTests` to guard the responsive layout contracts and preserved reservation workflow bindings.
- Added a progress note for the completed Reservations responsive workflow slice.

## Why this was the highest-value next step

Current repo notes still identify Windows visual QA, scaled desktop usability, loading speed, and grid responsiveness as release risks. Recent merged runs completed adjacent dense workbenches for Activity Logs, Users, Reports, Maintenance, Calibration, Customers, Dashboard, Categories, Kits, and Settings. Source readback showed Reservations still had the same concrete risks: a fixed four-column metric strip, large hold-directory/pickup-handoff split minimums, no explicit reservation-grid scrollbar/virtualization/full-row-selection contract, a wider empty state, and hidden handoff scrolling. Reservations is a complete operational workflow with search, status filters, hold triage, row actions, confirm/fulfill/cancel, handoff copy/print, list printing, and selected-hold details, so tightening it improves a real workflow.

## Why this is large enough to count as real progress

This covers more than ten focused workflow-level improvements across summary layout, card sizing, metric value behavior, header sizing, search/filter sizing, split sizing, splitter sizing, WPF shrink behavior, grid virtualization, grid scrolling, row selection, column sizing, empty-state sizing, handoff scrolling, preserved row actions, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ReservationPage.xaml`
  - `InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-reservations-responsive-workbench.md`
- Connector source readback confirmed Reservations now uses wrapping bounded metric cards, lower split minimums, shrinkable pane shells, a narrower splitter, explicit reservation-grid virtualization/scrollbars, full-row selection, reduced column minimums, bounded empty state, and automatic handoff scrolling.
- Connector source readback confirmed `ReservationPageResponsiveContractTests` covers the responsive layout contracts and preserved reservation commands/context-menu row handoff.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `f65e529b6f0924e0933669cdfa43b6dd156a8512` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Reservations on Windows at 1366 x 768 and higher DPI scales, including search, filters, add/edit/details, confirm, fulfill, cancel, delete, row double-click, context-menu actions, copy/print handoff, print list, and pickup handoff scrolling.