### PR TITLE
[codex] Improve record edit dialog responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/RecordEditWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/RecordEditWindowResponsiveContractTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RecordEditWindowResponsiveContractTests
+    {
+        [Fact]
+        public void ItemEditWindow_UsesSaferScaledDialogBoundsAndWrappingSummaryCards()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ItemEditWindow.xaml");
+
+            Assert.Contains("Width=\"800\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Height=\"660\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"660\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Margin=\"0,0,0,8\">", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "Style=\"{StaticResource DesktopSummaryCard}\" MinWidth=\"150\" MaxWidth=\"210\"") >= 4);
+            Assert.DoesNotContain("<UniformGrid Columns=\"4\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"840\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"760\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemEditWindow_ReducesSplitPressureAndKeepsSaveActionsReachable()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ItemEditWindow.xaml");
+
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"2*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"8\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"130\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Height=\"90\" AcceptsReturn=\"True\" TextWrapping=\"Wrap\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Height=\"190\" AcceptsReturn=\"True\" TextWrapping=\"Wrap\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<controls:SaveCancelBar Grid.Row=\"2\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"150\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Height=\"260\" AcceptsReturn=\"True\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerEditWindow_UsesWrappingSummaryAndScrollableShrinkableForm()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CustomerEditWindow.xaml");
+
+            Assert.Contains("Width=\"720\" Height=\"580\" MinWidth=\"600\" MinHeight=\"500\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,8\">", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "Style=\"{StaticResource DesktopSummaryCard}\" MinWidth=\"155\" MaxWidth=\"225\"") >= 3);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.1*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"104\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"82\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Row=\"1\" Columns=\"3\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"280\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"260\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerEditWindow_PreservesCustomerBindingsAndFooterStatus()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CustomerEditWindow.xaml");
+            var requiredContracts = new[]
+            {
+                "Customer.Company",
+                "Customer.Contact",
+                "Customer.Email",
+                "Customer.Phone",
+                "Customer.Mobile",
+                "Customer.Address",
+                "StatusMessage",
+                "<controls:SaveCancelBar Grid.Row=\"3\" Margin=\"0,8,0,0\"/>"
+            };
+
+            foreach (var contract in requiredContracts)
+                Assert.Contains(contract, xaml, StringComparison.Ordinal);
+
+            Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"96\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitEditWindow_UsesWrappingSummaryAndLowerSplitPressure()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "KitEditWindow.xaml");
+
+            Assert.Contains("Width=\"720\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Height=\"580\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"600\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"500\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,8\">", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "Style=\"{StaticResource DesktopSummaryCard}\" MinWidth=\"155\" MaxWidth=\"225\"") >= 3);
+            Assert.Contains("<ColumnDefinition Width=\"1.28*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"8\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Row=\"1\" Columns=\"3\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"680\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitEditWindow_PreservesKitBindingsWithReachableScrollingAndSaveCancel()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "KitEditWindow.xaml");
+            var requiredContracts = new[]
+            {
+                "Kit.KitNumber",
+                "Kit.Name",
+                "Kit.Category",
+                "Kit.IsActive",
+                "Kit.Description",
+                "<controls:SaveCancelBar Grid.Row=\"3\" Margin=\"0,8,0,0\"/>"
+            };
+
+            foreach (var contract in requiredContracts)
+                Assert.Contains(contract, xaml, StringComparison.Ordinal);
+
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"110\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"150\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-record-edit-dialog-responsive.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-record-edit-dialog-responsive.md
@@ -1,0 +1,17 @@
+# Record Edit Dialog Responsive Pass - 2026-07-03
+
+## Completed
+
+- Reduced safe startup and minimum dimensions for the Item, Customer, and Kit edit dialogs so record editing opens more comfortably on 1366 x 768 desktops and higher Windows scaling.
+- Replaced fixed summary `UniformGrid` strips with wrapping bounded summary cards so long labels and guidance copy do not force horizontal overflow.
+- Added shrinkable header columns and bounded record-state cards so long item, customer, and kit names stay inside the dialog shell.
+- Lowered split pressure in the item, customer, and kit edit form bodies by using star-sized shrinkable columns with `MinWidth="0"` and narrower gutters.
+- Disabled horizontal overflow in edit-form scroll regions and long-note text boxes while keeping vertical scrolling available.
+- Reduced fixed label-column widths and tall note/image regions so save/cancel actions remain reachable on scaled desktops.
+- Preserved the existing item, customer, and kit save/cancel workflows and all existing edit bindings.
+- Added `RecordEditWindowResponsiveContractTests` to guard the responsive layout contracts and preserved bindings.
+
+## Validation Notes
+
+- Local Windows/.NET/WPF validation still needs to run from a Windows-capable checkout with `pwsh -File scripts/run-full-validation.ps1`.
+- In this scheduled Linux environment, direct repository checkout and full WPF validation remain unavailable, so this slice depends on connector source readback and compare/status checks before PR review.

