### PR TITLE
[codex] Stream item and customer exporters

### DIFF
--- a/InventoryManagementApp.Tests/ImportExportExporterCancellationContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportExporterCancellationContractTests.cs
@@ -7,21 +7,21 @@ namespace InventoryManagementApp.Tests
     public class ImportExportExporterCancellationContractTests
     {
         [Theory]
-        [InlineData("InventoryManagementApp/Services/ImportExport/ItemCsvExporter.cs", "var items = data.ToList();", "CsvHelperUtil.ExportItemsToCsvAsync(filePath, items)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemCsvExporter.cs", "var items = data as IList<ItemModel> ?? data.ToList();", "CsvHelperUtil.ExportItemsToCsvAsync(filePath, items)")]
         [InlineData("InventoryManagementApp/Services/ImportExport/CustomerCsvExporter.cs", "var customers = data.Select(c => new CustomerModel", "CsvHelperUtil.ExportCustomersToCsv(filePath, customers)")]
-        [InlineData("InventoryManagementApp/Services/ImportExport/ItemJsonExporter.cs", "var items = data.ToList();", "File.WriteAllTextAsync(filePath, json, cancellationToken)")]
-        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerJsonExporter.cs", "var customers = data.ToList();", "File.WriteAllTextAsync(filePath, json, cancellationToken)")]
-        [InlineData("InventoryManagementApp/Services/ImportExport/ItemXmlExporter.cs", "var items = data.ToList();", "new StreamWriter(filePath)")]
-        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerXmlExporter.cs", "var customers = data.ToList();", "new StreamWriter(filePath)")]
-        public void ExportersHonorCancellationBeforeMaterializingRowsAndWritingFiles(
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemJsonExporter.cs", "await using var stream = new FileStream", "JsonSerializer.SerializeAsync(stream, data, JsonOptions, cancellationToken)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerJsonExporter.cs", "await using var stream = new FileStream", "JsonSerializer.SerializeAsync(stream, data, JsonOptions, cancellationToken)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemXmlExporter.cs", "foreach (var item in data)", "serializer.Serialize(writer, item, namespaces)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerXmlExporter.cs", "foreach (var customer in data)", "serializer.Serialize(writer, customer, namespaces)")]
+        public void ExportersHonorCancellationBeforePreparingRowsAndWritingFiles(
             string relativePath,
-            string materializeMarker,
+            string prepareMarker,
             string writeMarker)
         {
             var source = ReadRepoFile(relativePath);
 
-            AssertCancellationCheckBefore(source, materializeMarker);
-            AssertCancellationCheckBetween(source, materializeMarker, writeMarker);
+            AssertCancellationCheckBefore(source, prepareMarker);
+            AssertCancellationCheckBetween(source, prepareMarker, writeMarker);
         }
 
         [Theory]
@@ -36,6 +36,50 @@ namespace InventoryManagementApp.Tests
 
             var innerCancellation = source.IndexOf("cancellationToken.ThrowIfCancellationRequested();", taskStart, StringComparison.Ordinal);
             Assert.True(innerCancellation > taskStart, $"Expected {relativePath} to check cancellation inside the synchronous export task.");
+        }
+
+        [Theory]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemJsonExporter.cs")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerJsonExporter.cs")]
+        public void JsonExportersStreamDirectlyToFileWithoutIntermediateRowCopies(string relativePath)
+        {
+            var source = ReadRepoFile(relativePath);
+
+            Assert.Contains("await using var stream = new FileStream", source, StringComparison.Ordinal);
+            Assert.Contains("JsonSerializer.SerializeAsync(stream, data, JsonOptions, cancellationToken)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("data.ToList()", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("JsonSerializer.Serialize(", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("File.WriteAllTextAsync", source, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData("InventoryManagementApp/Services/ImportExport/ItemXmlExporter.cs", "WriteStartElement(\"Items\")", "foreach (var item in data)", "serializer.Serialize(writer, item, namespaces)")]
+        [InlineData("InventoryManagementApp/Services/ImportExport/CustomerXmlExporter.cs", "WriteStartElement(\"Customers\")", "foreach (var customer in data)", "serializer.Serialize(writer, customer, namespaces)")]
+        public void XmlExportersStreamRowsInsideTheExistingRootElement(
+            string relativePath,
+            string rootMarker,
+            string loopMarker,
+            string serializeMarker)
+        {
+            var source = ReadRepoFile(relativePath);
+
+            Assert.Contains("XmlWriter.Create(filePath", source, StringComparison.Ordinal);
+            Assert.Contains(rootMarker, source, StringComparison.Ordinal);
+            Assert.Contains(loopMarker, source, StringComparison.Ordinal);
+            Assert.Contains(serializeMarker, source, StringComparison.Ordinal);
+            Assert.Contains("writer.WriteEndElement();", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("data.ToList()", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("typeof(List<", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new StreamWriter(filePath)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemCsvExporterReusesExistingListInputsBeforeFallingBackToMaterialization()
+        {
+            var source = ReadRepoFile("InventoryManagementApp/Services/ImportExport/ItemCsvExporter.cs");
+
+            Assert.Contains("var items = data as IList<ItemModel> ?? data.ToList();", source, StringComparison.Ordinal);
+            Assert.Contains("CsvHelperUtil.ExportItemsToCsvAsync(filePath, items)", source, StringComparison.Ordinal);
         }
 
         private static void AssertCancellationCheckBefore(string source, string marker)

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-exporter-streaming-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-exporter-streaming-performance.md
@@ -1,0 +1,32 @@
+# Exporter Streaming Performance
+
+Date: 2026-07-03
+
+## Summary
+
+Reduced import/export file writer memory pressure by removing avoidable full-row copies and intermediate JSON strings from item/customer exporters while preserving cancellation checks and existing XML root shapes.
+
+## Completed Work
+
+- Streamed item JSON exports directly to an async `FileStream` with `JsonSerializer.SerializeAsync`.
+- Streamed customer JSON exports directly to an async `FileStream` with `JsonSerializer.SerializeAsync`.
+- Removed the intermediate JSON string allocation before writing item exports.
+- Removed the intermediate JSON string allocation before writing customer exports.
+- Removed extra JSON exporter `data.ToList()` materialization for item rows.
+- Removed extra JSON exporter `data.ToList()` materialization for customer rows.
+- Streamed item XML rows through `XmlWriter` inside the existing `Items` root element instead of building a `List<ItemModel>` for `XmlSerializer`.
+- Streamed customer XML rows through `XmlWriter` inside the existing `Customers` root element instead of building a `List<Customer>` for `XmlSerializer`.
+- Preserved cancellation checks before export setup, during row iteration, before final XML close-out, and before JSON serialization.
+- Reused existing list inputs in the item CSV exporter before falling back to materialization, avoiding a duplicate copy when service export collectors already hand over a list.
+- Added source-contract coverage that guards JSON streaming, XML row streaming, preserved root elements, cancellation placement, and the item CSV list-reuse fallback.
+
+## Validation
+
+- GitHub connector readback and source-contract inspection are available in this scheduled environment.
+- Full local validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or the WPF runtime.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test item/customer CSV, JSON, and XML exports plus re-import of XML exports with realistic large datasets.
+- If CSV memory pressure remains visible after runtime testing, consider adding streaming CSV helpers that write records directly instead of receiving a fully collected list.

--- a/InventoryManagementApp/Services/ImportExport/CustomerJsonExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/CustomerJsonExporter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -36,11 +35,10 @@ namespace InventoryManagementApp.Services.ImportExport
                 throw new ArgumentNullException(nameof(data));
 
             cancellationToken.ThrowIfCancellationRequested();
-            var customers = data.ToList();
+            await using var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 64 * 1024, useAsync: true);
             cancellationToken.ThrowIfCancellationRequested();
 
-            var json = JsonSerializer.Serialize(customers, JsonOptions);
-            await File.WriteAllTextAsync(filePath, json, cancellationToken).ConfigureAwait(false);
+            await JsonSerializer.SerializeAsync(stream, data, JsonOptions, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/InventoryManagementApp/Services/ImportExport/CustomerXmlExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/CustomerXmlExporter.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Serialization;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
@@ -32,12 +31,23 @@ namespace InventoryManagementApp.Services.ImportExport
             await Task.Run(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var customers = data.ToList();
-                cancellationToken.ThrowIfCancellationRequested();
+                var serializer = new XmlSerializer(typeof(Customer));
+                var namespaces = new XmlSerializerNamespaces();
+                namespaces.Add(string.Empty, string.Empty);
 
-                var serializer = new XmlSerializer(typeof(List<Customer>), new XmlRootAttribute("Customers"));
-                using var writer = new StreamWriter(filePath);
-                serializer.Serialize(writer, customers);
+                using var writer = XmlWriter.Create(filePath, new XmlWriterSettings { Indent = true });
+                writer.WriteStartDocument();
+                writer.WriteStartElement("Customers");
+
+                foreach (var customer in data)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    serializer.Serialize(writer, customer, namespaces);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                writer.WriteEndElement();
+                writer.WriteEndDocument();
             }, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/InventoryManagementApp/Services/ImportExport/ItemCsvExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/ItemCsvExporter.cs
@@ -27,7 +27,7 @@ namespace InventoryManagementApp.Services.ImportExport
                 throw new ArgumentNullException(nameof(data));
 
             cancellationToken.ThrowIfCancellationRequested();
-            var items = data.ToList();
+            var items = data as IList<ItemModel> ?? data.ToList();
             cancellationToken.ThrowIfCancellationRequested();
 
             await CsvHelperUtil.ExportItemsToCsvAsync(filePath, items).ConfigureAwait(false);

--- a/InventoryManagementApp/Services/ImportExport/ItemJsonExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/ItemJsonExporter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -36,11 +35,10 @@ namespace InventoryManagementApp.Services.ImportExport
                 throw new ArgumentNullException(nameof(data));
 
             cancellationToken.ThrowIfCancellationRequested();
-            var items = data.ToList();
+            await using var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 64 * 1024, useAsync: true);
             cancellationToken.ThrowIfCancellationRequested();
 
-            var json = JsonSerializer.Serialize(items, JsonOptions);
-            await File.WriteAllTextAsync(filePath, json, cancellationToken).ConfigureAwait(false);
+            await JsonSerializer.SerializeAsync(stream, data, JsonOptions, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/InventoryManagementApp/Services/ImportExport/ItemXmlExporter.cs
+++ b/InventoryManagementApp/Services/ImportExport/ItemXmlExporter.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Serialization;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
@@ -32,12 +31,23 @@ namespace InventoryManagementApp.Services.ImportExport
             await Task.Run(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var items = data.ToList();
-                cancellationToken.ThrowIfCancellationRequested();
+                var serializer = new XmlSerializer(typeof(ItemModel));
+                var namespaces = new XmlSerializerNamespaces();
+                namespaces.Add(string.Empty, string.Empty);
 
-                var serializer = new XmlSerializer(typeof(List<ItemModel>), new XmlRootAttribute("Items"));
-                using var writer = new StreamWriter(filePath);
-                serializer.Serialize(writer, items);
+                using var writer = XmlWriter.Create(filePath, new XmlWriterSettings { Indent = true });
+                writer.WriteStartDocument();
+                writer.WriteStartElement("Items");
+
+                foreach (var item in data)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    serializer.Serialize(writer, item, namespaces);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                writer.WriteEndElement();
+                writer.WriteEndDocument();
             }, cancellationToken).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
## What changed

- Streamed item JSON exports directly to an async `FileStream` with `JsonSerializer.SerializeAsync`.
- Streamed customer JSON exports directly to an async `FileStream` with `JsonSerializer.SerializeAsync`.
- Removed intermediate JSON string allocation for item exports.
- Removed intermediate JSON string allocation for customer exports.
- Removed extra JSON `data.ToList()` materialization for item rows.
- Removed extra JSON `data.ToList()` materialization for customer rows.
- Streamed item XML exports through `XmlWriter` inside the existing `Items` root element.
- Streamed customer XML exports through `XmlWriter` inside the existing `Customers` root element.
- Removed XML `List<T>` materialization before serialization for both item and customer exporters.
- Preserved cancellation checks before export setup, during XML row iteration, before XML close-out, and before JSON serialization.
- Reused existing list inputs in the item CSV exporter before falling back to materialization.
- Extended source-contract coverage for JSON streaming, XML row streaming/root preservation, cancellation placement, and CSV list reuse.
- Added progress note `InventoryManagementApp/ProgressNotes/2026-07-03-exporter-streaming-performance.md`.

## Why this was highest value

Current repo notes list large export memory pressure as a remaining concrete follow-up after recent paged service collectors. Source readback showed the exporter layer still copied generic export inputs into lists and built full JSON strings before writing files. Tightening that layer directly supports loading speed, UI responsiveness, and large-data export reliability without repeating recently completed layout/print work.

## Why this is real progress

This is a complete import/export performance slice across item and customer JSON/XML writers plus item CSV handoff behavior, cancellation contracts, source-contract coverage, and progress records. It reduces avoidable memory pressure in realistic large export workflows rather than changing isolated formatting.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 7 focused commits, and limited to exporter implementations, source-contract coverage, and one progress note.
- Connector source readback confirmed JSON exporters now use async file streams and `JsonSerializer.SerializeAsync` without `data.ToList()` or `File.WriteAllTextAsync`.
- Connector source readback confirmed XML exporters now write `Items` / `Customers` roots with `XmlWriter`, serialize each row from the enumerable, and avoid `typeof(List<...>)` writer materialization.
- Connector source readback confirmed the item CSV exporter reuses `IList<ItemModel>` inputs before materializing.
- Connector source readback confirmed tests guard streaming, root preservation, cancellation placement, and list reuse.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- `dotnet restore/build/test/publish`
- WPF runtime export/import smoke tests
- XML round-trip validation with real exported files
- `gh` checks

This scheduled Linux environment still cannot clone GitHub directly (`CONNECT tunnel failed, response 403`) and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

## Follow-up

- Run the full Windows validation runner.
- Smoke test item/customer CSV, JSON, and XML exports plus XML re-import with realistic large datasets.
- If CSV export memory pressure remains visible after runtime testing, add streaming CSV helper methods that write rows directly instead of accepting fully collected lists.