### PR TITLE
Polish Import Export run-log print output

### DIFF
--- a/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
+++ b/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
@@ -35,6 +35,26 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ImportExportRunLogPrintUsesProfessionalFlexibleLayout()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
+
+            Assert.Contains("BuildSummarySection(title, summary, safeLogs.Count)", source, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Packet\", title)", source, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Result Count\", logCount.ToString())", source, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Session Summary\", ValueOrNotRecorded(summary))", source, StringComparison.Ordinal);
+            Assert.Contains("table.Columns.Add(new TableColumn { Width = new GridLength(0.14, GridUnitType.Star) });", source, StringComparison.Ordinal);
+            Assert.Contains("table.Columns.Add(new TableColumn { Width = new GridLength(0.86, GridUnitType.Star) });", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Entry\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Operation Result\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("Review skipped rows, failures, backup paths, and restore notices", source, StringComparison.Ordinal);
+            Assert.Contains("Review one selected data-operation result before copying, printing, or filing the handoff.", source, StringComparison.Ordinal);
+            Assert.Contains("Review the current session's import, export, image, backup, and restore results before staff handoff.", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new GridLength(680)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("table.Columns.Add(new TableColumn { Width = new GridLength(55) });", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void DashboardPrintActionsUseDialogPreviewService()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "DashboardViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-import-export-run-log-print-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-import-export-run-log-print-polish.md
@@ -1,0 +1,29 @@
+# Import / Export Run Log Print Polish
+
+Date: 2026-07-03
+
+## Summary
+
+Improved the Import / Export run-log print package so selected-result and whole-session previews produce clearer handoff documents without fixed-width table assumptions.
+
+## Completed Work
+
+- Kept selected-result printing ahead of whole-session log printing.
+- Added explicit print preview descriptions for selected-result and whole-session run-log previews.
+- Added a run-log summary section with packet name, result count, and session summary.
+- Replaced fixed 55px / 680px print table columns with proportional star columns so print preview can rebalance content for the configured page width.
+- Renamed print table headers from shorthand `#` / `Result` to `Entry` / `Operation Result`.
+- Trimmed printed log rows while preserving the original selected/run-log data in the view model.
+- Added an empty-document fallback message for defensive print document generation.
+- Added a review note reminding staff to inspect skipped rows, failures, backup paths, and restore notices before clearing the in-app run log.
+- Added source-contract coverage in `AdminDataPrintPreviewRouteTests` for the flexible table, summary section, preview descriptions, and no fixed 680px column regression.
+
+## Validation
+
+- GitHub connector readback and source-contract inspection are available in this scheduled environment.
+- Full local validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or the WPF runtime.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test Import / Export selected-result and whole-session print preview with short, long, skipped-row, failure, backup, and restore log entries.

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -87,10 +87,7 @@ namespace InventoryManagementApp.Views.Pages
                         new[] { selectedLog },
                         "Selected import/export operation result.",
                         "Import / Export Selected Result");
-                    new PrintPreviewWindow().ShowPreview(
-                        selectedDocument,
-                        "Import / Export Selected Result",
-                        "Review one selected data-operation result before copying, printing, or filing the handoff.");
+                    new PrintPreviewWindow().ShowPreview(selectedDocument, "Import / Export Selected Result", "Review one selected data-operation result before copying, printing, or filing the handoff.");
                     return;
                 }
 
@@ -101,10 +98,7 @@ namespace InventoryManagementApp.Views.Pages
                 }
 
                 var document = BuildPrintDocument(vm.ImportExportLogs.ToList(), vm.LogSummary);
-                new PrintPreviewWindow().ShowPreview(
-                    document,
-                    "Import / Export Log",
-                    "Review the current session's import, export, image, backup, and restore results before staff handoff.");
+                new PrintPreviewWindow().ShowPreview(document, "Import / Export Log", "Review the current session's import, export, image, backup, and restore results before staff handoff.");
             });
         }
 

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Media;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Views.Windows;
 using WpfMessageBox = System.Windows.MessageBox;
