### PR TITLE
[codex] Bound item search intelligence refresh work

### DIFF
--- a/InventoryManagementApp.Tests/ItemSearchPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemSearchPageResponsiveContractTests.cs
@@ -86,6 +86,28 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ItemSearchPage_BoundsSearchIntelligenceRefreshWork()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs");
+
+            Assert.Contains("private const int SearchHistoryLimit = 10;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private const int UnavailableDemandLimit = 12;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private const int SearchSignatureItemLimit = 250;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var snapshot = CreateSearchSnapshot(_attachedViewModel.SearchResults);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (resultIds.Count < SearchSignatureItemLimit)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (unavailableItems.Count < UnavailableDemandLimit", codeBehind, StringComparison.Ordinal);
+            Assert.Contains(".Take(UnavailableDemandLimit)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("while (_searchHistory.Count > SearchHistoryLimit)", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("var results = _attachedViewModel.SearchResults.ToList();", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("var unavailable = results.Where(IsUnavailable).ToList();", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("results.Select(item => item.ItemID).OrderBy", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("unavailable.Select(item => item.ItemID).OrderBy", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("unavailableItems.GroupBy", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain(".Take(12)", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("_searchHistory.Count > 10", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ItemSearchPage_PreservesSearchActionsAndRowHandlers()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml");

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-item-search-intelligence-snapshot-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-item-search-intelligence-snapshot-performance.md
@@ -1,0 +1,23 @@
+# Item Search Intelligence Snapshot Performance - 2026-07-04
+
+## Completed
+
+- Replaced the Item Search intelligence refresh path's full `SearchResults.ToList()` and unavailable-row `ToList()` snapshots with a single bounded scan.
+- Added named limits for recent-search history, unavailable-demand rows, and search-signature IDs so large searches do not spend extra UI-thread time sorting or materializing every row just to update the intelligence pane.
+- Preserved visible result and unavailable counts while only carrying the bounded unavailable row sample needed for the existing demand panel.
+- Kept duplicate-refresh detection deterministic by including result counts, unavailable counts, and bounded display-order ID samples in the search signature.
+- Reused the named limits when pruning search history and rebuilding unavailable-demand rows.
+- Added source-contract coverage in `ItemSearchPageResponsiveContractTests` to prevent reintroducing full list materialization, full ID sorting, grouped unavailable enumeration, or magic row-limit values in this hot path.
+
+## Validation
+
+- Source readback confirmed the Item Search page now builds search intelligence through `CreateSearchSnapshot` and named limits.
+- Source-contract test readback confirmed the bounded snapshot and anti-regression assertions were added.
+
+## Not Run Here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- .NET restore/build/test
+- WPF runtime responsiveness checks or screenshots
+
+Those remain unavailable in this scheduled Linux environment because direct checkout is blocked and `dotnet`, PowerShell/`pwsh`, `gh`, and the WPF runtime are not available.

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -17,6 +17,10 @@ namespace InventoryManagementApp.Views.Pages
 {
     public partial class ItemSearchPage : Page
     {
+        private const int SearchHistoryLimit = 10;
+        private const int UnavailableDemandLimit = 12;
+        private const int SearchSignatureItemLimit = 250;
+
         private readonly ObservableCollection<SearchHistoryEntry> _searchHistory = new();
         private readonly ObservableCollection<UnavailableDemandEntry> _unavailableDemand = new();
         private readonly Dictionary<int, UnavailableDemandEntry> _demandByItemId = new();
@@ -172,23 +176,51 @@ namespace InventoryManagementApp.Views.Pages
             var category = string.IsNullOrWhiteSpace(_attachedViewModel.SelectedCategory)
                 ? "All"
                 : _attachedViewModel.SelectedCategory;
-            var results = _attachedViewModel.SearchResults.ToList();
-            var unavailable = results.Where(IsUnavailable).ToList();
-            var signature = BuildSearchSignature(term, category, results, unavailable);
+            var snapshot = CreateSearchSnapshot(_attachedViewModel.SearchResults);
+            var signature = BuildSearchSignature(term, category, snapshot);
             if (string.Equals(signature, _lastSearchSignature, StringComparison.Ordinal))
                 return;
 
             _lastSearchSignature = signature;
-            UpsertSearchHistory(term, category, results.Count, unavailable.Count);
-            CaptureUnavailableDemand(term, unavailable);
+            UpsertSearchHistory(term, category, snapshot.ResultCount, snapshot.UnavailableCount);
+            CaptureUnavailableDemand(term, snapshot.UnavailableItems);
             UpdateSearchIntelligenceSummary();
         }
 
-        private static string BuildSearchSignature(string term, string category, IEnumerable<ItemModel> results, IEnumerable<ItemModel> unavailable)
+        private static SearchSnapshot CreateSearchSnapshot(IEnumerable<ItemModel> results)
         {
-            var resultIds = string.Join(",", results.Select(item => item.ItemID).OrderBy(id => id));
-            var unavailableIds = string.Join(",", unavailable.Select(item => item.ItemID).OrderBy(id => id));
-            return $"{term}|{category}|{resultIds}|{unavailableIds}";
+            var resultIds = new List<int>(SearchSignatureItemLimit);
+            var unavailableIds = new List<int>(SearchSignatureItemLimit);
+            var unavailableItems = new List<ItemModel>(UnavailableDemandLimit);
+            var capturedUnavailableItemIds = new HashSet<int>();
+            var resultCount = 0;
+            var unavailableCount = 0;
+
+            foreach (var item in results)
+            {
+                resultCount++;
+
+                if (resultIds.Count < SearchSignatureItemLimit)
+                    resultIds.Add(item.ItemID);
+
+                if (!IsUnavailable(item))
+                    continue;
+
+                unavailableCount++;
+
+                if (unavailableIds.Count < SearchSignatureItemLimit)
+                    unavailableIds.Add(item.ItemID);
+
+                if (unavailableItems.Count < UnavailableDemandLimit && capturedUnavailableItemIds.Add(item.ItemID))
+                    unavailableItems.Add(item);
+            }
+
+            return new SearchSnapshot(resultCount, unavailableCount, resultIds, unavailableIds, unavailableItems);
+        }
+
+        private static string BuildSearchSignature(string term, string category, SearchSnapshot snapshot)
+        {
+            return $"{term}|{category}|{snapshot.ResultCount}|{snapshot.UnavailableCount}|{string.Join(",", snapshot.ResultIds)}|{string.Join(",", snapshot.UnavailableIds)}";
         }
 
         private void UpsertSearchHistory(string term, string category, int resultCount, int unavailableCount)
@@ -209,13 +241,13 @@ namespace InventoryManagementApp.Views.Pages
             existing.LastSearched = DateTime.Now;
             _searchHistory.Insert(0, existing);
 
-            while (_searchHistory.Count > 10)
+            while (_searchHistory.Count > SearchHistoryLimit)
                 _searchHistory.RemoveAt(_searchHistory.Count - 1);
         }
 
         private void CaptureUnavailableDemand(string term, IEnumerable<ItemModel> unavailableItems)
         {
-            foreach (var item in unavailableItems.GroupBy(item => item.ItemID).Select(group => group.First()))
+            foreach (var item in unavailableItems)
             {
                 if (!_demandByItemId.TryGetValue(item.ItemID, out var entry))
                 {
@@ -231,7 +263,7 @@ namespace InventoryManagementApp.Views.Pages
                          .OrderByDescending(entry => entry.HitCount)
                          .ThenByDescending(entry => entry.LastSearched)
                          .ThenBy(entry => entry.Name)
-                         .Take(12))
+                         .Take(UnavailableDemandLimit))
             {
                 _unavailableDemand.Add(entry);
             }
@@ -627,6 +659,13 @@ namespace InventoryManagementApp.Views.Pages
             var summary = string.Join(" | ", values.Where(value => !string.IsNullOrWhiteSpace(value)));
             return string.IsNullOrWhiteSpace(summary) ? "No notes recorded" : summary;
         }
