### PR TITLE
Improve Activity Logs loading and print preview responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogsLoadingPerformanceContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogsLoadingPerformanceContractTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ActivityLogsLoadingPerformanceContractTests
+    {
+        [Fact]
+        public void ActivityLogsViewModel_DoesNotStartDuplicateConstructorLoad()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
+
+            Assert.Contains("RefreshCommand = new AsyncRelayCommand(LoadLogsAsync, () => !IsLoading);", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsLoading", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsLoading)", source, StringComparison.Ordinal);
+            Assert.Contains("return false;", source, StringComparison.Ordinal);
+            Assert.Contains("IsLoading = true;", source, StringComparison.Ordinal);
+            Assert.Contains("finally", source, StringComparison.Ordinal);
+            Assert.Contains("IsLoading = false;", source, StringComparison.Ordinal);
+            Assert.Contains("RefreshCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("_ = RefreshCommand.ExecuteAsync(null);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsPage_LoadsOncePerPageInstanceAndStillAllowsRefresh()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("private bool _hasLoadedLogs;", source, StringComparison.Ordinal);
+            Assert.Contains("if (!_hasLoadedLogs && DataContext is ActivityLogsViewModel vm)", source, StringComparison.Ordinal);
+            Assert.Contains("_hasLoadedLogs = await vm.LoadLogsAsync();", source, StringComparison.Ordinal);
+            Assert.Contains("private async void RefreshLogs_Click", source, StringComparison.Ordinal);
+            Assert.Contains("await vm.LoadLogsAsync();", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Loaded += async", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
+++ b/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
@@ -55,6 +55,29 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ActivityLogsPrintPreviewUsesBoundedProfessionalHandoffPacket()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("private const int MaxActivityPrintRows = 250;", source, StringComparison.Ordinal);
+            Assert.Contains("var totalFilteredCount = vm.FilteredLogs.Count;", source, StringComparison.Ordinal);
+            Assert.Contains("var printRows = vm.FilteredLogs.Take(MaxActivityPrintRows).ToList();", source, StringComparison.Ordinal);
+            Assert.Contains("BuildPrintDocument(printRows, totalFilteredCount, vm.StatusMessage, vm.ActivitySummary)", source, StringComparison.Ordinal);
+            Assert.Contains("Large result sets print the first 250 rows so preview stays responsive.", source, StringComparison.Ordinal);
+            Assert.Contains("BuildSummarySection(summary, activitySummary, totalFilteredCount, printedRowCount, omittedRowCount)", source, StringComparison.Ordinal);
+            Assert.Contains("AddSummaryLine(group, \"Print Packet\"", source, StringComparison.Ordinal);
+            Assert.Contains("AddSummaryLine(group, \"Omitted Rows\"", source, StringComparison.Ordinal);
+            Assert.Contains("table.Columns.Add(new TableColumn { Width = new GridLength(0.16, GridUnitType.Star) });", source, StringComparison.Ordinal);
+            Assert.Contains("table.Columns.Add(new TableColumn { Width = new GridLength(0.34, GridUnitType.Star) });", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"When / User\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Next Action\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Activity Detail\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("Review destination, next action, and any omitted rows before filing the audit handoff.", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("BuildPrintDocument(vm.FilteredLogs.ToList()", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var width in new[] { 115.0, 105.0, 100.0, 105.0, 275.0 })", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void DashboardPrintActionsUseDialogPreviewService()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "DashboardViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-activity-logs-print-preview-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-activity-logs-print-preview-performance.md
@@ -1,0 +1,22 @@
+# Activity Logs Print Preview Performance
+
+Date: 2026-07-04
+
+## Completed
+
+- Bounded Activity Logs print preview generation to the first 250 filtered rows so very large audit filters do not build an oversized FlowDocument on the UI thread.
+- Preserved honest output by showing the total filtered count, printed row count, and omitted row count in the print packet summary.
+- Replaced fixed-width print table columns with proportional star columns so the document adapts better to preview and printer page widths.
+- Added handoff-focused columns for timestamp/user, activity type, destination, next action, and activity detail.
+- Added a review note that tells operators to verify destination, next action, and omitted rows before filing the audit handoff.
+- Added source-contract coverage to keep the bounded print packet, proportional columns, preview description, and no-full-list snapshot behavior from regressing.
+
+## Validation
+
+- Source readback through the GitHub connector confirmed the Activity Logs print path and source-contract test updates on the branch.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime smoke tests, screenshots, and print-preview rendering could not be run in this scheduled Linux environment because direct checkout is blocked and the required Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full validation runner from a Windows/.NET-capable checkout.
+- Smoke test Activity Logs print preview with small, empty-after-filter, and large audit result sets to verify printed pagination and truncation messaging.

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-activity-logs-print-preview-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-activity-logs-print-preview-performance.md
@@ -9,14 +9,18 @@ Date: 2026-07-04
 - Replaced fixed-width print table columns with proportional star columns so the document adapts better to preview and printer page widths.
 - Added handoff-focused columns for timestamp/user, activity type, destination, next action, and activity detail.
 - Added a review note that tells operators to verify destination, next action, and omitted rows before filing the audit handoff.
+- Removed the constructor-triggered activity log load so opening Activity Logs does not race a second page-loaded refresh.
+- Added an `IsLoading` guard and refresh-command can-execute hook so repeated refresh clicks do not start concurrent audit reads.
+- Kept the page loaded handler as the first-load owner while allowing manual refresh to continue working after the initial load.
 - Added source-contract coverage to keep the bounded print packet, proportional columns, preview description, and no-full-list snapshot behavior from regressing.
+- Added source-contract coverage for the no-constructor-load, one-page-load, and guarded-refresh contracts.
 
 ## Validation
 
-- Source readback through the GitHub connector confirmed the Activity Logs print path and source-contract test updates on the branch.
+- Source readback through the GitHub connector confirmed the Activity Logs print path, Activity Logs startup load guard, and source-contract test updates on the branch.
 - Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime smoke tests, screenshots, and print-preview rendering could not be run in this scheduled Linux environment because direct checkout is blocked and the required Windows/.NET/WPF tooling is unavailable.
 
 ## Follow-up
 
 - Run the full validation runner from a Windows/.NET-capable checkout.
-- Smoke test Activity Logs print preview with small, empty-after-filter, and large audit result sets to verify printed pagination and truncation messaging.
+- Smoke test Activity Logs first open, rapid refresh clicks, and print preview with small, empty-after-filter, and large audit result sets to verify loading state, printed pagination, and truncation messaging.

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -96,6 +96,17 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        private bool _isLoading;
+        public bool IsLoading
+        {
+            get => _isLoading;
+            private set
+            {
+                if (SetProperty(ref _isLoading, value))
+                    RefreshCommand.NotifyCanExecuteChanged();
+            }
+        }
+
         public string LastLoadedText => LastLoadedAt.HasValue ? LastLoadedAt.Value.ToString("g") : "Not loaded";
         public int TotalLogCount => Logs.Count;
         public int FilteredLogCount => FilteredLogs.Count;
@@ -164,17 +175,20 @@ namespace InventoryManagementApp.ViewModels
         {
             _service = service;
             _logger = logger ?? NullLogger<ActivityLogsViewModel>.Instance;
-            RefreshCommand = new AsyncRelayCommand(LoadLogsAsync);
+            RefreshCommand = new AsyncRelayCommand(LoadLogsAsync, () => !IsLoading);
             ClearFiltersCommand = new RelayCommand(ClearFilters, HasActiveFilter);
             UserFilters.Add(AllUsersFilter);
             ActionFilters.Add(AllActionsFilter);
-            _ = RefreshCommand.ExecuteAsync(null);
         }
 
         public async Task<bool> LoadLogsAsync()
         {
+            if (IsLoading)
+                return false;
+
             try
             {
+                IsLoading = true;
                 StatusMessage = "Loading recent activity...";
                 Logs.Clear();
                 var result = await _service.GetRecentLogsAsync();
@@ -199,6 +213,10 @@ namespace InventoryManagementApp.ViewModels
                 _logger.LogError(ex, "Failed to load activity logs");
                 ClearActivityLogRowsAfterLoadFailure("Activity logs could not be loaded. Activity rows were cleared until refresh succeeds.");
                 return false;
+            }
+            finally
+            {
+                IsLoading = false;
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -15,6 +15,7 @@ namespace InventoryManagementApp.Views.Pages
     public partial class ActivityLogsPage : Page
     {
         private const int MaxActivityPrintRows = 250;
+        private bool _hasLoadedLogs;
 
         public ActivityLogsPage()
         {
@@ -24,9 +25,9 @@ namespace InventoryManagementApp.Views.Pages
 
         private async void ActivityLogsPage_Loaded(object sender, RoutedEventArgs e)
         {
-            if (DataContext is ActivityLogsViewModel vm)
+            if (!_hasLoadedLogs && DataContext is ActivityLogsViewModel vm)
             {
-                await vm.LoadLogsAsync();
+                _hasLoadedLogs = await vm.LoadLogsAsync();
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -14,6 +14,8 @@ namespace InventoryManagementApp.Views.Pages
 {
     public partial class ActivityLogsPage : Page
     {
+        private const int MaxActivityPrintRows = 250;
+
         public ActivityLogsPage()
         {
             InitializeComponent();
@@ -146,11 +148,13 @@ namespace InventoryManagementApp.Views.Pages
                     return;
                 }
 
-                var document = BuildPrintDocument(vm.FilteredLogs.ToList(), vm.StatusMessage, vm.ActivitySummary);
+                var totalFilteredCount = vm.FilteredLogs.Count;
+                var printRows = vm.FilteredLogs.Take(MaxActivityPrintRows).ToList();
+                var document = BuildPrintDocument(printRows, totalFilteredCount, vm.StatusMessage, vm.ActivitySummary);
                 new PrintPreviewWindow().ShowPreview(
                     document,
                     "Activity Logs",
-                    "Review the filtered audit trail, destination routing, and operator handoff before printing.");
+                    "Review the filtered audit trail, destination routing, and operator handoff before printing. Large result sets print the first 250 rows so preview stays responsive.");
             });
         }
 
@@ -175,12 +179,15 @@ namespace InventoryManagementApp.Views.Pages
                    $"Action: {SafeText(log.Action, "No activity detail was recorded.")}";
         }
 
-        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<ActivityLog> logs, string summary, string activitySummary)
+        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<ActivityLog> logs, int totalFilteredCount, string summary, string activitySummary)
         {
+            var printedRowCount = logs.Count;
+            var omittedRowCount = Math.Max(0, totalFilteredCount - printedRowCount);
             var document = new FlowDocument
             {
                 FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
-                FontSize = 10
+                FontSize = 10,
+                PagePadding = new Thickness(36)
             };
 
             document.Blocks.Add(new Paragraph(new Run("Activity Logs"))
@@ -189,48 +196,88 @@ namespace InventoryManagementApp.Views.Pages
                 FontWeight = FontWeights.SemiBold,
                 Margin = new Thickness(0, 0, 0, 4)
             });
-            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - {summary}"))
+            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g}"))
             {
                 FontSize = 10,
                 Margin = new Thickness(0, 0, 0, 4)
             });
-            document.Blocks.Add(new Paragraph(new Run(activitySummary))
-            {
-                FontSize = 10,
-                Margin = new Thickness(0, 0, 0, 10)
-            });
+            document.Blocks.Add(BuildSummarySection(summary, activitySummary, totalFilteredCount, printedRowCount, omittedRowCount));
 
             var table = new Table { CellSpacing = 0 };
-            foreach (var width in new[] { 115.0, 105.0, 100.0, 105.0, 275.0 })
-                table.Columns.Add(new TableColumn { Width = new GridLength(width) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.16, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.16, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.16, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.18, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.34, GridUnitType.Star) });
 
             var rowGroup = new TableRowGroup();
             table.RowGroups.Add(rowGroup);
 
             var header = new TableRow { FontWeight = FontWeights.SemiBold };
             rowGroup.Rows.Add(header);
-            AddCell(header, "Timestamp");
-            AddCell(header, "User");
-            AddCell(header, "Type");
-            AddCell(header, "Destination");
-            AddCell(header, "Action");
+            AddCell(header, "When / User", true);
+            AddCell(header, "Type", true);
+            AddCell(header, "Destination", true);
+            AddCell(header, "Next Action", true);
+            AddCell(header, "Activity Detail", true);
 
-            foreach (var log in logs)
+            if (printedRowCount == 0)
             {
-                var row = new TableRow();
-                rowGroup.Rows.Add(row);
-                AddCell(row, log.Timestamp.ToString("g"));
-                AddCell(row, SafeText(log.UserName, "Unknown user"));
-                AddCell(row, ActivityLogsViewModel.ClassifyAction(log.Action));
-                AddCell(row, ActivityLogsViewModel.BuildDestinationName(ActivityLogsViewModel.BuildDestinationKey(log.Action)));
-                AddCell(row, SafeText(log.Action, "No activity detail was recorded."));
+                var emptyRow = new TableRow();
+                rowGroup.Rows.Add(emptyRow);
+                AddCell(emptyRow, "No activity rows matched the current print packet.", false, 5);
+            }
+            else
+            {
+                foreach (var log in logs)
+                {
+                    var destinationKey = ActivityLogsViewModel.BuildDestinationKey(log.Action);
+                    var row = new TableRow();
+                    rowGroup.Rows.Add(row);
+                    AddCell(row, $"{log.Timestamp:g}\n{SafeText(log.UserName, "Unknown user")} (ID {log.UserID})");
+                    AddCell(row, ActivityLogsViewModel.ClassifyAction(log.Action));
+                    AddCell(row, ActivityLogsViewModel.BuildDestinationName(destinationKey));
+                    AddCell(row, ActivityLogsViewModel.BuildNextAction(log.Action));
+                    AddCell(row, SafeText(log.Action, "No activity detail was recorded."));
+                }
             }
 
             document.Blocks.Add(table);
+            document.Blocks.Add(new Paragraph(new Run("Review destination, next action, and any omitted rows before filing the audit handoff."))
+            {
+                FontSize = 9,
+                FontStyle = FontStyles.Italic,
+                Margin = new Thickness(0, 8, 0, 0)
+            });
             return document;
         }
 
-        private static void AddCell(TableRow row, string text)
+        private static Block BuildSummarySection(string summary, string activitySummary, int totalFilteredCount, int printedRowCount, int omittedRowCount)
+        {
+            var group = new Section
+            {
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderThickness = new Thickness(0, 0, 0, 0.5),
+                Padding = new Thickness(0, 0, 0, 8),
+                Margin = new Thickness(0, 0, 0, 10)
+            };
+
+            AddSummaryLine(group, "Print Packet", $"{printedRowCount} of {totalFilteredCount} filtered activity row(s)");
+            AddSummaryLine(group, "Omitted Rows", omittedRowCount == 0 ? "None" : $"{omittedRowCount} row(s) not printed; narrow filters or print again after refining the audit search.");
+            AddSummaryLine(group, "Filter Status", ValueOrNotRecorded(summary));
+            AddSummaryLine(group, "Activity Mix", ValueOrNotRecorded(activitySummary));
+            return group;
+        }
+
+        private static void AddSummaryLine(Section group, string label, string value)
+        {
+            var paragraph = new Paragraph { Margin = new Thickness(0, 0, 0, 2) };
+            paragraph.Inlines.Add(new Run($"{label}: ") { FontWeight = FontWeights.SemiBold });
+            paragraph.Inlines.Add(new Run(value));
+            group.Blocks.Add(paragraph);
+        }
+
+        private static void AddCell(TableRow row, string text, bool isHeader = false, int columnSpan = 1)
         {
             row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
             {
@@ -239,13 +286,20 @@ namespace InventoryManagementApp.Views.Pages
             {
                 BorderBrush = System.Windows.Media.Brushes.Gray,
                 BorderThickness = new Thickness(0, 0, 0, 0.5),
+                ColumnSpan = columnSpan,
+                FontWeight = isHeader ? FontWeights.SemiBold : FontWeights.Normal,
                 Padding = new Thickness(3, 2, 3, 2)
             });
         }
 
+        private static string ValueOrNotRecorded(string? text)
+        {
+            return SafeText(text, "Not recorded");
+        }
+
         private static string SafeText(string? text, string fallback)
         {
-            return string.IsNullOrWhiteSpace(text) ? fallback : text;
+            return string.IsNullOrWhiteSpace(text) ? fallback : text.Trim();
         }
     }
 }


