### PR TITLE
[codex] Improve reservation editor responsive dialog

### DIFF
--- a/InventoryManagementApp.Tests/ReservationEditWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationEditWindowResponsiveContractTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReservationEditWindowResponsiveContractTests
+    {
+        [Fact]
+        public void ReservationEditWindow_UsesScaledDesktopSafeDialogSizing()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ReservationEditWindow.xaml");
+            var code = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ReservationEditWindow.xaml.cs");
+
+            Assert.Contains("Width=\"820\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Height=\"620\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"660\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("this.UseResponsiveDefaultSize(820, 640);", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("this.UseResponsiveDefaultSize(1000, 780);", code, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationEditWindow_KeepsHeaderAndSummaryCardsWrappedAndBounded()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ReservationEditWindow.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"150\" MaxWidth=\"190\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,8\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"ReservationSummaryCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"145\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"220\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"170\" Margin=\"14,0,0,0\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"240\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationEditWindow_LowersMainSplitPressureAndKeepsPanesScrollable()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ReservationEditWindow.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"0.8*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.9*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\" Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\"") >= 2);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"240\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"8\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationEditWindow_VirtualizesItemLookupAndBoundsLookupRows()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ReservationEditWindow.xaml");
+
+            Assert.Contains("MinHeight=\"150\" MaxHeight=\"220\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.IsVirtualizing=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.VirtualizationMode=\"Recycling\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"96\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"110\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<RowDefinition Height=\"210\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"112\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"130\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationEditWindow_BoundsDetailsFormAndFooterWithoutLosingCommands()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ReservationEditWindow.xaml");
+            var requiredContracts = new[]
+            {
+                "ItemSearchText",
+                "ItemSearchResults",
+                "SelectedSearchItem",
+                "ClearItemSearchCommand",
+                "ApplySelectedItemCommand",
+                "StatusOptions",
+                "Reservation.ItemNumber",
+                "Reservation.ItemName",
+                "Reservation.CustomerName",
+                "Reservation.StartDate",
+                "Reservation.EndDate",
+                "Reservation.Quantity",
+                "Reservation.RentalID",
+                "Reservation.Notes",
+                "controls:SaveCancelBar"
+            };
+
+            Assert.Contains("<ColumnDefinition Width=\"96\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"78\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"132\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextAlignment=\"Right\"", xaml, StringComparison.Ordinal);
+
+            foreach (var contract in requiredContracts)
+                Assert.Contains(contract, xaml, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-reservation-editor-responsive-dialog.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-reservation-editor-responsive-dialog.md
@@ -1,0 +1,23 @@
+# 2026-07-03 Reservation editor responsive dialog
+
+## Completed
+
+- Reduced the Reservation editor default and minimum dimensions so new/edit request dialogs open more safely on 1366 x 768 desktops and higher Windows scaling.
+- Reworked the header into shrinkable columns with bounded request-state context so long guidance text and statuses do not widen the dialog.
+- Replaced the fixed four-column request summary strip with wrapping bounded cards for item, customer, needed date, and quantity.
+- Added bounded summary value styling so long item numbers, customer names, and statuses trim inside their cards.
+- Lowered the main request-snapshot/detail split pressure with shrinkable star-sized panes and a narrower splitter.
+- Made the request snapshot pane vertically scrollable with horizontal overflow disabled.
+- Bounded the item lookup panel height so search results cannot push the form and save/cancel bar off-screen.
+- Added explicit virtualization, recycling, content scrolling, and automatic scrollbars to the item lookup result list.
+- Reduced fixed lookup row column pressure while preserving item number, name, and location display.
+- Put lookup summary text into shrinkable wrapping columns instead of a fixed DockPanel handoff.
+- Made the reservation detail form vertically scrollable with horizontal overflow disabled.
+- Reduced fixed label/status columns in the detail form while preserving item, customer, dates, quantity, rental ID, notes, status, item-search, clear, apply, save, and cancel bindings.
+- Reworked the footer into shrinkable columns with wrapping guidance text.
+- Added source-contract coverage for the responsive layout contracts and preserved workflow bindings.
+
+## Validation
+
+- GitHub connector readback and compare should be used for this scheduled run because the environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
+- Full Windows validation still needs to run with `pwsh -File scripts/run-full-validation.ps1`.

--- a/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml
@@ -3,10 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         Title="Reservation"
-        Width="860"
-        Height="650"
-        MinWidth="780"
-        MinHeight="590"
+        Width="820"
+        Height="620"
+        MinWidth="660"
+        MinHeight="520"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Window.Resources>
@@ -17,6 +17,16 @@
         <Style x:Key="ReservationFieldText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="Margin" Value="0,2,0,0"/>
+        </Style>
+        <Style x:Key="ReservationSummaryCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
+            <Setter Property="MinWidth" Value="145"/>
+            <Setter Property="MaxWidth" Value="220"/>
+            <Setter Property="MinHeight" Value="72"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+        <Style x:Key="ReservationSummaryValue" TargetType="TextBlock" BasedOn="{StaticResource HeadingTextBlock}">
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="TextWrapping" Value="NoWrap"/>
         </Style>
     </Window.Resources>
 
@@ -30,69 +40,69 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="14,12">
-            <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <TextBlock Text="Reservation Request" Style="{StaticResource PageTitleTextBlock}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" VerticalAlignment="Center" MinWidth="0">
+                    <TextBlock Text="Reservation Request"
+                               Style="{StaticResource PageTitleTextBlock}"
+                               TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Capture the exact item, customer, date window, quantity, and fulfillment notes before the hold reaches the operations queue."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
-                               Margin="0,3,0,0"/>
+                               Margin="0,3,12,0"/>
                 </StackPanel>
-                <Border DockPanel.Dock="Right" Style="{StaticResource DesktopSummaryCard}" Width="170" Margin="14,0,0,0" Padding="10,8">
+                <Border Grid.Column="1" Style="{StaticResource DesktopSummaryCard}" MinWidth="150" MaxWidth="190" Margin="12,0,0,0" Padding="10,8">
                     <StackPanel>
                         <TextBlock Text="Request State" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding Reservation.Status, TargetNullValue=Draft}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                        <TextBlock Text="{Binding Reservation.Status, TargetNullValue=Draft}" Style="{StaticResource ReservationSummaryValue}"/>
                         <TextBlock Text="Save when item, dates, and customer are ready" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                     </StackPanel>
                 </Border>
-            </DockPanel>
+            </Grid>
         </Border>
 
-        <Grid Grid.Row="1" Margin="0,0,0,8">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Border Grid.Column="0" Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,8">
+            <Border Style="{StaticResource ReservationSummaryCard}">
                 <StackPanel>
                     <TextBlock Text="Item" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding Reservation.ItemNumber, TargetNullValue=Not selected}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding Reservation.ItemNumber, TargetNullValue=Not selected}" Style="{StaticResource ReservationSummaryValue}"/>
                     <TextBlock Text="Item being held" Style="{StaticResource ReservationFieldText}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Column="1" Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,0">
