### PR TITLE
[codex] Improve import/output dialog responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ImportOutputDialogResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportOutputDialogResponsiveContractTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ImportOutputDialogResponsiveContractTests
+    {
+        [Fact]
+        public void PrintLabelWindow_UsesResponsiveQueueReviewLayout()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintLabelWindow.xaml");
+            var codeBehind = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintLabelWindow.xaml.cs");
+
+            Assert.Contains("Width=\"820\" Height=\"540\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"700\" MinHeight=\"480\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("this.UseResponsiveDefaultSize(820, 540);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel>", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Width=\"1.2*\" MinWidth=\"140\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("PreviewCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CloseCommand", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel Orientation=\"Horizontal\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportMappingWindow_UsesResponsiveVirtualizedMappingTable()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ImportMappingWindow.xaml");
+            var codeBehind = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ImportMappingWindow.xaml.cs");
+
+            Assert.Contains("Width=\"980\" Height=\"700\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"760\" MinHeight=\"560\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("this.UseResponsiveDefaultSize(980, 700);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Row=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"180\" MaxWidth=\"280\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxDropDownHeight=\"320\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("DataContext.ColumnHeaders", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectedColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged", xaml, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OkCommand", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Row=\"1\" Columns=\"3\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImageImportMappingWindow_UsesResponsiveIdentifierSetupLayout()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ImageImportMappingWindow.xaml");
+            var codeBehind = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ImageImportMappingWindow.xaml.cs");
+
+            Assert.Contains("Width=\"720\" Height=\"620\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"600\" MinHeight=\"500\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("this.UseResponsiveDefaultSize(720, 620);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Row=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"170\" MaxWidth=\"250\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.25*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"8\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("UseItemNumber", xaml, StringComparison.Ordinal);
+            Assert.Contains("UsePartNumber", xaml, StringComparison.Ordinal);
+            Assert.Contains("UseName", xaml, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OkCommand", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Row=\"1\" Columns=\"3\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-import-output-dialog-responsive-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-import-output-dialog-responsive-performance.md
@@ -1,0 +1,39 @@
+# Import And Output Dialog Responsive Performance
+
+Date: 2026-07-03
+
+## Summary
+
+Improved the auxiliary label output, CSV import mapping, and image matching dialogs so data-review workflows stay readable and responsive on 1366 x 768 desktops and higher Windows scaling.
+
+## Completed Work
+
+- Reduced the Label Output dialog default and minimum dimensions.
+- Added responsive runtime default sizing for Label Output so startup matches the XAML budget.
+- Reworked the label header into shrinkable columns with a bounded queue status card.
+- Replaced the fixed label-template toolbar grid with wrapping template, QR, and preview guidance controls.
+- Added explicit label queue grid row/column virtualization, content scrolling, automatic scrollbars, full-row selection, and lower column pressure.
+- Replaced the fixed horizontal label action strip with wrapping Preview, Print, and Close actions.
+- Reduced the CSV Import Mapping dialog default and minimum dimensions.
+- Added responsive runtime default sizing for CSV Import Mapping.
+- Replaced the fixed three-column mapping summary strip with wrapping bounded summary cards.
+- Reworked mapping table header and import handoff guidance into shrinkable/wrapping regions.
+- Added explicit mapping grid row/column virtualization, content scrolling, automatic scrollbars, full-row selection, lower column pressure, and bounded ComboBox dropdown behavior.
+- Reworked the mapping footer into wrapping status text.
+- Reduced the Image Import Mapping dialog default and minimum dimensions.
+- Replaced the fixed three-column image matching summary strip with wrapping bounded summary cards.
+- Lowered image matching split pressure with shrinkable columns and a narrower gutter.
+- Reworked the image matching header/table/status regions so long guidance wraps without widening the dialog.
+- Preserved existing label Preview/Print/Close commands, CSV mapping OK/Cancel commands, selected-column binding, image matching OK/Cancel commands, and identifier checkbox bindings.
+- Added source-contract coverage for the responsive layout and preserved command/binding contracts.
+
+## Validation
+
+- Local XML parsing confirmed the revised `PrintLabelWindow.xaml`, `ImportMappingWindow.xaml`, and `ImageImportMappingWindow.xaml` files are well-formed.
+- Local source scans confirmed the expected responsive sizing, wrapping summaries/actions, grid virtualization/scrollbar contracts, bounded mapping ComboBox dropdown, preserved commands, and code-behind responsive sizing markers.
+- Full local validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or the WPF runtime.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test label output, CSV import mapping, and image matching at 1366 x 768 and common Windows scaling levels, including long item labels, long CSV headers, long selected mappings, ComboBox dropdowns, Preview, Print, Close, OK, and Cancel.

--- a/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
@@ -5,8 +5,8 @@
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Import {0} Pictures'}"
-        Width="780" Height="680"
-        MinWidth="700" MinHeight="560"
+        Width="720" Height="620"
+        MinWidth="600" MinHeight="500"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="14">
@@ -19,75 +19,83 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
-            <DockPanel LastChildFill="True">
-                <Border DockPanel.Dock="Right" Style="{StaticResource DesktopNoteCard}" Padding="12,7" Margin="16,0,0,0" VerticalAlignment="Center">
-                    <StackPanel>
-                        <TextBlock Text="Photo Import" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="Filename matching" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-                <StackPanel>
-                    <TextBlock Text="Picture Matching Setup" Style="{StaticResource PageTitleTextBlock}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel MinWidth="0">
+                    <TextBlock Text="Picture Matching Setup" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Choose which item fields can match incoming image filenames during photo import so pictures attach to the right inventory records."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,2,0,0"/>
                 </StackPanel>
-            </DockPanel>
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,7" Margin="12,0,0,0" VerticalAlignment="Center" MaxWidth="170">
+                    <StackPanel>
+                        <TextBlock Text="Photo Import" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock Text="Filename matching" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
-        <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,8">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="170" MaxWidth="250">
                 <StackPanel>
                     <TextBlock Text="01 Identifier" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Item number" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Item number" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Best when filenames include the app's primary item number."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="170" MaxWidth="250">
                 <StackPanel>
                     <TextBlock Text="02 Supplier Code" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Part number" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Part number" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Useful when vendor or stockroom photo names use part numbers."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="6,0,0,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="170" MaxWidth="250">
                 <StackPanel>
                     <TextBlock Text="03 Human Label" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Name" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Name" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Helpful for small batches where names are reliable and distinct."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-        </UniformGrid>
+        </WrapPanel>
 
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinHeight="280">
-            <Grid>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinHeight="240" MinWidth="0">
+            <Grid MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
-                    <DockPanel LastChildFill="True">
-                        <TextBlock DockPanel.Dock="Left" Text="Match Images By" Style="{StaticResource SectionHeader}" Margin="0"/>
-                        <TextBlock Text="Enable the identifiers expected in image file names." Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                    </DockPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Match Images By" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
+                        <TextBlock Grid.Column="1" Text="Enable expected filename identifiers." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" MaxWidth="260" Margin="12,0,0,0"/>
+                    </Grid>
                 </Border>
                 <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                    <Grid Margin="14" MinHeight="190">
+                    <Grid Margin="12" MinHeight="170" MinWidth="0">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1.35*"/>
-                            <ColumnDefinition Width="12"/>
-                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="1.25*" MinWidth="0"/>
+                            <ColumnDefinition Width="8"/>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
                         </Grid.ColumnDefinitions>
-                        <Border Grid.Column="0" Style="{StaticResource DesktopInsetCard}" Padding="14,12">
+                        <Border Grid.Column="0" Style="{StaticResource DesktopInsetCard}" Padding="12,10" MinWidth="0">
                             <StackPanel>
-                                <TextBlock Text="Identifier Rules" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Text="Identifier Rules" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                 <TextBlock Text="More than one matching rule can be selected. Start with the most unique identifier and add fallbacks only when filenames are consistent."
                                            Style="{StaticResource CaptionTextBlock}"
                                            TextWrapping="Wrap"
@@ -105,9 +113,9 @@
                                           FontWeight="SemiBold"/>
                             </StackPanel>
                         </Border>
-                        <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}" Margin="0">
+                        <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}" Margin="0" MinWidth="0">
                             <StackPanel>
-                                <TextBlock Text="Import Confidence" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Text="Import Confidence" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                 <TextBlock Text="Pick the most reliable filename identifiers first, then review mapped photos in the data operations workflow before trusting the batch."
                                            Style="{StaticResource CaptionTextBlock}"
                                            TextWrapping="Wrap"
@@ -128,13 +136,15 @@
                                   RightCommand="{Binding OkCommand}"/>
 
         <Border Grid.Row="4" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
-            <DockPanel LastChildFill="True">
-                <TextBlock DockPanel.Dock="Left" Text="Image matching setup ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
+            <WrapPanel>
+                <TextBlock Text="Image matching setup ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,4"/>
                 <TextBlock Text="Image matching rules are applied after OK is selected; cancel returns without changing the import setup."
                            Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
+                           MaxWidth="560"
+                           Margin="0,0,0,4"
                            VerticalAlignment="Center"/>
-            </DockPanel>
+            </WrapPanel>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml.cs
@@ -9,7 +9,7 @@ namespace InventoryManagementApp.Views.Windows
         public ImageImportMappingWindow()
         {
             InitializeComponent();
-            this.UseResponsiveDefaultSize(780, 680);
+            this.UseResponsiveDefaultSize(720, 620);
             DataContext = new ImageImportMappingViewModel(
                 () => { DialogResult = true; Close(); },
                 () => { DialogResult = false; Close(); });

--- a/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml
@@ -4,8 +4,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Import Mapping"
-        Width="1140" Height="760"
-        MinWidth="980" MinHeight="660"
+        Width="980" Height="700"
+        MinWidth="760" MinHeight="560"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="14">
@@ -18,74 +18,84 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
-            <DockPanel LastChildFill="True">
-                <Border DockPanel.Dock="Right" Style="{StaticResource DesktopNoteCard}" Padding="12,7" Margin="16,0,0,0" VerticalAlignment="Center">
-                    <StackPanel>
-                        <TextBlock Text="Mapping Mode" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="CSV column review" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-                <StackPanel>
-                    <TextBlock Text="Import Mapping Workbench" Style="{StaticResource PageTitleTextBlock}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel MinWidth="0">
+                    <TextBlock Text="Import Mapping Workbench" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Match each application field to the incoming CSV column before the import continues. Required fields should be paired first, then optional detail fields can be reviewed."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,2,0,0"/>
                 </StackPanel>
-            </DockPanel>
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,7" Margin="12,0,0,0" VerticalAlignment="Center" MaxWidth="190">
+                    <StackPanel>
+                        <TextBlock Text="Mapping Mode" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock Text="CSV column review" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
-        <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,8">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="180" MaxWidth="280">
                 <StackPanel>
                     <TextBlock Text="01 Required Fields" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Review destinations" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Review destinations" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Start with identifiers, names, and any fields needed for the import to land cleanly."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="180" MaxWidth="280">
                 <StackPanel>
                     <TextBlock Text="02 CSV Columns" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Choose each source" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Choose each source" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Use the drop-down in each row to pair incoming columns with app fields."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="6,0,0,0">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="180" MaxWidth="280">
                 <StackPanel>
                     <TextBlock Text="03 Confirm" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Apply mapping" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Apply mapping" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="OK accepts the selected mapping; Cancel returns to data operations without applying changes."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-        </UniformGrid>
+        </WrapPanel>
 
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
-            <Grid>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+            <Grid MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
-                    <DockPanel LastChildFill="True">
-                        <TextBlock DockPanel.Dock="Left" Text="Field Mapping Table" Style="{StaticResource SectionHeader}" Margin="0"/>
-                        <TextBlock Text="Destination field to CSV column" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                    </DockPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Field Mapping Table" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
+                        <TextBlock Grid.Column="1" Text="Destination field to CSV column" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" MaxWidth="260" Margin="12,0,0,0"/>
+                    </Grid>
                 </Border>
                 <Border Grid.Row="1" Style="{StaticResource DesktopSectionActionStrip}" Padding="10">
-                    <DockPanel LastChildFill="True">
-                        <TextBlock DockPanel.Dock="Left" Text="Import handoff" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                    <WrapPanel>
+                        <TextBlock Text="Import handoff" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,10,6"/>
                         <TextBlock Text="Edit cells in the CSV Column field, then review the completed table before pressing OK. Blank mappings remain intentionally unmapped."
                                    Style="{StaticResource CaptionTextBlock}"
                                    TextWrapping="Wrap"
+                                   MaxWidth="620"
+                                   Margin="0,0,0,6"
                                    VerticalAlignment="Center"/>
-                    </DockPanel>
+                    </WrapPanel>
                 </Border>
                 <DataGrid Grid.Row="2"
                           ItemsSource="{Binding Mappings}"
@@ -95,13 +105,20 @@
                           CanUserDeleteRows="False"
                           IsReadOnly="False"
                           Style="{StaticResource VirtualizedDataGridStyle}"
-                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
+                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}"
+                          EnableRowVirtualization="True"
+                          EnableColumnVirtualization="True"
+                          SelectionMode="Single"
+                          SelectionUnit="FullRow"
+                          ScrollViewer.CanContentScroll="True"
+                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                          ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="Application Field" Binding="{Binding PropertyName}" IsReadOnly="True" Width="2*"/>
-                        <DataGridTemplateColumn Header="CSV Column" Width="3*">
+                        <DataGridTextColumn Header="Application Field" Binding="{Binding PropertyName}" IsReadOnly="True" Width="2*" MinWidth="190"/>
+                        <DataGridTemplateColumn Header="CSV Column" Width="3*" MinWidth="220">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
-                                    <TextBlock Text="{Binding SelectedColumn}" VerticalAlignment="Center" Margin="4,0"/>
+                                    <TextBlock Text="{Binding SelectedColumn}" VerticalAlignment="Center" Margin="4,0" TextTrimming="CharacterEllipsis"/>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                             <DataGridTemplateColumn.CellEditingTemplate>
@@ -109,6 +126,10 @@
                                     <ComboBox ItemsSource="{Binding DataContext.ColumnHeaders, RelativeSource={RelativeSource AncestorType=Window}}"
                                               SelectedItem="{Binding SelectedColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                               Margin="0"
+                                              MaxDropDownHeight="320"
+                                              ScrollViewer.CanContentScroll="True"
+                                              ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                               ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellEditingTemplate>
@@ -126,13 +147,15 @@
                                   RightCommand="{Binding OkCommand}"/>
 
         <Border Grid.Row="4" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
-            <DockPanel LastChildFill="True">
-                <TextBlock DockPanel.Dock="Left" Text="Import mapping ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
+            <WrapPanel>
+                <TextBlock Text="Import mapping ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,4"/>
                 <TextBlock Text="Mapping choices are applied only after OK is selected; cancel keeps the source data untouched."
                            Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
+                           MaxWidth="680"
+                           Margin="0,0,0,4"
                            VerticalAlignment="Center"/>
-            </DockPanel>
+            </WrapPanel>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml.cs
@@ -13,6 +13,7 @@ namespace InventoryManagementApp.Views.Windows
         public ImportMappingWindow(IEnumerable<string> headers, IEnumerable<string> propertyNames, IEnumerable<string>? requiredPropertyNames = null)
         {
             InitializeComponent();
+            this.UseResponsiveDefaultSize(980, 700);
             DataContext = new ImportMappingViewModel(
                 headers,
                 propertyNames,

--- a/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
@@ -8,11 +8,11 @@
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         mc:Ignorable="d"
         Title="Print Labels"
-        Width="860" Height="560"
-        MinWidth="780" MinHeight="500"
+        Width="820" Height="540"
+        MinWidth="700" MinHeight="480"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="16">
+    <Grid Margin="14">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -21,68 +21,64 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
+        <Border Style="{StaticResource ToolbarCard}" Padding="14,12">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel>
-                    <TextBlock Text="Label Output Workbench" Style="{StaticResource HeadingTextBlock}"/>
+                <StackPanel MinWidth="0">
+                    <TextBlock Text="Label Output Workbench" Style="{StaticResource HeadingTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Select the label format, review the queued items, then preview or print."
                                Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="Wrap"
                                Margin="0,4,0,0"/>
                 </StackPanel>
-                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="12,8" VerticalAlignment="Center">
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="10,7" Margin="12,0,0,0" VerticalAlignment="Center" MaxWidth="170">
                     <StackPanel>
                         <TextBlock Text="Queue" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="Ready to review" Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0"/>
+                        <TextBlock Text="Ready to review" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                     </StackPanel>
                 </Border>
             </Grid>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource ToolbarCard}" Margin="0,12,0,10" Padding="12">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="260"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="Label Template" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                <ComboBox Grid.Column="1"
-                          ItemsSource="{Binding Templates}"
+        <Border Grid.Row="1" Style="{StaticResource ToolbarCard}" Margin="0,10,0,8" Padding="10">
+            <WrapPanel>
+                <TextBlock Text="Label Template" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                <ComboBox ItemsSource="{Binding Templates}"
                           SelectedItem="{Binding SelectedTemplate}"
-                          Margin="10,0,18,0"
+                          MinWidth="180"
+                          MaxWidth="300"
+                          Margin="0,0,14,6"
                           ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
-                <CheckBox Grid.Column="2"
-                          Content="Include QR"
+                <CheckBox Content="Include QR"
                           IsChecked="{Binding IncludeQr}"
-                          VerticalAlignment="Center"/>
-                <TextBlock Grid.Column="3"
-                           Text="Preview first when labels include item photos, QR codes, or updated location text."
+                          VerticalAlignment="Center"
+                          Margin="0,0,14,6"/>
+                <TextBlock Text="Preview first when labels include item photos, QR codes, or updated location text."
                            Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
-                           Margin="18,0,0,0"
+                           MaxWidth="420"
+                           Margin="0,1,0,6"
                            VerticalAlignment="Center"/>
-            </Grid>
+            </WrapPanel>
         </Border>
 
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
-            <Grid>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+            <Grid MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <Border Style="{StaticResource ToolbarCard}" Padding="12,10" Margin="0">
+                <Border Style="{StaticResource ToolbarCard}" Padding="10,8" Margin="0">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Text="Queued Label Items" Style="{StaticResource SectionHeader}"/>
-                        <TextBlock Grid.Column="1" Text="Item number, name, and location" Style="{StaticResource CaptionTextBlock}"/>
+                        <TextBlock Text="Queued Label Items" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                        <TextBlock Grid.Column="1" Text="Item number, name, and location" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" MaxWidth="260" Margin="12,0,0,0"/>
                     </Grid>
                 </Border>
                 <DataGrid Grid.Row="1"
@@ -90,26 +86,33 @@
                           AutoGenerateColumns="False"
                           IsReadOnly="True"
                           Style="{StaticResource VirtualizedDataGridStyle}"
-                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
+                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}"
+                          EnableRowVirtualization="True"
+                          EnableColumnVirtualization="True"
+                          SelectionMode="Single"
+                          SelectionUnit="FullRow"
+                          ScrollViewer.CanContentScroll="True"
+                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                          ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="140"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*"/>
-                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="220"/>
+                        <DataGridTextColumn Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="120" MinWidth="96"/>
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*" MinWidth="180"/>
+                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="1.2*" MinWidth="140"/>
                     </DataGrid.Columns>
                 </DataGrid>
             </Grid>
         </Border>
 
-        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="12">
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button Style="{StaticResource GhostButton}" Content="Preview" Command="{Binding PreviewCommand}" MinWidth="112"/>
-                <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintCommand}" MinWidth="112" Margin="8,0,0,0"/>
-                <Button Style="{StaticResource GhostButton}" Content="Close" Command="{Binding CloseCommand}" MinWidth="112" Margin="8,0,0,0"/>
-            </StackPanel>
+        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,10,0,0" Padding="10">
+            <WrapPanel HorizontalAlignment="Right">
+                <Button Style="{StaticResource GhostButton}" Content="Preview" Command="{Binding PreviewCommand}" MinWidth="104" Margin="0,0,8,6"/>
+                <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintCommand}" MinWidth="104" Margin="0,0,8,6"/>
+                <Button Style="{StaticResource GhostButton}" Content="Close" Command="{Binding CloseCommand}" MinWidth="104" Margin="0,0,0,6"/>
+            </WrapPanel>
         </Border>
 
