### PR TITLE
[codex] Improve import export workbench responsive layout

### DIFF
--- a/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ImportExportPageResponsiveContractTests
+    {
+        [Fact]
+        public void ImportExportPage_KeepsHeaderMetricsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"230\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("DataOperationStatValueText", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"390\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"540\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportPage_AvoidsLargeFixedMinimumsAcrossDataSplits()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.65*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.55*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.45*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\" Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"500\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"420\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"430\" MinWidth=\"360\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportPage_WrapsLaneCardsAndMakesHandoffPanesScrollable()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
+
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"220\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"360\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Margin=\"8\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Column=\"2\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Columns=\"2\" Margin=\"8\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel Grid.Column=\"2\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportPage_EnablesRunLogGridVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
+
+            Assert.Contains("x:Name=\"ImportExportLogGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportPage_BoundsEmptyStateHandoffTextAndFooterProgress()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
+
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"340\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\" MaxHeight=\"260\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel>\n                <TextBlock Text=\"{Binding LogSummary}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ProgressBar Width=\"120\" Height=\"14\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"360\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Columns=\"2\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel DockPanel.Dock=\"Right\" Orientation=\"Horizontal\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportPage_PreservesDataCommandsAndLogRowHandlers()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
+
+            Assert.Contains("ImportItemsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ExportItemsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ImportCustomersCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ExportCustomersCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("BackupDatabaseCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("RestoreBackupCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenImageImportMappingWindowCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ClearImportExportLogsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedLog_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintLogs_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenSelectedLog_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("ImportExportLogGrid_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("ImportExportLogRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-02-import-export-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-02-import-export-responsive-workbench.md
@@ -1,0 +1,33 @@
+# Import / Export Responsive Workbench
+
+Date: 2026-07-02
+
+## Summary
+
+Improved the Import / Export workbench so the data operations desk stays usable at scaled desktop widths and keeps long run-log details readable without forcing horizontal overflow.
+
+## Completed Work
+
+- Replaced the fixed header metric grid with wrapping bounded operation cards.
+- Added bounded metric value styling for item, customer, backup, and run-log summary text.
+- Reduced the header title and metric column pressure with shrinkable star columns.
+- Changed the overview, item data, customer, backup/images, and run-log splits to lower minimum pressure with shrinkable panes.
+- Narrowed splitters from 8px to 6px to match the newer responsive workbench pattern.
+- Converted overview lane cards from a fixed two-column `UniformGrid` into wrapping cards with bounded widths.
+- Added automatic vertical scrolling and disabled horizontal overflow for handoff and advisory panes.
+- Wrapped backup/restore and run-log footer actions so commands remain reachable at scaled widths.
+- Enabled explicit row and column virtualization on the Import / Export run-log grid.
+- Enabled automatic run-log grid horizontal and vertical scrollbars plus content scrolling.
+- Switched the run-log grid to full-row single selection for clearer double-click and context-menu actions.
+- Bounded the empty log state and selected-log detail panel so long result messages remain readable.
+- Added source-contract coverage for the responsive layout contracts and preserved data/log commands.
+
+## Validation
+
+- Added `ImportExportPageResponsiveContractTests` to guard the XAML layout contracts and preserved command/row-handler wiring.
+- Full local validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or the WPF runtime.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test Import / Export at 1366 x 768 and common Windows scaling levels, including item import/export, customer import/export, backup, restore, image mapping, run-log selection, copy, print, clear, double-click, and context-menu actions.

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
@@ -8,14 +8,26 @@
         <Style x:Key="DataOperationStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="MinHeight" Value="78"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="MinWidth" Value="150"/>
+            <Setter Property="MaxWidth" Value="230"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+        <Style x:Key="DataOperationStatValueText" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="Margin" Value="0,3,0,0"/>
         </Style>
         <Style x:Key="DataLaneCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
-            <Setter Property="Margin" Value="0,0,0,8"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+            <Setter Property="MinWidth" Value="220"/>
+            <Setter Property="MaxWidth" Value="360"/>
         </Style>
         <Style x:Key="DataLaneText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
             <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
             <Setter Property="Margin" Value="0,2,0,0"/>
         </Style>
         <Style x:Key="DataActionButton" TargetType="Button" BasedOn="{StaticResource GhostButton}">
@@ -35,46 +47,46 @@
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" MinWidth="390"/>
-                    <ColumnDefinition Width="14"/>
-                    <ColumnDefinition Width="3*" MinWidth="540"/>
+                    <ColumnDefinition Width="1.15*" MinWidth="0"/>
+                    <ColumnDefinition Width="10"/>
+                    <ColumnDefinition Width="1.85*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center">
+                <StackPanel VerticalAlignment="Center" MinWidth="220" MaxWidth="460">
                     <TextBlock Text="Data Operations Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
                     <TextBlock Text="Coordinate item files, customer directories, image mapping, backups, and result review from one controlled data desk."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <UniformGrid Grid.Column="2" Columns="4">
+                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
                     <Border Style="{StaticResource DataOperationStatCard}">
                         <StackPanel>
                             <TextBlock Text="ITEM DATA" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource DataOperationStatValueText}"/>
                             <TextBlock Text="CSV, JSON, XML" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource DataOperationStatCard}">
                         <StackPanel>
                             <TextBlock Text="CUSTOMERS" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Directory" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="Directory" Style="{StaticResource DataOperationStatValueText}"/>
                             <TextBlock Text="Import and export" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource DataOperationStatCard}">
                         <StackPanel>
                             <TextBlock Text="PROTECTION" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Full Backup" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="Full Backup" Style="{StaticResource DataOperationStatValueText}"/>
                             <TextBlock Text="Database and assets" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}" Padding="12,10" MinHeight="78">
+                    <Border Style="{StaticResource DataOperationStatCard}">
                         <StackPanel>
                             <TextBlock Text="RUN LOG" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding LogSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding LogSummary}" Style="{StaticResource DataOperationStatValueText}"/>
                         </StackPanel>
                     </Border>
