### PR TITLE
[codex] Polish shell navigation and workflow display

### DIFF
--- a/InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs
@@ -11,8 +11,9 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
 
-            Assert.Contains("Width=\"1180\" Height=\"760\" MinWidth=\"920\" MinHeight=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Width=\"1180\" Height=\"760\" MinWidth=\"880\" MinHeight=\"520\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Width=\"1280\" Height=\"800\" MinWidth=\"1040\" MinHeight=\"540\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"920\" MinHeight=\"520\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -44,15 +45,48 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void MainWindow_MenuScrollsInsteadOfClippingNavigationAtScaledWidths()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("<ScrollViewer HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VerticalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Focusable=\"False\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Menu x:Name=\"ShellSectionMenu\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Overview\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Operations\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Insights\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Data\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Admin\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void MainWindow_PageHeaderWrapsWorkflowActionsInBoundedArea()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
 
-            Assert.Contains("<ColumnDefinition Width=\"Auto\" MinWidth=\"0\" MaxWidth=\"380\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"44\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"Auto\" MinWidth=\"0\" MaxWidth=\"420\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<StackPanel VerticalAlignment=\"Center\" MinWidth=\"0\" Margin=\"0,0,12,0\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<WrapPanel Grid.Column=\"1\" Orientation=\"Horizontal\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\" MaxWidth=\"380\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"1\" Orientation=\"Horizontal\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\" MaxWidth=\"420\">", xaml, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(xaml, "MinWidth=\"96\"\n                            MaxWidth=\"180\""));
             Assert.Contains("Margin=\"0,0,4,4\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Margin=\"0,0,0,4\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainWindow_FrameKeepsNavigationChromeOutOfPageKeyboardFlow()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("Name=\"MainFrame\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("NavigationUIVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("JournalOwnership=\"OwnsJournal\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Focusable=\"False\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ClipToBounds=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("KeyboardNavigation.TabNavigation=\"Cycle\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -65,6 +99,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<ColumnDefinition Width=\"1.7*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"Auto\" MinWidth=\"0\" MaxWidth=\"380\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<Grid Grid.Column=\"0\" ClipToBounds=\"True\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"Workflow status\" Style=\"{StaticResource LabelTextBlock}\" TextTrimming=\"CharacterEllipsis\" MaxWidth=\"120\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel Grid.Column=\"3\" Orientation=\"Horizontal\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\" MaxWidth=\"380\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<StackPanel Grid.Column=\"3\" Orientation=\"Horizontal\"", xaml, StringComparison.Ordinal);
         }
@@ -90,6 +125,10 @@ namespace InventoryManagementApp.Tests
             var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
 
             Assert.Contains("OpenDashboardCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenManageItemsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenRentalsCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenCustomersCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OpenReportsCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("GlobalSearchText", xaml, StringComparison.Ordinal);
             Assert.Contains("GlobalSearchCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("SwitchUserCommand", xaml, StringComparison.Ordinal);
@@ -98,6 +137,20 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("CurrentWorkflowSecondaryCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("CurrentWorkflowGuide", xaml, StringComparison.Ordinal);
             Assert.Contains("CurrentUserRole", xaml, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         xmlns:pages="clr-namespace:InventoryManagementApp.Views.Pages"
-        Title="{Binding WindowTitle}" Width="1180" Height="760" MinWidth="920" MinHeight="520" WindowStartupLocation="CenterScreen"
+        Title="{Binding WindowTitle}" Width="1180" Height="760" MinWidth="880" MinHeight="520" WindowStartupLocation="CenterScreen"
         WindowState="Maximized"
         Background="{DynamicResource BackgroundBrush}"
         FontFamily="{DynamicResource ThemeFontFamily}">
@@ -119,35 +119,42 @@
                 BorderBrush="{DynamicResource BorderBrushBase}"
                 BorderThickness="0,0,0,1"
                 Effect="{DynamicResource ThemeRaisedShadow}"
-                Padding="4,3">
-            <Menu Style="{StaticResource SectionMenu}">
-                <MenuItem Header="Overview" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown">
-                    <MenuItem Header="Dashboard" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenDashboardCommand}"/>
-                    <MenuItem Header="Search Tools" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenSearchItemsCommand}" Visibility="{Binding CanUseSearchTools, Converter={StaticResource BoolToVis}}"/>
-                </MenuItem>
-                <MenuItem Header="Operations" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown" Visibility="{Binding IsOperationsSectionVisible, Converter={StaticResource BoolToVis}}">
-                    <MenuItem Header="Tools" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenManageItemsCommand}" Visibility="{Binding CanManageItems, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Rentals" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenRentalsCommand}" Visibility="{Binding CanUseRentals, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Customers" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenCustomersCommand}" Visibility="{Binding CanUseCustomers, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Maintenance" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenMaintenanceCommand}" Visibility="{Binding CanUseMaintenance, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Calibration" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenCalibrationCommand}" Visibility="{Binding CanUseCalibration, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Reservations" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenReservationsCommand}" Visibility="{Binding CanUseReservations, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Kits" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenKitManagementCommand}" Visibility="{Binding CanUseKits, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Categories" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenCategoriesCommand}" Visibility="{Binding CanUseCategories, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Print Labels" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenPrintLabelWindowCommand}" Visibility="{Binding CanPrintLabels, Converter={StaticResource BoolToVis}}"/>
-                </MenuItem>
-                <MenuItem Header="Insights" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown" Visibility="{Binding IsInsightsSectionVisible, Converter={StaticResource BoolToVis}}">
-                    <MenuItem Header="Reports" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenReportsCommand}" Visibility="{Binding CanUseReports, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Activity Logs" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenActivityLogsCommand}" Visibility="{Binding CanUseActivityLogs, Converter={StaticResource BoolToVis}}"/>
-                </MenuItem>
-                <MenuItem Header="Data" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown" Visibility="{Binding IsDataSectionVisible, Converter={StaticResource BoolToVis}}">
-                    <MenuItem Header="Import / Export" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenImportExportCommand}" Visibility="{Binding CanUseImportExport, Converter={StaticResource BoolToVis}}"/>
-                </MenuItem>
-                <MenuItem Header="Admin" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown" Visibility="{Binding IsAdminSectionVisible, Converter={StaticResource BoolToVis}}">
-                    <MenuItem Header="Users" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenUsersCommand}" Visibility="{Binding CanManageUsers, Converter={StaticResource BoolToVis}}"/>
-                    <MenuItem Header="Settings" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenSettingsCommand}" Visibility="{Binding CanUseSettings, Converter={StaticResource BoolToVis}}"/>
-                </MenuItem>
-            </Menu>
+                Padding="4,2">
+            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                          VerticalScrollBarVisibility="Disabled"
+                          CanContentScroll="True"
+                          Focusable="False">
+                <Menu x:Name="ShellSectionMenu"
+                      Style="{StaticResource SectionMenu}"
+                      MinWidth="0">
+                    <MenuItem Header="Overview" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown">
+                        <MenuItem Header="Dashboard" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenDashboardCommand}"/>
+                        <MenuItem Header="Search Tools" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenSearchItemsCommand}" Visibility="{Binding CanUseSearchTools, Converter={StaticResource BoolToVis}}"/>
+                    </MenuItem>
+                    <MenuItem Header="Operations" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown" Visibility="{Binding IsOperationsSectionVisible, Converter={StaticResource BoolToVis}}">
+                        <MenuItem Header="Tools" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenManageItemsCommand}" Visibility="{Binding CanManageItems, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Rentals" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenRentalsCommand}" Visibility="{Binding CanUseRentals, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Customers" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenCustomersCommand}" Visibility="{Binding CanUseCustomers, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Maintenance" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenMaintenanceCommand}" Visibility="{Binding CanUseMaintenance, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Calibration" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenCalibrationCommand}" Visibility="{Binding CanUseCalibration, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Reservations" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenReservationsCommand}" Visibility="{Binding CanUseReservations, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Kits" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenKitManagementCommand}" Visibility="{Binding CanUseKits, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Categories" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenCategoriesCommand}" Visibility="{Binding CanUseCategories, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Print Labels" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenPrintLabelWindowCommand}" Visibility="{Binding CanPrintLabels, Converter={StaticResource BoolToVis}}"/>
+                    </MenuItem>
+                    <MenuItem Header="Insights" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown" Visibility="{Binding IsInsightsSectionVisible, Converter={StaticResource BoolToVis}}">
+                        <MenuItem Header="Reports" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenReportsCommand}" Visibility="{Binding CanUseReports, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Activity Logs" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenActivityLogsCommand}" Visibility="{Binding CanUseActivityLogs, Converter={StaticResource BoolToVis}}"/>
+                    </MenuItem>
+                    <MenuItem Header="Data" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown" Visibility="{Binding IsDataSectionVisible, Converter={StaticResource BoolToVis}}">
+                        <MenuItem Header="Import / Export" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenImportExportCommand}" Visibility="{Binding CanUseImportExport, Converter={StaticResource BoolToVis}}"/>
+                    </MenuItem>
+                    <MenuItem Header="Admin" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown" Visibility="{Binding IsAdminSectionVisible, Converter={StaticResource BoolToVis}}">
+                        <MenuItem Header="Users" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenUsersCommand}" Visibility="{Binding CanManageUsers, Converter={StaticResource BoolToVis}}"/>
+                        <MenuItem Header="Settings" Style="{StaticResource SectionDropDownItem}" Command="{Binding OpenSettingsCommand}" Visibility="{Binding CanUseSettings, Converter={StaticResource BoolToVis}}"/>
+                    </MenuItem>
+                </Menu>
+            </ScrollViewer>
         </Border>
 
         <Border x:Name="PageHeaderBand"
