### PR TITLE
[codex] Improve operational edit dialog responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/OperationalEditWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/OperationalEditWindowResponsiveContractTests.cs
@@ -66,7 +66,6 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<ColumnDefinition Width=\"0.9*\" MinWidth=\"240\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("Style=\"{StaticResource AdminHandoffCard}\" Margin=\"0\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2*\"/>", xaml, StringComparison.Ordinal);
-            Assert.DoesNotContain("<ColumnDefinition Width=\"12\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"1.15*\"/>", xaml, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/OperationalEditWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/OperationalEditWindowResponsiveContractTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class OperationalEditWindowResponsiveContractTests
+    {
+        [Fact]
+        public void MaintenanceEditWindow_UsesSafeScaledDesktopBoundsAndShrinkableHeader()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "MaintenanceEditWindow.xaml");
+
+            Assert.Contains("Width=\"720\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Height=\"540\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"600\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"460\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"220\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextTrimming=\"CharacterEllipsis\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"760\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"700\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationEditWindow_UsesSafeScaledDesktopBoundsAndShrinkableHeader()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CalibrationEditWindow.xaml");
+
+            Assert.Contains("Width=\"720\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Height=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"600\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"460\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"220\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextTrimming=\"CharacterEllipsis\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"760\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"700\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData("MaintenanceEditWindow.xaml")]
+        [InlineData("CalibrationEditWindow.xaml")]
+        public void OperationalEditWindows_WrapSummaryCardsInsteadOfUsingFixedUniformGrid(string fileName)
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", fileName);
+
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,8\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"170\" MaxWidth=\"235\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Margin=\"0,0,8,8\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Row=\"1\" Columns=\"3\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Margin=\"6,0,0,0\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData("MaintenanceEditWindow.xaml")]
+        [InlineData("CalibrationEditWindow.xaml")]
+        public void OperationalEditWindows_KeepBodyShrinkableAndScrollable(string fileName)
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", fileName);
+
+            Assert.Contains("<Border Grid.Row=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.45*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"8\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.9*\" MinWidth=\"240\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource AdminHandoffCard}\" Margin=\"0\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"2*\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"12\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"1.15*\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData("MaintenanceEditWindow.xaml", "<ColumnDefinition Width=\"105\"/>")]
+        [InlineData("CalibrationEditWindow.xaml", "<ColumnDefinition Width=\"108\"/>")]
+        public void OperationalEditWindows_ReduceFixedFormColumnPressure(string fileName, string labelColumnMarker)
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", fileName);
+
+            Assert.Contains(labelColumnMarker, xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"12\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"120\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"124\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"18\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData("MaintenanceEditWindow.xaml", "MaintenanceRecord.ItemNumber", "MaintenanceRecord.Notes")]
+        [InlineData("CalibrationEditWindow.xaml", "CalibrationRecord.ItemNumber", "CalibrationRecord.Notes")]
+        public void OperationalEditWindows_BoundNotesAndPreservePrimaryBindings(string fileName, string identityBinding, string notesBinding)
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", fileName);
+
+            Assert.Contains(identityBinding, xaml, StringComparison.Ordinal);
+            Assert.Contains(notesBinding, xaml, StringComparison.Ordinal);
+            Assert.Contains("AcceptsReturn=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"160\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<controls:SaveCancelBar Grid.Row=\"3\" Margin=\"0,10,0,0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinHeight=\"210\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-operational-edit-dialog-responsive.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-operational-edit-dialog-responsive.md
@@ -1,0 +1,29 @@
+# Operational Edit Dialog Responsiveness
+
+Date: 2026-07-03
+
+## Completed
+
+- Reduced the Maintenance edit dialog default and minimum dimensions so it opens more safely on 1366 x 768 desktops and higher Windows scaling.
+- Reduced the Calibration edit dialog default and minimum dimensions with the same scaled-desktop safety target.
+- Reworked both dialog headers into shrinkable title columns plus bounded state/result cards so long status text does not widen the window.
+- Replaced fixed three-column summary `UniformGrid` strips with wrapping bounded summary cards.
+- Added bounded summary card sizing so asset, timing/certificate, and handoff/verification text wraps instead of forcing horizontal overflow.
+- Made both dialog body cards explicitly shrinkable with `MinWidth="0"` pane shells.
+- Wrapped the maintenance and calibration form bodies in vertical `ScrollViewer` containers with horizontal overflow disabled so save/cancel actions stay reachable when DPI scaling reduces available height.
+- Reduced the main form/handoff split pressure with star-sized columns, a narrower gutter, and practical minimums for the notes pane.
+- Reduced fixed form label columns and center spacing while preserving two-column data entry for item identity, dates, status/result, owner, certificate, and cost fields.
+- Lowered technician/verification notes minimum height while keeping multi-line wrapping and vertical scrolling.
+- Preserved existing maintenance and calibration bindings, option lists, notes editing, and the shared save/cancel workflow.
+- Added source-contract coverage for responsive bounds, shrinkable headers, wrapping summaries, scrollable bodies, reduced form columns, bounded notes, and preserved primary bindings.
+
+## Validation
+
+- GitHub connector source readback should confirm the revised Maintenance and Calibration edit dialogs use smaller safe bounds, wrapping bounded summary cards, shrinkable/scrollable form bodies, reduced form columns, bounded notes, and preserved save/cancel bindings.
+- GitHub connector source readback should confirm `OperationalEditWindowResponsiveContractTests` guards both dialogs and rejects the old fixed summary/oversized form patterns.
+- Local `dotnet`/PowerShell/WPF validation could not be run in the scheduled Linux environment because direct checkout is blocked and the required Windows/.NET tooling is unavailable.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test Maintenance and Calibration edit dialogs on Windows at 1366 x 768 and higher DPI scales, including long item names, status/result values, date edits, combo selections, notes scrolling, save, and cancel.

--- a/InventoryManagementApp/Views/Windows/CalibrationEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/CalibrationEditWindow.xaml
@@ -3,10 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         Title="Calibration"
-        Width="760"
-        Height="540"
-        MinWidth="700"
-        MinHeight="500"
+        Width="720"
+        Height="520"
+        MinWidth="600"
+        MinHeight="460"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="14">
@@ -19,137 +19,150 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
-            <DockPanel LastChildFill="True">
-                <Border DockPanel.Dock="Right" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="14,0,0,0" VerticalAlignment="Center">
-                    <StackPanel>
-                        <TextBlock Text="Certificate Result" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding CalibrationRecord.Result}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-                <StackPanel>
-                    <TextBlock Text="Calibration Certificate" Style="{StaticResource PageTitleTextBlock}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" MinWidth="0">
+                    <TextBlock Text="Calibration Certificate" Style="{StaticResource PageTitleTextBlock}" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Record measurement readiness, certificate identity, due dates, and verification notes before returning to the calibration board."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,2,0,0"/>
                 </StackPanel>
-            </DockPanel>
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="14,0,0,0" VerticalAlignment="Center" MaxWidth="220">
+                    <StackPanel>
+                        <TextBlock Text="Certificate Result" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock Text="{Binding CalibrationRecord.Result}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
-        <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,8">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="170" MaxWidth="235" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="01 Asset" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Item identity" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                     <TextBlock Text="Confirm item number and item name before saving." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="170" MaxWidth="235" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="02 Certificate" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Dates and result" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                     <TextBlock Text="Certificate timing drives due-state and shelf release decisions." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="6,0,0,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="170" MaxWidth="235" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="03 Verification" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Calibrator notes" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                     <TextBlock Text="Capture certificate context for future audits." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-        </UniformGrid>
+        </WrapPanel>
 
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
-            <Grid>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+            <Grid MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
                 <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
-                    <DockPanel LastChildFill="True">
-                        <TextBlock Text="Calibration Details" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                        <TextBlock Text="Keep certificate fields aligned for quick bench entry and repeat audits." Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                    </DockPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="Calibration Details" Style="{StaticResource SectionHeader}" Margin="0,0,12,0"/>
+                        <TextBlock Grid.Column="1" Text="Keep certificate fields aligned for quick bench entry and repeat audits."
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   TextWrapping="Wrap"
+                                   HorizontalAlignment="Right"/>
+                    </Grid>
                 </Border>
 
-                <Grid Grid.Row="1" Margin="12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="12"/>
-                        <ColumnDefinition Width="1.15*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <Grid Grid.Column="0">
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <Grid Margin="12" MinWidth="0">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="124"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="18"/>
-                            <ColumnDefinition Width="124"/>
-                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="1.45*" MinWidth="0"/>
+                            <ColumnDefinition Width="8"/>
+                            <ColumnDefinition Width="0.9*" MinWidth="240"/>
                         </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.ColumnSpan="5" Text="Certificate Fields" Style="{StaticResource SectionHeader}" Margin="0,0,0,8"/>
-
-                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Item #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding CalibrationRecord.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-                        <TextBlock Grid.Row="1" Grid.Column="3" Text="Item Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <TextBox Grid.Row="1" Grid.Column="4" Text="{Binding CalibrationRecord.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Calibration Date" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <DatePicker Grid.Row="2" Grid.Column="1" SelectedDate="{Binding CalibrationRecord.CalibrationDate}" Margin="0,0,0,8"/>
-                        <TextBlock Grid.Row="2" Grid.Column="3" Text="Next Due" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <DatePicker Grid.Row="2" Grid.Column="4" SelectedDate="{Binding CalibrationRecord.NextCalibrationDue}" Margin="0,0,0,8"/>
-
-                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Calibrated By" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding CalibrationRecord.CalibratedBy, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-                        <TextBlock Grid.Row="3" Grid.Column="3" Text="Certificate #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <TextBox Grid.Row="3" Grid.Column="4" Text="{Binding CalibrationRecord.CertificateNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-
-                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Result" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding ResultOptions}" SelectedItem="{Binding CalibrationRecord.Result}" Margin="0,0,0,8"/>
-
-                        <Border Grid.Row="5" Grid.ColumnSpan="5" Style="{StaticResource DesktopNoteCard}" Padding="10" Margin="0,4,0,0">
-                            <TextBlock Text="Save after checking dates, certificate number, and result so calibration due lists and release decisions stay accurate."
-                                       Style="{StaticResource CaptionTextBlock}"
-                                       TextWrapping="Wrap"/>
-                        </Border>
-                    </Grid>
-
-                    <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}" Margin="0">
-                        <Grid>
+                        <Grid Grid.Column="0" MinWidth="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="108"/>
+                                <ColumnDefinition Width="*" MinWidth="0"/>
+                                <ColumnDefinition Width="12"/>
+                                <ColumnDefinition Width="108"/>
+                                <ColumnDefinition Width="*" MinWidth="0"/>
+                            </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Row="0" Text="Verification Notes" Style="{StaticResource SectionHeader}"/>
-                            <TextBlock Grid.Row="1" Text="Record standard, variance, pass/fail context, and any shelf-release caution for the next operator."
-                                       Style="{StaticResource CaptionTextBlock}"
-                                       TextWrapping="Wrap"
-                                       Margin="0,2,0,8"/>
-                            <TextBox Grid.Row="2"
-                                     Text="{Binding CalibrationRecord.Notes, UpdateSourceTrigger=PropertyChanged}"
-                                     AcceptsReturn="True"
-                                     TextWrapping="Wrap"
-                                     MinHeight="210"
-                                     VerticalScrollBarVisibility="Auto"/>
+
+                            <TextBlock Grid.Row="0" Grid.ColumnSpan="5" Text="Certificate Fields" Style="{StaticResource SectionHeader}" Margin="0,0,0,8"/>
+
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Item #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding CalibrationRecord.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="1" Grid.Column="3" Text="Item Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <TextBox Grid.Row="1" Grid.Column="4" Text="{Binding CalibrationRecord.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Calibration Date" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <DatePicker Grid.Row="2" Grid.Column="1" SelectedDate="{Binding CalibrationRecord.CalibrationDate}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="2" Grid.Column="3" Text="Next Due" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <DatePicker Grid.Row="2" Grid.Column="4" SelectedDate="{Binding CalibrationRecord.NextCalibrationDue}" Margin="0,0,0,8"/>
+
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Calibrated By" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding CalibrationRecord.CalibratedBy, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="3" Grid.Column="3" Text="Certificate #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <TextBox Grid.Row="3" Grid.Column="4" Text="{Binding CalibrationRecord.CertificateNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Result" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding ResultOptions}" SelectedItem="{Binding CalibrationRecord.Result}" Margin="0,0,0,8"/>
+
+                            <Border Grid.Row="5" Grid.ColumnSpan="5" Style="{StaticResource DesktopNoteCard}" Padding="10" Margin="0,4,0,0">
+                                <TextBlock Text="Save after checking dates, certificate number, and result so calibration due lists and release decisions stay accurate."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"/>
+                            </Border>
                         </Grid>
-                    </Border>
-                </Grid>
+
+                        <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}" Margin="0" MinWidth="0">
+                            <Grid MinWidth="0">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="0" Text="Verification Notes" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Grid.Row="1" Text="Record standard, variance, pass/fail context, and any shelf-release caution for the next operator."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,2,0,8"/>
+                                <TextBox Grid.Row="2"
+                                         Text="{Binding CalibrationRecord.Notes, UpdateSourceTrigger=PropertyChanged}"
+                                         AcceptsReturn="True"
+                                         TextWrapping="Wrap"
+                                         MinHeight="160"
+                                         VerticalScrollBarVisibility="Auto"/>
+                            </Grid>
+                        </Border>
+                    </Grid>
+                </ScrollViewer>
             </Grid>
         </Border>
 