-                </UniformGrid>
+                </WrapPanel>
             </Grid>
         </Border>
 
@@ -101,7 +113,7 @@
                         <Button Style="{StaticResource DataActionButton}" Content="Copy Selected" Click="CopySelectedLog_Click"/>
                         <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click"/>
                         <Button Style="{StaticResource DataActionButton}" Content="Clear Log" Command="{Binding ClearImportExportLogsCommand}"/>
-                        <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" VerticalAlignment="Center" Margin="6,1,0,4"/>
+                        <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" VerticalAlignment="Center" Margin="6,1,0,4" MaxWidth="520"/>
                     </WrapPanel>
                 </DockPanel>
             </Grid>
@@ -112,12 +124,12 @@
                 <Border Style="{StaticResource DesktopContentPane}">
                     <Grid Margin="12">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="2*" MinWidth="520"/>
-                            <ColumnDefinition Width="8"/>
-                            <ColumnDefinition Width="1.25*" MinWidth="360"/>
+                            <ColumnDefinition Width="1.65*" MinWidth="0"/>
+                            <ColumnDefinition Width="6"/>
+                            <ColumnDefinition Width="0.95*" MinWidth="300"/>
                         </Grid.ColumnDefinitions>
 
-                        <Grid Grid.Column="0">
+                        <Grid Grid.Column="0" MinWidth="0">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
@@ -128,9 +140,9 @@
                                     <TextBlock Text="Choose the safest lane for the work: item exchange, customer exchange, recovery, or image mapping." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                                 </StackPanel>
                             </Border>
-                            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
-                                <UniformGrid Columns="2" Margin="8">
-                                    <Border Style="{StaticResource DataLaneCard}" Margin="0,0,8,8">
+                            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                <WrapPanel Margin="8">
+                                    <Border Style="{StaticResource DataLaneCard}">
                                         <StackPanel>
                                             <TextBlock Text="Item Exchange" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                                             <TextBlock Text="{Binding ItemDataSummary}" Style="{StaticResource DataLaneText}"/>
@@ -140,7 +152,7 @@
                                             </WrapPanel>
                                         </StackPanel>
                                     </Border>
-                                    <Border Style="{StaticResource DataLaneCard}" Margin="0,0,0,8">
+                                    <Border Style="{StaticResource DataLaneCard}">
                                         <StackPanel>
                                             <TextBlock Text="Customer Exchange" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                                             <TextBlock Text="{Binding CustomerDataSummary}" Style="{StaticResource DataLaneText}"/>
@@ -150,7 +162,7 @@
                                             </WrapPanel>
                                         </StackPanel>
                                     </Border>
