### PR TITLE
[codex] Load shell branding asynchronously at startup

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelStartupPerformanceContractTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelStartupPerformanceContractTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MainViewModelStartupPerformanceContractTests
+    {
+        [Fact]
+        public void MainViewModel_LoadsShellBrandingWithoutBlockingConstructor()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MainViewModel.cs");
+
+            Assert.Contains("Task? _shellBrandingLoadTask;", source, StringComparison.Ordinal);
+            Assert.Contains("_shellBrandingLoadTask = LoadShellBrandingAsync();", source, StringComparison.Ordinal);
+            Assert.Contains("async Task LoadShellBrandingAsync()", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetSettingAsync(\"CompanyLogoPath\").GetAwaiter().GetResult()", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetSettingAsync(\"ApplicationName\").GetAwaiter().GetResult()", source, StringComparison.Ordinal);
+            Assert.DoesNotContain(".Result;", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainViewModel_LoadsBrandingSettingsTogetherAndKeepsDefaultTitleVisible()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MainViewModel.cs");
+
+            Assert.Contains("var logoPathTask = _settingsService.GetSettingAsync(\"CompanyLogoPath\");", source, StringComparison.Ordinal);
+            Assert.Contains("var appNameTask = _settingsService.GetSettingAsync(\"ApplicationName\");", source, StringComparison.Ordinal);
+            Assert.Contains("await Task.WhenAll(logoPathTask, appNameTask).ConfigureAwait(true);", source, StringComparison.Ordinal);
+            Assert.Contains("public string WindowTitle => string.IsNullOrWhiteSpace(ApplicationName)", source, StringComparison.Ordinal);
+            Assert.Contains("? $\"{LabelProvider.Instance.ItemLabelPlural} Management\"", source, StringComparison.Ordinal);
+            Assert.Contains(": ApplicationName;", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainViewModel_AppliesOnlyNonBlankBrandingAndLogsReadFailures()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MainViewModel.cs");
+
+            Assert.Contains("if (!string.IsNullOrWhiteSpace(logoPath))", source, StringComparison.Ordinal);
+            Assert.Contains("CompanyLogoPath = logoPath;", source, StringComparison.Ordinal);
+            Assert.Contains("if (!string.IsNullOrWhiteSpace(appName))", source, StringComparison.Ordinal);
+            Assert.Contains("ApplicationName = appName;", source, StringComparison.Ordinal);
+            Assert.Contains("catch (Exception ex)", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogWarning(ex, \"Failed to load shell branding settings\");", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainViewModel_PreservesLiveSettingsBrandingUpdates()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MainViewModel.cs");
+
+            Assert.Contains("else if (e.PropertyName == nameof(SettingsViewModel.CompanyLogoPath))", source, StringComparison.Ordinal);
+            Assert.Contains("CompanyLogoPath = Settings.CompanyLogoPath;", source, StringComparison.Ordinal);
+            Assert.Contains("else if (e.PropertyName == nameof(SettingsViewModel.ApplicationName))", source, StringComparison.Ordinal);
+            Assert.Contains("ApplicationName = Settings.ApplicationName;", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-async-shell-branding-startup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-async-shell-branding-startup.md
@@ -1,0 +1,30 @@
+# Async Shell Branding Startup
+
+Date: 2026-07-03
+
+## Summary
+
+Improved app startup responsiveness by removing synchronous settings waits from the main shell ViewModel constructor. The shell can now show its default title immediately while company logo and application-name branding load asynchronously.
+
+## Completed Work
+
+- Removed blocking `GetAwaiter().GetResult()` settings reads for `CompanyLogoPath` during `MainViewModel` construction.
+- Removed blocking `GetAwaiter().GetResult()` settings reads for `ApplicationName` during `MainViewModel` construction.
+- Added an asynchronous shell-branding loader that starts after the core page commands and shared ViewModels are initialized.
+- Started logo-path and application-name reads together before awaiting both results, reducing sequential startup I/O.
+- Kept the existing default `{item label} Management` title visible until a non-blank application name is available.
+- Preserved non-blank guards so empty branding settings do not erase visible shell branding.
+- Logged shell-branding read failures as warnings instead of failing the main shell constructor or dashboard startup.
+- Preserved live Settings page branding updates for company logo and application name.
+- Added source-contract coverage that prevents constructor-blocking settings reads from being reintroduced.
+- Added source-contract coverage for concurrent branding reads, default title fallback, non-blank application, warning logging, and live settings update preservation.
+
+## Validation
+
+- Connector source readback and compare can verify this branch is limited to `MainViewModel.cs`, startup performance source-contract coverage, and this progress note.
+- Direct local validation could not run in this scheduled Linux environment because direct checkout is blocked and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test first app launch with blank branding settings, populated branding settings, and an unavailable or slow settings store to confirm the default title appears quickly and branding updates shortly after load.

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -55,6 +55,7 @@ namespace InventoryManagementApp.ViewModels
         int _autoLogoutMinutes;
         CancellationTokenSource? _pageLoadCts;
         CancellationTokenSource? _globalSearchCts;
+        Task? _shellBrandingLoadTask;
         int _isRefreshingOpenSurface;
 
         EventHandler<User?>? _userContextChangedHandler;
@@ -379,6 +380,29 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        async Task LoadShellBrandingAsync()
+        {
+            try
+            {
+                var logoPathTask = _settingsService.GetSettingAsync("CompanyLogoPath");
+                var appNameTask = _settingsService.GetSettingAsync("ApplicationName");
+
+                await Task.WhenAll(logoPathTask, appNameTask).ConfigureAwait(true);
+
+                var logoPath = await logoPathTask.ConfigureAwait(true);
+                if (!string.IsNullOrWhiteSpace(logoPath))
+                    CompanyLogoPath = logoPath;
+
+                var appName = await appNameTask.ConfigureAwait(true);
+                if (!string.IsNullOrWhiteSpace(appName))
+                    ApplicationName = appName;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to load shell branding settings");
+            }
+        }
+
         public IAsyncRelayCommand OpenDashboardCommand { get; }
         public IAsyncRelayCommand OpenSearchItemsCommand { get; }
         public IAsyncRelayCommand OpenManageItemsCommand { get; }
@@ -505,12 +529,7 @@ namespace InventoryManagementApp.ViewModels
             CalibrationManagement = new CalibrationManagementViewModel(calibrationService ?? throw new ArgumentNullException(nameof(calibrationService)), _dialogService);
             ReservationManagement = new ReservationManagementViewModel(reservationService ?? throw new ArgumentNullException(nameof(reservationService)), _dialogService);
             KitManagement = new KitManagementViewModel(kitService ?? throw new ArgumentNullException(nameof(kitService)), _dialogService);
-            var logoPath = _settingsService.GetSettingAsync("CompanyLogoPath").GetAwaiter().GetResult();
-            if (!string.IsNullOrWhiteSpace(logoPath))
-                CompanyLogoPath = logoPath;
-            var appName = _settingsService.GetSettingAsync("ApplicationName").GetAwaiter().GetResult();
-            if (!string.IsNullOrWhiteSpace(appName))
-                ApplicationName = appName;
+            _shellBrandingLoadTask = LoadShellBrandingAsync();
             _autoLogoutTimer = autoLogoutTimer ?? new DispatcherTimerWrapper();
             _autoLogoutTimer.Tick += OnAutoLogoutTimerTick;
             Settings.PropertyChanged += Settings_PropertyChanged;


### PR DESCRIPTION
## Summary

- Move main shell logo and application-name settings reads out of the `MainViewModel` constructor's blocking path.
- Load `CompanyLogoPath` and `ApplicationName` together asynchronously, preserving the default shell title until non-blank branding is available.
- Log branding read failures as warnings instead of failing or delaying shell startup.
- Add source-contract coverage for non-blocking startup branding, concurrent settings reads, default title fallback, non-blank guards, warning logging, and live Settings-page branding updates.
- Record the completed startup responsiveness slice in progress notes.

## Why this was highest value

Current repo evidence shows broad recent work on grid/layout/export responsiveness, while `MainViewModel` still synchronously waited on settings reads during construction. That is a direct first-paint/startup responsiveness risk for every app launch, especially when settings persistence is slow or unavailable.

## Scope and progress

This is a focused vertical slice across app startup logic, source-contract coverage, and progress documentation. It avoids reworking recently completed workbenches and targets a shared shell path that affects all screens.

## Validation

- GitHub connector compare confirmed the PR is limited to:
  - `InventoryManagementApp/ViewModels/MainViewModel.cs`
  - `InventoryManagementApp.Tests/MainViewModelStartupPerformanceContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-async-shell-branding-startup.md`
- Connector source readback confirmed the branch uses async branding loading and no longer contains the two constructor `GetAwaiter().GetResult()` settings waits.
- Checked this scheduled environment for local validation tooling: `dotnet` and `pwsh` are unavailable.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET build/test
- WPF runtime startup timing, screenshots, or scaling smoke tests

Those require a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not include the WPF toolchain.

## Follow-up

- Run the full validation script on Windows.
- Smoke test first launch with blank branding, populated branding, and slow/unavailable settings persistence to confirm the default title appears quickly and branding updates after load.