### PR TITLE
[codex] Improve rental history responsive dialog

### DIFF
--- a/InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalHistoryWindowResponsiveContractTests
+    {
+        [Fact]
+        public void RentalHistoryWindow_KeepsSummaryCardsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
+
+            Assert.Contains("Width=\"1040\" Height=\"660\" MinWidth=\"760\" MinHeight=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"RentalHistoryMetricCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"190\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"RentalHistoryMetricValue\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Row=\"1\" Columns=\"3\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"1160\" Height=\"700\" MinWidth=\"940\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryWindow_WrapsHeaderSearchAndFooterActions()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"1\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<pages:SearchBar Width=\"300\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"360\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"1\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel DockPanel.Dock=\"Right\" Orientation=\"Horizontal\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"340\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryWindow_EnablesHistoryGridVirtualizationScrollingAndFullRowSelection()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
+
+            Assert.Contains("x:Name=\"RentalHistoryDataGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Location\" Binding=\"{Binding ItemLocation}\" Width=\"140\" MinWidth=\"90\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryWindow_BoundsEmptyStateAndPaneText()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
+
+            Assert.Contains("Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Grid MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border MaxWidth=\"340\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"No rental history records\" Style=\"{StaticResource SectionHeader}\" TextAlignment=\"Center\" TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Width=\"360\" HorizontalAlignment=\"Center\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryWindow_PreservesHistoryCommandsAndRowHandlers()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
+
+            Assert.Contains("OpenDetailsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CloseCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("SearchCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ClearSearchCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ExportCsvCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("HistoryRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
+            Assert.Contains("HistoryRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+            Assert.Contains("Open Details", xaml, StringComparison.Ordinal);
+            Assert.Contains("Export Current View", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-rental-history-responsive-dialog.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-rental-history-responsive-dialog.md
@@ -1,0 +1,32 @@
+# Rental History Responsive Dialog
+
+Date: 2026-07-03
+
+## Completed
+
+- Reduced the Rental History dialog default and minimum size so it opens more safely on 1366 x 768 desktops and higher Windows scaling.
+- Reworked the header into a shrinkable title area with wrapping Details and Close actions.
+- Replaced the fixed three-column summary strip with wrapping bounded metric cards.
+- Added bounded metric value styling so long result and selected-rental summaries stay inside their cards.
+- Added shrinkable pane shells so WPF can reduce available width without forcing horizontal overflow.
+- Reworked the rental-record pane header so long guidance text wraps inside a bounded width.
+- Replaced the fixed search/action grid with wrapping Find, search, summary, Clear, and Export CSV controls.
+- Gave the rental search box practical width and minimum contracts for scaled desktop use.
+- Added explicit row and column virtualization to the rental-history grid.
+- Added explicit content scrolling plus automatic horizontal and vertical scrollbars to the rental-history grid.
+- Switched the rental-history grid to full-row single selection for clearer keyboard, double-click, and context-menu handoff.
+- Reduced the Location column pressure while preserving the item location field.
+- Replaced the fixed empty-state width with a bounded margin-protected empty state.
+- Reworked the footer into shrinkable selected-row status text plus wrapping Details, Export CSV, and Close actions.
+- Preserved the existing details, close, search, clear, export, double-click, and context-menu workflows.
+- Added `RentalHistoryWindowResponsiveContractTests` to guard the responsive shell, wrapped actions, grid virtualization/scrolling, bounded empty state, and preserved command hooks.
+
+## Validation
+
+- Source readback should confirm the responsive XAML contracts and source-contract test coverage.
+- Full Windows validation, WPF screenshots, runtime smoke testing, and CSV export checks still need to run in a Windows/.NET-capable checkout because the scheduled Linux environment cannot clone the repo directly and does not provide `dotnet`, `pwsh`, `gh`, or the WPF runtime.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test Rental History at 1366 x 768 and higher Windows scaling, including search, clear, row double-click, row context menu, details, export CSV, empty state, and footer wrapping.

--- a/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
@@ -4,9 +4,22 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:pages="clr-namespace:InventoryManagementApp.Views.Pages"
         Title="Rental History"
-        Width="1160" Height="700" MinWidth="940" MinHeight="560"
+        Width="1040" Height="660" MinWidth="760" MinHeight="520"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
+    <Window.Resources>
+        <Style x:Key="RentalHistoryMetricCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
+            <Setter Property="MinWidth" Value="190"/>
+            <Setter Property="MaxWidth" Value="300"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+        <Style x:Key="RentalHistoryMetricValue" TargetType="TextBlock" BasedOn="{StaticResource SectionHeader}">
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="MaxHeight" Value="48"/>
+        </Style>
+    </Window.Resources>
+
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -16,44 +29,48 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
-            <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="14,0,0,0">
-                    <Button Style="{StaticResource PrimaryButton}" Width="92" Content="Details" Command="{Binding OpenDetailsCommand}" Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource GhostButton}" Width="92" Content="Close" Command="{Binding CloseCommand}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" MinWidth="0">
+                    <TextBlock Text="Rental History Workbench" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding ItemDisplayName}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,12,0"/>
                 </StackPanel>
-                <StackPanel>
-                    <TextBlock Text="Rental History Workbench" Style="{StaticResource PageTitleTextBlock}"/>
-                    <TextBlock Text="{Binding ItemDisplayName}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                </StackPanel>
-            </DockPanel>
+                <WrapPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="14,0,0,0">
+                    <Button Style="{StaticResource PrimaryButton}" MinWidth="86" Content="Details" Command="{Binding OpenDetailsCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" MinWidth="86" Content="Close" Command="{Binding CloseCommand}" Margin="0,0,0,6"/>
+                </WrapPanel>
+            </Grid>
         </Border>
 
-        <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
+            <Border Style="{StaticResource RentalHistoryMetricCard}">
                 <StackPanel>
                     <TextBlock Text="01 Current View" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding ResultsSummary}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding ResultsSummary}" Style="{StaticResource RentalHistoryMetricValue}"/>
                     <TextBlock Text="Search and exported CSV use the same filtered record set." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0">
+            <Border Style="{StaticResource RentalHistoryMetricCard}">
                 <StackPanel>
                     <TextBlock Text="02 Selected Rental" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding SelectedEntrySummary}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding SelectedEntrySummary}" Style="{StaticResource RentalHistoryMetricValue}"/>
                     <TextBlock Text="Double-click or open details for row-level handoff context." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="6,0,0,0">
+            <Border Style="{StaticResource RentalHistoryMetricCard}">
                 <StackPanel>
                     <TextBlock Text="03 Output" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Details and CSV" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Details and CSV" Style="{StaticResource RentalHistoryMetricValue}"/>
                     <TextBlock Text="Export preserves the current search result for audit review." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-        </UniformGrid>
+        </WrapPanel>
 
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
-            <Grid>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+            <Grid MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
@@ -61,38 +78,49 @@
                 </Grid.RowDefinitions>
 
                 <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
-                    <DockPanel LastChildFill="True">
-                        <TextBlock Text="Rental Records" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                        <TextBlock Text="Double-click, press Details, or use the context menu to inspect a selected rental." Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                    </DockPanel>
-                </Border>
-
-                <Border Grid.Row="1" Style="{StaticResource DesktopSectionActionStrip}" Padding="8">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="340"/>
-                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                        <pages:SearchBar Grid.Column="1"
-                                         Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
-                                         SearchCommand="{Binding SearchCommand}"
-                                         SearchLabel=""/>
-                        <TextBlock Grid.Column="2" Text="{Binding ResultsSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0" TextWrapping="Wrap"/>
-                        <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0,0,0">
-                            <Button Style="{StaticResource GhostButton}" Width="82" Content="Clear" Command="{Binding ClearSearchCommand}" Margin="0,0,6,0"/>
-                            <Button Style="{StaticResource PrimaryButton}" Width="104" Content="Export CSV" Command="{Binding ExportCsvCommand}"/>
-                        </StackPanel>
+                        <TextBlock Grid.Column="0" Text="Rental Records" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
+                        <TextBlock Grid.Column="1" Text="Double-click, press Details, or use the context menu to inspect a selected rental."
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   HorizontalAlignment="Right"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="520"
+                                   Margin="12,0,0,0"/>
                     </Grid>
                 </Border>
 
-                <Grid Grid.Row="2">
-                    <DataGrid ItemsSource="{Binding History}"
+                <Border Grid.Row="1" Style="{StaticResource DesktopSectionActionStrip}" Padding="8">
+                    <WrapPanel VerticalAlignment="Center">
+                        <TextBlock Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                        <pages:SearchBar Width="300"
+                                         MinWidth="220"
+                                         Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                                         SearchCommand="{Binding SearchCommand}"
+                                         SearchLabel=""
+                                         Margin="0,0,10,6"/>
+                        <TextBlock Text="{Binding ResultsSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="360" Margin="0,0,10,6"/>
+                        <Button Style="{StaticResource GhostButton}" MinWidth="82" Content="Clear" Command="{Binding ClearSearchCommand}" Margin="0,0,6,6"/>
+                        <Button Style="{StaticResource PrimaryButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" Margin="0,0,0,6"/>
+                    </WrapPanel>
+                </Border>
+
+                <Grid Grid.Row="2" MinWidth="0">
+                    <DataGrid x:Name="RentalHistoryDataGrid"
+                              ItemsSource="{Binding History}"
                               SelectedItem="{Binding SelectedEntry}"
                               IsReadOnly="True"
                               AutoGenerateColumns="False"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
+                              SelectionMode="Single"
+                              SelectionUnit="FullRow"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
@@ -103,7 +131,7 @@
                         <DataGrid.Columns>
                             <StaticResource ResourceKey="RentalIdColumn"/>
                             <StaticResource ResourceKey="RentalItemNumberColumn"/>
-                            <DataGridTextColumn Header="Location" Binding="{Binding ItemLocation}" Width="160"/>
+                            <DataGridTextColumn Header="Location" Binding="{Binding ItemLocation}" Width="140" MinWidth="90"/>
                             <StaticResource ResourceKey="RentalCustomerColumn"/>
                             <StaticResource ResourceKey="RentalOutColumn"/>
                             <StaticResource ResourceKey="RentalDueColumn"/>
@@ -119,7 +147,7 @@
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>
-                    <Border Width="360" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Border MaxWidth="340" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource AdminHandoffCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -131,7 +159,7 @@
                             </Style>
                         </Border.Style>
                         <StackPanel>
-                            <TextBlock Text="No rental history records" Style="{StaticResource SectionHeader}" TextAlignment="Center"/>
+                            <TextBlock Text="No rental history records" Style="{StaticResource SectionHeader}" TextAlignment="Center" TextWrapping="Wrap"/>
                             <TextBlock Text="Adjust the search or clear the filter to review previous rental activity for this item."
                                        Style="{StaticResource CaptionTextBlock}"
                                        TextWrapping="Wrap"
@@ -144,14 +172,18 @@
         </Border>
 
         <Border Grid.Row="3" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
-            <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <Button Style="{StaticResource PrimaryButton}" Width="92" Content="Details" Command="{Binding OpenDetailsCommand}" Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource GhostButton}" Width="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource GhostButton}" Width="92" Content="Close" Command="{Binding CloseCommand}"/>
-                </StackPanel>
-                <TextBlock Text="{Binding SelectedEntrySummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,12,0"/>
-            </DockPanel>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="{Binding SelectedEntrySummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,12,4"/>
+                <WrapPanel Grid.Column="1" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource PrimaryButton}" MinWidth="86" Content="Details" Command="{Binding OpenDetailsCommand}" Margin="0,0,6,4"/>
+                    <Button Style="{StaticResource GhostButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" Margin="0,0,6,4"/>
+                    <Button Style="{StaticResource GhostButton}" MinWidth="86" Content="Close" Command="{Binding CloseCommand}" Margin="0,0,0,4"/>
+                </WrapPanel>
+            </Grid>
         </Border>
     </Grid>
 </Window>