@@ -82,8 +83,14 @@ namespace InventoryManagementApp.Views.Pages
                 var selectedLog = GetSelectedLogForAction();
                 if (!string.IsNullOrWhiteSpace(selectedLog))
                 {
-                    var selectedDocument = BuildPrintDocument(new[] { selectedLog }, "Selected import/export operation result.", "Import / Export Selected Result");
-                    new PrintPreviewWindow().ShowPreview(selectedDocument, "Import / Export Selected Result", null);
+                    var selectedDocument = BuildPrintDocument(
+                        new[] { selectedLog },
+                        "Selected import/export operation result.",
+                        "Import / Export Selected Result");
+                    new PrintPreviewWindow().ShowPreview(
+                        selectedDocument,
+                        "Import / Export Selected Result",
+                        "Review one selected data-operation result before copying, printing, or filing the handoff.");
                     return;
                 }
 
@@ -94,7 +101,10 @@ namespace InventoryManagementApp.Views.Pages
                 }
 
                 var document = BuildPrintDocument(vm.ImportExportLogs.ToList(), vm.LogSummary);
-                new PrintPreviewWindow().ShowPreview(document, "Import / Export Log", null);
+                new PrintPreviewWindow().ShowPreview(
+                    document,
+                    "Import / Export Log",
+                    "Review the current session's import, export, image, backup, and restore results before staff handoff.");
             });
         }
 
@@ -103,10 +113,14 @@ namespace InventoryManagementApp.Views.Pages
             string summary,
             string title = "Import / Export Operation Log")
         {
+            var safeLogs = logs?.Where(log => !string.IsNullOrWhiteSpace(log)).ToList() ?? new List<string>();
             var document = new FlowDocument
             {
-                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
-                FontSize = 11
+                FontFamily = new FontFamily("Segoe UI"),
+                FontSize = 11,
+                PagePadding = new Thickness(36),
+                ColumnGap = 0,
+                TextAlignment = TextAlignment.Left
             };
 
             document.Blocks.Add(new Paragraph(new Run(title))
@@ -115,49 +129,113 @@ namespace InventoryManagementApp.Views.Pages
                 FontWeight = FontWeights.SemiBold,
                 Margin = new Thickness(0, 0, 0, 4)
             });
-            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - {summary}"))
+            document.Blocks.Add(new Paragraph(new Run($"Prepared {DateTime.Now:g}"))
             {
                 FontSize = 10,
-                Margin = new Thickness(0, 0, 0, 10)
+                Margin = new Thickness(0, 0, 0, 2)
             });
 
-            var table = new Table { CellSpacing = 0 };
-            table.Columns.Add(new TableColumn { Width = new GridLength(55) });
-            table.Columns.Add(new TableColumn { Width = new GridLength(680) });
+            document.Blocks.Add(BuildSummarySection(title, summary, safeLogs.Count));
+
+            if (safeLogs.Count == 0)
+            {
+                document.Blocks.Add(new Paragraph(new Run("No import/export operation results were available when this packet was prepared."))
+                {
+                    FontStyle = FontStyles.Italic,
+                    Margin = new Thickness(0, 8, 0, 0)
+                });
+                return document;
+            }
+
+            var table = new Table
+            {
+                CellSpacing = 0,
+                Margin = new Thickness(0, 8, 0, 0)
+            };
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.14, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.86, GridUnitType.Star) });
 
             var rowGroup = new TableRowGroup();
             table.RowGroups.Add(rowGroup);
 
             var header = new TableRow { FontWeight = FontWeights.SemiBold };
             rowGroup.Rows.Add(header);
-            AddCell(header, "#");
-            AddCell(header, "Result");
+            AddCell(header, "Entry", true);
+            AddCell(header, "Operation Result", true);
 
             var number = 1;
-            foreach (var log in logs)
+            foreach (var log in safeLogs)
             {
                 var row = new TableRow();
                 rowGroup.Rows.Add(row);
                 AddCell(row, number.ToString());
-                AddCell(row, log);
+                AddCell(row, log.Trim());
                 number++;
             }
 
             document.Blocks.Add(table);
+            document.Blocks.Add(new Paragraph(new Run("Review skipped rows, failures, backup paths, and restore notices before clearing the in-app run log."))
+            {
+                FontSize = 10,
+                FontStyle = FontStyles.Italic,
+                Margin = new Thickness(0, 10, 0, 0)
+            });
             return document;
         }
 