### PR DESCRIPTION
## What changed

- Removed the constructor-triggered Activity Logs load so opening the page no longer races the WPF `Loaded` refresh.
- Added an `IsLoading` guard and refresh-command can-execute hook to prevent concurrent audit log reads from repeated refresh actions.
- Kept the page loaded handler as the first-load owner while preserving manual refresh behavior.
- Bounded Activity Logs print preview generation to the first 250 filtered rows instead of building a document from every visible audit row.
- Added an honest print packet summary with total filtered rows, printed rows, omitted rows, filter status, and activity mix.
- Replaced fixed print table widths with proportional columns and added destination/next-action handoff columns for more professional preview output.
- Added source-contract coverage for both the loading guard and bounded print-preview packet.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-activity-logs-print-preview-performance.md`.

## Why this was highest value

Recent runs already improved Activity Logs layout, but the workflow still had two performance risks: opening the page could start duplicate audit reads, and printing a large filtered audit set could build a very large FlowDocument on the UI thread. This targets first-open responsiveness, refresh safety, and professional audit output without inventing a new workflow.

## Scope and progress

This is a focused vertical slice across page code, view-model loading behavior, print document generation, source-contract coverage, and progress notes. It improves screen opening, refresh responsiveness, large-result print preview behavior, print readability, and future regression coverage.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by focused changes only, and touches five files.
- GitHub connector readback confirmed the Activity Logs print path, loading guard, and source-contract test content on the branch.

Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime smoke tests, screenshots, or print-preview rendering because this scheduled Linux environment still cannot clone the repo directly and does not provide the required Windows/.NET/WPF tooling.

## Follow-up

- Run full validation on a Windows/.NET-capable checkout.
- Smoke test Activity Logs first open, rapid refresh clicks, and print preview with small, empty-after-filter, and large audit result sets.