### PR TITLE
[codex] Improve item search responsive workbench layout

### DIFF
--- a/InventoryManagementApp.Tests/ItemSearchPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemSearchPageResponsiveContractTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemSearchPageResponsiveContractTests
+    {
+        [Fact]
+        public void ItemSearchPage_WrapsSearchToolbarAndSummaryActions()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml");
+
+            Assert.Contains("<DockPanel LastChildFill=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBox Width=\"260\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"180\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ComboBox Width=\"150\" MinWidth=\"120\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\" Orientation=\"Horizontal\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel VerticalAlignment=\"Center\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"320\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"180\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemSearchPage_AvoidsLargeFixedMinimumsInMainSearchSplit()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.7*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\" Width=\"5\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Grid Grid.Column=\"2\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"560\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"1.25*\" MinWidth=\"430\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemSearchPage_WrapsPaneHeadersAndIntelligenceActionCards()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml");
+
+            Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\" MinWidth=\"180\" MaxWidth=\"420\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\" MinWidth=\"170\" MaxWidth=\"360\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\" MinWidth=\"180\" MaxWidth=\"360\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"145\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"230\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel>\n                                <Border Style=\"{StaticResource InsightStatCard}\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Grid.ColumnDefinitions>\n                                    <ColumnDefinition Width=\"1.7*\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemSearchPage_EnablesAllWorkbenchGridsVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml");
+
+            Assert.Contains("x:Name=\"ResultsGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"CheckedOutGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"RecentSearchGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"UnavailableDemandGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Equal(4, CountOccurrences(xaml, "EnableRowVirtualization=\"True\""));
+            Assert.Equal(4, CountOccurrences(xaml, "EnableColumnVirtualization=\"True\""));
+            Assert.Equal(4, CountOccurrences(xaml, "SelectionMode=\"Single\""));
+            Assert.Equal(4, CountOccurrences(xaml, "SelectionUnit=\"FullRow\""));
+            Assert.Equal(4, CountOccurrences(xaml, "ScrollViewer.CanContentScroll=\"True\""));
+            Assert.Equal(4, CountOccurrences(xaml, "ScrollViewer.HorizontalScrollBarVisibility=\"Auto\""));
+            Assert.Equal(4, CountOccurrences(xaml, "ScrollViewer.VerticalScrollBarVisibility=\"Auto\""));
+        }
+
+        [Fact]
+        public void ItemSearchPage_ReducesOversizedGridColumnsAndSidePanePressure()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml");
+
+            Assert.Contains("<RowDefinition Height=\"1.15*\" MinHeight=\"160\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<RowDefinition Height=\"*\" MinHeight=\"200\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Row=\"1\" Height=\"5\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Photo\" Width=\"66\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Status\" Width=\"104\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Stock\" Width=\"86\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Activity\" Width=\"128\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Out Since\" Width=\"104\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<RowDefinition Height=\"1.25*\" MinHeight=\"190\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<RowDefinition Height=\"*\" MinHeight=\"230\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemSearchPage_PreservesSearchActionsAndRowHandlers()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml");
+
+            Assert.Contains("ViewDetailsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenRentalsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ToggleCheckOutCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintSearchResults_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintCheckedOut_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("RepeatSelectedSearch_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenDemandItem_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintSearchIntelligence_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("ClearSearchIntelligence_Click", xaml, StringComparison.Ordinal);
+            Assert.Contains("ItemGrid_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("RecentSearchGrid_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("UnavailableDemandGrid_MouseDoubleClick", xaml, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-item-search-responsive-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-item-search-responsive-workbench.md
@@ -1,0 +1,22 @@
+# Item Search Responsive Workbench
+
+Date: 2026-07-03
+
+## Completed
+
+- Reworked the Item Search toolbar from fixed grid columns into wrapping search/filter, status-summary, and print-action groups.
+- Added practical minimums to the search box and brand filter so controls remain usable on scaled desktop widths without forcing the whole page wider.
+- Reduced the main search/results split from large fixed minimums to shrinkable star columns with a practical 300 px side-workbench minimum.
+- Added shrinkable pane shells across the search results, checked-out, and search-intelligence work areas.
+- Replaced header-only horizontal action stacks with wrapping action groups for results, checked-out items, and search intelligence.
+- Reduced right-side vertical split pressure and narrowed both splitters to keep the screen usable at 1366 x 768 and Windows scaling.
+- Enabled explicit row and column virtualization, content scrolling, automatic horizontal/vertical scrollbars, single selection, and full-row selection across the results, checked-out, recent-search, and unavailable-demand grids.
+- Reduced oversized item-search and checked-out grid columns while preserving photo, item identity, status, stock, activity, holder, and check-in actions.
+- Replaced fixed search-intelligence statistic columns with wrapping bounded cards so session pulse, recent-search, and unavailable-demand summaries do not force horizontal overflow.
+- Preserved the existing details, rentals, check-out/check-in, print, repeat-search, open-demand-item, clear-intelligence, double-click, and context-menu workflows.
+- Added `ItemSearchPageResponsiveContractTests` to guard the responsive layout, grid virtualization/scrollbar contracts, bounded intelligence cards, and preserved workflow actions.
+
+## Validation notes
+
+- Source changes are limited to Item Search XAML, source-contract tests, and this progress note.
+- Direct Windows/WPF runtime validation, screenshots, and `pwsh -File scripts/run-full-validation.ps1` still need to be run from a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or WPF runtime tooling.

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -48,66 +48,66 @@
         </Style>
         <Style x:Key="InsightStatCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="10,8"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+            <Setter Property="MinWidth" Value="145"/>
+            <Setter Property="MaxWidth" Value="230"/>
             <Setter Property="MinHeight" Value="58"/>
         </Style>
     </Page.Resources>
 
-    <Grid Margin="4">
+    <Grid Margin="4" MinWidth="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="320"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="180"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="Find item" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                <TextBox Grid.Column="1"
-                         Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
-                         ToolTip="Search by name, item number, part number, brand, location, or keyword"/>
-                <TextBlock Grid.Column="2" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="10,0,6,0"/>
-                <ComboBox Grid.Column="3" ItemsSource="{Binding Categories}" SelectedItem="{Binding SelectedCategory}"/>
-                <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0,0,0">
-                    <TextBlock Text="{Binding SearchResultsSummary}" Style="{StaticResource CaptionTextBlock}" Margin="0,0,12,0"/>
-                    <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource CaptionTextBlock}"/>
-                </StackPanel>
-                <StackPanel Grid.Column="5" Orientation="Horizontal">
-                    <Button Content="Print Results" Click="PrintSearchResults_Click" Margin="0,0,4,0"/>
-                    <Button Content="Print Checked Out" Click="PrintCheckedOut_Click"/>
-                </StackPanel>
-            </Grid>
+            <DockPanel LastChildFill="True">
+                <WrapPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+                    <TextBlock Text="Find item" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
+                    <TextBox Width="260"
+                             MinWidth="180"
+                             Margin="0,0,10,4"
+                             Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                             ToolTip="Search by name, item number, part number, brand, location, or keyword"/>
+                    <TextBlock Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
+                    <ComboBox Width="150" MinWidth="120" Margin="0,0,10,4" ItemsSource="{Binding Categories}" SelectedItem="{Binding SelectedCategory}"/>
+                </WrapPanel>
+                <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="10,0,0,0">
+                    <Button Content="Print Results" Click="PrintSearchResults_Click" Margin="0,0,4,4"/>
+                    <Button Content="Print Checked Out" Click="PrintCheckedOut_Click" Margin="0,0,0,4"/>
+                </WrapPanel>
+                <WrapPanel VerticalAlignment="Center" MinWidth="0">
+                    <TextBlock Text="{Binding SearchResultsSummary}" Style="{StaticResource CaptionTextBlock}" Margin="0,0,12,4" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,4" TextTrimming="CharacterEllipsis"/>
+                </WrapPanel>
+            </DockPanel>
         </Border>
 
-        <Grid Grid.Row="1">
+        <Grid Grid.Row="1" MinWidth="0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*" MinWidth="560"/>
-                <ColumnDefinition Width="6"/>
-                <ColumnDefinition Width="1.25*" MinWidth="430"/>
+                <ColumnDefinition Width="1.7*" MinWidth="0"/>
+                <ColumnDefinition Width="5"/>
+                <ColumnDefinition Width="0.95*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
-                <Grid>
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                <Grid MinWidth="0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0" BorderThickness="0,0,0,2">
                         <DockPanel LastChildFill="True">
-                            <TextBlock Text="Search Results" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0"/>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
-                                <Button Content="Details" Command="{Binding ViewDetailsCommand}" Style="{StaticResource GhostButton}" Margin="0,0,4,0"/>
-                                <Button Content="Rent Out" Command="{Binding OpenRentalsCommand}" Style="{StaticResource GhostButton}" Margin="0,0,4,0"/>
-                                <Button Content="Check Out / In" Command="{Binding ToggleCheckOutCommand}" CommandParameter="{Binding SelectedItem}" Style="{StaticResource GhostButton}"/>
+                            <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="180" MaxWidth="420">
+                                <TextBlock Text="Search Results" Style="{StaticResource SectionHeader}" Margin="0"/>
+                                <TextBlock Text="Rows include photo, stock, holder, and location; double-click for full details." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                             </StackPanel>
-                            <TextBlock Text="Rows include photo, stock, holder, and location; double-click for full details." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                            <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="10,0,0,0">
+                                <Button Content="Details" Command="{Binding ViewDetailsCommand}" Style="{StaticResource GhostButton}" Margin="0,0,4,4"/>
+                                <Button Content="Rent Out" Command="{Binding OpenRentalsCommand}" Style="{StaticResource GhostButton}" Margin="0,0,4,4"/>
+                                <Button Content="Check Out / In" Command="{Binding ToggleCheckOutCommand}" CommandParameter="{Binding SelectedItem}" Style="{StaticResource GhostButton}" Margin="0,0,0,4"/>
+                            </WrapPanel>
                         </DockPanel>
                     </Border>
                     <DataGrid x:Name="ResultsGrid"
@@ -117,6 +117,12 @@
                               SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
                               RowHeight="78"
                               EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
+                              SelectionMode="Single"
+                              SelectionUnit="FullRow"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               MouseDoubleClick="ItemGrid_MouseDoubleClick">
                         <DataGrid.ContextMenu>
                             <ContextMenu>
@@ -128,7 +134,7 @@
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                         <DataGrid.Columns>
-                            <DataGridTemplateColumn Header="Photo" Width="70" IsReadOnly="True">
+                            <DataGridTemplateColumn Header="Photo" Width="66" IsReadOnly="True">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Width="62" Height="62" HorizontalAlignment="Center" VerticalAlignment="Center" Background="{DynamicResource ControlBackgroundBrush}">
@@ -149,10 +155,10 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Item" Width="2.3*" IsReadOnly="True">
+                            <DataGridTemplateColumn Header="Item" Width="1.8*" IsReadOnly="True">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <Grid Margin="0,3">
+                                        <Grid Margin="0,3" MinWidth="0">
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto"/>
                                                 <RowDefinition Height="Auto"/>
@@ -177,7 +183,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Status" Width="112" IsReadOnly="True">
+                            <DataGridTemplateColumn Header="Status" Width="104" IsReadOnly="True">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="0,4">
@@ -187,7 +193,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Stock" Width="92" IsReadOnly="True">
+                            <DataGridTemplateColumn Header="Stock" Width="86" IsReadOnly="True">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="0,4">
@@ -203,7 +209,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Activity" Width="145" IsReadOnly="True">
+                            <DataGridTemplateColumn Header="Activity" Width="128" IsReadOnly="True">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Margin="0,4">
@@ -218,29 +224,31 @@
                 </Grid>
             </Border>
 
-            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushAlt}"/>
+            <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushAlt}"/>
 