-        <Border Grid.Row="4" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="10,7">
-            <TextBlock Text="Label output ready; preview verifies the final sheet before printing." Style="{StaticResource CaptionTextBlock}"/>
+        <Border Grid.Row="4" Style="{StaticResource ToolbarCard}" Margin="0,8,0,0" Padding="10,7">
+            <TextBlock Text="Label output ready; preview verifies the final sheet before printing." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml.cs
@@ -27,6 +27,7 @@ namespace InventoryManagementApp.Views.Windows
         public PrintLabelWindow(IDialogService dialogService)
         {
             InitializeComponent();
+            this.UseResponsiveDefaultSize(820, 540);
             _dialogService = dialogService;
             DataContext = new PrintLabelViewModel(_dialogService, () => Close());
             this.DisposeDataContextOnUnload();


### PR DESCRIPTION
## What changed

- Reduced the Label Output dialog default and minimum dimensions for safer 1366 x 768 and higher Windows scaling.
- Added responsive runtime default sizing for Label Output so startup matches the XAML budget.
- Reworked the Label Output header into shrinkable columns with a bounded queue status card.
- Replaced the fixed label-template toolbar grid with wrapping template, QR, and preview guidance controls.
- Added explicit label queue grid row/column virtualization, content scrolling, automatic scrollbars, full-row selection, and lower column pressure.
- Replaced the fixed horizontal label action strip with wrapping Preview, Print, and Close actions.
- Reduced the CSV Import Mapping dialog default and minimum dimensions.
- Added responsive runtime default sizing for CSV Import Mapping.
- Replaced the fixed three-column mapping summary strip with wrapping bounded summary cards.
- Reworked mapping table header and import handoff guidance into shrinkable/wrapping regions.
- Added explicit mapping grid row/column virtualization, content scrolling, automatic scrollbars, full-row selection, lower column pressure, and bounded ComboBox dropdown behavior.
- Reworked the mapping footer into wrapping status text.
- Reduced the Image Import Mapping dialog default and minimum dimensions.
- Added responsive runtime default sizing for Image Import Mapping.
- Replaced the fixed three-column image matching summary strip with wrapping bounded summary cards.
- Lowered image matching split pressure with shrinkable columns and a narrower gutter.
- Reworked image matching header/table/status regions so long guidance wraps without widening the dialog.
- Preserved existing label Preview/Print/Close commands, CSV mapping OK/Cancel commands, selected-column binding, image matching OK/Cancel commands, and identifier checkbox bindings.
- Added source-contract coverage plus a progress note for the completed workflow slice.

## Why this was highest value

Recent merged work covered the main workbenches through Import / Export, while current open draft PRs cover several page and record-dialog responsive passes. Source readback showed the auxiliary import/output dialogs still had oversized fixed startup bounds, fixed summary strips, grid/action areas without explicit virtualization or wrapping contracts, and unbounded status/header pressure. These dialogs sit inside import, image mapping, and label/print workflows, so tightening them improves data display responsiveness without overlapping the current open drafts.

## Why this is real progress

This covers more than ten workflow-level improvements across three related dialogs: safer startup sizing, runtime responsive defaults, shrinkable headers, bounded status cards, wrapping toolbar controls, explicit queue/mapping grid virtualization, scrollbars, full-row selection, reduced column pressure, bounded mapping dropdowns, wrapping footers/actions, preserved commands/bindings, source-contract coverage, and progress notes.

## Validation

- Local XML parsing confirmed the revised `PrintLabelWindow.xaml`, `ImportMappingWindow.xaml`, and `ImageImportMappingWindow.xaml` files are well-formed.
- Local source scans confirmed the responsive sizing, wrapping summary/action regions, grid virtualization/scrollbar contracts, bounded mapping ComboBox dropdown, preserved commands/bindings, and code-behind responsive sizing markers.
- GitHub connector compare confirmed the branch is current with `master`, ahead by 8 focused commits, and limited to:
  - `InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml`
  - `InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml.cs`
  - `InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml`
  - `InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml.cs`
  - `InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml`
  - `InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml.cs`
  - `InventoryManagementApp.Tests/ImportOutputDialogResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-import-output-dialog-responsive-performance.md`
- Connector source readback confirmed the pushed responsive layout/test markers.
- Connector status readback found no attached commit statuses on branch head `38f647466ca08c808dec999b3b601698f5cefb63`.
- Connector workflow readback found no workflow runs attached to branch head `38f647466ca08c808dec999b3b601698f5cefb63`.

## Could not be checked

- Direct local checkout/clone remains blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, GitHub CLI, WPF runtime tooling, screenshots, local source-contract execution, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
- Because the requested full Windows validation could not run, this PR is left as a draft and was not merged.

## Known follow-up work

- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
- Smoke test Label Output, CSV Import Mapping, and Image Import Mapping on Windows at 1366 x 768 and higher DPI scales, including long item labels, long CSV headers, long selected mappings, ComboBox dropdowns, Preview, Print, Close, OK, and Cancel.