+            <Border Style="{StaticResource ReservationSummaryCard}">
                 <StackPanel>
                     <TextBlock Text="Customer" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding Reservation.CustomerName, TargetNullValue=Not selected}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding Reservation.CustomerName, TargetNullValue=Not selected}" Style="{StaticResource ReservationSummaryValue}"/>
                     <TextBlock Text="Pickup contact" Style="{StaticResource ReservationFieldText}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Column="2" Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,0">
+            <Border Style="{StaticResource ReservationSummaryCard}">
                 <StackPanel>
                     <TextBlock Text="Needed" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding Reservation.StartDate, StringFormat={}{0:yyyy-MM-dd}}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding Reservation.StartDate, StringFormat={}{0:yyyy-MM-dd}}" Style="{StaticResource ReservationSummaryValue}"/>
                     <TextBlock Text="Reservation start date" Style="{StaticResource ReservationFieldText}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Column="3" Style="{StaticResource DesktopSummaryCard}" Margin="0">
+            <Border Style="{StaticResource ReservationSummaryCard}">
                 <StackPanel>
                     <TextBlock Text="Quantity" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding Reservation.Quantity}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding Reservation.Quantity}" Style="{StaticResource ReservationSummaryValue}"/>
                     <TextBlock Text="Requested units" Style="{StaticResource ReservationFieldText}"/>
                 </StackPanel>
             </Border>