### PR DESCRIPTION
## What changed

- Reduced the Rental History dialog default and minimum dimensions so it opens more safely on 1366 x 768 desktops and higher Windows scaling.
- Reworked the header into a shrinkable title area plus wrapping Details and Close actions.
- Replaced the fixed three-column summary strip with wrapping bounded metric cards.
- Added bounded metric value styling so long current-view and selected-rental summaries stay inside cards.
- Added shrinkable pane shells so WPF can reduce available width without forcing horizontal overflow.
- Reworked the rental-record pane header so long guidance text wraps inside a bounded width.
- Replaced the fixed search/action grid with wrapping Find, search, summary, Clear, and Export CSV controls.
- Gave the rental search box practical width and minimum contracts for scaled desktop use.
- Added explicit row and column virtualization to the rental-history grid.
- Added explicit content scrolling plus automatic horizontal and vertical scrollbars to the rental-history grid.
- Switched the rental-history grid to full-row single selection for clearer keyboard, double-click, and context-menu handoff.
- Reduced Location column pressure while preserving the item location field.
- Replaced the fixed empty-state width with a bounded margin-protected empty state.
- Reworked the footer into shrinkable selected-row status text plus wrapping Details, Export CSV, and Close actions.
- Preserved the existing details, close, search, clear, export, double-click, and context-menu workflows.
- Added `RentalHistoryWindowResponsiveContractTests` plus a progress note for the completed workflow slice.

