### PR TITLE
[codex] Improve app shell responsive performance

### DIFF
--- a/InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MainWindowResponsiveContractTests
+    {
+        [Fact]
+        public void MainWindow_UsesScaledDesktopSafeShellDimensions()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("Width=\"1180\" Height=\"760\" MinWidth=\"920\" MinHeight=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"1280\" Height=\"800\" MinWidth=\"1040\" MinHeight=\"540\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainWindow_HeaderColumnsCanShrinkWithoutForcingHorizontalOverflow()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("<Grid VerticalAlignment=\"Center\" ClipToBounds=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"Auto\" MinWidth=\"0\" MaxWidth=\"260\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"Auto\" MinWidth=\"0\" MaxWidth=\"210\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"250\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"0\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"250\"\n                        MinWidth=\"210\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainWindow_BoundsSearchAndUserSwitcherForScaledWidths()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("<pages:SearchBar x:Name=\"ShellSearchBar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"180\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"720\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Button x:Name=\"ShellUserButton\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"196\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel MaxWidth=\"126\" MinWidth=\"0\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel Width=\"132\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainWindow_PageHeaderWrapsWorkflowActionsInBoundedArea()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"Auto\" MinWidth=\"0\" MaxWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel VerticalAlignment=\"Center\" MinWidth=\"0\" Margin=\"0,0,12,0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"1\" Orientation=\"Horizontal\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\" MaxWidth=\"380\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Margin=\"0,0,4,4\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Margin=\"0,0,0,4\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainWindow_FooterUsesShrinkableColumnsAndWrappingStatusActions()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"1.1*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"Auto\" MinWidth=\"0\" MaxWidth=\"145\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.7*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"Auto\" MinWidth=\"0\" MaxWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Grid Grid.Column=\"0\" ClipToBounds=\"True\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"3\" Orientation=\"Horizontal\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\" MaxWidth=\"380\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel Grid.Column=\"3\" Orientation=\"Horizontal\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainWindow_CodeBehindCompactsByWidthAndAvoidsRedundantResourceScaling()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml.cs");
+
+            Assert.Contains("const double CompactShellWidthThreshold = 1120;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("double? _lastAdaptiveResourceScale;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("availableWidth < CompactShellWidthThreshold", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SystemParameters.WorkArea.Width < CompactShellWidthThreshold", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (_lastAdaptiveResourceScale.HasValue && Math.Abs(_lastAdaptiveResourceScale.Value - scale) < 0.001)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_lastAdaptiveResourceScale = scale;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ShellUserButton.MaxWidth = compact ? 176 : 196;", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("ShellTitleButton.Width = compact ? 190 : 250;", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainWindow_PreservesCoreNavigationSearchUserAndWorkflowBindings()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("OpenDashboardCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("GlobalSearchText", xaml, StringComparison.Ordinal);
+            Assert.Contains("GlobalSearchCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("SwitchUserCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentPage", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentWorkflowPrimaryCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentWorkflowSecondaryCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentWorkflowGuide", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentUserRole", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         xmlns:pages="clr-namespace:InventoryManagementApp.Views.Pages"
-        Title="{Binding WindowTitle}" Width="1280" Height="800" MinWidth="1040" MinHeight="540" WindowStartupLocation="CenterScreen"
+        Title="{Binding WindowTitle}" Width="1180" Height="760" MinWidth="920" MinHeight="520" WindowStartupLocation="CenterScreen"
         WindowState="Maximized"
         Background="{DynamicResource BackgroundBrush}"
         FontFamily="{DynamicResource ThemeFontFamily}">
@@ -50,11 +50,11 @@
                 BorderThickness="0,0,0,1"
                 Effect="{DynamicResource ThemeSurfaceShadow}"
                 Padding="8,5">
-            <Grid VerticalAlignment="Center">
+            <Grid VerticalAlignment="Center" ClipToBounds="True">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto" MinWidth="0" MaxWidth="260"/>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto" MinWidth="0" MaxWidth="210"/>
                 </Grid.ColumnDefinitions>
 
                 <Button x:Name="ShellTitleButton"
@@ -62,11 +62,12 @@
                         Style="{StaticResource ShellTitleButton}"
                         Command="{Binding OpenDashboardCommand}"
                         ToolTip="Open dashboard"
-                        Width="250"
-                        MinWidth="210"
+                        MaxWidth="250"
+                        MinWidth="0"
+                        HorizontalAlignment="Stretch"
                         VerticalAlignment="Center"
-                        Margin="0,0,14,0">
-                    <StackPanel>
+                        Margin="0,0,12,0">
+                    <StackPanel MinWidth="0">
                         <TextBlock Text="{Binding WindowTitle}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
                         <TextBlock x:Name="ShellSubtitle" Text="Workshop inventory and rental control" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
                     </StackPanel>
@@ -74,30 +75,33 @@
 
                 <pages:SearchBar x:Name="ShellSearchBar"
                                  Grid.Column="1"
-                                 MinWidth="320"
-                                 MaxWidth="760"
+                                 MinWidth="180"
+                                 MaxWidth="720"
                                  HorizontalAlignment="Stretch"
                                  VerticalAlignment="Center"
-                                 Margin="0,0,14,0"
+                                 Margin="0,0,12,0"
                                  Text="{Binding GlobalSearchText}"
                                  SearchCommand="{Binding GlobalSearchCommand}"
                                  SearchLabel=""
                                  Visibility="{Binding CanUseSearchTools, Converter={StaticResource BoolToVis}}"/>
 
-                <Button Grid.Column="2"
+                <Button x:Name="ShellUserButton"
+                        Grid.Column="2"
                         Style="{StaticResource GhostButton}"
                         Command="{Binding SwitchUserCommand}"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center"
+                        MaxWidth="196"
+                        MinWidth="0"
                         ToolTip="Log out">
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" MinWidth="0">
                         <Border Width="26" Height="26" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Margin="0,0,6,0">
                             <controls:UserAvatar UserName="{Binding CurrentUserName}"
                                                   UserPhotoPath="{Binding CurrentUserPhotoPath}"
                                                   Foreground="{Binding CurrentUserInitialsBrush}"
                                                   FontSize="13"/>
                         </Border>
-                        <StackPanel Width="132" VerticalAlignment="Center">
+                        <StackPanel MaxWidth="126" MinWidth="0" VerticalAlignment="Center">
                             <TextBlock Text="{Binding CurrentUserName}" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="{Binding CurrentUserRole}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
@@ -204,25 +208,26 @@
                     </Style.Triggers>
                 </Style>
             </Border.Style>
-            <Grid>
+            <Grid ClipToBounds="True">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto" MinWidth="0" MaxWidth="380"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
+                <StackPanel VerticalAlignment="Center" MinWidth="0" Margin="0,0,12,0">
                     <TextBlock Text="{Binding CurrentPageTitle}" Style="{StaticResource PageTitleTextBlock}" TextTrimming="CharacterEllipsis"/>
                     <TextBlock x:Name="WorkflowGuideText" Text="{Binding CurrentWorkflowGuide}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
-                <WrapPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                <WrapPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" MaxWidth="380">
                     <Button Style="{StaticResource GhostButton}"
                             Content="{Binding CurrentWorkflowPrimaryActionText}"
                             Command="{Binding CurrentWorkflowPrimaryCommand}"
                             Visibility="{Binding HasCurrentWorkflowPrimaryAction, Converter={StaticResource BoolToVis}}"
-                            Margin="0,0,4,0"/>
+                            Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}"
                             Content="{Binding CurrentWorkflowSecondaryActionText}"
                             Command="{Binding CurrentWorkflowSecondaryCommand}"
-                            Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}"/>
+                            Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}"
+                            Margin="0,0,0,4"/>
                 </WrapPanel>
             </Grid>
         </Border>
@@ -233,7 +238,8 @@
                JournalOwnership="OwnsJournal"
                Background="{DynamicResource MainContentBackgroundBrush}"
                Content="{Binding CurrentPage}"
-               Margin="{StaticResource PagePadding}"/>
+               Margin="{StaticResource PagePadding}"
+               Focusable="False"/>
 
         <Border x:Name="ShellStatusFooter"
                 Grid.Row="4"
@@ -243,18 +249,22 @@
                 ToolTip="{Binding CurrentWorkflowGuide}">
             <Grid ClipToBounds="True">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="1.1*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto" MinWidth="0" MaxWidth="145"/>
+                    <ColumnDefinition Width="1.7*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto" MinWidth="0" MaxWidth="380"/>
                 </Grid.ColumnDefinitions>
 
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,14,0">
+                <Grid Grid.Column="0" ClipToBounds="True" MinWidth="0" VerticalAlignment="Center" Margin="0,0,12,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*" MinWidth="0"/>
+                    </Grid.ColumnDefinitions>
                     <TextBlock Text="Section" Style="{StaticResource LabelTextBlock}" Margin="0,0,5,0"/>
-                    <TextBlock Text="{Binding CurrentNavSectionTitle}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
-                    <TextBlock Text=" | " Style="{StaticResource CaptionTextBlock}" Margin="8,0"/>
-                    <TextBlock Text="{Binding CurrentPageTitle}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
-                </StackPanel>
+                    <TextBlock Grid.Column="1" Text="{Binding CurrentNavSectionTitle}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" Margin="0,0,8,0"/>
+                    <TextBlock Grid.Column="2" Text="{Binding CurrentPageTitle}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
+                </Grid>
 
                 <Border Grid.Column="1"
                         Background="{DynamicResource TextBoxBackgroundBrush}"
@@ -263,26 +273,26 @@
                         Padding="8,3"
                         Margin="0,0,12,0"
                         VerticalAlignment="Center">
-                    <TextBlock Text="Workflow status" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="Workflow status" Style="{StaticResource LabelTextBlock}" TextTrimming="CharacterEllipsis"/>
                 </Border>
 
-                <Grid Grid.Column="2" ClipToBounds="True" VerticalAlignment="Center">
+                <Grid Grid.Column="2" ClipToBounds="True" MinWidth="0" VerticalAlignment="Center">
                     <TextBlock x:Name="ShellWorkflowTicker"
                                Text="{Binding CurrentWorkflowGuide}"
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="NoWrap"
                                TextTrimming="CharacterEllipsis"
-                               HorizontalAlignment="Center"/>
+                               HorizontalAlignment="Stretch"/>
                 </Grid>
 
-                <StackPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="12,0,0,0">
+                <WrapPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" MaxWidth="380" Margin="12,0,0,0">
                     <TextBlock Text="Primary: " Style="{StaticResource LabelTextBlock}" Visibility="{Binding HasCurrentWorkflowPrimaryAction, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding CurrentWorkflowPrimaryActionText}" Style="{StaticResource CaptionTextBlock}" FontWeight="SemiBold" Visibility="{Binding HasCurrentWorkflowPrimaryAction, Converter={StaticResource BoolToVis}}" Margin="0,0,10,0"/>
+                    <TextBlock Text="{Binding CurrentWorkflowPrimaryActionText}" Style="{StaticResource CaptionTextBlock}" FontWeight="SemiBold" Visibility="{Binding HasCurrentWorkflowPrimaryAction, Converter={StaticResource BoolToVis}}" Margin="0,0,10,0" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Next: " Style="{StaticResource LabelTextBlock}" Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding CurrentWorkflowSecondaryActionText}" Style="{StaticResource CaptionTextBlock}" FontWeight="SemiBold" Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}" Margin="0,0,10,0"/>
+                    <TextBlock Text="{Binding CurrentWorkflowSecondaryActionText}" Style="{StaticResource CaptionTextBlock}" FontWeight="SemiBold" Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}" Margin="0,0,10,0" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Signed in: " Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding CurrentUserRole}" Style="{StaticResource CaptionTextBlock}" FontWeight="SemiBold"/>
-                </StackPanel>
+                    <TextBlock Text="{Binding CurrentUserRole}" Style="{StaticResource CaptionTextBlock}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                </WrapPanel>
             </Grid>
         </Border>
     </Grid>