-        <controls:SaveCancelBar Grid.Row="3"/>
+        <controls:SaveCancelBar Grid.Row="3" Margin="0,10,0,0"/>
 
         <Border Grid.Row="4" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
             <TextBlock Text="Calibration edit status: review item identity, certificate dates, result, and verification notes before saving."

--- a/InventoryManagementApp/Views/Windows/MaintenanceEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/MaintenanceEditWindow.xaml
@@ -3,10 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         Title="Maintenance"
-        Width="760"
-        Height="560"
-        MinWidth="700"
-        MinHeight="500"
+        Width="720"
+        Height="540"
+        MinWidth="600"
+        MinHeight="460"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="14">
@@ -19,139 +19,152 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
-            <DockPanel LastChildFill="True">
-                <Border DockPanel.Dock="Right" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="14,0,0,0" VerticalAlignment="Center">
-                    <StackPanel>
-                        <TextBlock Text="Work Order State" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding MaintenanceRecord.Status}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-                <StackPanel>
-                    <TextBlock Text="Maintenance Work Order" Style="{StaticResource PageTitleTextBlock}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" MinWidth="0">
+                    <TextBlock Text="Maintenance Work Order" Style="{StaticResource PageTitleTextBlock}" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Schedule service, record completion context, and capture technician notes before returning to the maintenance board."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,2,0,0"/>
                 </StackPanel>