+
+        private sealed record SearchSnapshot(
+            int ResultCount,
+            int UnavailableCount,
+            IReadOnlyList<int> ResultIds,
+            IReadOnlyList<int> UnavailableIds,
+            IReadOnlyList<ItemModel> UnavailableItems);
 
         public sealed class SearchHistoryEntry
         {


### PR DESCRIPTION
## What changed

- Added named limits for Item Search intelligence history, unavailable-demand rows, and search-signature ID samples.
- Replaced the search intelligence refresh path's full `SearchResults.ToList()` snapshot with a single bounded `CreateSearchSnapshot` scan.
- Preserved visible result and unavailable counts while carrying only the bounded unavailable row sample needed for the existing demand panel.
- Removed the extra unavailable-row `ToList()`, full ID sorting, and grouped unavailable enumeration from the UI-thread refresh path.
- Kept duplicate-refresh detection deterministic by including counts plus bounded display-order ID samples in the signature.
- Reused the named limits when pruning recent searches and rebuilding unavailable demand.
- Extended `ItemSearchPageResponsiveContractTests` to guard the performance contract and prevent reintroducing full materialization or magic row-limit values.
- Added a progress note for the completed slice.

## Why this was highest value

The recent responsive work made Item Search easier to use, but its local search-intelligence refresh still did avoidable work on every result update: materializing all results, materializing unavailable rows, sorting full ID lists, and grouping unavailable rows just to update a small side panel. That is exactly the kind of search/filter/data-display hot path the hourly focus calls out.

## Why this is real progress

This is a vertical workflow improvement for the active Item Search screen: it reduces UI-thread work during search result refreshes, preserves the existing operator-facing intelligence panel and print route, adds regression coverage, and records the change for future runs. It stays inside the existing WPF app and avoids unrelated features or dependencies.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by three commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs`
  - `InventoryManagementApp.Tests/ItemSearchPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-item-search-intelligence-snapshot-performance.md`
- Connector readback confirmed `CreateSearchSnapshot`, the named limits, bounded unavailable capture, signature counts/samples, named-limit pruning, and the source-contract assertions.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime responsiveness checks, screenshots, or Windows scaling checks

Those remain blocked in this scheduled Linux environment because direct checkout is blocked and `dotnet`, PowerShell/`pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full validation runner from a Windows/.NET-capable checkout.
- Smoke test rapid Item Search filtering with a large item list and confirm the intelligence pane stays responsive.