--- a/InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml
@@ -3,9 +3,9 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
-        Title="Customer" Width="760" Height="620" MinWidth="680" MinHeight="560" WindowStartupLocation="CenterOwner"
+        Title="Customer" Width="720" Height="580" MinWidth="600" MinHeight="500" WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="14">
+    <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -15,55 +15,59 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
-            <DockPanel LastChildFill="True">
-                <Border DockPanel.Dock="Right" Style="{StaticResource DesktopNoteCard}" Padding="12,7" Margin="16,0,0,0" VerticalAlignment="Center">
-                    <StackPanel>
-                        <TextBlock Text="Directory Record" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding Customer.Company, TargetNullValue='New customer'}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-                <StackPanel>
-                    <TextBlock Text="Customer Profile Workbench" Style="{StaticResource PageTitleTextBlock}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" MinWidth="0">
+                    <TextBlock Text="Customer Profile Workbench" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Keep account, contact, and delivery details ready for rentals, reservations, service handoffs, and printed customer sheets."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,2,0,0"/>
                 </StackPanel>
-            </DockPanel>
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="10,0,0,0" MaxWidth="190" VerticalAlignment="Center">
+                    <StackPanel>
+                        <TextBlock Text="Directory Record" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock Text="{Binding Customer.Company, TargetNullValue='New customer'}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
-        <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,8">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="155" MaxWidth="225" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="01 Account" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Company and contact" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Company and contact" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Primary identity used by customer lookup and rental handoffs."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="155" MaxWidth="225" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="02 Communication" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Email and phones" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Email and phones" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Follow-up details stay together for advisors and printouts."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="6,0,0,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="155" MaxWidth="225" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="03 Address" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Delivery notes" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Delivery notes" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Service address supports delivery, pickup, and customer sheets."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-        </UniformGrid>
+        </WrapPanel>
 
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
-            <Grid>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+            <Grid MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
@@ -71,29 +75,29 @@
 
                 <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
                     <DockPanel LastChildFill="True">
-                        <TextBlock DockPanel.Dock="Left" Text="Customer Directory Details" Style="{StaticResource SectionHeader}" Margin="0"/>
-                        <TextBlock Text="Aligned fields keep quick edits steady across customer records." Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        <TextBlock DockPanel.Dock="Left" Text="Customer Directory Details" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
+                        <TextBlock Text="Aligned fields keep quick edits steady across customer records." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" HorizontalAlignment="Right" Margin="12,0,0,0"/>
                     </DockPanel>
                 </Border>
 
-                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
-                    <Grid Margin="14">
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <Grid Margin="12" MinWidth="0">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1.1*" MinWidth="280"/>
-                            <ColumnDefinition Width="12"/>
-                            <ColumnDefinition Width="*" MinWidth="260"/>
+                            <ColumnDefinition Width="1.1*" MinWidth="0"/>
+                            <ColumnDefinition Width="8"/>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
                         </Grid.ColumnDefinitions>
 
-                        <Grid Grid.Column="0">
+                        <Grid Grid.Column="0" MinWidth="0">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <Border Grid.Row="0" Style="{StaticResource DesktopSectionActionStrip}" Padding="12" Margin="0,0,0,10">
+                            <Border Grid.Row="0" Style="{StaticResource DesktopSectionActionStrip}" Padding="10" Margin="0,0,0,8" MinWidth="0">
                                 <StackPanel>
-                                    <TextBlock Text="Account Identity" Style="{StaticResource SectionHeader}"/>
+                                    <TextBlock Text="Account Identity" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                     <TextBlock Text="The company and primary contact appear in customer lookup, printouts, and selected-customer handoffs."
                                                Style="{StaticResource CaptionTextBlock}"
                                                TextWrapping="Wrap"