@@ -155,6 +162,7 @@
                 BorderBrush="{DynamicResource BorderBrushBase}"
                 BorderThickness="0,0,0,1"
                 Effect="{DynamicResource ThemeSurfaceShadow}"
+                MinHeight="44"
                 Padding="8,6">
             <Border.Style>
                 <Style TargetType="Border">
@@ -211,22 +219,26 @@
             <Grid ClipToBounds="True">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" MinWidth="0"/>
-                    <ColumnDefinition Width="Auto" MinWidth="0" MaxWidth="380"/>
+                    <ColumnDefinition Width="Auto" MinWidth="0" MaxWidth="420"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel VerticalAlignment="Center" MinWidth="0" Margin="0,0,12,0">
                     <TextBlock Text="{Binding CurrentPageTitle}" Style="{StaticResource PageTitleTextBlock}" TextTrimming="CharacterEllipsis"/>
                     <TextBlock x:Name="WorkflowGuideText" Text="{Binding CurrentWorkflowGuide}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
-                <WrapPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" MaxWidth="380">
+                <WrapPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" MaxWidth="420">
                     <Button Style="{StaticResource GhostButton}"
                             Content="{Binding CurrentWorkflowPrimaryActionText}"
                             Command="{Binding CurrentWorkflowPrimaryCommand}"
                             Visibility="{Binding HasCurrentWorkflowPrimaryAction, Converter={StaticResource BoolToVis}}"
