### PR TITLE
[codex] Polish Reports print document output

### DIFF
--- a/InventoryManagementApp.Tests/ReportsPrintDocumentContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportsPrintDocumentContractTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReportsPrintDocumentContractTests
+    {
+        [Fact]
+        public void ReportsPrintDocumentUsesFlexibleProfessionalHandoffLayout()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
+
+            Assert.Contains("PagePadding = new Thickness(36)", source, StringComparison.Ordinal);
+            Assert.Contains("ColumnGap = 0", source, StringComparison.Ordinal);
+            Assert.Contains("BuildSummarySection(safeTitle, summary, lastRunText, safeLines.Count)", source, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Report\", title)", source, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Action Rows\", lineCount.ToString())", source, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Last Run\", ValueOrNotRecorded(lastRunText))", source, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Summary\", ValueOrNotRecorded(summary))", source, StringComparison.Ordinal);
+            Assert.Contains("Tag = \"KeyValue\"", source, StringComparison.Ordinal);
+            Assert.Contains("table.Columns.Add(new TableColumn { Width = new GridLength(0.08, GridUnitType.Star) });", source, StringComparison.Ordinal);
+            Assert.Contains("table.Columns.Add(new TableColumn { Width = new GridLength(0.36, GridUnitType.Star) });", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Entry\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Report Detail\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Next Action\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("No report rows were available when this packet was prepared.", source, StringComparison.Ordinal);
+            Assert.Contains("Review each destination, source-page route, and next action", source, StringComparison.Ordinal);
+            Assert.Contains("ValueOrNotRecorded(line.Category)", source, StringComparison.Ordinal);
+            Assert.Contains("ValueOrNotRecorded(line.DestinationName)", source, StringComparison.Ordinal);
+            Assert.Contains("ValueOrNotRecorded(line.Text)", source, StringComparison.Ordinal);
+            Assert.Contains("ValueOrNotRecorded(line.ActionHint)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var width in new[] { 45.0, 85.0, 105.0, 300.0, 205.0 })", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new GridLength(300.0)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new GridLength(205.0)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReportsPrintDocumentPreservesPreviewRouteAndReportActions()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
+
+            Assert.Contains("new PrintPreviewWindow().ShowPreview(", source, StringComparison.Ordinal);
+            Assert.Contains("Review the report summary, destination routing, and next-action handoff before printing.", source, StringComparison.Ordinal);
+            Assert.Contains("OpenSourcePage_Click", source, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedRow_Click", source, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", source, StringComparison.Ordinal);
+            Assert.Contains("Print Report", xaml, StringComparison.Ordinal);
+            Assert.Contains("Copy Handoff", xaml, StringComparison.Ordinal);
+            Assert.Contains("Open Source Page", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-reports-print-document-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-reports-print-document-polish.md
@@ -1,0 +1,30 @@
+# Reports Print Document Polish
+
+Date: 2026-07-03
+
+## Summary
+
+Improved the Reports Workbench print packet so generated report handoffs use flexible print columns, clearer summary context, defensive empty output, and safer row text for professional review and routing.
+
+## Completed Work
+
+- Kept the Reports Workbench print action routed through the shared `PrintPreviewWindow`.
+- Preserved the existing preview description for report summary, destination routing, and next-action handoff review.
+- Added a report summary section with report name, action row count, last-run text, and report summary.
+- Replaced fixed 45/85/105/300/205 print table columns with proportional star columns so report packets rebalance for page width.
+- Renamed the first table header from `#` to `Entry` for clearer printed handoffs.
+- Kept Type, Destination, Report Detail, and Next Action visible as first-class print columns.
+- Added defensive empty-document output when a report packet is prepared without rows.
+- Trimmed and defaulted printed report row text with `ValueOrNotRecorded` for category, destination, detail, and next action.
+- Added a review note reminding staff to verify each destination, source-page route, and next action before assigning follow-up work.
+- Added source-contract coverage in `ReportsPrintDocumentContractTests` for the flexible report print layout, empty state, row text handling, preserved preview route, preserved report actions, and grid virtualization contracts.
+
+## Validation
+
+- GitHub connector readback and source-contract inspection are available in this scheduled environment.
+- Full local validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or the WPF runtime.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test Reports Workbench print preview with empty, short, long, capped, and mixed-destination report rows at 1366 x 768 and higher Windows scaling.

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -197,7 +197,7 @@ namespace InventoryManagementApp.Views.Pages
             var header = new TableRow
             {
                 FontWeight = FontWeights.SemiBold,
-                Background = Brushes.LightGray
+                Background = System.Windows.Media.Brushes.LightGray
             };
             rowGroup.Rows.Add(header);
             AddCell(header, "Entry", true);

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Media;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Views.Windows;
 using WpfMessageBox = System.Windows.MessageBox;
@@ -135,43 +136,60 @@ namespace InventoryManagementApp.Views.Pages
 
         private static FlowDocument BuildReportDocument(string title, string summary, string lastRunText, IReadOnlyCollection<ReportLine> lines)
         {
+            var safeLines = lines?.Where(line => line != null).ToList() ?? new List<ReportLine>();
+            var safeTitle = ValueOrNotRecorded(title);
             var document = new FlowDocument
             {
-                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
+                FontFamily = new FontFamily("Segoe UI"),
                 FontSize = 11,
-                PagePadding = new Thickness(40)
+                PagePadding = new Thickness(36),
+                ColumnGap = 0,
+                TextAlignment = TextAlignment.Left
             };
 
-            document.Blocks.Add(new Paragraph(new Bold(new Run(title)))
+            document.Blocks.Add(new Paragraph(new Run(safeTitle))
             {
-                FontSize = 20,
+                FontSize = 18,
+                FontWeight = FontWeights.SemiBold,
                 TextAlignment = TextAlignment.Center,
-                Margin = new Thickness(0, 0, 0, 6)
+                Margin = new Thickness(0, 0, 0, 4)
             });
             document.Blocks.Add(new Paragraph(new Bold(new Run("REPORT HANDOFF")))
             {
-                FontSize = 16,
+                FontSize = 14,
                 TextAlignment = TextAlignment.Center,
-                Margin = new Thickness(0, 0, 0, 16)
+                Margin = new Thickness(0, 0, 0, 12)
             });
-            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - Last run {lastRunText} - {lines.Count} row(s)"))
+            document.Blocks.Add(new Paragraph(new Run($"Prepared {DateTime.Now:g}"))
             {
                 FontSize = 10,
-                Margin = new Thickness(0, 0, 0, 4)
+                Margin = new Thickness(0, 0, 0, 2)
             });
-            document.Blocks.Add(new Paragraph(new Run(summary))
+
+            document.Blocks.Add(BuildSummarySection(safeTitle, summary, lastRunText, safeLines.Count));
+
+            if (safeLines.Count == 0)
             {
-                Margin = new Thickness(0, 0, 0, 10)
-            });
+                document.Blocks.Add(new Paragraph(new Run("No report rows were available when this packet was prepared."))
+                {
+                    FontStyle = FontStyles.Italic,
+                    Margin = new Thickness(0, 8, 0, 0)
+                });
+                return document;
+            }
 
             var table = new Table
             {
                 CellSpacing = 0,
-                BorderBrush = System.Windows.Media.Brushes.Black,
+                Margin = new Thickness(0, 8, 0, 0),
+                BorderBrush = Brushes.Gray,
                 BorderThickness = new Thickness(1)
             };
-            foreach (var width in new[] { 45.0, 85.0, 105.0, 300.0, 205.0 })
-                table.Columns.Add(new TableColumn { Width = new GridLength(width) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.08, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.16, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.18, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.36, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.22, GridUnitType.Star) });
 
             var rowGroup = new TableRowGroup();
             table.RowGroups.Add(rowGroup);
@@ -179,43 +197,92 @@ namespace InventoryManagementApp.Views.Pages
             var header = new TableRow
             {
                 FontWeight = FontWeights.SemiBold,
-                Background = System.Windows.Media.Brushes.LightGray
+                Background = Brushes.LightGray
             };
             rowGroup.Rows.Add(header);
-            AddCell(header, "#");
-            AddCell(header, "Type");
-            AddCell(header, "Destination");
-            AddCell(header, "Report Detail");
-            AddCell(header, "Next Action");
+            AddCell(header, "Entry", true);
+            AddCell(header, "Type", true);
+            AddCell(header, "Destination", true);
+            AddCell(header, "Report Detail", true);
+            AddCell(header, "Next Action", true);
 
-            foreach (var line in lines)
+            foreach (var line in safeLines)
             {
                 var row = new TableRow();
                 if (line.Number % 2 == 0)
-                    row.Background = System.Windows.Media.Brushes.WhiteSmoke;
+                    row.Background = Brushes.WhiteSmoke;
                 rowGroup.Rows.Add(row);
                 AddCell(row, line.Number.ToString());
-                AddCell(row, line.Category);
-                AddCell(row, line.DestinationName);
-                AddCell(row, line.Text);
-                AddCell(row, line.ActionHint);
+                AddCell(row, ValueOrNotRecorded(line.Category));
+                AddCell(row, ValueOrNotRecorded(line.DestinationName));
+                AddCell(row, ValueOrNotRecorded(line.Text));
+                AddCell(row, ValueOrNotRecorded(line.ActionHint));
             }
 
             document.Blocks.Add(table);
+            document.Blocks.Add(new Paragraph(new Run("Review each destination, source-page route, and next action before closing the report packet or assigning follow-up work."))
+            {
+                FontSize = 10,
+                FontStyle = FontStyles.Italic,
+                Margin = new Thickness(0, 10, 0, 0)
+            });
             return document;
         }
 
-        private static void AddCell(TableRow row, string text)
+        private static Section BuildSummarySection(string title, string summary, string lastRunText, int lineCount)
+        {
+            var section = new Section
+            {
+                BorderBrush = Brushes.LightGray,
+                BorderThickness = new Thickness(0, 0, 0, 1),
+                Padding = new Thickness(0, 0, 0, 8),
+                Margin = new Thickness(0, 6, 0, 8)
+            };
+
+            var table = new Table
+            {
+                Tag = "KeyValue",
+                CellSpacing = 0,
+                Margin = new Thickness(0)
+            };
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.24, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.76, GridUnitType.Star) });
+
+            var group = new TableRowGroup();
+            table.RowGroups.Add(group);
+            AddKeyValueRow(group, "Report", title);
+            AddKeyValueRow(group, "Action Rows", lineCount.ToString());
+            AddKeyValueRow(group, "Last Run", ValueOrNotRecorded(lastRunText));
+            AddKeyValueRow(group, "Summary", ValueOrNotRecorded(summary));
+
+            section.Blocks.Add(table);
+            return section;
+        }
+
+        private static void AddKeyValueRow(TableRowGroup group, string label, string value)
+        {
+            var row = new TableRow();
+            group.Rows.Add(row);
+            AddCell(row, label, true);
+            AddCell(row, value);
+        }
+
+        private static void AddCell(TableRow row, string text, bool isHeader = false)
         {
             row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
             {
-                Margin = new Thickness(2)
+                Margin = new Thickness(2),
+                TextAlignment = TextAlignment.Left
             })
             {
-                BorderBrush = System.Windows.Media.Brushes.Black,
-                BorderThickness = new Thickness(0.5),
-                Padding = new Thickness(5, 3, 5, 3)
+                BorderBrush = Brushes.Gray,
+                BorderThickness = new Thickness(0, 0, 0, 0.5),
+                Padding = new Thickness(5, 3, 5, 3),
+                FontWeight = isHeader ? FontWeights.SemiBold : FontWeights.Normal
             });
         }