@@ -101,10 +105,10 @@
                                 </StackPanel>
                             </Border>
 
-                            <Grid Grid.Row="1">
+                            <Grid Grid.Row="1" MinWidth="0">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="118"/>
-                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="104"/>
+                                    <ColumnDefinition Width="*" MinWidth="0"/>
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
@@ -118,9 +122,9 @@
                                 <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Customer.Contact, UpdateSourceTrigger=PropertyChanged}"/>
                             </Grid>
 
-                            <Border Grid.Row="2" Style="{StaticResource AdminHandoffCard}" Margin="0,12,0,0">
+                            <Border Grid.Row="2" Style="{StaticResource AdminHandoffCard}" Margin="0,10,0,0" MinWidth="0">
                                 <StackPanel>
-                                    <TextBlock Text="Customer Operations Handoff" Style="{StaticResource SectionHeader}"/>
+                                    <TextBlock Text="Customer Operations Handoff" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                     <TextBlock Text="Save after confirming the account name, best contact path, and service address so directory rows and printed customer sheets remain trustworthy."
                                                Style="{StaticResource CaptionTextBlock}"
                                                TextWrapping="Wrap"
@@ -129,17 +133,17 @@
                             </Border>
                         </Grid>
 
-                        <Grid Grid.Column="2">
+                        <Grid Grid.Column="2" MinWidth="0">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
 
-                            <Border Grid.Row="0" Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
-                                <Grid>
+                            <Border Grid.Row="0" Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,8" MinWidth="0">
+                                <Grid MinWidth="0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="88"/>
-                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="82"/>
+                                        <ColumnDefinition Width="*" MinWidth="0"/>
                                     </Grid.ColumnDefinitions>
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
@@ -158,14 +162,14 @@
                                 </Grid>
                             </Border>
 
-                            <Border Grid.Row="1" Style="{StaticResource DesktopNoteCard}">
-                                <Grid>
+                            <Border Grid.Row="1" Style="{StaticResource DesktopNoteCard}" MinWidth="0">
+                                <Grid MinWidth="0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="*"/>
                                     </Grid.RowDefinitions>
-                                    <TextBlock Grid.Row="0" Text="Service Address" Style="{StaticResource SectionHeader}"/>
+                                    <TextBlock Grid.Row="0" Text="Service Address" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                     <TextBlock Grid.Row="1" Text="Keep this concise enough for directory rows, handoff sheets, and delivery notes."
                                                Style="{StaticResource CaptionTextBlock}"
                                                TextWrapping="Wrap"
@@ -174,8 +178,9 @@
                                              Text="{Binding Customer.Address, UpdateSourceTrigger=PropertyChanged}"
                                              AcceptsReturn="True"
                                              TextWrapping="Wrap"
-                                             MinHeight="118"
-                                             VerticalScrollBarVisibility="Auto"/>
+                                             MinHeight="96"
+                                             VerticalScrollBarVisibility="Auto"
+                                             HorizontalScrollBarVisibility="Disabled"/>
                                 </Grid>
                             </Border>
                         </Grid>
@@ -184,16 +189,20 @@
             </Grid>
         </Border>
 
-        <controls:SaveCancelBar Grid.Row="3" Margin="0,10,0,0"/>
+        <controls:SaveCancelBar Grid.Row="3" Margin="0,8,0,0"/>
 
         <Border Grid.Row="4" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
-            <DockPanel LastChildFill="True">
-                <TextBlock DockPanel.Dock="Left" Text="Customer profile ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <TextBlock Text="{Binding StatusMessage}"
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="Customer profile ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Grid.Column="1" Text="{Binding StatusMessage}"
                            Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
                            VerticalAlignment="Center"/>
-            </DockPanel>
+            </Grid>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
@@ -5,13 +5,13 @@
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}"
-        Width="840"
-        Height="720"
-        MinWidth="760"
-        MinHeight="620"
+        Width="800"
+        Height="660"
+        MinWidth="660"
+        MinHeight="520"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="16">
+    <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -19,78 +19,77 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,10">
+        <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <StackPanel>
-                    <TextBlock Text="Item Edit Workbench" Style="{StaticResource PageTitleTextBlock}"/>
+                <StackPanel MinWidth="0">
+                    <TextBlock Text="Item Edit Workbench" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Review identity, location, readiness, and image details before saving this inventory record."
                                Style="{StaticResource CaptionTextBlock}"
                                Margin="0,2,0,0"
                                TextWrapping="Wrap"/>
                 </StackPanel>
 