-            </DockPanel>
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="14,0,0,0" VerticalAlignment="Center" MaxWidth="220">
+                    <StackPanel>
+                        <TextBlock Text="Work Order State" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock Text="{Binding MaintenanceRecord.Status}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
-        <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,8">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="170" MaxWidth="235" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="01 Asset" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Item identity" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                     <TextBlock Text="Confirm item number and name before scheduling work." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="170" MaxWidth="235" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="02 Timing" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Scheduled and completed" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                     <TextBlock Text="Dates keep backlog and service history aligned." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="6,0,0,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="170" MaxWidth="235" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="03 Handoff" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Technician notes" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                     <TextBlock Text="Capture cost, owner, and service notes for the next workflow." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-        </UniformGrid>
+        </WrapPanel>
 
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
-            <Grid>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+            <Grid MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
                 <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
-                    <DockPanel LastChildFill="True">
-                        <TextBlock Text="Maintenance Details" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                        <TextBlock Text="Required scheduling fields stay aligned for repeat technician entry." Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                    </DockPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="Maintenance Details" Style="{StaticResource SectionHeader}" Margin="0,0,12,0"/>
+                        <TextBlock Grid.Column="1" Text="Required scheduling fields stay aligned for repeat technician entry."
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   TextWrapping="Wrap"
+                                   HorizontalAlignment="Right"/>
+                    </Grid>
                 </Border>
 