+                            MinWidth="96"
+                            MaxWidth="180"
                             Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}"
                             Content="{Binding CurrentWorkflowSecondaryActionText}"
                             Command="{Binding CurrentWorkflowSecondaryCommand}"
                             Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}"
+                            MinWidth="96"
+                            MaxWidth="180"
                             Margin="0,0,0,4"/>
                 </WrapPanel>
             </Grid>
@@ -239,7 +251,9 @@
                Background="{DynamicResource MainContentBackgroundBrush}"
                Content="{Binding CurrentPage}"
                Margin="{StaticResource PagePadding}"
-               Focusable="False"/>
+               Focusable="False"
+               ClipToBounds="True"
+               KeyboardNavigation.TabNavigation="Cycle"/>
 
         <Border x:Name="ShellStatusFooter"
                 Grid.Row="4"
@@ -273,7 +287,7 @@
                         Padding="8,3"
                         Margin="0,0,12,0"
                         VerticalAlignment="Center">
-                    <TextBlock Text="Workflow status" Style="{StaticResource LabelTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="Workflow status" Style="{StaticResource LabelTextBlock}" TextTrimming="CharacterEllipsis" MaxWidth="120"/>
                 </Border>
 
                 <Grid Grid.Column="2" ClipToBounds="True" MinWidth="0" VerticalAlignment="Center">