-                                    <Border Style="{StaticResource DataLaneCard}" Margin="0,0,8,0">
+                                    <Border Style="{StaticResource DataLaneCard}">
                                         <StackPanel>
                                             <TextBlock Text="Recovery Point" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                                             <TextBlock Text="{Binding BackupSummary}" Style="{StaticResource DataLaneText}"/>
@@ -166,13 +178,13 @@
                                             <Button Style="{StaticResource PrimaryButton}" Content="Open Image Mapping" Command="{Binding OpenImageImportMappingWindowCommand}" HorizontalAlignment="Left" Margin="0,10,0,0" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
                                         </StackPanel>
                                     </Border>
-                                </UniformGrid>
+                                </WrapPanel>
                             </ScrollViewer>
                         </Grid>
 
-                        <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+                        <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-                        <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+                        <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
@@ -184,28 +196,30 @@
                                         <TextBlock Text="Keep the current run state visible before staff copy, print, or clear result messages." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                                     </StackPanel>
                                 </Border>
-                                <StackPanel Grid.Row="1" Margin="8">
-                                    <Border Style="{StaticResource DataLaneCard}">
-                                        <StackPanel>
-                                            <TextBlock Text="Current Status" Style="{StaticResource LabelTextBlock}"/>
-                                            <TextBlock Text="{Binding LogSummary}" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                                        </StackPanel>
-                                    </Border>
-                                    <Border Style="{StaticResource DataLaneCard}">
-                                        <StackPanel>
-                                            <TextBlock Text="Selected Result" Style="{StaticResource SectionHeader}"/>
-                                            <TextBlock Text="{Binding SelectedLogTitle}" Style="{StaticResource DataLaneText}"/>
-                                            <TextBlock Text="{Binding SelectedLogDetail}" TextWrapping="Wrap" Margin="0,6,0,0"/>
-                                        </StackPanel>
-                                    </Border>
-                                    <Border Style="{StaticResource DesktopInsetCard}" Padding="10">
-                                        <WrapPanel>
-                                            <Button Style="{StaticResource PrimaryButton}" Content="Copy Result" Click="CopySelectedLog_Click" Margin="0,0,4,4"/>
-                                            <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click"/>
-                                            <Button Style="{StaticResource DataActionButton}" Content="Clear Log" Command="{Binding ClearImportExportLogsCommand}"/>
-                                        </WrapPanel>
-                                    </Border>
-                                </StackPanel>
+                                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                    <StackPanel Margin="8">
+                                        <Border Style="{StaticResource DataLaneCard}">
+                                            <StackPanel>
+                                                <TextBlock Text="Current Status" Style="{StaticResource LabelTextBlock}"/>
+                                                <TextBlock Text="{Binding LogSummary}" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                                            </StackPanel>
+                                        </Border>
+                                        <Border Style="{StaticResource DataLaneCard}">
+                                            <StackPanel>
+                                                <TextBlock Text="Selected Result" Style="{StaticResource SectionHeader}"/>
+                                                <TextBlock Text="{Binding SelectedLogTitle}" Style="{StaticResource DataLaneText}"/>
+                                                <TextBlock Text="{Binding SelectedLogDetail}" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                                            </StackPanel>
+                                        </Border>
+                                        <Border Style="{StaticResource DesktopInsetCard}" Padding="10">
+                                            <WrapPanel>
+                                                <Button Style="{StaticResource PrimaryButton}" Content="Copy Result" Click="CopySelectedLog_Click" Margin="0,0,4,4"/>
+                                                <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click"/>
+                                                <Button Style="{StaticResource DataActionButton}" Content="Clear Log" Command="{Binding ClearImportExportLogsCommand}"/>
+                                            </WrapPanel>
+                                        </Border>
+                                    </StackPanel>
+                                </ScrollViewer>
                             </Grid>
                         </Border>
                     </Grid>
@@ -216,11 +230,11 @@
                 <Border Style="{StaticResource DesktopContentPane}">
                     <Grid Margin="12">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1.55*" MinWidth="500"/>
-                            <ColumnDefinition Width="8"/>
-                            <ColumnDefinition Width="1*" MinWidth="330"/>
+                            <ColumnDefinition Width="1.55*" MinWidth="0"/>
+                            <ColumnDefinition Width="6"/>
+                            <ColumnDefinition Width="0.95*" MinWidth="300"/>
                         </Grid.ColumnDefinitions>
