### PR TITLE
[codex] Bound Users directory print preview work

### DIFF
--- a/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
+++ b/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
@@ -78,6 +78,30 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void UsersDirectoryPrintPreviewUsesBoundedProfessionalHandoffPacket()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs");
+
+            Assert.Contains("private const int MaxUsersPrintRows = 250;", source, StringComparison.Ordinal);
+            Assert.Contains("var totalVisibleCount = ViewModel.Users.Count;", source, StringComparison.Ordinal);
+            Assert.Contains("var printRows = ViewModel.Users.Take(MaxUsersPrintRows).ToList();", source, StringComparison.Ordinal);
+            Assert.Contains("BuildPrintDocument(printRows, totalVisibleCount, summary)", source, StringComparison.Ordinal);
+            Assert.Contains("Review the current account directory, access coverage, lockout state, and any omitted rows before filing an admin handoff.", source, StringComparison.Ordinal);
+            Assert.Contains("BuildSummarySection(summary, totalVisibleCount, users.Count, Math.Max(0, totalVisibleCount - users.Count))", source, StringComparison.Ordinal);
+            Assert.Contains("AddSummaryLine(group, \"Total Visible Rows\"", source, StringComparison.Ordinal);
+            Assert.Contains("AddSummaryLine(group, \"Omitted Rows\"", source, StringComparison.Ordinal);
+            Assert.Contains("AddSummaryLine(group, \"Large Directory Limit\"", source, StringComparison.Ordinal);
+            Assert.Contains("table.Columns.Add(new TableColumn { Width = new GridLength(0.26, GridUnitType.Star) });", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"User / Role\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Security\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Access\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("AddCell(header, \"Contact\", true)", source, StringComparison.Ordinal);
+            Assert.Contains("Review access coverage, lockout state, disabled accounts, and any omitted rows", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("BuildPrintDocument(ViewModel.Users.ToList()", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var width in new[] { 55.0, 130.0, 95.0, 250.0, 190.0, 90.0, 80.0 })", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void DashboardPrintActionsUseDialogPreviewService()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "DashboardViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-users-directory-print-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-users-directory-print-performance.md
@@ -1,0 +1,23 @@
+# Users Directory Print Performance
+
+Completed on 2026-07-04 NZST.
+
+## What changed
+
+- Bounded Users directory print preview generation to the first 250 visible account rows so large directories do not build oversized FlowDocuments on the UI thread.
+- Added print packet accounting for total visible rows, printed rows, omitted rows, and the large-directory row limit.
+- Replaced fixed Users print table widths with proportional star columns that rebalance inside the shared print preview page.
+- Combined account, role, security, access, contact, and active state into a tighter handoff table.
+- Added a professional preview description and review note covering access coverage, lockout state, disabled accounts, and omitted rows.
+- Added defensive empty packet text and default text for missing user fields.
+- Extended source-contract coverage so the print route stays bounded, uses flexible columns, and avoids full-directory materialization.
+
+## Validation
+
+- GitHub connector source readback confirmed the Users print path, summary packet, proportional table columns, preview description, and source-contract assertions.
+- Full Windows/.NET validation, WPF runtime smoke tests, print-preview rendering, screenshots, and `pwsh -File scripts/run-full-validation.ps1` could not be run from this scheduled Linux environment.
+
+## Follow-up
+
+- Run the full validation runner from a Windows/.NET-capable checkout.
+- Smoke test Users print preview with empty, short, filtered, and 250+ account directories at 1366 x 768 and higher Windows scaling.

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
@@ -18,6 +18,8 @@ namespace InventoryManagementApp.Views.Pages
     /// </summary>
     public partial class UsersPage : Page
     {
+        private const int MaxUsersPrintRows = 250;
+
         public UsersPage(UserManagementViewModel? viewModel)
         {
             DataContext = viewModel;
@@ -96,8 +98,11 @@ namespace InventoryManagementApp.Views.Pages
                     return;
                 }
 
-                var document = BuildPrintDocument(ViewModel.Users.ToList(), $"Visible users: {ViewModel.Users.Count}");
-                ShowPrintPreview(document, "User Directory");
+                var totalVisibleCount = ViewModel.Users.Count;
+                var printRows = ViewModel.Users.Take(MaxUsersPrintRows).ToList();
+                var summary = $"Visible users: {totalVisibleCount}; printed rows: {printRows.Count}; omitted rows: {Math.Max(0, totalVisibleCount - printRows.Count)}";
+                var document = BuildPrintDocument(printRows, totalVisibleCount, summary);
+                ShowPrintPreview(document, "User Directory", "Review the current account directory, access coverage, lockout state, and any omitted rows before filing an admin handoff.");
             });
         }
 