-                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="14,0,0,0" VerticalAlignment="Center">
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="10,0,0,0" MaxWidth="190" VerticalAlignment="Center">
                     <StackPanel>
                         <TextBlock Text="Edit State" Style="{StaticResource LabelTextBlock}"/>
                         <TextBlock Text="Unsaved changes stay in this dialog until Save is selected."
                                    Style="{StaticResource CaptionTextBlock}"
-                                   TextWrapping="Wrap"
-                                   MaxWidth="220"/>
+                                   TextWrapping="Wrap"/>
                     </StackPanel>
                 </Border>
             </Grid>
         </Border>
 
-        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
             <StackPanel>
-                <UniformGrid Columns="4" Margin="0,0,0,10">
-                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,0">
+                <WrapPanel Margin="0,0,0,8">
+                    <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="150" MaxWidth="210" Margin="0,0,8,8">
                         <StackPanel>
                             <TextBlock Text="Identity" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Number, name, brand" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Number, name, brand" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                             <TextBlock Text="Required search fields stay grouped together." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,0">
+                    <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="150" MaxWidth="210" Margin="0,0,8,8">
                         <StackPanel>
                             <TextBlock Text="Shelf" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Location and supplier" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Location and supplier" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                             <TextBlock Text="Stockroom context is checked before save." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,0">
+                    <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="150" MaxWidth="210" Margin="0,0,8,8">
                         <StackPanel>
                             <TextBlock Text="Readiness" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Rental and powered flags" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Rental and powered flags" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                             <TextBlock Text="Availability intent remains visible while editing." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
-                    <Border Style="{StaticResource DesktopSummaryCard}">
+                    <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="150" MaxWidth="210" Margin="0,0,8,8">
                         <StackPanel>
                             <TextBlock Text="Condition" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Notes and issues" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Notes and issues" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                             <TextBlock Text="Incomplete records get explicit handoff notes." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
-                </UniformGrid>
+                </WrapPanel>
 
-                <Grid Margin="0,0,0,10">
+                <Grid Margin="0,0,0,8">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="12"/>
-                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2*" MinWidth="0"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition Width="1*" MinWidth="0"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border Grid.Column="0" Style="{StaticResource Card}" Padding="14">
-                        <Grid>
+                    <Border Grid.Column="0" Style="{StaticResource Card}" Padding="12" MinWidth="0">
+                        <Grid MinWidth="0">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="150"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="130"/>
+                                <ColumnDefinition Width="*" MinWidth="0"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -110,7 +109,7 @@
                             <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Capture the record information operators use to find, shelve, and source this item."
                                        Style="{StaticResource CaptionTextBlock}"
                                        TextWrapping="Wrap"
-                                       Margin="0,2,0,12"/>
+                                       Margin="0,2,0,10"/>
 
                             <TextBlock Grid.Row="2" Text="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} Number'}" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ItemModel.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
@@ -121,7 +120,7 @@
                             <TextBlock Grid.Row="4" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                             <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding ItemModel.Brand, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
 
-                            <TextBlock Grid.Row="5" Grid.ColumnSpan="2" Text="Shelf and Sourcing" Style="{StaticResource SectionHeader}" Margin="0,8,0,8"/>
+                            <TextBlock Grid.Row="5" Grid.ColumnSpan="2" Text="Shelf and Sourcing" Style="{StaticResource SectionHeader}" Margin="0,6,0,8"/>
 
                             <TextBlock Grid.Row="6" Text="Location" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                             <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding ItemModel.Location, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
@@ -135,7 +134,7 @@
                             <TextBlock Grid.Row="9" Text="Keywords" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                             <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding ItemModel.Keywords, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
 
-                            <Border Grid.Row="10" Grid.ColumnSpan="2" Style="{StaticResource DesktopNoteCard}" Padding="10,8" Margin="0,6,0,0">
+                            <Border Grid.Row="10" Grid.ColumnSpan="2" Style="{StaticResource DesktopNoteCard}" Padding="10,8" Margin="0,4,0,0">
                                 <TextBlock Text="Save after checking the item number, name, shelf location, and supplier details against the physical item."
                                            Style="{StaticResource CaptionTextBlock}"
                                            TextWrapping="Wrap"/>