-        </Grid>
+        </WrapPanel>
 
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="240"/>
-                <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="0.8*" MinWidth="0"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="1.9*" MinWidth="0"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <DockPanel LastChildFill="True">
                     <Border DockPanel.Dock="Top" Style="{StaticResource DesktopPaneHeader}">
                         <StackPanel>
@@ -100,36 +110,38 @@
                             <TextBlock Text="Quick read before saving the hold." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
-                    <StackPanel Margin="12">
-                        <Border Style="{StaticResource AdminHandoffCard}">
-                            <StackPanel>
-                                <TextBlock Text="Fulfillment Handoff" Style="{StaticResource SectionHeader}"/>
-                                <TextBlock Text="Confirm the item and customer first, then use the notes field for pickup timing, substitutes, or advisor instructions."
-                                           Style="{StaticResource ReservationFieldText}"/>
-                            </StackPanel>
-                        </Border>
-                        <TextBlock Text="Item #" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding Reservation.ItemNumber, TargetNullValue=-}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,8"/>
-                        <TextBlock Text="Customer" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding Reservation.CustomerName, TargetNullValue=-}" TextWrapping="Wrap" Margin="0,0,0,8"/>
-                        <TextBlock Text="Needed" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding Reservation.StartDate, StringFormat={}{0:yyyy-MM-dd}}" TextWrapping="Wrap"/>
-                        <TextBlock Text="{Binding Reservation.EndDate, StringFormat=to {0:yyyy-MM-dd}}" TextWrapping="Wrap" Margin="0,0,0,8"/>
-                        <TextBlock Text="Status" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding Reservation.Status, TargetNullValue=-}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,8"/>
-                        <TextBlock Text="Rental ID" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding Reservation.RentalID, TargetNullValue=-}" TextWrapping="Wrap"/>
-                    </StackPanel>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                        <StackPanel Margin="12">
+                            <Border Style="{StaticResource AdminHandoffCard}">
+                                <StackPanel>
+                                    <TextBlock Text="Fulfillment Handoff" Style="{StaticResource SectionHeader}"/>
+                                    <TextBlock Text="Confirm the item and customer first, then use the notes field for pickup timing, substitutes, or advisor instructions."
+                                               Style="{StaticResource ReservationFieldText}"/>
+                                </StackPanel>
+                            </Border>
+                            <TextBlock Text="Item #" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding Reservation.ItemNumber, TargetNullValue=-}" FontWeight="SemiBold" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" Margin="0,0,0,8"/>
+                            <TextBlock Text="Customer" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding Reservation.CustomerName, TargetNullValue=-}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" Margin="0,0,0,8"/>
+                            <TextBlock Text="Needed" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding Reservation.StartDate, StringFormat={}{0:yyyy-MM-dd}}" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding Reservation.EndDate, StringFormat=to {0:yyyy-MM-dd}}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                            <TextBlock Text="Status" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding Reservation.Status, TargetNullValue=-}" FontWeight="SemiBold" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" Margin="0,0,0,8"/>
+                            <TextBlock Text="Rental ID" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding Reservation.RentalID, TargetNullValue=-}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </ScrollViewer>
                 </DockPanel>
             </Border>
 
-            <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="210"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
 
@@ -142,7 +154,7 @@
                         </StackPanel>
                     </Border>
 