-                        <Border Style="{StaticResource Card}" Padding="0">
+                        <Border Style="{StaticResource Card}" Padding="0" MinWidth="0">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
@@ -233,18 +247,20 @@
                                         <TextBlock Text="Import mapped files, export the current catalog, and keep skipped rows visible for review." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                                     </StackPanel>
                                 </Border>
-                                <StackPanel Grid.Row="1" Margin="12">
-                                    <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
-                                    <TextBlock Text="{Binding ItemDataSummary}" TextWrapping="Wrap" Margin="0,4,0,14"/>
-                                    <Border Style="{StaticResource DataLaneCard}">
-                                        <StackPanel>
-                                            <TextBlock Text="Supported Workflow" Style="{StaticResource SectionHeader}"/>
-                                            <TextBlock Text="1. Choose the source file or export destination." TextWrapping="Wrap" Margin="0,4,0,3"/>
-                                            <TextBlock Text="2. For CSV imports, map file columns to app fields before writing rows." TextWrapping="Wrap" Margin="0,0,0,3"/>
-                                            <TextBlock Text="3. Review skipped rows and completion messages in the run log." TextWrapping="Wrap"/>
-                                        </StackPanel>
-                                    </Border>
-                                </StackPanel>
+                                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                    <StackPanel Margin="12">
+                                        <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
+                                        <TextBlock Text="{Binding ItemDataSummary}" TextWrapping="Wrap" Margin="0,4,0,14"/>
+                                        <Border Style="{StaticResource DataLaneCard}">
+                                            <StackPanel>
+                                                <TextBlock Text="Supported Workflow" Style="{StaticResource SectionHeader}"/>
+                                                <TextBlock Text="1. Choose the source file or export destination." TextWrapping="Wrap" Margin="0,4,0,3"/>
+                                                <TextBlock Text="2. For CSV imports, map file columns to app fields before writing rows." TextWrapping="Wrap" Margin="0,0,0,3"/>
+                                                <TextBlock Text="3. Review skipped rows and completion messages in the run log." TextWrapping="Wrap"/>
+                                            </StackPanel>
+                                        </Border>
+                                    </StackPanel>
+                                </ScrollViewer>
                                 <Border Grid.Row="2" Style="{StaticResource DesktopPaneSubheader}" BorderThickness="0,1,0,0">
                                     <WrapPanel>
                                         <Button Style="{StaticResource PrimaryButton}" Content="Import CSV / JSON / XML" Command="{Binding ImportItemsCommand}" Margin="0,0,4,4"/>
@@ -254,27 +270,29 @@
                                 </Border>
                             </Grid>
                         </Border>
-                        <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
-                        <StackPanel Grid.Column="2">
-                            <Border Style="{StaticResource DataLaneCard}">
-                                <StackPanel>
-                                    <TextBlock Text="Import Safety" Style="{StaticResource SectionHeader}"/>
-                                    <TextBlock Text="Item number and name stay required for mapped CSV imports. JSON and XML use direct schema matching." Style="{StaticResource DataLaneText}"/>
-                                </StackPanel>
-                            </Border>
-                            <Border Style="{StaticResource DataLaneCard}">
-                                <StackPanel>
-                                    <TextBlock Text="Best Next Step" Style="{StaticResource SectionHeader}"/>
-                                    <TextBlock Text="Create a backup first when replacing large portions of the catalog or importing from a new vendor file." TextWrapping="Wrap"/>
-                                </StackPanel>
-                            </Border>
-                            <Border Style="{StaticResource DataLaneCard}">
-                                <StackPanel>
-                                    <TextBlock Text="Result Review" Style="{StaticResource SectionHeader}"/>
-                                    <TextBlock Text="Use the Run Log tab to copy or print exact import results for admin handoff." TextWrapping="Wrap"/>
-                                </StackPanel>
-                            </Border>
-                        </StackPanel>
+                        <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+                        <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel>
+                                <Border Style="{StaticResource DataLaneCard}">
+                                    <StackPanel>
+                                        <TextBlock Text="Import Safety" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="Item number and name stay required for mapped CSV imports. JSON and XML use direct schema matching." Style="{StaticResource DataLaneText}"/>
+                                    </StackPanel>
+                                </Border>
+                                <Border Style="{StaticResource DataLaneCard}">
+                                    <StackPanel>
+                                        <TextBlock Text="Best Next Step" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="Create a backup first when replacing large portions of the catalog or importing from a new vendor file." TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
+                                <Border Style="{StaticResource DataLaneCard}">
+                                    <StackPanel>
+                                        <TextBlock Text="Result Review" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="Use the Run Log tab to copy or print exact import results for admin handoff." TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
             </TabItem>