@@ -143,24 +142,24 @@
                         </Grid>
                     </Border>
 
-                    <StackPanel Grid.Column="2">
-                        <Border Style="{StaticResource AdminHandoffCard}">
+                    <StackPanel Grid.Column="2" MinWidth="0">
+                        <Border Style="{StaticResource AdminHandoffCard}" MinWidth="0">
                             <StackPanel>
-                                <TextBlock Text="Image and Availability" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Text="Image and Availability" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                 <TextBlock Text="Keep the visual identifier and checkout intent aligned with the shelf record."
                                            Style="{StaticResource CaptionTextBlock}"
                                            TextWrapping="Wrap"
-                                           Margin="0,2,0,10"/>
+                                           Margin="0,2,0,8"/>
 
-                                <Border Width="170" Height="150" Background="{DynamicResource SurfaceBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Margin="0,0,0,10" HorizontalAlignment="Left">
+                                <Border Width="150" Height="130" Background="{DynamicResource SurfaceBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Margin="0,0,0,8" HorizontalAlignment="Left">
                                     <Image Stretch="Uniform"
                                            Source="{Binding ItemModel, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                                 </Border>
 
-                                <WrapPanel Margin="0,0,0,12">
-                                    <Button Content="Browse" Style="{StaticResource PrimaryButton}" Command="{Binding BrowseImageCommand}" Width="92" Margin="0,0,8,0"/>
-                                    <Button Content="Remove" Style="{StaticResource GhostButton}" Command="{Binding RemoveImageCommand}" Width="92" Margin="0,0,8,0"/>
-                                    <Button Content="Remove Background" Style="{StaticResource GhostButton}" Command="{Binding RemoveImageBackgroundCommand}" MinWidth="150"/>
+                                <WrapPanel Margin="0,0,0,10">
+                                    <Button Content="Browse" Style="{StaticResource PrimaryButton}" Command="{Binding BrowseImageCommand}" Width="88" Margin="0,0,8,8"/>
+                                    <Button Content="Remove" Style="{StaticResource GhostButton}" Command="{Binding RemoveImageCommand}" Width="88" Margin="0,0,8,8"/>
+                                    <Button Content="Remove Background" Style="{StaticResource GhostButton}" Command="{Binding RemoveImageBackgroundCommand}" MinWidth="138" Margin="0,0,8,8"/>
                                 </WrapPanel>
 
                                 <CheckBox Content="Powered item" IsChecked="{Binding ItemModel.IsPowered}" Margin="0,0,0,6"/>
@@ -168,9 +167,9 @@
                             </StackPanel>
                         </Border>
 
-                        <Border Style="{StaticResource DesktopNoteCard}" Padding="12">
+                        <Border Style="{StaticResource DesktopNoteCard}" Padding="10" MinWidth="0">
                             <StackPanel>
-                                <TextBlock Text="Save Review" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Text="Save Review" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                 <TextBlock Text="Operators see these fields across search, checkout, maintenance, calibration, and printed handoffs."
                                            Style="{StaticResource CaptionTextBlock}"
                                            TextWrapping="Wrap"/>
@@ -181,46 +180,46 @@
 
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="12"/>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*" MinWidth="0"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition Width="*" MinWidth="0"/>
                     </Grid.ColumnDefinitions>
 
-                    <StackPanel Grid.Column="0">
-                        <Border Style="{StaticResource Card}" Padding="14" Margin="0,0,0,10">
+                    <StackPanel Grid.Column="0" MinWidth="0">
+                        <Border Style="{StaticResource Card}" Padding="12" Margin="0,0,0,8" MinWidth="0">
                             <StackPanel>
-                                <TextBlock Text="General Notes" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
+                                <TextBlock Text="General Notes" Style="{StaticResource SectionHeader}" Margin="0,0,0,6" TextWrapping="Wrap"/>
                                 <TextBlock Text="Use this area for normal handling notes, storage reminders, or service context."
                                            Style="{StaticResource CaptionTextBlock}"
                                            TextWrapping="Wrap"
                                            Margin="0,0,0,8"/>
-                                <TextBox Text="{Binding ItemModel.Notes, UpdateSourceTrigger=PropertyChanged}" Height="110" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+                                <TextBox Text="{Binding ItemModel.Notes, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"/>
                             </StackPanel>
                         </Border>
 