-                    <Border Grid.Row="1" Style="{StaticResource DesktopInsetCard}" Margin="12,12,12,8">
+                    <Border Grid.Row="1" Style="{StaticResource DesktopInsetCard}" Margin="12,12,12,8" MinHeight="150" MaxHeight="220">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -150,86 +162,96 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="92"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="84"/>
+                                <ColumnDefinition Width="*" MinWidth="0"/>
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Find item" Style="{StaticResource ReservationFieldLabel}"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ItemSearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,8"/>
+                            <TextBox Grid.Row="0" Grid.Column="1" MinWidth="150" Text="{Binding ItemSearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,8"/>
                             <Button Grid.Row="0" Grid.Column="2" Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearItemSearchCommand}" Margin="0,0,8,8"/>
                             <Button Grid.Row="0" Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Apply" Command="{Binding ApplySelectedItemCommand}" Margin="0,0,0,8"/>
                             <ListBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="4"
                                      ItemsSource="{Binding ItemSearchResults}"
                                      SelectedItem="{Binding SelectedSearchItem, Mode=TwoWay}"
+                                     VirtualizingPanel.IsVirtualizing="True"
+                                     VirtualizingPanel.VirtualizationMode="Recycling"
+                                     ScrollViewer.CanContentScroll="True"
+                                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
                                      ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate>
                                         <Grid Margin="4,3">
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="112"/>
-                                                <ColumnDefinition Width="*"/>
-                                                <ColumnDefinition Width="130"/>
+                                                <ColumnDefinition Width="96"/>
+                                                <ColumnDefinition Width="*" MinWidth="0"/>
+                                                <ColumnDefinition Width="110"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0" Text="{Binding ItemNumber}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
-                                            <TextBlock Grid.Column="1" Text="{Binding Name}" TextTrimming="CharacterEllipsis" Margin="10,0"/>
+                                            <TextBlock Grid.Column="1" Text="{Binding Name}" TextTrimming="CharacterEllipsis" Margin="8,0"/>
                                             <TextBlock Grid.Column="2" Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
                                         </Grid>
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
                             </ListBox>
-                            <DockPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4" Margin="0,6,0,0">
-                                <TextBlock Text="{Binding ItemSearchSummary}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Left"/>
-                                <TextBlock Text="{Binding SelectedItemSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                            </DockPanel>
+                            <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4" Margin="0,6,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" MinWidth="0"/>
+                                    <ColumnDefinition Width="*" MinWidth="0"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{Binding ItemSearchSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,8,0"/>
+                                <TextBlock Grid.Column="1" Text="{Binding SelectedItemSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" TextAlignment="Right"/>
+                            </Grid>
                         </Grid>
                     </Border>
 
-                    <Grid Grid.Row="2" Margin="12,0,12,12">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="112"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="88"/>
-                            <ColumnDefinition Width="148"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
+                    <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Margin="12,0,12,12">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="96"/>
+                                <ColumnDefinition Width="*" MinWidth="0"/>
+                                <ColumnDefinition Width="78"/>
+                                <ColumnDefinition Width="132"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Item #" Style="{StaticResource ReservationFieldLabel}"/>
-                        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Reservation.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,8"/>
-                        <TextBlock Grid.Row="0" Grid.Column="2" Text="Status" Style="{StaticResource ReservationFieldLabel}"/>
-                        <ComboBox Grid.Row="0" Grid.Column="3" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding Reservation.Status}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Item #" Style="{StaticResource ReservationFieldLabel}"/>
+                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Reservation.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,8"/>
+                            <TextBlock Grid.Row="0" Grid.Column="2" Text="Status" Style="{StaticResource ReservationFieldLabel}"/>
+                            <ComboBox Grid.Row="0" Grid.Column="3" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding Reservation.Status}" Margin="0,0,0,8"/>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Item Name" Style="{StaticResource ReservationFieldLabel}"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Item Name" Style="{StaticResource ReservationFieldLabel}"/>
+                            <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Customer" Style="{StaticResource ReservationFieldLabel}"/>
-                        <TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.CustomerName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Customer" Style="{StaticResource ReservationFieldLabel}"/>
+                            <TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.CustomerName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Start Date" Style="{StaticResource ReservationFieldLabel}"/>
-                        <DatePicker Grid.Row="3" Grid.Column="1" SelectedDate="{Binding Reservation.StartDate}" Margin="0,0,8,8"/>
-                        <TextBlock Grid.Row="3" Grid.Column="2" Text="End Date" Style="{StaticResource ReservationFieldLabel}"/>
-                        <DatePicker Grid.Row="3" Grid.Column="3" SelectedDate="{Binding Reservation.EndDate}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Start Date" Style="{StaticResource ReservationFieldLabel}"/>
+                            <DatePicker Grid.Row="3" Grid.Column="1" SelectedDate="{Binding Reservation.StartDate}" Margin="0,0,8,8"/>
+                            <TextBlock Grid.Row="3" Grid.Column="2" Text="End Date" Style="{StaticResource ReservationFieldLabel}"/>
+                            <DatePicker Grid.Row="3" Grid.Column="3" SelectedDate="{Binding Reservation.EndDate}" Margin="0,0,0,8"/>
 