+
+        private static string ValueOrNotRecorded(string? value) =>
+            string.IsNullOrWhiteSpace(value) ? "Not recorded" : value.Trim();
     }
 }


### PR DESCRIPTION
## What changed

- Kept Reports Workbench printing routed through the shared `PrintPreviewWindow`.
- Added a report summary section with report name, action row count, last-run text, and report summary.
- Replaced fixed report print table widths with proportional star columns so packets rebalance for page width.
- Renamed the first print column from `#` to `Entry` while preserving Type, Destination, Report Detail, and Next Action columns.
- Added defensive empty-document output when a report packet is prepared without rows.
- Trimmed/defaulted printed row text for category, destination, detail, and next action with `ValueOrNotRecorded`.
- Added a review note for destination, source-page route, and next-action verification before handoff.
- Added `ReportsPrintDocumentContractTests` to guard the flexible print layout, empty state, row text handling, preserved preview route, preserved actions, and grid virtualization contracts.
- Added progress note `InventoryManagementApp/ProgressNotes/2026-07-03-reports-print-document-polish.md`.

## Why this was highest value

Current repo evidence shows broad Reports Workbench responsive layout is already complete, but `ReportsPage.xaml.cs` still generated the print packet with fixed 45/85/105/300/205 table widths and sparse report context. Since loading speed, UI responsiveness, professional data display, reports, preview, and printing are recurring priorities, this was a concrete remaining report-output gap adjacent to existing completed work rather than a speculative new feature.

## Why this is real progress

This is a complete Reports print/preview workflow slice: print document structure, page-width behavior, summary context, row data handling, empty output, operator review guidance, preserved preview/action routes, source-contract coverage, and progress record all changed together.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 4 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs`
  - `InventoryManagementApp.Tests/ReportsPrintDocumentContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-reports-print-document-polish.md`
- Connector source readback confirmed the summary section, proportional table columns, `Entry` header, defensive empty message, `ValueOrNotRecorded` row handling, review note, preserved preview route/actions, and new source-contract tests.
- Connector status/workflow readback found no attached statuses or workflow runs on branch head `19d76f4562c68b1bdac60c6d29134d0457817215`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- `dotnet restore/build/test/publish`
- WPF runtime print-preview screenshots or smoke tests
- Local source-contract execution
- `gh` checks

This scheduled Linux environment still cannot clone GitHub directly (`CONNECT tunnel failed, response 403`) and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Reports Workbench print preview with empty, short, long, capped, and mixed-destination report rows at 1366 x 768 and higher Windows scaling.