@@ -283,11 +301,11 @@
                 <Border Style="{StaticResource DesktopContentPane}">
                     <Grid Margin="12">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1.45*" MinWidth="500"/>
-                            <ColumnDefinition Width="8"/>
-                            <ColumnDefinition Width="1*" MinWidth="330"/>
+                            <ColumnDefinition Width="1.45*" MinWidth="0"/>
+                            <ColumnDefinition Width="6"/>
+                            <ColumnDefinition Width="0.95*" MinWidth="300"/>
                         </Grid.ColumnDefinitions>
-                        <Border Style="{StaticResource Card}" Padding="0">
+                        <Border Style="{StaticResource Card}" Padding="0" MinWidth="0">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
@@ -300,13 +318,15 @@
                                         <TextBlock Text="Move customer records with a visible advisor handoff path and run-log review." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                                     </StackPanel>
                                 </Border>
-                                <StackPanel Grid.Row="1" Margin="12">
-                                    <TextBlock Text="Customer Directory" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
-                                    <TextBlock Text="{Binding CustomerDataSummary}" TextWrapping="Wrap" Margin="0,4,0,14"/>
-                                    <Border Style="{StaticResource DataLaneCard}">
-                                        <TextBlock Text="Use this lane before advisor handoff, customer cleanup, and directory migration. Imported rows and skipped rows are written into the run log below." TextWrapping="Wrap"/>
-                                    </Border>
-                                </StackPanel>
+                                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                    <StackPanel Margin="12">
+                                        <TextBlock Text="Customer Directory" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
+                                        <TextBlock Text="{Binding CustomerDataSummary}" TextWrapping="Wrap" Margin="0,4,0,14"/>
+                                        <Border Style="{StaticResource DataLaneCard}">
+                                            <TextBlock Text="Use this lane before advisor handoff, customer cleanup, and directory migration. Imported rows and skipped rows are written into the run log below." TextWrapping="Wrap"/>
+                                        </Border>
+                                    </StackPanel>
+                                </ScrollViewer>
                                 <Border Grid.Row="2" Style="{StaticResource DesktopPaneSubheader}" BorderThickness="0,1,0,0">
                                     <WrapPanel>
                                         <Button Style="{StaticResource PrimaryButton}" Content="Import Customers" Command="{Binding ImportCustomersCommand}" Margin="0,0,4,4"/>
@@ -315,21 +335,23 @@
                                 </Border>
                             </Grid>
                         </Border>
-                        <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
-                        <StackPanel Grid.Column="2">
-                            <Border Style="{StaticResource DataLaneCard}">
-                                <StackPanel>
-                                    <TextBlock Text="Advisor Handoff" Style="{StaticResource SectionHeader}"/>
-                                    <TextBlock Text="After import, print or copy the run log so front-desk staff know which customer rows were created, skipped, or exported." TextWrapping="Wrap"/>
-                                </StackPanel>
-                            </Border>
-                            <Border Style="{StaticResource DataLaneCard}">
-                                <StackPanel>
-                                    <TextBlock Text="Cleanup Rhythm" Style="{StaticResource SectionHeader}"/>
-                                    <TextBlock Text="Run customer exchange separately from item exchange so skipped rows and advisor follow-up stay easy to read." TextWrapping="Wrap"/>
-                                </StackPanel>
-                            </Border>
-                        </StackPanel>
+                        <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+                        <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel>
+                                <Border Style="{StaticResource DataLaneCard}">
+                                    <StackPanel>
+                                        <TextBlock Text="Advisor Handoff" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="After import, print or copy the run log so front-desk staff know which customer rows were created, skipped, or exported." TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
+                                <Border Style="{StaticResource DataLaneCard}">
+                                    <StackPanel>
+                                        <TextBlock Text="Cleanup Rhythm" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="Run customer exchange separately from item exchange so skipped rows and advisor follow-up stay easy to read." TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
             </TabItem>
