### PR TITLE
Improve rental reminder due-date loading and run accounting

### DIFF
--- a/InventoryManagementApp.Tests/RentalReminderWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalReminderWorkflowContractTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalReminderWorkflowContractTests
+    {
+        [Fact]
+        public void ReminderRunUsesDueDateQueryInsteadOfMaterializingAllActiveRentals()
+        {
+            var reminderSource = ReadRepoFile("InventoryManagementApp", "Services", "Notifications", "RentalReminderService.cs");
+            var rentalInterfaceSource = ReadRepoFile("InventoryManagementApp", "Interfaces", "IRentalService.cs");
+            var rentalServiceSource = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+            var reminderMethod = ExtractMethod(
+                reminderSource,
+                "public async Task CheckAndSendRemindersAsync()",
+                "private Task<string> GetEmailSignatureAsync()");
+            var dueDateQuery = ExtractMethod(
+                rentalServiceSource,
+                "public async Task<List<Rental>> GetActiveRentalsDueOnAsync(DateTime dueDate)",
+                "public async Task<List<Rental>> GetOverdueRentalsAsync()");
+
+            Assert.Contains("Task<List<Rental>> GetActiveRentalsDueOnAsync(DateTime dueDate);", rentalInterfaceSource, StringComparison.Ordinal);
+            Assert.Contains("var tomorrow = DateTime.Today.AddDays(1);", reminderMethod, StringComparison.Ordinal);
+            Assert.Contains("var rentalsDueTomorrowTask = _rentalService.GetActiveRentalsDueOnAsync(tomorrow);", reminderMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetActiveRentalsAsync()", reminderMethod, StringComparison.Ordinal);
+            Assert.DoesNotContain(".Where(r => r.DueDate.Date == tomorrow)", reminderMethod, StringComparison.Ordinal);
+
+            AssertContainsAll(
+                dueDateQuery,
+                "WHERE r.Status='Rented'",
+                "AND date(r.DueDate) = date(@DueDate)",
+                "ORDER BY r.DueDate ASC, r.RentalID ASC",
+                "LIMIT @RentalListLimit",
+                "new SqliteParameter(\"@DueDate\", dueDate.Date)",
+                "new SqliteParameter(\"@RentalListLimit\", MaxRentalListCount)");
+        }
+
+        [Fact]
+        public void ReminderRunPreventsOverlappingTimerAndManualExecutions()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Notifications", "RentalReminderService.cs");
+            var method = ExtractMethod(source, "public async Task CheckAndSendRemindersAsync()", "private Task<string> GetEmailSignatureAsync()");
+
+            Assert.Contains("private readonly SemaphoreSlim _checkLock = new(1, 1);", source, StringComparison.Ordinal);
+            Assert.Contains("if (!await _checkLock.WaitAsync(0).ConfigureAwait(false))", method, StringComparison.Ordinal);
+            Assert.Contains("Rental reminder check is already running. Skipping overlapping run.", method, StringComparison.Ordinal);
+            Assert.Contains("finally", method, StringComparison.Ordinal);
+            Assert.Contains("_checkLock.Release();", method, StringComparison.Ordinal);
+            Assert.Contains("_checkLock.Dispose();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReminderRunLoadsSettingsAndTemplatesConcurrentlyBeforeSending()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Notifications", "RentalReminderService.cs");
+            var method = ExtractMethod(source, "public async Task CheckAndSendRemindersAsync()", "private Task<string> GetEmailSignatureAsync()");
+
+            AssertContainsAll(
+                method,
+                "var rentalsDueTomorrowTask = _rentalService.GetActiveRentalsDueOnAsync(tomorrow);",
+                "var emailSignatureTask = GetEmailSignatureAsync();",
+                "var reminderSubjectTemplateTask = GetReminderSubjectTemplateAsync();",
+                "var reminderBodyTemplateTask = GetReminderBodyTemplateAsync();",
+                "var companyNameTask = GetCompanyNameAsync();",
+                "var logoPathTask = GetCompanyLogoPathAsync();",
+                "await Task.WhenAll(",
+                "rentalsDueTomorrowTask,",
+                "emailSignatureTask,",
+                "reminderSubjectTemplateTask,",
+                "reminderBodyTemplateTask,",
+                "companyNameTask,",
+                "logoPathTask).ConfigureAwait(false);");
+
+            Assert.True(
+                method.IndexOf("var rentalsDueTomorrowTask = _rentalService.GetActiveRentalsDueOnAsync(tomorrow);", StringComparison.Ordinal) <
+                method.IndexOf("await Task.WhenAll(", StringComparison.Ordinal),
+                "Expected reminder workflow to start rental/config reads before awaiting them.");
+            Assert.True(
+                method.IndexOf("await Task.WhenAll(", StringComparison.Ordinal) <
+                method.IndexOf("foreach (var rental in rentalsDueTomorrow)", StringComparison.Ordinal),
+                "Expected reminder workflow to finish shared reads before sending emails.");
+        }
+
+        [Fact]
+        public void ReminderRunReportsHonestSentSkippedAndFailedCounts()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Notifications", "RentalReminderService.cs");
+            var method = ExtractMethod(source, "public async Task CheckAndSendRemindersAsync()", "private Task<string> GetEmailSignatureAsync()");
+
+            AssertContainsAll(
+                method,
+                "var sentCount = 0;",
+                "var skippedCount = 0;",
+                "var failedCount = 0;",
+                "skippedCount++;",
+                "sentCount++;",
+                "failedCount++;",
+                "Completed rental reminder run. Due: {DueCount}, Sent: {SentCount}, Skipped: {SkippedCount}, Failed: {FailedCount}",
+                "rentalsDueTomorrow.Count,",
+                "sentCount,",
+                "skippedCount,",
+                "failedCount");
+
+            Assert.DoesNotContain("Completed sending {Count} rental reminders", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReminderStartReplacesExistingTimerBeforeSchedulingNextRun()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Notifications", "RentalReminderService.cs");
+            var startMethod = ExtractMethod(source, "public void Start()", "public void Stop()");
+
+            Assert.Contains("Stop();", startMethod, StringComparison.Ordinal);
+            Assert.True(
+                startMethod.IndexOf("Stop();", StringComparison.Ordinal) <
+                startMethod.IndexOf("_timer = new System.Threading.Timer(", StringComparison.Ordinal),
+                "Expected repeated Start calls to dispose the old timer before scheduling a replacement.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/Interfaces/IRentalService.cs
+++ b/InventoryManagementApp/Interfaces/IRentalService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
@@ -32,6 +32,7 @@ namespace InventoryManagementApp.Interfaces
             throw new NotSupportedException("This rental service does not support swapping rental items.");
         Task DeleteRentalAsync(int rentalID);
         Task<List<Rental>> GetActiveRentalsAsync();
+        Task<List<Rental>> GetActiveRentalsDueOnAsync(DateTime dueDate);
         Task<int> CountRentalsAsync();
         Task<int> CountActiveRentalsAsync();
         Task<List<Rental>> GetOverdueRentalsAsync();

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-rental-reminder-due-date-query.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-rental-reminder-due-date-query.md
@@ -1,0 +1,34 @@
+# Rental Reminder Due Date Query
+
+Date: 2026-07-03
+
+## Summary
+
+Improved the rental reminder workflow so the scheduled reminder job loads only active rentals due on the reminder date instead of materializing the full active-rental list and filtering in memory.
+
+## Completed Work
+
+- Added `IRentalService.GetActiveRentalsDueOnAsync(DateTime dueDate)` for reminder-specific active rental reads.
+- Implemented a bounded, deterministic due-date rental query in `RentalService` using the existing visible rental projection.
+- Kept the due-date reminder query under the shared active-rental list cap.
+- Filtered due rentals in SQLite with a bound `@DueDate` parameter instead of scanning the active rental list in memory.
+- Ordered reminder candidates by due date and rental ID for stable processing.
+- Routed `RentalReminderService.CheckAndSendRemindersAsync()` through the due-date query.
+- Added a non-blocking reminder run lock so timer/manual runs do not overlap and duplicate reminder batches.
+- Replaced sequential reminder configuration reads with concurrent rental/config/template/logo tasks before email sending begins.
+- Tracked sent, skipped, and failed reminder counts separately.
+- Updated completion logging so it reports due, sent, skipped, and failed counts instead of treating every due rental as sent.
+- Made repeated `Start()` calls dispose the existing timer before scheduling a replacement.
+- Disposed the reminder run lock with the service.
+- Added source-contract tests covering due-date query routing, SQL bounds/order, overlap prevention, concurrent shared reads, honest accounting, and timer replacement.
+
+## Validation
+
+- GitHub connector readback should confirm the branch changes are limited to the reminder workflow, rental query contract/implementation, source-contract tests, and this progress note.
+- Full local validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or the WPF runtime.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test server/startup reminder scheduling with configured SMTP settings.
+- Confirm a realistic rental dataset sends only tomorrow's due reminders and logs accurate sent/skipped/failed totals.

--- a/InventoryManagementApp/Services/Notifications/RentalReminderService.cs
+++ b/InventoryManagementApp/Services/Notifications/RentalReminderService.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
@@ -22,6 +20,7 @@ namespace InventoryManagementApp.Services.Notifications
         private readonly ISettingsService? _settingsService;
         private readonly ILogger<RentalReminderService> _logger;
         private readonly string _contactInfo;
+        private readonly SemaphoreSlim _checkLock = new(1, 1);
         private System.Threading.Timer? _timer;
         private bool _disposed;
 
@@ -51,6 +50,8 @@ namespace InventoryManagementApp.Services.Notifications
                 _logger.LogWarning("Email service not configured. Rental reminders will not be sent.");
                 return;
             }
+
+            Stop();
 
             var now = DateTime.Now;
             var scheduledTime = new DateTime(now.Year, now.Month, now.Day, 14, 30, 0);
@@ -92,23 +93,44 @@ namespace InventoryManagementApp.Services.Notifications
                 return;
             }
 
+            if (!await _checkLock.WaitAsync(0).ConfigureAwait(false))
+            {
+                _logger.LogWarning("Rental reminder check is already running. Skipping overlapping run.");
+                return;
+            }
+
             try
             {
                 _logger.LogInformation("Checking for rentals due tomorrow...");
 
-                var activeRentals = await _rentalService.GetActiveRentalsAsync().ConfigureAwait(false);
                 var tomorrow = DateTime.Today.AddDays(1);
-                var emailSignature = _rentalConfigService == null ? RentalConfigurationService.DefaultEmailSignature : await _rentalConfigService.GetEmailSignatureAsync().ConfigureAwait(false);
-                var reminderSubjectTemplate = _rentalConfigService == null ? RentalConfigurationService.DefaultReminderSubjectTemplate : await _rentalConfigService.GetReminderSubjectTemplateAsync().ConfigureAwait(false);
-                var reminderBodyTemplate = _rentalConfigService == null ? RentalConfigurationService.DefaultReminderBodyTemplate : await _rentalConfigService.GetReminderBodyTemplateAsync().ConfigureAwait(false);
-                var companyName = _rentalConfigService == null ? "Equipment Rentals" : await _rentalConfigService.GetCompanyNameAsync().ConfigureAwait(false);
-                var logoPath = _settingsService == null ? null : await _settingsService.GetSettingAsync("CompanyLogoPath").ConfigureAwait(false);
-                
-                var rentalsDueTomorrow = activeRentals
-                    .Where(r => r.DueDate.Date == tomorrow)
-                    .ToList();
+                var rentalsDueTomorrowTask = _rentalService.GetActiveRentalsDueOnAsync(tomorrow);
+                var emailSignatureTask = GetEmailSignatureAsync();
+                var reminderSubjectTemplateTask = GetReminderSubjectTemplateAsync();
+                var reminderBodyTemplateTask = GetReminderBodyTemplateAsync();
+                var companyNameTask = GetCompanyNameAsync();
+                var logoPathTask = GetCompanyLogoPathAsync();
+
+                await Task.WhenAll(
+                    rentalsDueTomorrowTask,
+                    emailSignatureTask,
+                    reminderSubjectTemplateTask,
+                    reminderBodyTemplateTask,
+                    companyNameTask,
+                    logoPathTask).ConfigureAwait(false);
+
+                var rentalsDueTomorrow = await rentalsDueTomorrowTask.ConfigureAwait(false);
+                var emailSignature = await emailSignatureTask.ConfigureAwait(false);
+                var reminderSubjectTemplate = await reminderSubjectTemplateTask.ConfigureAwait(false);
+                var reminderBodyTemplate = await reminderBodyTemplateTask.ConfigureAwait(false);
+                var companyName = await companyNameTask.ConfigureAwait(false);
+                var logoPath = await logoPathTask.ConfigureAwait(false);
 
                 _logger.LogInformation("Found {Count} rentals due tomorrow", rentalsDueTomorrow.Count);
+
+                var sentCount = 0;
+                var skippedCount = 0;
+                var failedCount = 0;
 
                 foreach (var rental in rentalsDueTomorrow)
                 {
@@ -116,6 +138,7 @@ namespace InventoryManagementApp.Services.Notifications
                     {
                         if (string.IsNullOrWhiteSpace(rental.CustomerEmail))
                         {
+                            skippedCount++;
                             _logger.LogWarning("Rental {RentalID} has no customer email, skipping reminder",
                                 rental.RentalID);
                             continue;
@@ -134,28 +157,75 @@ namespace InventoryManagementApp.Services.Notifications
                             reminderSubjectTemplate,
                             reminderBodyTemplate).ConfigureAwait(false);
 
+                        sentCount++;
                         _logger.LogInformation("Sent reminder for rental {RentalID} to {Email}",
                             rental.RentalID, rental.CustomerEmail);
                     }
                     catch (Exception ex)
                     {
+                        failedCount++;
                         _logger.LogError(ex, "Failed to send reminder for rental {RentalID}",
                             rental.RentalID);
                     }
                 }
 
-                _logger.LogInformation("Completed sending {Count} rental reminders", rentalsDueTomorrow.Count);
+                _logger.LogInformation(
+                    "Completed rental reminder run. Due: {DueCount}, Sent: {SentCount}, Skipped: {SkippedCount}, Failed: {FailedCount}",
+                    rentalsDueTomorrow.Count,
+                    sentCount,
+                    skippedCount,
+                    failedCount);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error while checking and sending rental reminders");
             }
+            finally
+            {
+                _checkLock.Release();
+            }
+        }
+
+        private Task<string> GetEmailSignatureAsync()
+        {
+            return _rentalConfigService == null
+                ? Task.FromResult(RentalConfigurationService.DefaultEmailSignature)
+                : _rentalConfigService.GetEmailSignatureAsync();
+        }
+
+        private Task<string> GetReminderSubjectTemplateAsync()
+        {
+            return _rentalConfigService == null
+                ? Task.FromResult(RentalConfigurationService.DefaultReminderSubjectTemplate)
+                : _rentalConfigService.GetReminderSubjectTemplateAsync();
+        }
+
+        private Task<string> GetReminderBodyTemplateAsync()
+        {
+            return _rentalConfigService == null
+                ? Task.FromResult(RentalConfigurationService.DefaultReminderBodyTemplate)
+                : _rentalConfigService.GetReminderBodyTemplateAsync();
+        }
+
+        private Task<string> GetCompanyNameAsync()
+        {
+            return _rentalConfigService == null
+                ? Task.FromResult("Equipment Rentals")
+                : _rentalConfigService.GetCompanyNameAsync();
+        }
+
+        private Task<string?> GetCompanyLogoPathAsync()
+        {
+            return _settingsService == null
+                ? Task.FromResult<string?>(null)
+                : _settingsService.GetSettingAsync("CompanyLogoPath");
         }
 
         public void Dispose()
         {
             if (_disposed) return;
             Stop();
+            _checkLock.Dispose();
             _disposed = true;
             GC.SuppressFinalize(this);
         }

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -427,6 +427,23 @@ namespace InventoryManagementApp.Services.Rentals
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
+        public async Task<List<Rental>> GetActiveRentalsDueOnAsync(DateTime dueDate)
+        {
+            const string sql = BaseSelect + @"
+                WHERE r.Status='Rented'
+                  AND date(r.DueDate) = date(@DueDate)
+                ORDER BY r.DueDate ASC, r.RentalID ASC
+                LIMIT @RentalListLimit";
+            var p = new[]
+            {
+                new SqliteParameter("@DueDate", dueDate.Date),
+                new SqliteParameter("@RentalListLimit", MaxRentalListCount)
+            };
+            using var conn = _dbService.CreateConnection();
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
+            return list.Where(r => r != null).Select(r => r!).ToList();
+        }
+
         public async Task<List<Rental>> GetOverdueRentalsAsync()
         {
             const string sql = BaseSelect + @" WHERE r.Status = 'Rented' AND r.DueDate < @Today ORDER BY r.DueDate ASC LIMIT @RentalListLimit";


### PR DESCRIPTION
## What changed

- Added `IRentalService.GetActiveRentalsDueOnAsync(DateTime dueDate)` and implemented it in `RentalService` with the existing visible rental projection.
- Routed rental reminders through a bounded SQL due-date query instead of loading active rentals and filtering in memory.
- Added deterministic due-date reminder ordering by due date and rental ID.
- Protected reminder checks with a non-blocking run lock so timer/manual invocations do not overlap.
- Started rental/config/template/logo reads together before email sending begins.
- Added honest reminder run accounting for due, sent, skipped, and failed reminders.
- Made repeated reminder `Start()` calls replace an existing timer before scheduling a new one.
- Added source-contract coverage for the workflow, SQL bounds/order, overlap guard, concurrent reads, accounting, and timer replacement.
- Added a progress note for this completed slice.

## Why this was highest value

Current repo evidence emphasizes loading speed, UI responsiveness, and avoiding broad data materialization. The reminder job was still doing a broad active-rental read before in-memory due-date filtering, and scheduled/manual runs could overlap. Tightening that background workflow reduces database/read pressure and prevents duplicate reminder batches without inventing a new feature.

## Why this is real progress

This is a complete vertical workflow slice: service contract, SQL implementation, reminder orchestration, logging/accounting, lifecycle behavior, tests, and progress record all moved together.

## Validation

- Connector compare/readback confirmed the branch is current with `master`, ahead by 5 focused commits, and limited to reminder/rental workflow files, source-contract coverage, and one progress note.
- Connector source readback confirmed `RentalReminderService` now uses `GetActiveRentalsDueOnAsync(tomorrow)`, prevents overlapping runs with `SemaphoreSlim.WaitAsync(0)`, starts shared config/template/logo reads before `Task.WhenAll`, and reports due/sent/skipped/failed counts.
- Connector source readback confirmed `RentalService.GetActiveRentalsDueOnAsync(DateTime dueDate)` uses a bound `@DueDate`, the shared rental list cap, and deterministic ordering.
- Connector source readback confirmed `IRentalService` exposes the new query contract.
- Connector status/workflow readback found no attached statuses or workflow runs for branch head `524b74cc8069c64f20c9b30824d3773a893b143c` before PR creation.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- `dotnet restore/build/test/publish`
- WPF runtime/screenshot checks
- SMTP reminder smoke testing
- `gh` or local checkout checks

This scheduled Linux environment still cannot clone GitHub directly (`CONNECT tunnel failed, response 403`) and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

## Follow-up

- Run the full Windows validation runner.
- Smoke test configured SMTP reminder scheduling with realistic rentals due tomorrow, missing emails, and email send failures.
- Merge after validation is green and no blocking statuses are present.