@@ -119,12 +124,13 @@ namespace InventoryManagementApp.Views.Pages
                    "Next steps: edit profile details, tick the app sections this user can access, upload a current photo, reset the password if the user is blocked, or review activity logs for recent account actions.";
         }
 
-        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<UserModel> users, string summary)
+        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<UserModel> users, int totalVisibleCount, string summary)
         {
             var document = new FlowDocument
             {
                 FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
-                FontSize = 10
+                FontSize = 10,
+                PagePadding = new Thickness(32)
             };
 
             document.Blocks.Add(new Paragraph(new Run("User Directory"))
@@ -133,56 +139,108 @@ namespace InventoryManagementApp.Views.Pages
                 FontWeight = FontWeights.SemiBold,
                 Margin = new Thickness(0, 0, 0, 4)
             });
-            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - {summary}"))
+            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g}"))
             {
                 FontSize = 10,
-                Margin = new Thickness(0, 0, 0, 10)
+                Margin = new Thickness(0, 0, 0, 8)
             });
 
+            document.Blocks.Add(BuildSummarySection(summary, totalVisibleCount, users.Count, Math.Max(0, totalVisibleCount - users.Count)));
+
+            if (users.Count == 0)
+            {
+                document.Blocks.Add(new Paragraph(new Run("No user rows were available for this print packet."))
+                {
+                    Margin = new Thickness(0, 0, 0, 10),
+                    FontStyle = FontStyles.Italic
+                });
+                return document;
+            }
+
             var table = new Table { CellSpacing = 0 };
-            foreach (var width in new[] { 55.0, 130.0, 95.0, 250.0, 190.0, 90.0, 80.0 })
-                table.Columns.Add(new TableColumn { Width = new GridLength(width) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.12, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.18, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.14, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.26, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.20, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.10, GridUnitType.Star) });
 
             var rowGroup = new TableRowGroup();
             table.RowGroups.Add(rowGroup);
 
-            var header = new TableRow { FontWeight = FontWeights.SemiBold };
+            var header = new TableRow { FontWeight = FontWeights.SemiBold, Background = System.Windows.Media.Brushes.LightGray };
             rowGroup.Rows.Add(header);
-            AddCell(header, "ID");
-            AddCell(header, "User");
-            AddCell(header, "Role");
-            AddCell(header, "Access");
-            AddCell(header, "Email");
-            AddCell(header, "Lockout");
-            AddCell(header, "Active");
+            AddCell(header, "User ID", true);
+            AddCell(header, "User / Role", true);
+            AddCell(header, "Security", true);
+            AddCell(header, "Access", true);
+            AddCell(header, "Contact", true);
+            AddCell(header, "Active", true);
 
+            var index = 0;
             foreach (var user in users)
             {
                 var row = new TableRow();
+                if (index % 2 == 1)
+                    row.Background = System.Windows.Media.Brushes.WhiteSmoke;
+
                 rowGroup.Rows.Add(row);
                 AddCell(row, user.UserID.ToString());
-                AddCell(row, user.UserName);
-                AddCell(row, ResolveRole(user));
-                AddCell(row, user.AccessSummary);
-                AddCell(row, user.Email);
-                AddCell(row, user.LockoutStatus);
+                AddCell(row, $"{ValueOrNotRecorded(user.UserName)}\n{ResolveRole(user)}");
+                AddCell(row, $"{ValueOrNotRecorded(user.LockoutStatus)}\nPassword expired: {FormatBool(user.PasswordExpired)}");
+                AddCell(row, ValueOrNotRecorded(user.AccessSummary));
+                AddCell(row, $"{ValueOrNotRecorded(user.Email)}\n{ValueOrNotRecorded(user.Phone)}");
                 AddCell(row, FormatBool(user.IsActive));
+                index++;
             }
 
             document.Blocks.Add(table);
+            document.Blocks.Add(new Paragraph(new Run("Review access coverage, lockout state, disabled accounts, and any omitted rows before changing permissions or filing this directory packet."))
+            {
+                FontSize = 10,
+                FontStyle = FontStyles.Italic,
+                Margin = new Thickness(0, 10, 0, 0)
+            });
+
             return document;
         }
 