-            <Grid Grid.Column="2">
+            <Grid Grid.Column="2" MinWidth="0">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="1.25*" MinHeight="190"/>
-                    <RowDefinition Height="6"/>
-                    <RowDefinition Height="*" MinHeight="230"/>
+                    <RowDefinition Height="1.15*" MinHeight="160"/>
+                    <RowDefinition Height="5"/>
+                    <RowDefinition Height="*" MinHeight="200"/>
                 </Grid.RowDefinitions>
 
-                <Border Grid.Row="0" Style="{StaticResource Card}" Padding="0">
-                    <Grid>
+                <Border Grid.Row="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                    <Grid MinWidth="0">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
                         <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0" BorderThickness="0,0,0,2">
                             <DockPanel LastChildFill="True">
-                                <TextBlock Text="Currently Checked Out" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0"/>
-                                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
-                                    <Button Content="Print" Click="PrintCheckedOut_Click" Style="{StaticResource GhostButton}" Margin="0,0,4,0"/>
-                                    <Button Content="Details" Command="{Binding ViewDetailsCommand}" Style="{StaticResource GhostButton}"/>
+                                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="170" MaxWidth="360">
+                                    <TextBlock Text="Currently Checked Out" Style="{StaticResource SectionHeader}" Margin="0"/>
+                                    <TextBlock Text="Visible while searching; double-click to inspect or check back in." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                                 </StackPanel>
-                                <TextBlock Text="Visible while searching; double-click to inspect or check back in." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                                <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="10,0,0,0">
+                                    <Button Content="Print" Click="PrintCheckedOut_Click" Style="{StaticResource GhostButton}" Margin="0,0,4,4"/>
+                                    <Button Content="Details" Command="{Binding ViewDetailsCommand}" Style="{StaticResource GhostButton}" Margin="0,0,0,4"/>
+                                </WrapPanel>
                             </DockPanel>
                         </Border>
                         <DataGrid x:Name="CheckedOutGrid"