-        private static void AddCell(TableRow row, string text)
+        private static Section BuildSummarySection(string title, string summary, int logCount)
+        {
+            var section = new Section
+            {
+                BorderBrush = Brushes.LightGray,
+                BorderThickness = new Thickness(0, 0, 0, 1),
+                Padding = new Thickness(0, 0, 0, 8),
+                Margin = new Thickness(0, 6, 0, 8)
+            };
+
+            var table = new Table
+            {
+                Tag = "KeyValue",
+                CellSpacing = 0,
+                Margin = new Thickness(0)
+            };
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.26, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.74, GridUnitType.Star) });
+
+            var group = new TableRowGroup();
+            table.RowGroups.Add(group);
+            AddKeyValueRow(group, "Packet", title);
+            AddKeyValueRow(group, "Result Count", logCount.ToString());
+            AddKeyValueRow(group, "Session Summary", ValueOrNotRecorded(summary));
+
+            section.Blocks.Add(table);
+            return section;
+        }
+
+        private static void AddKeyValueRow(TableRowGroup group, string label, string value)
+        {
+            var row = new TableRow();
+            group.Rows.Add(row);
+            AddCell(row, label, true);
+            AddCell(row, value);
+        }
+
+        private static void AddCell(TableRow row, string text, bool isHeader = false)
         {
             row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
             {
-                Margin = new Thickness(2)
+                Margin = new Thickness(2),
+                TextAlignment = TextAlignment.Left
             })
             {
-                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderBrush = Brushes.Gray,
                 BorderThickness = new Thickness(0, 0, 0, 0.5),
-                Padding = new Thickness(3, 2, 3, 2)
+                Padding = new Thickness(4, 3, 4, 3),
+                FontWeight = isHeader ? FontWeights.SemiBold : FontWeights.Normal
             });
         }
+
+        private static string ValueOrNotRecorded(string? value) =>
+            string.IsNullOrWhiteSpace(value) ? "Not recorded" : value.Trim();
     }
 }


### PR DESCRIPTION
## What changed

- Polished the Import / Export run-log print document for both selected-result and whole-session preview routes.
- Added explicit preview descriptions so the print preview tells staff whether they are reviewing one selected result or the current session packet.
- Added a packet summary section with packet name, result count, and session summary.
- Replaced fixed 55px / 680px print table columns with proportional star columns so the shared print preview page-width rebalance can do its job.
- Renamed print headers from shorthand `#` / `Result` to `Entry` / `Operation Result`.
- Trimmed printed log rows, added a defensive empty-document message, and added a handoff note for skipped rows, failures, backup paths, and restore notices.
- Added source-contract coverage in `AdminDataPrintPreviewRouteTests` and recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-03-import-export-run-log-print-polish.md`.

## Why this was highest value

The current repo evidence points to full validation and runtime smoke testing as the main release blocker, but those are unavailable in this scheduled Linux container. Within the code that could be safely inspected and changed, Import / Export run-log printing was a concrete professional-output gap: it still used hard-coded print-table widths and sparse handoff context while the shared print preview layer now expects scalable document content.

## Why this is real progress

This is a complete print/preview workflow slice: selected-result route, whole-session route, document structure, preview descriptions, flexible data display, defensive empty state, source-contract coverage, and a progress note all changed together.

## Validation

- GitHub connector compare/readback confirmed a focused three-file diff.
- Source readback confirmed selected-result printing still resolves before whole-session printing.
- Source readback confirmed the run-log print document now has a packet summary, proportional columns, clearer table headers, defensive empty output, and no fixed `GridLength(680)` / 55px print columns.
- Source readback confirmed `AdminDataPrintPreviewRouteTests` guards the new print contract while preserving the existing shared `PrintPreviewWindow` route check.
- GitHub status readback found no attached commit statuses for the branch head.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`, `dotnet` build/test, WPF print preview screenshots, and runtime smoke tests could not be run because this scheduled Linux environment has no local checkout access and no `dotnet`, `pwsh`, `gh`, or WPF runtime.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Import / Export selected-result and whole-session print preview with short, long, skipped-row, failure, backup, and restore log entries.