## Why this was highest value

Recent scheduled work has covered the main workbench pages and the shared print-preview shell, while source readback showed the Rental History dialog still had fixed summary columns, a fixed search/action row, no explicit grid scrollbar/virtualization/full-row-selection contract, a fixed empty-state width, and fixed footer actions. Rental History is an operational audit/export workflow reached from item/rental paths, so tightening it directly improves loading responsiveness, table usability, and professional data display without overlapping the open draft Item Search, Manage Rentals, or Print Preview PRs.

## Why this is real progress

This covers more than ten workflow-level improvements across dialog sizing, header wrapping, summary metrics, metric text bounding, shrinkable pane behavior, pane-header wrapping, search/action wrapping, search sizing, grid row virtualization, grid column virtualization, grid scrolling, row selection, column pressure, empty-state sizing, footer wrapping, preserved workflow commands, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to:
  - `InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml`
  - `InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-rental-history-responsive-dialog.md`
- Connector source readback confirmed smaller safe window sizing, wrapping bounded summary cards, bounded metric text, shrinkable pane shells, wrapped search/actions/footer, explicit grid row/column virtualization, automatic grid scrollbars, full-row selection, reduced Location column pressure, bounded empty state, preserved commands, and source-contract coverage.
- Connector status readback found no attached commit statuses on branch head `1b3fbb7c6290d4b00583e815a161c137e197e0cb`.
- Connector workflow readback found no workflow runs attached to branch head `1b3fbb7c6290d4b00583e815a161c137e197e0cb`.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, CSV export runtime checks, layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
- Because the requested full Windows validation could not run, this PR is left as a draft and was not merged.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Rental History on Windows at 1366 x 768 and higher DPI scales, including search, clear, row double-click, row context menu, details, export CSV, empty state, and footer wrapping.