-                        <Border Style="{StaticResource Card}" Padding="14">
+                        <Border Style="{StaticResource Card}" Padding="12" MinWidth="0">
                             <StackPanel>
-                                <TextBlock Text="Issues / Problems" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
+                                <TextBlock Text="Issues / Problems" Style="{StaticResource SectionHeader}" Margin="0,0,0,6" TextWrapping="Wrap"/>
                                 <TextBlock Text="Record known problems that should be visible before checkout or service assignment."
                                            Style="{StaticResource CaptionTextBlock}"
                                            TextWrapping="Wrap"
                                            Margin="0,0,0,8"/>
-                                <TextBox Text="{Binding ItemModel.IssuesNotes, UpdateSourceTrigger=PropertyChanged}" Height="110" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" ToolTip="Describe any issues or problems with this item"/>
+                                <TextBox Text="{Binding ItemModel.IssuesNotes, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" ToolTip="Describe any issues or problems with this item"/>
                             </StackPanel>
                         </Border>
                     </StackPanel>
 
-                    <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}">
+                    <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}" MinWidth="0">
                         <StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                            <WrapPanel Margin="0,0,0,8">
                                 <CheckBox Content="Mark as Incomplete/Missing Components" IsChecked="{Binding ItemModel.IsIncomplete}" Foreground="{DynamicResource ErrorBrush}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                            </StackPanel>
+                            </WrapPanel>
                             <TextBlock Text="Missing Components" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4" Foreground="{DynamicResource ErrorBrush}"/>
                             <TextBlock Text="List every missing part so the record gives clear handoff guidance before the item is released."
                                        Style="{StaticResource CaptionTextBlock}"
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,8"/>
-                            <TextBox Text="{Binding ItemModel.MissingComponentsNotes, UpdateSourceTrigger=PropertyChanged}" Height="260" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" ToolTip="List missing parts or components"/>
+                            <TextBox Text="{Binding ItemModel.MissingComponentsNotes, UpdateSourceTrigger=PropertyChanged}" Height="190" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" ToolTip="List missing parts or components"/>
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/InventoryManagementApp/Views/Windows/KitEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/KitEditWindow.xaml
@@ -3,13 +3,13 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         Title="Kit"
-        Width="760"
-        Height="640"
-        MinWidth="680"
-        MinHeight="560"
+        Width="720"
+        Height="580"
+        MinWidth="600"
+        MinHeight="500"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="14">
+    <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -19,121 +19,127 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
-            <DockPanel LastChildFill="True">
-                <Border DockPanel.Dock="Right" Style="{StaticResource DesktopNoteCard}" Padding="12,7" Margin="16,0,0,0" VerticalAlignment="Center">
-                    <StackPanel>
-                        <TextBlock Text="Kit Record" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding Kit.Name, TargetNullValue='Draft kit'}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-                <StackPanel>
-                    <TextBlock Text="Kit Setup" Style="{StaticResource PageTitleTextBlock}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" MinWidth="0">
+                    <TextBlock Text="Kit Setup" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Define the kit identity, category, description, and active state used by the kit operations workbench and printed kit sheets."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,2,0,0"/>
                 </StackPanel>
-            </DockPanel>
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="10,0,0,0" MaxWidth="190" VerticalAlignment="Center">
+                    <StackPanel>
+                        <TextBlock Text="Kit Record" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock Text="{Binding Kit.Name, TargetNullValue='Draft kit'}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
-        <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,8">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="155" MaxWidth="225" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="01 Identity" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Number and name" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Number and name" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="These values drive lookup, membership review, and printed kit documents."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="155" MaxWidth="225" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="02 Category" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Directory grouping" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Directory grouping" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Use a consistent category so operators can find the kit quickly."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="6,0,0,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="155" MaxWidth="225" Margin="0,0,8,8">
                 <StackPanel>
                     <TextBlock Text="03 Release" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Active state" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Active state" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Only active kits should appear in routine operations and pick sheets."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-        </UniformGrid>
+        </WrapPanel>
 
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="2" MinWidth="0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1.28*"/>
-                <ColumnDefinition Width="12"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="1.28*" MinWidth="0"/>
+                <ColumnDefinition Width="8"/>
+                <ColumnDefinition Width="*" MinWidth="0"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
-                <Grid>
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                <Grid MinWidth="0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
                         <StackPanel>
