### PR TITLE
[codex] Improve print preview responsive shell

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
@@ -33,6 +33,50 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void PrintPreviewWindow_UsesResponsiveMinimumsAndWrappingHeaderActions()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("Width=\"1120\" Height=\"760\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"760\" MinHeight=\"560\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<DockPanel Grid.Column=\"0\" LastChildFill=\"True\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"1\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\" MaxWidth=\"330\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextTrimming=\"CharacterEllipsis\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"1220\" Height=\"820\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"980\" MinHeight=\"680\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel Orientation=\"Horizontal\" DockPanel.Dock=\"Right\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewWindow_KeepsPreviewCanvasShrinkableAndScrollable()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"6\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.36*\" MinWidth=\"240\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource ThemedWindowPane}\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"280\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewWindow_KeepsChecklistPaneAndFooterReachableOnScaledScreens()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("<ScrollViewer Grid.Column=\"2\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel Margin=\"8,0,0,0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource DesktopSummaryCard}\" Margin=\"0,0,0,10\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Available actions\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("LastChildFill=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel Grid.Column=\"1\" Margin=\"10,0,0,0\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void PrintPreviewWindow_AppliesSharedDocumentPolishToEveryPreview()
         {
             var codeBehind = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-print-preview-responsive-shell.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-print-preview-responsive-shell.md
@@ -1,0 +1,30 @@
+# Print Preview Responsive Shell
+
+Date: 2026-07-03
+
+## Completed
+
+- Reduced the print preview window's default and minimum dimensions so it opens more safely on 1366 x 768 desktops and higher Windows scaling.
+- Reworked the preview header into a shrinkable title area plus wrapping Page Setup, Print, and Close actions.
+- Bounded preview title and description text so long report titles do not force the dialog wider.
+- Changed the document/checklist layout from a fixed 280 px side rail to star-sized panes with a practical 240 px checklist minimum.
+- Added a splitter between the document canvas and checklist pane so operators can recover space for wide reports.
+- Kept the document canvas shrinkable and enabled horizontal scrolling for wide printable content.
+- Wrapped the document canvas header/status text to avoid clipping on scaled screens.
+- Put the checklist, branding, and available-action cards inside a vertical ScrollViewer with horizontal overflow disabled.
+- Bounded the side-panel cards so checklist content remains reachable instead of widening the preview window.
+- Allowed footer status text to wrap so both status labels remain visible at smaller dialog widths.
+- Preserved the existing logo, title, FlowDocument viewer, Page Setup, Print, Close, document polish, printer-page sizing, and table-polish workflows.
+- Extended `PrintPreviewWindowXamlTests` to guard the responsive shell contracts and existing print-preview behavior.
+
+## Validation
+
+- Source readback confirmed the print preview XAML now uses smaller safe window minimums, wrapping header actions, shrinkable panes, a splitter, document horizontal scrolling, scrollable side content, and wrapping footer status text.
+- Source-contract coverage was added in `InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs` for the responsive window minimums, wrapping header controls, shrinkable canvas/checklist split, scrollable checklist pane, and preserved document viewer/print commands.
+
+## Not Run Here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- WPF runtime launch, screenshots, printer dialog, or print-preview visual QA
+
+Those checks require a Windows/.NET-capable checkout; this scheduled Linux environment still cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
@@ -3,8 +3,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Print Preview"
-        Width="1220" Height="820"
-        MinWidth="980" MinHeight="680"
+        Width="1120" Height="760"
+        MinWidth="760" MinHeight="560"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundBrush}"
         FontFamily="{DynamicResource ThemeFontFamily}">
@@ -18,119 +18,140 @@
         <Border Grid.RowSpan="3" Style="{StaticResource ThemedWindowOverlay}"/>
 
         <Border Grid.Row="0" Style="{StaticResource ThemedWindowHeader}">
-            <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,16,0">
-                    <Border Width="48" Height="48"
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <DockPanel Grid.Column="0" LastChildFill="True" MinWidth="0" Margin="0,0,12,0">
+                    <Border DockPanel.Dock="Left"
+                            Width="42" Height="42"
                             Background="{DynamicResource SurfaceBrush}"
                             BorderBrush="{DynamicResource BorderBrushAlt}"
                             BorderThickness="{DynamicResource ThemeControlBorderThickness}"
                             CornerRadius="{DynamicResource ThemePanelCornerRadius}"
                             Effect="{DynamicResource ThemeControlShadow}"
-                            Margin="0,0,12,0">
+                            Margin="0,0,10,0">
                         <Image x:Name="PreviewLogo"
-                               Width="34" Height="34"
+                               Width="30" Height="30"
                                Stretch="Uniform"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Center"/>
                     </Border>
-                    <StackPanel VerticalAlignment="Center">
+                    <StackPanel VerticalAlignment="Center" MinWidth="0">
                         <TextBlock Text="Preview Workstation" Style="{StaticResource CaptionTextBlock}"/>
                         <TextBlock x:Name="PreviewTitle"
                                    Style="{StaticResource HeadingTextBlock}"
                                    TextWrapping="Wrap"
-                                   MaxWidth="580"/>
+                                   TextTrimming="CharacterEllipsis"
+                                   MaxWidth="520"/>
                         <TextBlock x:Name="PreviewDescription"
                                    Style="{StaticResource CaptionTextBlock}"
                                    TextWrapping="Wrap"
-                                   MaxWidth="620"
+                                   MaxWidth="560"
                                    Margin="0,3,0,0"/>
                     </StackPanel>
-                </StackPanel>
+                </DockPanel>
 
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
+                <WrapPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" MaxWidth="330">
                     <Button Style="{StaticResource GhostButton}"
                             Content="Page Setup"
                             Command="{Binding PageSetupCommand}"
-                            MinWidth="108"/>
+                            MinWidth="104"
+                            Margin="0,0,6,6"/>
                     <Button Style="{StaticResource PrimaryButton}"
                             Content="Print"
-                            Margin="8,0,0,0"
                             Command="{Binding PrintCommand}"
-                            MinWidth="88"/>
+                            MinWidth="84"
+                            Margin="0,0,6,6"/>
                     <Button Style="{StaticResource GhostButton}"
                             Content="Close"
-                            Margin="8,0,0,0"
                             Command="{Binding CloseCommand}"
-                            MinWidth="88"/>
-                </StackPanel>
-            </DockPanel>
+                            MinWidth="84"
+                            Margin="0,0,0,6"/>
+                </WrapPanel>
+            </Grid>
         </Border>
 
         <Grid Grid.Row="1" Margin="0,10,0,10">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="280"/>
+                <ColumnDefinition Width="*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="0.36*" MinWidth="240"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource ThemedWindowPane}">
-                <Grid>
+            <Border Grid.Column="0" Style="{StaticResource ThemedWindowPane}" MinWidth="0">
+                <Grid MinWidth="0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <DockPanel Grid.Row="0" LastChildFill="False" Margin="0,0,0,10">
-                        <StackPanel DockPanel.Dock="Left">
-                            <TextBlock Text="Document Canvas" Style="{StaticResource SubheadingTextBlock}"/>
+                    <DockPanel Grid.Row="0" LastChildFill="True" Margin="0,0,0,10">
+                        <StackPanel DockPanel.Dock="Left" MinWidth="0" Margin="0,0,12,0">
+                            <TextBlock Text="Document Canvas" Style="{StaticResource SubheadingTextBlock}" TextTrimming="CharacterEllipsis"/>
                             <TextBlock Text="Live preview of the printable content with the current app logo and report title." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
-                        <TextBlock DockPanel.Dock="Right" Text="Output Review" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
+                        <TextBlock DockPanel.Dock="Right" Text="Output Review" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap"/>
                     </DockPanel>
 
-                    <Border Grid.Row="1" Style="{StaticResource ThemedDocumentCanvasFrame}">
+                    <Border Grid.Row="1" Style="{StaticResource ThemedDocumentCanvasFrame}" MinWidth="0">
                         <FlowDocumentScrollViewer x:Name="DocViewer"
                                                   Style="{StaticResource ThemedDocumentPreviewViewer}"
                                                   IsToolBarVisible="False"
-                                                  VerticalScrollBarVisibility="Auto"/>
+                                                  VerticalScrollBarVisibility="Auto"
+                                                  HorizontalScrollBarVisibility="Auto"/>
                     </Border>
                 </Grid>
             </Border>
 
-            <StackPanel Grid.Column="1" Margin="10,0,0,0">
-                <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
-                    <StackPanel>
-                        <TextBlock Text="Print checklist" Style="{StaticResource SectionHeader}"/>
-                        <TextBlock Text="1. Confirm the title and logo match the handoff." TextWrapping="Wrap" Margin="0,6,0,0"/>
-                        <TextBlock Text="2. Use Page Setup when content needs a wider sheet." TextWrapping="Wrap" Margin="0,4,0,0"/>
-                        <TextBlock Text="3. Print only after the preview reads cleanly." TextWrapping="Wrap" Margin="0,4,0,0"/>
-                    </StackPanel>
-                </Border>
+            <GridSplitter Grid.Column="1"
+                          Width="6"
+                          HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          Background="{DynamicResource BorderBrushBase}"/>
 
-                <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
-                    <StackPanel>
-                        <TextBlock Text="Branding confidence" Style="{StaticResource SectionHeader}"/>
-                        <TextBlock Text="This frame gives every directory, sheet, invoice, and handoff preview the same review surface before staff produce customer-facing output." TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
+            <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" MinWidth="0">
+                <StackPanel Margin="8,0,0,0" MinWidth="0">
+                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10" MinWidth="0">
+                        <StackPanel>
+                            <TextBlock Text="Print checklist" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="1. Confirm the title and logo match the handoff." TextWrapping="Wrap" Margin="0,6,0,0"/>
+                            <TextBlock Text="2. Use Page Setup when content needs a wider sheet." TextWrapping="Wrap" Margin="0,4,0,0"/>
+                            <TextBlock Text="3. Print only after the preview reads cleanly." TextWrapping="Wrap" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
 
-                <Border Style="{StaticResource DesktopSummaryCard}">
-                    <StackPanel>
-                        <TextBlock Text="Available actions" Style="{StaticResource SectionHeader}"/>
-                        <TextBlock Text="Page setup adjusts the document width, Print opens the Windows printer dialog, and Close returns to the originating workflow." TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-            </StackPanel>
+                    <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10" MinWidth="0">
+                        <StackPanel>
+                            <TextBlock Text="Branding confidence" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="This frame gives every directory, sheet, invoice, and handoff preview the same review surface before staff produce customer-facing output." TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="0">
+                        <StackPanel>
+                            <TextBlock Text="Available actions" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Page setup adjusts the document width, Print opens the Windows printer dialog, and Close returns to the originating workflow." TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </ScrollViewer>
         </Grid>
 
         <Border Grid.Row="2" Style="{StaticResource ThemedWindowFooter}">
-            <DockPanel LastChildFill="False">
+            <DockPanel LastChildFill="True">
                 <TextBlock DockPanel.Dock="Left"
                            Text="Ready for final print review"
                            Style="{StaticResource CaptionTextBlock}"
-                           VerticalAlignment="Center"/>
-                <TextBlock DockPanel.Dock="Right"
-                           Text="Preview footer status"
+                           VerticalAlignment="Center"
+                           TextWrapping="Wrap"
+                           Margin="0,0,12,0"/>
+                <TextBlock Text="Preview footer status"
                            Style="{StaticResource CaptionTextBlock}"
-                           VerticalAlignment="Center"/>
+                           HorizontalAlignment="Right"
+                           VerticalAlignment="Center"
+                           TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
     </Grid>


### PR DESCRIPTION
## What changed

- Reduced the print preview window's default and minimum dimensions so it opens more safely on 1366 x 768 desktops and higher Windows scaling.
- Reworked the header into a shrinkable title/description area plus wrapping Page Setup, Print, and Close actions.
- Bounded long preview titles/descriptions so report names do not force the dialog wider.
- Replaced the fixed 280 px checklist rail with a star-sized document/checklist layout and a practical 240 px checklist minimum.
- Added a splitter between the document canvas and checklist pane so operators can recover horizontal space for wide reports.
- Kept the document canvas shrinkable and enabled horizontal scrolling for wide printable content.
- Wrapped the document canvas header/status text to reduce clipping risk on scaled desktops.
- Put checklist, branding, and available-action cards inside a vertical ScrollViewer with horizontal overflow disabled.
- Bounded the side-panel cards so checklist content remains reachable instead of widening the preview window.
- Allowed footer status text to wrap so status labels remain visible at smaller dialog widths.
- Preserved the existing logo, title, FlowDocument viewer, Page Setup, Print, Close, document polish, printer-page sizing, and table-polish workflows.
- Extended `PrintPreviewWindowXamlTests` to guard the responsive shell contracts and preserved print-preview behavior.
- Added a progress note for the completed workflow slice.

## Why this was highest value

Recent scheduled work already completed responsive passes for the major workbench pages, while the print preview window still used a large fixed default/minimum size and a fixed checklist rail. Print/preview is a cross-workflow path for reports, directories, invoices, sheets, and handoffs, so improving this shell directly supports the current speed, responsiveness, and professional output requirements without conflicting with the two open draft workbench PRs.

## Why this is real progress

This covers more than ten workflow-level improvements across window sizing, scaled-screen behavior, header wrapping, command reachability, title bounding, pane sizing, splitter recovery, document scrolling, side-panel scrolling, card bounding, footer wrapping, preserved print commands, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to:
  - `InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml`
  - `InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-print-preview-responsive-shell.md`
- Connector source readback confirmed smaller safe window minimums, wrapping header actions, bounded title/description text, shrinkable document/checklist panes, a splitter, document horizontal scrolling, scrollable side content, bounded cards, wrapping footer status text, preserved viewer/commands, and source-contract coverage.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, printer dialog checks, print-preview visual QA, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
- Because the requested full Windows validation could not run, this PR is left as a draft and was not merged.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Print Preview on Windows at 1366 x 768 and higher DPI scales, including long report titles, Page Setup, Print, Close, wide report content, checklist scrolling, splitter resizing, and report/print preview output from several originating workflows.