-                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Quantity" Style="{StaticResource ReservationFieldLabel}"/>
-                        <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Reservation.Quantity, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,8"/>
-                        <TextBlock Grid.Row="4" Grid.Column="2" Text="Rental ID" Style="{StaticResource ReservationFieldLabel}"/>
-                        <TextBox Grid.Row="4" Grid.Column="3" Text="{Binding Reservation.RentalID, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Quantity" Style="{StaticResource ReservationFieldLabel}"/>
+                            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Reservation.Quantity, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,8"/>
+                            <TextBlock Grid.Row="4" Grid.Column="2" Text="Rental ID" Style="{StaticResource ReservationFieldLabel}"/>
+                            <TextBox Grid.Row="4" Grid.Column="3" Text="{Binding Reservation.RentalID, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Notes" Style="{StaticResource ReservationFieldLabel}" VerticalAlignment="Top" Margin="0,3,8,0"/>
-                        <TextBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3"
-                                 Text="{Binding Reservation.Notes, UpdateSourceTrigger=PropertyChanged}"
-                                 AcceptsReturn="True"
-                                 TextWrapping="Wrap"
-                                 VerticalScrollBarVisibility="Auto"
-                                 MinHeight="96"/>
-                    </Grid>
+                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Notes" Style="{StaticResource ReservationFieldLabel}" VerticalAlignment="Top" Margin="0,3,8,0"/>
+                            <TextBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3"
+                                     Text="{Binding Reservation.Notes, UpdateSourceTrigger=PropertyChanged}"
+                                     AcceptsReturn="True"
+                                     TextWrapping="Wrap"
+                                     VerticalScrollBarVisibility="Auto"
+                                     MinHeight="96"/>
+                        </Grid>
+                    </ScrollViewer>
                 </Grid>
             </Border>
         </Grid>
@@ -237,14 +259,19 @@
         <controls:SaveCancelBar Grid.Row="3" Margin="0,8,0,0"/>
 
         <Border Grid.Row="4" Style="{StaticResource DesktopStatusFooter}" Margin="0,4,0,0">
-            <DockPanel>
-                <TextBlock DockPanel.Dock="Left" Text="Reservation editor ready" FontSize="11" VerticalAlignment="Center"/>
-                <TextBlock DockPanel.Dock="Right"
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="Reservation editor ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Grid.Column="1"
                            Text="Save keeps this request available for pickup planning; cancel returns without applying edits."
                            Style="{StaticResource CaptionTextBlock}"
                            VerticalAlignment="Center"
+                           TextAlignment="Right"
                            TextWrapping="Wrap"/>