@@ -338,11 +360,11 @@
                 <Border Style="{StaticResource DesktopContentPane}">
                     <Grid Margin="12">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" MinWidth="420"/>
-                            <ColumnDefinition Width="8"/>
-                            <ColumnDefinition Width="*" MinWidth="420"/>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
+                            <ColumnDefinition Width="6"/>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
                         </Grid.ColumnDefinitions>
-                        <Border Style="{StaticResource Card}" Padding="0">
+                        <Border Style="{StaticResource Card}" Padding="0" MinWidth="0">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
@@ -354,21 +376,23 @@
                                         <TextBlock Text="Create a restore point before bulk data movement or workstation changes." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                                     </StackPanel>
                                 </Border>
-                                <StackPanel Grid.Row="1" Margin="12">
-                                    <TextBlock Text="Full Backup and Restore" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
-                                    <TextBlock Text="{Binding BackupSummary}" TextWrapping="Wrap" Margin="0,4,0,12"/>
-                                    <Border Style="{StaticResource DataLaneCard}">
-                                        <TextBlock Text="Recommended before imports, image remaps, customer cleanup, workstation migration, or restoring older data." TextWrapping="Wrap"/>
-                                    </Border>
-                                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                                        <Button Style="{StaticResource PrimaryButton}" Content="Create Full Backup" Command="{Binding BackupDatabaseCommand}" HorizontalAlignment="Left" Margin="0,0,6,0"/>
-                                        <Button Style="{StaticResource GhostButton}" Content="Restore Backup" Command="{Binding RestoreBackupCommand}" HorizontalAlignment="Left"/>
+                                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                    <StackPanel Margin="12">
+                                        <TextBlock Text="Full Backup and Restore" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
+                                        <TextBlock Text="{Binding BackupSummary}" TextWrapping="Wrap" Margin="0,4,0,12"/>
+                                        <Border Style="{StaticResource DataLaneCard}">
+                                            <TextBlock Text="Recommended before imports, image remaps, customer cleanup, workstation migration, or restoring older data." TextWrapping="Wrap"/>
+                                        </Border>
+                                        <WrapPanel Margin="0,6,0,0">
+                                            <Button Style="{StaticResource PrimaryButton}" Content="Create Full Backup" Command="{Binding BackupDatabaseCommand}" HorizontalAlignment="Left" Margin="0,0,6,4"/>
+                                            <Button Style="{StaticResource GhostButton}" Content="Restore Backup" Command="{Binding RestoreBackupCommand}" HorizontalAlignment="Left" Margin="0,0,4,4"/>
+                                        </WrapPanel>
                                     </StackPanel>
-                                </StackPanel>
+                                </ScrollViewer>
                             </Grid>
                         </Border>
-                        <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
-                        <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+                        <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+                        <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
@@ -380,14 +404,16 @@
                                         <TextBlock Text="Map image folders to item records and keep skipped filenames visible for follow-up." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                                     </StackPanel>
                                 </Border>
-                                <StackPanel Grid.Row="1" Margin="12">
-                                    <TextBlock Text="Image Import" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
-                                    <TextBlock Text="{Binding ImageImportSummary}" TextWrapping="Wrap" Margin="0,4,0,12"/>
-                                    <Border Style="{StaticResource DataLaneCard}">
-                                        <TextBlock Text="Match folder images to item records, then check the run log for any rows or filenames that need follow-up." TextWrapping="Wrap"/>
-                                    </Border>
-                                    <Button Style="{StaticResource PrimaryButton}" Content="Open Image Mapping" Command="{Binding OpenImageImportMappingWindowCommand}" HorizontalAlignment="Left" Margin="0,6,0,0" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
-                                </StackPanel>
+                                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                    <StackPanel Margin="12">
+                                        <TextBlock Text="Image Import" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
+                                        <TextBlock Text="{Binding ImageImportSummary}" TextWrapping="Wrap" Margin="0,4,0,12"/>
+                                        <Border Style="{StaticResource DataLaneCard}">
+                                            <TextBlock Text="Match folder images to item records, then check the run log for any rows or filenames that need follow-up." TextWrapping="Wrap"/>
+                                        </Border>
+                                        <Button Style="{StaticResource PrimaryButton}" Content="Open Image Mapping" Command="{Binding OpenImageImportMappingWindowCommand}" HorizontalAlignment="Left" Margin="0,6,0,0" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
+                                    </StackPanel>
+                                </ScrollViewer>
                             </Grid>
                         </Border>
                     </Grid>