--- a/InventoryManagementApp/ProgressNotes/2026-07-03-shell-navigation-data-display-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-03-shell-navigation-data-display-polish.md
@@ -1,0 +1,33 @@
+# Shell Navigation Data Display Polish
+
+Date: 2026-07-03
+
+## Summary
+
+Improved the shared app shell so navigation and workflow status remain professional and reachable at scaled desktop widths while preserving the existing command surface.
+
+## Completed Work
+
+- Lowered the main shell minimum width from 920 px to 880 px so the app has more room to fit 1366 x 768 desktops with Windows scaling.
+- Wrapped the top menu in a horizontal `ScrollViewer` so visible navigation sections stay reachable instead of clipping when permissions expose many sections.
+- Kept the menu vertically bounded and non-focusable so it does not add extra keyboard stops or vertical scroll pressure.
+- Added a named, shrinkable shell menu contract for future layout checks.
+- Added a minimum page-header band height to keep title/action rhythm stable while switching screens.
+- Expanded the bounded workflow action area from 380 px to 420 px, giving common primary/secondary actions more room without forcing overflow.
+- Added minimum and maximum widths to the page-header workflow buttons so long action labels stay controlled and short labels remain easy to click.
+- Added frame clipping so oversized page content stays inside the shell instead of bleeding into chrome during layout transitions.
+- Added cyclical tab navigation inside the page frame so keyboard focus remains within the active workflow surface.
+- Bounded the footer workflow-status label so it truncates cleanly instead of crowding the ticker and action summary.
+- Preserved Dashboard, item management, rentals, customers, reports, search, user switching, current page, workflow action, workflow guide, and signed-in role bindings.
+- Extended `MainWindowResponsiveContractTests` to guard the shell navigation, workflow action, frame, footer, and command-preservation contracts.
+
+## Validation
+
+- GitHub connector readback and compare can verify this branch is limited to `MainWindow.xaml`, `MainWindowResponsiveContractTests.cs`, and this progress note.
+- Direct local validation could not run in this scheduled Linux environment because direct checkout is blocked and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test the top menu at 1366 x 768 with 125%, 150%, and 200% Windows scaling, especially admin users that can see every navigation section.
+- Check keyboard focus through the shell frame while switching between Dashboard, Search, Rentals, Customers, Reports, Activity Logs, Import / Export, Users, and Settings.


### PR DESCRIPTION
## What changed

- Lowered the main shell minimum width from 920 px to 880 px for scaled 1366 x 768 desktops.
- Wrapped the top shell menu in a horizontal `ScrollViewer` so all visible navigation sections remain reachable instead of clipping for high-permission users or high Windows scaling.
- Kept the shell menu vertically bounded and non-focusable to avoid extra keyboard stops and vertical layout pressure.
- Added a named shrinkable menu contract for future layout checks.
- Added a stable page-header minimum height for cleaner screen switching.
- Expanded the workflow action area and bounded the two workflow action buttons with minimum/maximum widths.
- Clipped the main frame and set cyclical tab navigation inside the active page surface.
- Bounded the footer workflow-status label so it truncates cleanly instead of crowding the ticker and action summary.
- Extended `MainWindowResponsiveContractTests` to cover the menu, page-header actions, frame behavior, footer behavior, and preserved bindings.
- Recorded the completed progress note.

## Why this was highest value

Recent work already improved many individual pages and dialogs. The remaining shared shell could still constrain every workflow at scaled desktop widths, especially the top menu and workflow-action/status areas. This PR improves navigation reachability and professional data display across Dashboard, Search, Rentals, Customers, Reports, Activity Logs, Import / Export, Users, Settings, and other shell-hosted workflows without reworking recently touched pages.

## Why this is real progress

This is a vertical shell polish slice: shared UI layout, keyboard/frame behavior, source-contract coverage, and progress documentation. It is intentionally focused on the active WPF app and avoids unrelated features or dependencies.

## Validation

- GitHub connector compare confirmed the branch is ahead of `master` by three commits and limited to:
  - `InventoryManagementApp/MainWindow.xaml`
  - `InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-03-shell-navigation-data-display-polish.md`
- Connector readback confirmed the scrollable shell menu, bounded workflow action area, clipped/tab-cycling frame, bounded footer status label, preserved navigation/search/workflow bindings, and updated source-contract checks.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke test, screenshots, or Windows scaling checks

Those remain blocked in this scheduled Linux environment because direct checkout is blocked and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full validation runner from a Windows/.NET-capable checkout.
- Smoke test the top menu at 1366 x 768 with 125%, 150%, and 200% scaling, especially for admin users with every navigation section visible.