-            </DockPanel>
+            </Grid>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml.cs
@@ -11,7 +11,7 @@ namespace InventoryManagementApp.Views.Windows
         public ReservationEditWindow(Reservation reservation, bool isNew, IItemService? itemService = null)
         {
             InitializeComponent();
-            this.UseResponsiveDefaultSize(1000, 780);
+            this.UseResponsiveDefaultSize(820, 640);
             DataContext = new ReservationEditViewModel(reservation, isNew,
                 onSave: () => DialogResult = true,
                 onCancel: () => DialogResult = false,


### PR DESCRIPTION
## What changed

- Reduced the Reservation editor default and minimum dimensions so new/edit request dialogs open more safely on 1366 x 768 desktops and higher Windows scaling.
- Reworked the header into shrinkable columns with bounded request-state context so long guidance text and statuses do not widen the dialog.
- Replaced the fixed four-column request summary strip with wrapping bounded cards for item, customer, needed date, and quantity.
- Added bounded summary value styling so long item numbers, customer names, and statuses trim inside their cards.
- Lowered the main request-snapshot/detail split pressure with shrinkable star-sized panes and a narrower splitter.
- Made the request snapshot pane vertically scrollable with horizontal overflow disabled.
- Bounded the item lookup panel height so search results cannot push the form and save/cancel bar off-screen.
- Added explicit virtualization, recycling, content scrolling, and automatic scrollbars to the item lookup result list.
- Reduced fixed lookup row column pressure while preserving item number, name, and location display.
- Put lookup summary text into shrinkable wrapping columns instead of a fixed DockPanel handoff.
- Made the reservation detail form vertically scrollable with horizontal overflow disabled.
- Reduced fixed label/status columns in the detail form while preserving item, customer, dates, quantity, rental ID, notes, status, item-search, clear, apply, save, and cancel bindings.
- Reworked the footer into shrinkable columns with wrapping guidance text.
- Added `ReservationEditWindowResponsiveContractTests` plus a progress note for the completed workflow slice.

## Why this was highest value

Recent scheduled work already covered the major workbench pages and several central dialogs, while source readback showed the Reservation editor still had a large fixed startup size, a fixed four-column summary strip, a fixed 240 px snapshot pane, a fixed-height item lookup area, larger fixed lookup/form columns, and no explicit lookup-list virtualization. Reservation editing is used by request/hold and pickup-planning workflows, so tightening it directly improves scaled-desktop responsiveness and professional data display without overlapping the current open draft PRs.

## Why this is real progress

This covers more than ten workflow-level improvements across dialog sizing, responsive default sizing, header shrink behavior, request-state bounding, summary card wrapping, summary text bounding, split sizing, splitter width, pane scrolling, item lookup height, lookup-list virtualization, lookup-list scrolling, lookup row sizing, lookup summary wrapping, detail-form scrolling, form column sizing, footer wrapping, preserved workflow commands, source-contract coverage, and progress notes.

## Validation

- Local XML parse confirmed the revised `ReservationEditWindow.xaml` is well-formed.
- Local source scan confirmed the new responsive sizing, wrapping summary card, lower split pressure, item lookup virtualization, and preserved save/cancel markers are present while the old large size/fixed split markers are absent.
- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to:
  - `InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml`
  - `InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml.cs`
  - `InventoryManagementApp.Tests/ReservationEditWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-reservation-editor-responsive-dialog.md`
- Connector source readback confirmed smaller safe window sizing, smaller responsive default sizing, wrapping bounded summary cards, lower split pressure, narrower splitter, scrollable snapshot/detail panes, bounded item lookup height, explicit lookup virtualization/scrollbars, reduced lookup/form columns, wrapped footer guidance, preserved item-search/save/cancel bindings, and source-contract coverage.
- Connector status readback found no attached commit statuses on branch head `42af67e08a0615e3ad7c115183e3e51ed356b3d8`.
- Connector workflow readback found no workflow runs attached to branch head `42af67e08a0615e3ad7c115183e3e51ed356b3d8`.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, dialog layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
- Because the requested full Windows validation could not run, this PR is left as a draft and was not merged.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Reservation editor on Windows at 1366 x 768 and higher DPI scales, including new requests, editing existing requests, item search, clear/apply item, status changes, date/quantity/rental ID edits, long item/customer names, notes, save, cancel, and footer wrapping.