--- a/InventoryManagementApp/MainWindow.xaml.cs
+++ b/InventoryManagementApp/MainWindow.xaml.cs
@@ -16,9 +16,11 @@ namespace InventoryManagementApp
     public partial class MainWindow : Window, IMainWindow
     {
         const double CompactShellHeightThreshold = 820;
+        const double CompactShellWidthThreshold = 1120;
         readonly IDatabaseService? _ownedDb;
         MainViewModel? _mainViewModel;
         bool? _isCompactShellLayout;
+        double? _lastAdaptiveResourceScale;
         readonly Dictionary<string, double> _baseAdaptiveDoubleResources = new(StringComparer.Ordinal);
         readonly Dictionary<string, Thickness> _baseAdaptiveThicknessResources = new(StringComparer.Ordinal);
 
@@ -67,8 +69,11 @@ namespace InventoryManagementApp
         void UpdateShellLayout()
         {
             var availableHeight = ActualHeight > 0 ? ActualHeight : SystemParameters.WorkArea.Height;
+            var availableWidth = ActualWidth > 0 ? ActualWidth : SystemParameters.WorkArea.Width;
             var compact = availableHeight < CompactShellHeightThreshold ||
-                          SystemParameters.WorkArea.Height < CompactShellHeightThreshold;
+                          availableWidth < CompactShellWidthThreshold ||
+                          SystemParameters.WorkArea.Height < CompactShellHeightThreshold ||
+                          SystemParameters.WorkArea.Width < CompactShellWidthThreshold;
 
             if (_isCompactShellLayout != compact)
             {
@@ -85,10 +90,11 @@ namespace InventoryManagementApp
             ShellMenu.Padding = compact ? new Thickness(4, 1, 4, 1) : new Thickness(4, 3, 4, 3);
             PageHeaderBand.Padding = compact ? new Thickness(8, 3, 8, 3) : new Thickness(8, 6, 8, 6);
 
-            ShellTitleButton.Width = compact ? 190 : 250;
-            ShellTitleButton.MinWidth = compact ? 160 : 210;
-            ShellSearchBar.MinWidth = compact ? 220 : 320;
-            ShellSearchBar.MaxWidth = compact ? 620 : 760;
+            ShellTitleButton.MaxWidth = compact ? 190 : 250;
+            ShellTitleButton.MinWidth = 0;
+            ShellSearchBar.MinWidth = compact ? 160 : 180;
+            ShellSearchBar.MaxWidth = compact ? 560 : 720;
+            ShellUserButton.MaxWidth = compact ? 176 : 196;
 
             ShellSubtitle.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
             WorkflowGuideText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
@@ -108,6 +114,10 @@ namespace InventoryManagementApp
         void ApplyAdaptiveResourceScale()
         {
             var scale = GetAdaptiveResourceScale(ActualWidth > 0 ? ActualWidth : Width);
+            if (_lastAdaptiveResourceScale.HasValue && Math.Abs(_lastAdaptiveResourceScale.Value - scale) < 0.001)
+                return;
+
+            _lastAdaptiveResourceScale = scale;
 
             SetScaledDoubleResource("ThemeCaptionFontSize", scale);
             SetScaledDoubleResource("ThemeBodyFontSize", scale);

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-app-shell-responsive-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-app-shell-responsive-performance.md
@@ -1,0 +1,35 @@
+# App Shell Responsive Performance
+
+Date: 2026-07-03
+
+## Summary
+
+Improved the shared app shell so every page starts from a more responsive frame at scaled desktop widths, with less fixed header/footer pressure and less repeated resource work during resize transitions.
+
+## Completed Work
+
+- Reduced the default and minimum main window dimensions for safer first paint on 1366 x 768 desktops and higher Windows scaling.
+- Added shrinkable shell header columns with bounded title and user-switcher regions.
+- Removed the fixed title-button width and kept the title/subtitle bounded with ellipsis behavior.
+- Lowered the global search minimum width while preserving a bounded maximum for wide displays.
+- Bounded the signed-in user switcher and removed its fixed profile text width.
+- Added clipping and shrink contracts around the page header so long workflow titles do not force horizontal overflow.
+- Bounded the page-header action area and allowed workflow action buttons to wrap with bottom spacing.
+- Made the main content frame non-focusable so keyboard focus stays with page controls and commands.
+- Reworked the status footer into shrinkable columns with bounded status label and action regions.
+- Replaced the fixed horizontal footer action strip with a wrapping status/action group.
+- Added width-based compact shell switching for scaled desktop layouts, not just short-height layouts.
+- Avoided redundant adaptive resource writes when resizing within the same scale bucket.
+- Added source-contract tests for responsive shell dimensions, header sizing, search/user bounds, page-header wrapping, footer wrapping, resize resource throttling, and preserved navigation/workflow bindings.
+
+## Validation
+
+- Added `MainWindowResponsiveContractTests` to guard the source contracts and preserved app-shell bindings.
+- GitHub connector readback/compare should confirm this branch is limited to `MainWindow.xaml`, `MainWindow.xaml.cs`, the new source-contract tests, and this progress note.
+- Full local validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or the WPF runtime.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test the shell at 1366 x 768 and 125%, 150%, and 200% scaling while switching between Dashboard, Search, Manage Items, Rentals, Customers, Reports, Import / Export, Users, and Settings.
+- Check long window titles, long user names/roles, long workflow guide text, and primary/secondary workflow actions in light and dark themes.


### PR DESCRIPTION
## What changed

- Reduced the main app shell default and minimum dimensions so first paint is safer on 1366 x 768 desktops and higher Windows scaling.
- Added shrinkable clipped header columns so title, search, and signed-in user regions stop forcing horizontal overflow before page content loads.
- Removed the fixed title-button width and bounded title/subtitle display with ellipsis behavior.
- Lowered the global search minimum width while keeping a practical wide-display maximum.
- Bounded the signed-in user switcher and removed the fixed profile text width.
- Added shrink/clip contracts around the page header title and workflow guide text.
- Bounded the page-header action area and allowed workflow primary/secondary actions to wrap with spacing.
- Made the main frame non-focusable so keyboard focus remains with the active page controls and commands.
- Reworked the status footer into shrinkable columns with bounded status label and ticker regions.
- Replaced the fixed horizontal footer action strip with a wrapping status/action group.
- Added width-aware compact shell switching in addition to the existing height-aware compact behavior.
- Avoided redundant adaptive resource writes while resizing within the same scale bucket.
- Added `MainWindowResponsiveContractTests` to guard shell dimensions, header/search/user/page-header/footer responsiveness, resize resource throttling, and preserved navigation/search/user/workflow bindings.
- Added a progress note for the completed app-shell workflow slice.

## Why this was highest value

Recent scheduled work has hardened many individual workbenches and dialogs, while source readback showed the shared `MainWindow` shell still had fixed title/user widths, non-shrinkable header/footer pressure, and adaptive resource writes on every size change. Because every screen opens inside this shell, reducing shell pressure improves loading feel, tab/page switching, and scaled-desktop responsiveness across the whole app without overlapping the open dialog/workbench draft PRs.

## Why this is real progress

This covers more than ten workflow-level improvements across shell sizing, header column behavior, title display, global search sizing, user switcher sizing, page-header wrapping, workflow action reachability, frame focus behavior, footer layout, footer action wrapping, compact-mode triggering, resize-time resource churn, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to:
  - `InventoryManagementApp/MainWindow.xaml`
  - `InventoryManagementApp/MainWindow.xaml.cs`
  - `InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-app-shell-responsive-performance.md`
- Connector source readback confirmed the smaller shell dimensions, shrinkable header columns, bounded title/search/user areas, wrapping bounded page-header actions, non-focusable frame, shrinkable/wrapping footer, width-aware compact threshold, redundant-resource-write guard, preserved bindings, and source-contract coverage.
- Connector status readback found no attached commit statuses on branch head `1793b8439f5c8e0090acdfbdf83a0827b8b38d7d`.
- Connector workflow readback found no workflow runs attached to branch head `1793b8439f5c8e0090acdfbdf83a0827b8b38d7d`.

## Could not be checked

- Direct local checkout/clone and archive download are blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, shell layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
- Because the requested full Windows validation could not run, this PR is left as a draft and was not merged.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test the shell on Windows at 1366 x 768 and common Windows scaling levels, including long window titles, long user names/roles, long workflow guides, primary/secondary workflow actions, global search, navigation menus, page switching, light/dark themes, and top/bottom shell behavior.