@@ -250,6 +258,12 @@
                                   SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
                                   RowHeight="64"
                                   EnableRowVirtualization="True"
+                                  EnableColumnVirtualization="True"
+                                  SelectionMode="Single"
+                                  SelectionUnit="FullRow"
+                                  ScrollViewer.CanContentScroll="True"
+                                  ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                  ScrollViewer.VerticalScrollBarVisibility="Auto"
                                   MouseDoubleClick="ItemGrid_MouseDoubleClick">
                             <DataGrid.ContextMenu>
                                 <ContextMenu>
@@ -260,7 +274,7 @@
                                 </ContextMenu>
                             </DataGrid.ContextMenu>
                             <DataGrid.Columns>
-                                <DataGridTemplateColumn Header="Photo" Width="56" IsReadOnly="True">
+                                <DataGridTemplateColumn Header="Photo" Width="52" IsReadOnly="True">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <Image Width="44" Height="44" Stretch="UniformToFill" Source="{Binding Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
@@ -281,14 +295,14 @@
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
-                                <DataGridTemplateColumn Header="Out Since" Width="118" IsReadOnly="True">
+                                <DataGridTemplateColumn Header="Out Since" Width="104" IsReadOnly="True">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding CheckedOutTime, StringFormat=yyyy-MM-dd HH:mm}" Margin="0,4" TextWrapping="Wrap"/>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
-                                <DataGridTemplateColumn Header="Action" Width="76">
+                                <DataGridTemplateColumn Header="Action" Width="72">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <Button Content="Check In"
@@ -304,10 +318,10 @@
                     </Grid>
                 </Border>
 