@@ -398,12 +424,12 @@
                 <Border Style="{StaticResource DesktopContentPane}">
                     <Grid Margin="8">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="2.35*" MinWidth="560"/>
-                            <ColumnDefinition Width="8"/>
-                            <ColumnDefinition Width="430" MinWidth="360"/>
+                            <ColumnDefinition Width="1.55*" MinWidth="0"/>
+                            <ColumnDefinition Width="6"/>
+                            <ColumnDefinition Width="0.95*" MinWidth="300"/>
                         </Grid.ColumnDefinitions>
 
-                        <Border Style="{StaticResource Card}" Padding="0">
+                        <Border Style="{StaticResource Card}" Padding="0" MinWidth="0">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
@@ -413,11 +439,11 @@
                                 </Grid.RowDefinitions>
                                 <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
                                     <DockPanel>
-                                        <StackPanel DockPanel.Dock="Left">
+                                        <StackPanel DockPanel.Dock="Left" MinWidth="220" MaxWidth="520">
                                             <TextBlock Text="01 Operation Results" Style="{StaticResource SectionHeader}" Margin="0"/>
                                             <TextBlock Text="Review import, export, backup, and image-mapping results before clearing the session." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                                         </StackPanel>
-                                        <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                                        <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="320"/>
                                     </DockPanel>
                                 </Border>
                                 <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
@@ -434,6 +460,13 @@
                                           IsReadOnly="True"
                                           AutoGenerateColumns="False"
                                           Style="{StaticResource VirtualizedDataGridStyle}"
+                                          EnableRowVirtualization="True"
+                                          EnableColumnVirtualization="True"
+                                          SelectionMode="Single"
+                                          SelectionUnit="FullRow"
+                                          ScrollViewer.CanContentScroll="True"
+                                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                                           MouseDoubleClick="ImportExportLogGrid_MouseDoubleClick">
                                     <DataGrid.RowStyle>
                                         <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
@@ -449,7 +482,7 @@
                                         </ContextMenu>
                                     </DataGrid.ContextMenu>
                                     <DataGrid.Columns>
-                                        <DataGridTemplateColumn Header="Run Result" Width="*">
+                                        <DataGridTemplateColumn Header="Run Result" Width="*" MinWidth="240">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
                                                     <Border Padding="8,5">
@@ -463,7 +496,7 @@
                                         </DataGridTemplateColumn>
                                     </DataGrid.Columns>
                                 </DataGrid>
-                                <Border Grid.Row="2" Width="360" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <Border Grid.Row="2" MaxWidth="340" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <Border.Style>
                                         <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                             <Setter Property="Visibility" Value="Collapsed"/>
@@ -485,9 +518,9 @@
                             </Grid>
                         </Border>
 
-                        <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+                        <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-                        <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+                        <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
@@ -500,7 +533,7 @@
                                         <TextBlock Text="Keep the selected result readable while copying or printing the session packet." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                                     </StackPanel>
                                 </Border>
-                                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                                     <StackPanel Margin="8">
                                         <Border Style="{StaticResource DataRunLogCard}" Padding="12" Margin="0,0,0,8">
                                             <StackPanel>
@@ -510,17 +543,17 @@
                                             </StackPanel>
                                         </Border>
                                         <Border Style="{StaticResource DataLaneCard}">
-                                            <ScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="260">
+                                            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" MaxHeight="260">
                                                 <TextBlock Text="{Binding SelectedLogDetail}" TextWrapping="Wrap"/>
                                             </ScrollViewer>
                                         </Border>
                                     </StackPanel>
                                 </ScrollViewer>
                                 <Border Grid.Row="2" Style="{StaticResource DesktopInsetCard}" Padding="10">
-                                    <UniformGrid Columns="2">
+                                    <WrapPanel>
                                         <Button Style="{StaticResource DataActionButton}" Content="Copy" Click="CopySelectedLog_Click"/>
                                         <Button Style="{StaticResource DataActionButton}" Content="Print" Click="PrintLogs_Click"/>
-                                    </UniformGrid>
+                                    </WrapPanel>
                                 </Border>
                             </Grid>
                         </Border>