-                <Grid Grid.Row="1" Margin="12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="12"/>
-                        <ColumnDefinition Width="1.15*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <Grid Grid.Column="0">
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <Grid Margin="12" MinWidth="0">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="120"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="18"/>
-                            <ColumnDefinition Width="120"/>
-                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="1.45*" MinWidth="0"/>
+                            <ColumnDefinition Width="8"/>
+                            <ColumnDefinition Width="0.9*" MinWidth="240"/>
                         </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.ColumnSpan="5" Text="Work Order Fields" Style="{StaticResource SectionHeader}" Margin="0,0,0,8"/>
-
-                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Item #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding MaintenanceRecord.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-                        <TextBlock Grid.Row="1" Grid.Column="3" Text="Item Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <TextBox Grid.Row="1" Grid.Column="4" Text="{Binding MaintenanceRecord.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Type" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding MaintenanceTypeOptions}" SelectedItem="{Binding MaintenanceRecord.MaintenanceType}" Margin="0,0,0,8"/>
-                        <TextBlock Grid.Row="2" Grid.Column="3" Text="Status" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <ComboBox Grid.Row="2" Grid.Column="4" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding MaintenanceRecord.Status}" Margin="0,0,0,8"/>
-
-                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Scheduled" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <DatePicker Grid.Row="3" Grid.Column="1" SelectedDate="{Binding MaintenanceRecord.ScheduledDate}" Margin="0,0,0,8"/>
-                        <TextBlock Grid.Row="3" Grid.Column="3" Text="Completed" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <DatePicker Grid.Row="3" Grid.Column="4" SelectedDate="{Binding MaintenanceRecord.CompletedDate}" Margin="0,0,0,8"/>
-
-                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Performed By" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding MaintenanceRecord.PerformedBy, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-                        <TextBlock Grid.Row="4" Grid.Column="3" Text="Cost" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                        <TextBox Grid.Row="4" Grid.Column="4" Text="{Binding MaintenanceRecord.Cost, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-
-                        <Border Grid.Row="5" Grid.ColumnSpan="5" Style="{StaticResource DesktopNoteCard}" Padding="10" Margin="0,4,0,0">
-                            <TextBlock Text="Confirm the asset and dates before saving so maintenance history, dashboard issue counts, and printed schedules stay consistent."
-                                       Style="{StaticResource CaptionTextBlock}"
-                                       TextWrapping="Wrap"/>
-                        </Border>
-                    </Grid>
-
-                    <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}" Margin="0">
-                        <Grid>
+                        <Grid Grid.Column="0" MinWidth="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="105"/>
+                                <ColumnDefinition Width="*" MinWidth="0"/>
+                                <ColumnDefinition Width="12"/>
+                                <ColumnDefinition Width="105"/>
+                                <ColumnDefinition Width="*" MinWidth="0"/>
+                            </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Row="0" Text="Technician Handoff" Style="{StaticResource SectionHeader}"/>
-                            <TextBlock Grid.Row="1" Text="Record what was checked, repaired, replaced, or deferred so the next operator has clear context."
-                                       Style="{StaticResource CaptionTextBlock}"
-                                       TextWrapping="Wrap"
-                                       Margin="0,2,0,8"/>
-                            <TextBox Grid.Row="2"
-                                     Text="{Binding MaintenanceRecord.Notes, UpdateSourceTrigger=PropertyChanged}"
-                                     AcceptsReturn="True"
-                                     TextWrapping="Wrap"
-                                     MinHeight="210"
-                                     VerticalScrollBarVisibility="Auto"/>
+
+                            <TextBlock Grid.Row="0" Grid.ColumnSpan="5" Text="Work Order Fields" Style="{StaticResource SectionHeader}" Margin="0,0,0,8"/>
+
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Item #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding MaintenanceRecord.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="1" Grid.Column="3" Text="Item Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <TextBox Grid.Row="1" Grid.Column="4" Text="{Binding MaintenanceRecord.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Type" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding MaintenanceTypeOptions}" SelectedItem="{Binding MaintenanceRecord.MaintenanceType}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="2" Grid.Column="3" Text="Status" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <ComboBox Grid.Row="2" Grid.Column="4" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding MaintenanceRecord.Status}" Margin="0,0,0,8"/>
+
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Scheduled" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <DatePicker Grid.Row="3" Grid.Column="1" SelectedDate="{Binding MaintenanceRecord.ScheduledDate}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="3" Grid.Column="3" Text="Completed" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <DatePicker Grid.Row="3" Grid.Column="4" SelectedDate="{Binding MaintenanceRecord.CompletedDate}" Margin="0,0,0,8"/>
+
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Performed By" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding MaintenanceRecord.PerformedBy, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                            <TextBlock Grid.Row="4" Grid.Column="3" Text="Cost" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                            <TextBox Grid.Row="4" Grid.Column="4" Text="{Binding MaintenanceRecord.Cost, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+                            <Border Grid.Row="5" Grid.ColumnSpan="5" Style="{StaticResource DesktopNoteCard}" Padding="10" Margin="0,4,0,0">
+                                <TextBlock Text="Confirm the asset and dates before saving so maintenance history, dashboard issue counts, and printed schedules stay consistent."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"/>
+                            </Border>
                         </Grid>
-                    </Border>
-                </Grid>
+
+                        <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}" Margin="0" MinWidth="0">
+                            <Grid MinWidth="0">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="0" Text="Technician Handoff" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Grid.Row="1" Text="Record what was checked, repaired, replaced, or deferred so the next operator has clear context."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,2,0,8"/>
+                                <TextBox Grid.Row="2"
+                                         Text="{Binding MaintenanceRecord.Notes, UpdateSourceTrigger=PropertyChanged}"
+                                         AcceptsReturn="True"
+                                         TextWrapping="Wrap"
+                                         MinHeight="160"
+                                         VerticalScrollBarVisibility="Auto"/>
+                            </Grid>
+                        </Border>
+                    </Grid>
+                </ScrollViewer>
             </Grid>
         </Border>
 