-                <GridSplitter Grid.Row="1" Height="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushAlt}"/>
+                <GridSplitter Grid.Row="1" Height="5" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushAlt}"/>
 
-                <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
-                    <Grid>
+                <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                    <Grid MinWidth="0">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
@@ -315,7 +329,7 @@
                         </Grid.RowDefinitions>
                         <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0" BorderThickness="0,0,0,2">
                             <DockPanel LastChildFill="True">
-                                <StackPanel DockPanel.Dock="Left">
+                                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="180" MaxWidth="360">
                                     <TextBlock Text="Search Intelligence" Style="{StaticResource SectionHeader}" Margin="0"/>
                                     <TextBlock Text="Recent searches and unavailable demand signals stay visible while the team works the counter." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                                 </StackPanel>
@@ -329,31 +343,26 @@
                         </Border>
 
                         <Border Grid.Row="1" Style="{StaticResource DesktopSectionActionStrip}" Margin="0" BorderThickness="0,0,0,1">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="1.7*"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Grid.Column="0" Style="{StaticResource InsightStatCard}">
+                            <WrapPanel>
+                                <Border Style="{StaticResource InsightStatCard}">
                                     <StackPanel>
                                         <TextBlock Text="Session Pulse" Style="{StaticResource LabelTextBlock}"/>
                                         <TextBlock x:Name="SearchIntelligenceSummaryText" Text="No search activity yet" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                                     </StackPanel>
                                 </Border>