@@ -530,14 +563,12 @@
         </TabControl>
 
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,6,0,0" Padding="8,5">
-            <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <TextBlock Text="Data desk ready" FontSize="11" Margin="0,0,10,0" VerticalAlignment="Center"/>
-                    <TextBlock Text="Item import running" FontSize="11" Margin="0,0,6,0" Visibility="{Binding ImportItemsCommand.IsRunning, Converter={StaticResource BoolToVis}}" VerticalAlignment="Center"/>
-                    <ProgressBar Width="140" Height="14" IsIndeterminate="True" Visibility="{Binding ImportItemsCommand.IsRunning, Converter={StaticResource BoolToVis}}"/>
-                </StackPanel>
-                <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
+            <WrapPanel>
+                <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="680" Margin="0,0,10,4"/>
+                <TextBlock Text="Data desk ready" FontSize="11" Margin="0,0,10,4" VerticalAlignment="Center"/>
+                <TextBlock Text="Item import running" FontSize="11" Margin="0,0,6,4" Visibility="{Binding ImportItemsCommand.IsRunning, Converter={StaticResource BoolToVis}}" VerticalAlignment="Center"/>
+                <ProgressBar Width="120" Height="14" IsIndeterminate="True" Visibility="{Binding ImportItemsCommand.IsRunning, Converter={StaticResource BoolToVis}}" Margin="0,0,0,4"/>
+            </WrapPanel>
         </Border>
     </Grid>
 </Page>


### PR DESCRIPTION
## What changed

- Reworked the Import / Export Workbench header from fixed metric columns into wrapping bounded operation cards.
- Added bounded metric value styling so item, customer, backup, and run-log summary text stays inside cards at scaled desktop widths.
- Reduced header column pressure with shrinkable star columns and bounded title copy.
- Changed the overview, item data, customer, backup/images, and run-log splits from large fixed minimums to lower-pressure shrinkable panes.
- Narrowed splitters to match the newer responsive workbench pattern.
- Converted overview data-control lanes from a fixed two-column `UniformGrid` into wrapping bounded cards.
- Added automatic vertical scrolling with disabled horizontal overflow for overview handoff, item/customer advisory panes, backup/image content, and run-log handoff content.
- Wrapped backup/restore and run-log footer actions so commands remain reachable at scaled desktop widths.
- Enabled explicit row and column virtualization on the Import / Export run-log grid.
- Enabled automatic horizontal/vertical run-log grid scrollbars and content scrolling.
- Switched the run-log grid to full-row single selection for clearer double-click and context-menu actions.
- Bounded the empty log state and selected-log detail panel so long results remain readable.
- Added `ImportExportPageResponsiveContractTests` plus a progress note for the completed workflow slice.

## Why this was highest value

Recent scheduled work completed responsive passes for Activity Logs, Users, Reports, Maintenance, Calibration, Customers, Dashboard, Categories, Kits, Settings, Reservations, and Manage Items. Current source evidence showed Import / Export still had fixed header metric columns, fixed two-column lane cards, high tab split minimums, fixed run-log side pane pressure, no explicit run-log grid virtualization/scrollbar/full-row-selection contract, a fixed empty-state width, and horizontal-only footer progress. Import / Export is a core operational workflow for item/customer data movement, backups, image mapping, and result handoff, so tightening it directly improves speed, responsiveness, and professional data display.

## Why this is real workflow progress

This covers more than ten focused workflow-level improvements across header metrics, metric text bounding, split sizing, splitter sizing, lane-card wrapping, handoff scrolling, tab content scrolling, backup/restore action wrapping, run-log grid virtualization, run-log grid scrolling, row selection, empty-state sizing, selected-log detail bounding, footer progress wrapping, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ImportExportPage.xaml`
  - `InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-02-import-export-responsive-workbench.md`
- Connector source readback confirmed wrapping bounded header metrics, bounded metric values, lower split pressure, shrinkable pane shells, wrapping lane cards, automatic handoff/advisory scrolling, explicit run-log grid virtualization/scrollbars, full-row selection, bounded empty state, bounded selected-log detail, wrapping footer progress, and preserved commands/row handlers.
- Connector status readback found no attached commit statuses on branch head `5cb58c339a0cca91216cbb6d028cd7177be550f8` before PR creation.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Import / Export on Windows at 1366 x 768 and higher DPI scales, including item import/export, customer import/export, backup, restore, image mapping, run-log selection, copy, print, clear, double-click, context-menu actions, and footer progress while an import is running.