-        <controls:SaveCancelBar Grid.Row="3"/>
+        <controls:SaveCancelBar Grid.Row="3" Margin="0,10,0,0"/>
 
         <Border Grid.Row="4" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
             <TextBlock Text="Maintenance edit status: save only after asset, schedule, status, cost, and handoff notes are reviewed."


### PR DESCRIPTION
## What changed

- Reduced the Maintenance edit dialog default and minimum dimensions for safer 1366 x 768 and higher Windows scaling.
- Reduced the Calibration edit dialog default and minimum dimensions with the same scaled-desktop target.
- Reworked both dialog headers into shrinkable title columns with bounded state/result cards.
- Replaced fixed three-column summary strips with wrapping bounded summary cards.
- Bounded summary card sizing so asset, timing/certificate, and handoff/verification copy wraps instead of widening the dialogs.
- Made both dialog body cards explicitly shrinkable with `MinWidth="0"` pane shells.
- Wrapped both form bodies in vertical scroll viewers with horizontal overflow disabled so save/cancel actions remain reachable at high scaling.
- Reduced the main form/handoff split pressure with star-sized columns, narrower gutters, and practical notes-pane minimums.
- Reduced fixed form label columns and internal spacing while preserving two-column data entry.
- Lowered notes minimum height while keeping multi-line wrapping and vertical scrolling.
- Preserved maintenance/calibration bindings, option lists, notes editing, and the shared save/cancel workflow.
- Added `OperationalEditWindowResponsiveContractTests` plus a progress note for the completed workflow slice.