-                                <Border Grid.Column="1" Style="{StaticResource InsightStatCard}">
+                                <Border Style="{StaticResource InsightStatCard}">
                                     <StackPanel>
                                         <TextBlock Text="Recent Searches" Style="{StaticResource LabelTextBlock}"/>
                                         <TextBlock Text="Repeat common lookups without retyping." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                                     </StackPanel>
                                 </Border>
-                                <Border Grid.Column="2" Style="{StaticResource InsightStatCard}" Margin="0">
+                                <Border Style="{StaticResource InsightStatCard}">
                                     <StackPanel>
                                         <TextBlock Text="Unavailable Demand" Style="{StaticResource LabelTextBlock}"/>
                                         <TextBlock Text="Spot items customers wanted but could not take." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                                     </StackPanel>
                                 </Border>
-                            </Grid>
+                            </WrapPanel>
                         </Border>
 
                         <TabControl Grid.Row="2" Margin="0" Padding="0">
@@ -363,6 +372,13 @@
                                           AutoGenerateColumns="False"
                                           IsReadOnly="True"
                                           RowHeight="30"
+                                          EnableRowVirtualization="True"
+                                          EnableColumnVirtualization="True"
+                                          SelectionMode="Single"
+                                          SelectionUnit="FullRow"
+                                          ScrollViewer.CanContentScroll="True"
+                                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                                           MouseDoubleClick="RecentSearchGrid_MouseDoubleClick">
                                     <DataGrid.ContextMenu>
                                         <ContextMenu>
@@ -374,10 +390,10 @@
                                     </DataGrid.ContextMenu>
                                     <DataGrid.Columns>
                                         <DataGridTextColumn Header="Search" Binding="{Binding Term}" Width="1.4*"/>
-                                        <DataGridTextColumn Header="Brand" Binding="{Binding Category}" Width="90"/>
-                                        <DataGridTextColumn Header="Results" Binding="{Binding ResultCount}" Width="64"/>
-                                        <DataGridTextColumn Header="Unavailable" Binding="{Binding UnavailableCount}" Width="90"/>
-                                        <DataGridTextColumn Header="Last" Binding="{Binding LastSearched, StringFormat={}{0:HH:mm}}" Width="64"/>
+                                        <DataGridTextColumn Header="Brand" Binding="{Binding Category}" Width="82"/>
+                                        <DataGridTextColumn Header="Results" Binding="{Binding ResultCount}" Width="58"/>
+                                        <DataGridTextColumn Header="Unavailable" Binding="{Binding UnavailableCount}" Width="82"/>
+                                        <DataGridTextColumn Header="Last" Binding="{Binding LastSearched, StringFormat={}{0:HH:mm}}" Width="58"/>
                                     </DataGrid.Columns>
                                 </DataGrid>
                             </TabItem>
@@ -387,6 +403,13 @@
                                           AutoGenerateColumns="False"
                                           IsReadOnly="True"
                                           RowHeight="36"
+                                          EnableRowVirtualization="True"
+                                          EnableColumnVirtualization="True"
+                                          SelectionMode="Single"
+                                          SelectionUnit="FullRow"
+                                          ScrollViewer.CanContentScroll="True"
+                                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                                           MouseDoubleClick="UnavailableDemandGrid_MouseDoubleClick">
                                     <DataGrid.ContextMenu>
                                         <ContextMenu>
@@ -397,14 +420,14 @@
                                         </ContextMenu>
                                     </DataGrid.ContextMenu>
                                     <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="82"/>