-                            <TextBlock Text="Kit Identity" Style="{StaticResource SectionHeader}" Margin="0"/>
+                            <TextBlock Text="Kit Identity" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
                             <TextBlock Text="Keep the core directory fields aligned for quick review." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
-                    <Grid Grid.Row="1" Margin="14">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="126"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                        <Grid Margin="12" MinWidth="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="110"/>
+                                <ColumnDefinition Width="*" MinWidth="0"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Kit Number" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,10" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Kit.KitNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10"/>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Kit Number" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,10" VerticalAlignment="Center"/>
+                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Kit.KitNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10"/>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,10" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Kit.Name, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,10" VerticalAlignment="Center"/>
+                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Kit.Name, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10"/>
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Category" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,10" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Kit.Category, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Category" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,10" VerticalAlignment="Center"/>
+                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Kit.Category, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10"/>
 
-                        <Border Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource DesktopSectionActionStrip}" Padding="12" VerticalAlignment="Top">
-                            <StackPanel>
-                                <TextBlock Text="Operations Handoff" Style="{StaticResource SectionHeader}"/>
-                                <TextBlock Text="A complete identity makes the kit easier to select, print, and audit from the kit operations workbench."
-                                           Style="{StaticResource CaptionTextBlock}"
-                                           TextWrapping="Wrap"
-                                           Margin="0,2,0,0"/>
-                            </StackPanel>
-                        </Border>
-                    </Grid>
+                            <Border Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource DesktopSectionActionStrip}" Padding="10" VerticalAlignment="Top">
+                                <StackPanel>
+                                    <TextBlock Text="Operations Handoff" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                                    <TextBlock Text="A complete identity makes the kit easier to select, print, and audit from the kit operations workbench."
+                                               Style="{StaticResource CaptionTextBlock}"
+                                               TextWrapping="Wrap"
+                                               Margin="0,2,0,0"/>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+                    </ScrollViewer>
                 </Grid>
             </Border>
 
-            <Grid Grid.Column="2">
+            <Grid Grid.Column="2" MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <Border Grid.Row="0" Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
+                <Border Grid.Row="0" Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,8" MinWidth="0">
                     <DockPanel LastChildFill="True">
                         <CheckBox DockPanel.Dock="Right"
                                   Content="Active"
                                   IsChecked="{Binding Kit.IsActive}"
                                   FontWeight="SemiBold"
                                   VerticalAlignment="Center"
-                                  Margin="12,0,0,0"/>
-                        <StackPanel>
-                            <TextBlock Text="Release State" Style="{StaticResource SectionHeader}"/>
+                                  Margin="10,0,0,0"/>
+                        <StackPanel MinWidth="0">
+                            <TextBlock Text="Release State" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                             <TextBlock Text="Active kits remain available to the operations workbench and printed pick sheets."
                                        Style="{StaticResource CaptionTextBlock}"
                                        TextWrapping="Wrap"
@@ -142,14 +148,14 @@
                     </DockPanel>
                 </Border>
 
-                <Border Grid.Row="1" Style="{StaticResource AdminHandoffCard}">
-                    <Grid>
+                <Border Grid.Row="1" Style="{StaticResource AdminHandoffCard}" MinWidth="0">
+                    <Grid MinWidth="0">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
-                        <TextBlock Grid.Row="0" Text="Kit Description" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Row="0" Text="Kit Description" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                         <TextBlock Grid.Row="1" Text="Summarize included use cases, shelf notes, inspection expectations, or pickup constraints for the selected kit."
                                    Style="{StaticResource CaptionTextBlock}"
                                    TextWrapping="Wrap"
@@ -158,23 +164,28 @@
                                  Text="{Binding Kit.Description, UpdateSourceTrigger=PropertyChanged}"
                                  AcceptsReturn="True"
                                  TextWrapping="Wrap"
-                                 MinHeight="190"
-                                 VerticalScrollBarVisibility="Auto"/>
+                                 MinHeight="150"
+                                 VerticalScrollBarVisibility="Auto"
+                                 HorizontalScrollBarVisibility="Disabled"/>
                     </Grid>
                 </Border>
             </Grid>
         </Grid>
 