## Why this was highest value

Recent merged and draft work already covered the major workbenches, app shell, search/rentals pages, print preview, and item/reservation/rental-history dialogs. Current source readback showed the Maintenance and Calibration edit dialogs still used large startup/minimum sizes, fixed `UniformGrid` summary strips, fixed form label columns, non-scrollable form bodies, and tall notes boxes that could pressure the save/cancel row on scaled desktops. These dialogs are high-frequency operational record workflows, so improving them directly supports loading responsiveness, professional data display, and scaled desktop usability without overlapping the open draft PRs.

## Why this is real progress

This covers more than ten workflow-level improvements across two related dialogs: scaled startup bounds, minimum sizing, shrinkable headers, bounded state/result cards, wrapping summary cards, bounded summary text, shrinkable body shells, scrollable form bodies, horizontal-overflow prevention, reduced split pressure, narrower gutters, reduced label columns, bounded notes, preserved bindings, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 focused commits, and limited to:
  - `InventoryManagementApp/Views/Windows/MaintenanceEditWindow.xaml`
  - `InventoryManagementApp/Views/Windows/CalibrationEditWindow.xaml`
  - `InventoryManagementApp.Tests/OperationalEditWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-operational-edit-dialog-responsive.md`
- Connector source readback confirmed smaller safe dialog bounds, shrinkable headers, bounded state/result cards, wrapping bounded summary cards, shrinkable/scrollable form bodies, lower split pressure, reduced form columns, bounded notes, preserved save/cancel bindings, and source-contract coverage.
- Connector status readback found no attached commit statuses on branch head `5ecae6eb0aa1edc36704970163be3954b9fb24d0`.
- Connector workflow readback found no workflow runs attached to branch head `5ecae6eb0aa1edc36704970163be3954b9fb24d0`.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, dialog layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
- Because the requested full Windows validation could not run, this PR is left as a draft and was not merged.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Maintenance and Calibration edit dialogs on Windows at 1366 x 768 and higher DPI scales, including long item names, long status/result values, date edits, combo selections, notes scrolling, save, and cancel.