-                                        <DataGridTextColumn Header="Item" Binding="{Binding Name}" Width="1.6*"/>
-                                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="88"/>
-                                        <DataGridTextColumn Header="Hits" Binding="{Binding HitCount}" Width="48"/>
-                                        <DataGridTextColumn Header="Holder" Binding="{Binding Holder}" Width="96"/>
-                                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="90"/>
-                                        <DataGridTextColumn Header="Last" Binding="{Binding LastSearched, StringFormat={}{0:HH:mm}}" Width="60"/>
-                                        <DataGridTextColumn Header="Terms" Binding="{Binding SearchTerms}" Width="140"/>
+                                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="76"/>
+                                        <DataGridTextColumn Header="Item" Binding="{Binding Name}" Width="1.5*"/>
+                                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="80"/>
+                                        <DataGridTextColumn Header="Hits" Binding="{Binding HitCount}" Width="44"/>
+                                        <DataGridTextColumn Header="Holder" Binding="{Binding Holder}" Width="88"/>
+                                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="84"/>
+                                        <DataGridTextColumn Header="Last" Binding="{Binding LastSearched, StringFormat={}{0:HH:mm}}" Width="56"/>
+                                        <DataGridTextColumn Header="Terms" Binding="{Binding SearchTerms}" Width="120"/>
                                     </DataGrid.Columns>
                                 </DataGrid>
                             </TabItem>


### PR DESCRIPTION
## What changed

- Reworked the Item Search toolbar from fixed grid columns into wrapping search/filter, status-summary, and print-action groups.
- Added practical minimums to the search box and brand filter so controls remain usable on scaled desktop widths without forcing the whole page wider.
- Reduced the main search/results split from large fixed minimums to shrinkable star columns with a practical 300 px side-workbench minimum.
- Added shrinkable pane shells across the search results, checked-out, and search-intelligence work areas.
- Replaced header-only horizontal action stacks with wrapping action groups for results, checked-out items, and search intelligence.
- Reduced right-side vertical split pressure and narrowed both splitters to keep the screen usable at 1366 x 768 and Windows scaling.
- Enabled explicit row and column virtualization, content scrolling, automatic horizontal/vertical scrollbars, single selection, and full-row selection across the results, checked-out, recent-search, and unavailable-demand grids.
- Reduced oversized item-search and checked-out grid columns while preserving photo, item identity, status, stock, activity, holder, and check-in actions.
- Replaced fixed search-intelligence statistic columns with wrapping bounded cards so session pulse, recent-search, and unavailable-demand summaries do not force horizontal overflow.
- Preserved the existing details, rentals, check-out/check-in, print, repeat-search, open-demand-item, clear-intelligence, double-click, and context-menu workflows.
- Added `ItemSearchPageResponsiveContractTests` and a progress note for the completed workflow slice.

## Why this was highest value

Recent scheduled work already completed responsive passes for Dashboard, Reports, Activity Logs, Users, Customers, Maintenance, Calibration, Categories, Kits, Reservations, Manage Items, Settings, Import / Export, and an open draft Manage Rentals pass. Item Search is a central counter workflow for search, checkout, current checked-out rows, print actions, and search-intelligence drilldown. Current source evidence still showed fixed toolbar columns, large split minimums, fixed intelligence statistic columns, and incomplete explicit grid virtualization/scroll contracts across its four grids.

## Why this is real progress

This covers more than ten workflow-level improvements across toolbar wrapping, search/filter sizing, summary wrapping, split sizing, splitter sizing, pane shrink behavior, results-grid virtualization, checked-out-grid virtualization, intelligence-grid virtualization, grid scrollbars, full-row selection, header action wrapping, side-pane vertical pressure, column sizing, bounded intelligence cards, preserved workflow commands, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ItemSearchPage.xaml`
  - `InventoryManagementApp.Tests/ItemSearchPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-item-search-responsive-workbench.md`
- Connector source readback confirmed wrapping toolbar groups, lower split pressure, narrower splitters, shrinkable pane shells, wrapping pane actions, bounded intelligence cards, explicit virtualization/scrollbar/full-row selection contracts for all four grids, reduced grid columns, and preserved commands/row handlers.
- Connector status readback found no attached commit statuses on branch head `9b98af0996d8d40fb07d4e49f4723d9f0ec414d6`.
- Connector workflow readback found no workflow runs attached to branch head `9b98af0996d8d40fb07d4e49f4723d9f0ec414d6`.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, print-preview/layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
- Because the requested full Windows validation could not run, this PR is left as a draft and was not merged.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Item Search on Windows at 1366 x 768 and higher DPI scales, including typing searches, switching brand filters, selecting rows, opening details, check-out/check-in, print results, print checked-out, repeat search, unavailable-demand open item, intelligence print/clear, context menus, and keyboard shortcuts.