-        <controls:SaveCancelBar Grid.Row="3" Margin="0,10,0,0"/>
+        <controls:SaveCancelBar Grid.Row="3" Margin="0,8,0,0"/>
 
         <Border Grid.Row="4" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
-            <DockPanel LastChildFill="True">
-                <TextBlock DockPanel.Dock="Left" Text="Kit setup ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <TextBlock Text="Save updates the kit directory and printed kit sheets; cancel returns without applying edits."
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="Kit setup ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Grid.Column="1" Text="Save updates the kit directory and printed kit sheets; cancel returns without applying edits."
                            Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
                            VerticalAlignment="Center"/>
-            </DockPanel>
+            </Grid>
         </Border>
     </Grid>
 </Window>


### PR DESCRIPTION
## What changed

- Reduced the Item edit dialog default/minimum size for safer 1366 x 768 and higher Windows scaling.
- Reduced the Customer edit dialog default/minimum size with the same scaled-desktop target.
- Reduced the Kit edit dialog default/minimum size with the same scaled-desktop target.
- Reworked Item, Customer, and Kit headers into shrinkable columns with bounded record-state cards so long names do not widen dialogs.
- Replaced fixed Item four-card and Customer/Kit three-card `UniformGrid` summary strips with wrapping bounded summary cards.
- Added bounded/trimming summary title text so long labels stay inside cards.
- Made each edit form body explicitly shrinkable with `MinWidth="0"` pane/grid contracts.
- Lowered main split pressure in the dialogs with star-sized columns and narrower gutters.
- Disabled horizontal overflow in edit-form scroll regions while preserving vertical scrolling.
- Reduced fixed form label columns in Item, Customer, and Kit editors while preserving aligned data entry.
- Reduced item image and note-region height pressure so save/cancel remains reachable at scaled desktop sizes.
- Added horizontal-overflow guards to long note/address/description text boxes while preserving vertical scrolling.
- Reworked Customer and Kit footers into shrinkable status grids with wrapping status text.
- Preserved existing Item, Customer, and Kit edit bindings plus the shared save/cancel workflow.
- Added `RecordEditWindowResponsiveContractTests` plus a progress note for the completed workflow slice.

## Why this was highest value

Recent merged work covered major workbenches, while several newer draft PRs already cover the app shell and operational/reservation/item-details/history dialogs. Current source readback showed the remaining core record-edit dialogs still had large fixed startup sizes, fixed summary strips, fixed form label columns, and horizontal pressure in headers, form splits, notes, and status areas. Item, Customer, and Kit editing are high-frequency data-entry workflows, so improving them directly supports loading feel, UI responsiveness, and professional data display without overlapping the open draft PRs.

## Why this is real progress

This covers more than ten workflow-level improvements across three related record-edit dialogs: scaled startup bounds, minimum sizing, shrinkable headers, bounded state cards, wrapping summary cards, bounded summary text, shrinkable body shells, lower split pressure, narrower gutters, scroll fallback, horizontal-overflow prevention, reduced label columns, lower note/image pressure, footer wrapping, preserved bindings, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 focused commits, and limited to:
  - `InventoryManagementApp/Views/Windows/ItemEditWindow.xaml`
  - `InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml`
  - `InventoryManagementApp/Views/Windows/KitEditWindow.xaml`
  - `InventoryManagementApp.Tests/RecordEditWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-record-edit-dialog-responsive.md`
- Connector source readback confirmed smaller safe dialog bounds, shrinkable headers, bounded record-state cards, wrapping bounded summary cards, shrinkable form body grids, lower split pressure, disabled horizontal form overflow, reduced form columns, bounded note/address/description areas, preserved save/cancel bindings, and source-contract coverage.
- Connector status readback found no attached commit statuses on branch head `cbfabb6b78807ffcd84b42c64a18becd5e9385fe`.
- Connector workflow readback found no workflow runs attached to branch head `cbfabb6b78807ffcd84b42c64a18becd5e9385fe`.

## Could not be checked

- Direct local checkout/clone is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local banned-word checks, dialog layout checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
- Because the requested full Windows validation could not run, this PR is left as a draft and was not merged.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Item, Customer, and Kit edit dialogs on Windows at 1366 x 768 and higher DPI scales, including long item/customer/kit names, long notes/address/description text, image browse/remove actions, active/incomplete toggles, save, cancel, and footer/status wrapping.