-        private static void ShowPrintPreview(FlowDocument document, string title)
+        private static Table BuildSummarySection(string summary, int totalVisibleCount, int printedRowCount, int omittedRowCount)
         {
-            new PrintPreviewWindow().ShowPreview(document, title, null);
+            var table = new Table { CellSpacing = 0, Margin = new Thickness(0, 0, 0, 10) };
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.25, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.75, GridUnitType.Star) });
+
+            var group = new TableRowGroup();
+            table.RowGroups.Add(group);
+            AddSummaryLine(group, "Print Packet", summary);
+            AddSummaryLine(group, "Total Visible Rows", totalVisibleCount.ToString());
+            AddSummaryLine(group, "Printed Rows", printedRowCount.ToString());
+            AddSummaryLine(group, "Omitted Rows", omittedRowCount == 0 ? "None" : $"{omittedRowCount} rows omitted to keep preview responsive");
+            AddSummaryLine(group, "Large Directory Limit", $"First {MaxUsersPrintRows} visible rows");
+
+            return table;
         }
 
-        private static void AddCell(TableRow row, string text)
+        private static void AddSummaryLine(TableRowGroup group, string label, string value)
+        {
+            var row = new TableRow();
+            group.Rows.Add(row);
+            AddCell(row, label, true);
+            AddCell(row, ValueOrNotRecorded(value));
+        }
+
+        private static void ShowPrintPreview(FlowDocument document, string title, string description)
+        {
+            new PrintPreviewWindow().ShowPreview(document, title, description);
+        }
+
+        private static void AddCell(TableRow row, string text, bool isHeader = false)
         {
             row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
             {
-                Margin = new Thickness(2)
+                Margin = new Thickness(2),
+                FontWeight = isHeader ? FontWeights.SemiBold : FontWeights.Normal
             })
             {
                 BorderBrush = System.Windows.Media.Brushes.Gray,
@@ -204,5 +262,7 @@ namespace InventoryManagementApp.Views.Pages
         private static string FormatDate(DateTime? value) => value.HasValue ? value.Value.ToString("yyyy-MM-dd") : "-";
 
         private static string ValueOrDash(string? value) => string.IsNullOrWhiteSpace(value) ? "-" : value;
+
+        private static string ValueOrNotRecorded(string? value) => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value.Trim();
     }
 }


### PR DESCRIPTION
## What changed

- Bounded Users directory print preview generation to the first 250 visible account rows.
- Replaced full-directory print materialization with an explicit `Take(MaxUsersPrintRows)` snapshot.
- Added honest print packet accounting for visible, printed, and omitted rows.
- Added a large-directory limit line so operators know why rows may be omitted.
- Replaced fixed-width Users print columns with proportional star columns.
- Reworked the print table into tighter user/role, security, access, contact, and active-state handoff columns.
- Added a preview description for the shared `PrintPreviewWindow` route.
- Added a review note covering access coverage, lockout state, disabled accounts, and omitted rows.
- Added defensive empty-packet text and default text for missing user fields.
- Kept the existing toolbar and context-menu Print Directory workflow intact.
- Added source-contract coverage to prevent reintroducing full-directory materialization or fixed print widths.
- Added a progress note for future scheduled runs.

## Why this was highest value

Recent merged work improved Activity Logs print preview performance, Item Search refresh work, shell startup, exporters, and shared popup behavior. Users still had a concrete print-preview hot path: it copied every visible account into a FlowDocument and used fixed print-table widths. That directly affects large account directories and professional admin handoff output without overlapping the most recent work.

## Why this is real progress

This is a complete workflow slice across the Users directory print route, print document structure, large-data responsiveness, professional data display, source-contract coverage, and repo progress notes. It includes more than ten focused improvements while staying inside the existing active WPF app.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/UsersPage.xaml.cs`
  - `InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-users-directory-print-performance.md`
- Connector readback confirmed the row cap, bounded print snapshot, summary packet, proportional columns, preview description, review note, fallback row text, and source-contract assertions.
- Connector status readback found no attached commit statuses on branch head `e18dd2a2fa76c1a4319b41df4114950dd608bcd0`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full validation runner from a Windows/.NET-capable checkout.
- Smoke test Users print preview with empty, short, filtered, and 250+ account directories at 1366 x 768 and higher Windows scaling.