### PR TITLE
Improve Rental History search responsiveness and export feedback

### DIFF
--- a/InventoryManagementApp.Tests/RentalHistorySearchPerformanceContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalHistorySearchPerformanceContractTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalHistorySearchPerformanceContractTests
+    {
+        [Fact]
+        public void RentalHistoryViewModel_UsesAsyncCancellableSearchInsteadOfBlockingCommand()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
+
+            Assert.Contains("public IAsyncRelayCommand SearchCommand { get; }", source, StringComparison.Ordinal);
+            Assert.Contains("SearchCommand = new AsyncRelayCommand(ExecuteSearchAsync, () => !IsFiltering);", source, StringComparison.Ordinal);
+            Assert.Contains("private CancellationTokenSource? _searchCts;", source, StringComparison.Ordinal);
+            Assert.Contains("Task.Run(() => BuildFilteredHistory(term, cts.Token), cts.Token)", source, StringComparison.Ordinal);
+            Assert.Contains("catch (OperationCanceledException)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("SearchCommand = new RelayCommand(ExecuteSearch);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("void ExecuteSearch()", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryViewModel_CachesSearchRowsAndSearchesOperationalFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
+
+            Assert.Contains("private sealed class RentalHistorySearchRow", source, StringComparison.Ordinal);
+            Assert.Contains(".OrderByDescending(r => r.RentalDate)", source, StringComparison.Ordinal);
+            Assert.Contains(".ThenByDescending(r => r.RentalID)", source, StringComparison.Ordinal);
+            Assert.Contains("rental.RentalID.ToString(CultureInfo.InvariantCulture)", source, StringComparison.Ordinal);
+            Assert.Contains("rental.ItemNumber", source, StringComparison.Ordinal);
+            Assert.Contains("rental.ItemLocation", source, StringComparison.Ordinal);
+            Assert.Contains("rental.CustomerName", source, StringComparison.Ordinal);
+            Assert.Contains("rental.Status", source, StringComparison.Ordinal);
+            Assert.Contains("rental.DueDate.ToString(\"yyyy-MM-dd\", CultureInfo.InvariantCulture)", source, StringComparison.Ordinal);
+            Assert.Contains("rental.ReturnDate?.ToString(\"yyyy-MM-dd\", CultureInfo.InvariantCulture)", source, StringComparison.Ordinal);
+            Assert.Contains("SearchText.Contains(term, StringComparison.OrdinalIgnoreCase)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryViewModel_PublishesProfessionalFilteredViewState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
+
+            Assert.Contains("public string SearchStatus => IsFiltering", source, StringComparison.Ordinal);
+            Assert.Contains("public bool HasActiveSearch => !string.IsNullOrWhiteSpace(AppliedSearchText);", source, StringComparison.Ordinal);
+            Assert.Contains("public bool HasNoResults => History.Count == 0;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool CanExportHistory => History.Count > 0 && !IsFiltering;", source, StringComparison.Ordinal);
+            Assert.Contains("public string EmptyStateTitle => HasActiveSearch ? \"No matching rental records\" : \"No rental history records\";", source, StringComparison.Ordinal);
+            Assert.Contains("public string ExportSummary => CanExportHistory", source, StringComparison.Ordinal);
+            Assert.Contains("void RestoreSelection(int? previousSelectionId)", source, StringComparison.Ordinal);
+            Assert.Contains("void NotifyHistoryViewChanged()", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryViewModel_ExportsVisibleRowsWithContextAndUserFeedback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
+
+            Assert.Contains("if (!CanExportHistory)", source, StringComparison.Ordinal);
+            Assert.Contains("FileName = BuildExportFileName()", source, StringComparison.Ordinal);
+            Assert.Contains("RentalID,ItemNumber,ItemLocation,CustomerName,RentalDate,DueDate,ReturnDate,Status,FilteredView", source, StringComparison.Ordinal);
+            Assert.Contains("Escape(SearchStatus)", source, StringComparison.Ordinal);
+            Assert.Contains("new UTF8Encoding(encoderShouldEmitUTF8Identifier: true)", source, StringComparison.Ordinal);
+            Assert.Contains("_dialogService.ShowInfo($\"Exported {History.Count} rental record(s) to {path}.\", \"Rental History Export\");", source, StringComparison.Ordinal);
+            Assert.Contains("rental_history{suffix}_{DateTime.Now:yyyyMMdd_HHmm}.csv", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryViewModel_DisposesOutstandingSearchWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
+
+            Assert.Contains("public class RentalHistoryViewModel : ObservableObject, IDisposable", source, StringComparison.Ordinal);
+            Assert.Contains("_searchCts?.Cancel();", source, StringComparison.Ordinal);
+            Assert.Contains("_searchCts?.Dispose();", source, StringComparison.Ordinal);
+            Assert.Contains("throw new ObjectDisposedException(nameof(RentalHistoryViewModel));", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs
@@ -17,6 +17,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Setter Property=\"MinWidth\" Value=\"190\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"300\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("x:Key=\"RentalHistoryMetricValue\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding SearchStatus}\" Style=\"{StaticResource CaptionTextBlock}\" TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding ExportSummary}\" Style=\"{StaticResource CaptionTextBlock}\" TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Row=\"1\" Columns=\"3\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Width=\"1160\" Height=\"700\" MinWidth=\"940\"", xaml, StringComparison.Ordinal);
         }
@@ -30,7 +32,9 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<WrapPanel Grid.Column=\"1\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<pages:SearchBar Width=\"300\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("MaxWidth=\"360\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SearchCommand=\"{Binding SearchCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ClearCommand=\"{Binding ClearSearchCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding SearchStatus}\" Style=\"{StaticResource CaptionTextBlock}\" VerticalAlignment=\"Center\" TextWrapping=\"Wrap\" MaxWidth=\"360\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel Grid.Column=\"1\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<StackPanel DockPanel.Dock=\"Right\" Orientation=\"Horizontal\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"340\"/>", xaml, StringComparison.Ordinal);
@@ -53,7 +57,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RentalHistoryWindow_BoundsEmptyStateAndPaneText()
+        public void RentalHistoryWindow_BoundsEmptyStateFilteringStateAndPaneText()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
 
@@ -61,7 +65,11 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Grid MinWidth=\"0\">", xaml, StringComparison.Ordinal);
             Assert.Contains("MaxWidth=\"520\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border MaxWidth=\"340\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Text=\"No rental history records\" Style=\"{StaticResource SectionHeader}\" TextAlignment=\"Center\" TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Binding=\"{Binding HasNoResults}\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding EmptyStateTitle}\" Style=\"{StaticResource SectionHeader}\" TextAlignment=\"Center\" TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding EmptyStateMessage}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border MaxWidth=\"300\" Margin=\"12\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Top\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Binding=\"{Binding IsFiltering}\" Value=\"True\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Width=\"360\" HorizontalAlignment=\"Center\"", xaml, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-rental-history-search-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-rental-history-search-performance.md
@@ -1,0 +1,31 @@
+# Rental History Search Performance And Export Feedback
+
+Date: 2026-07-04
+
+## Completed
+
+- Moved Rental History search from a synchronous relay command to an async command with cancellation so repeated Find actions do not queue stale UI-path filtering work.
+- Cached per-row searchable text once when the dialog view model is created instead of rebuilding every field comparison for each search predicate.
+- Sorted the initial rental history view newest-first by rental date and rental id for a more useful operational default.
+- Expanded search coverage to rental id, item number, item location, customer name, status, checked-out date, due date, and return date.
+- Added `IsFiltering`, `AppliedSearchText`, `SearchStatus`, `HasActiveSearch`, `HasNoResults`, `CanExportHistory`, `EmptyStateTitle`, `EmptyStateMessage`, and `ExportSummary` state for professional loading, empty, filtered, and export feedback.
+- Preserved the selected rental after search/clear when the row remains visible, and falls back to the first visible row when it does not.
+- Disabled CSV export while filtering or when no rows are visible.
+- Added filtered-view context to rental detail dialogs and CSV exports so handoff files show which view generated them.
+- Added timestamped filtered/unfiltered CSV file names and UTF-8 BOM output for friendlier spreadsheet opening.
+- Added successful export feedback with row count and path, while preserving existing export error handling.
+- Bound the Rental History search control's built-in clear command to the view model.
+- Replaced static empty-state copy with dynamic no-records versus no-matches messages.
+- Added a bounded filtering-state overlay so operators get visible feedback during slower searches.
+- Updated responsive XAML source-contract tests for the new search, empty, and filtering states.
+- Added source-contract coverage for cancellable async search, cached search rows, expanded search fields, professional filtered-view state, export metadata, and disposal of outstanding search work.
+
+## Validation
+
+- Source readback should confirm the changed view model, XAML, source-contract tests, and progress note were written to the PR branch.
+- Full Windows validation, WPF runtime smoke testing, screenshots, scaling checks, CSV export execution, and `pwsh -File scripts/run-full-validation.ps1` still need to run in a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repo directly and does not provide the required Windows/WPF runtime.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test Rental History search, repeated searches, clear, no-match empty state, details, context menu, and CSV export at 1366 x 768 plus higher Windows scaling.

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -3,9 +3,12 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Utilities.Extensions;
@@ -15,11 +18,13 @@ using InventoryManagementApp.Interfaces;
 
 namespace InventoryManagementApp.ViewModels.Rental
 {
-    public class RentalHistoryViewModel : ObservableObject
+    public class RentalHistoryViewModel : ObservableObject, IDisposable
     {
-        private readonly List<RentalModel> _allHistory;
+        private readonly List<RentalHistorySearchRow> _allHistory;
         private readonly ILogger<RentalHistoryViewModel> _logger;
         private readonly IDialogService _dialogService;
+        private CancellationTokenSource? _searchCts;
+        private bool _disposed;
 
         public ObservableCollection<RentalModel> History { get; }
         public string ItemDisplayName { get; }
@@ -29,6 +34,23 @@ namespace InventoryManagementApp.ViewModels.Rental
         public string ResultsSummary => History.Count == _allHistory.Count
             ? WindowSummary
             : $"{History.Count} of {_allHistory.Count} records shown";
+        public string SearchStatus => IsFiltering
+            ? "Searching rental history..."
+            : HasActiveSearch
+                ? $"{ResultsSummary} for \"{AppliedSearchText}\""
+                : WindowSummary;
+        public bool HasActiveSearch => !string.IsNullOrWhiteSpace(AppliedSearchText);
+        public bool HasNoResults => History.Count == 0;
+        public bool CanExportHistory => History.Count > 0 && !IsFiltering;
+        public string EmptyStateTitle => HasActiveSearch ? "No matching rental records" : "No rental history records";
+        public string EmptyStateMessage => HasActiveSearch
+            ? "Clear the search or try a rental number, item number, customer, location, status, or date."
+            : "Previous rental activity for this item will appear here once records exist.";
+        public string ExportSummary => CanExportHistory
+            ? $"Export {History.Count} visible record(s) to CSV."
+            : IsFiltering
+                ? "Wait for search to finish before exporting."
+                : "No visible rental records to export.";
         public string SelectedEntrySummary => SelectedEntry == null
             ? "Select a rental row to see holder, dates, and status. Double-click any row for details."
             : $"Rental #{SelectedEntry.RentalID} | {SelectedEntry.ItemNumber} | {SelectedEntry.CustomerName} | {SelectedEntry.Status}";
@@ -37,7 +59,44 @@ namespace InventoryManagementApp.ViewModels.Rental
         public string SearchText
         {
             get => _searchText;
-            set => SetProperty(ref _searchText, value);
+            set
+            {
+                if (SetProperty(ref _searchText, value))
+                    OnPropertyChanged(nameof(SearchPrompt));
+            }
+        }
+
+        private string _appliedSearchText = string.Empty;
+        public string AppliedSearchText
+        {
+            get => _appliedSearchText;
+            private set
+            {
+                if (SetProperty(ref _appliedSearchText, value))
+                {
+                    OnPropertyChanged(nameof(HasActiveSearch));
+                    OnPropertyChanged(nameof(SearchStatus));
+                    OnPropertyChanged(nameof(EmptyStateTitle));
+                    OnPropertyChanged(nameof(EmptyStateMessage));
+                }
+            }
+        }
+
+        private bool _isFiltering;
+        public bool IsFiltering
+        {
+            get => _isFiltering;
+            private set
+            {
+                if (SetProperty(ref _isFiltering, value))
+                {
+                    SearchCommand.NotifyCanExecuteChanged();
+                    ExportCsvCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SearchStatus));
+                    OnPropertyChanged(nameof(CanExportHistory));
+                    OnPropertyChanged(nameof(ExportSummary));
+                }
+            }
         }
 
         private RentalModel? _selectedEntry;
@@ -54,7 +113,11 @@ namespace InventoryManagementApp.ViewModels.Rental
             }
         }
 
-        public IRelayCommand SearchCommand { get; }
+        public string SearchPrompt => string.IsNullOrWhiteSpace(SearchText)
+            ? "Find by rental #, item, customer, location, status, or date"
+            : $"Find \"{SearchText.Trim()}\"";
+
+        public IAsyncRelayCommand SearchCommand { get; }
         public IRelayCommand ClearSearchCommand { get; }
         public IRelayCommand OpenDetailsCommand { get; }
         public IRelayCommand ExportCsvCommand { get; }
@@ -66,41 +129,109 @@ namespace InventoryManagementApp.ViewModels.Rental
                 ? $"{item.ItemNumber} - {item.Name}"
                 : "Rental History";
 
-            _allHistory = (history ?? Enumerable.Empty<RentalModel>()).ToList();
-            History = new ObservableCollection<RentalModel>(_allHistory);
+            _allHistory = (history ?? Enumerable.Empty<RentalModel>())
+                .OrderByDescending(r => r.RentalDate)
+                .ThenByDescending(r => r.RentalID)
+                .Select(r => new RentalHistorySearchRow(r))
+                .ToList();
+            History = new ObservableCollection<RentalModel>(_allHistory.Select(r => r.Rental));
             _logger = logger ?? NullLogger<RentalHistoryViewModel>.Instance;
             _dialogService = dialogService;
 
-            SearchCommand = new RelayCommand(ExecuteSearch);
+            SearchCommand = new AsyncRelayCommand(ExecuteSearchAsync, () => !IsFiltering);
             ClearSearchCommand = new RelayCommand(ClearSearch);
             OpenDetailsCommand = new RelayCommand(OpenDetails, () => SelectedEntry != null);
-            ExportCsvCommand = new RelayCommand(ExportCsv);
+            ExportCsvCommand = new RelayCommand(ExportCsv, () => CanExportHistory);
             CloseCommand = new RelayCommand(CloseWindow);
         }
 
-        void ExecuteSearch()
+        async Task ExecuteSearchAsync()
         {
-            var term = string.IsNullOrWhiteSpace(SearchText) ? string.Empty : SearchText.Trim();
-            IEnumerable<RentalModel> results = _allHistory;
-            if (!string.IsNullOrWhiteSpace(term))
-            {
-                results = _allHistory.Where(r =>
-                    r.RentalID.ToString().Contains(term, StringComparison.OrdinalIgnoreCase) ||
-                    (r.ItemNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (r.ItemLocation?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (r.CustomerName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (r.Status?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false));
-            }
+            ThrowIfDisposed();
 
-            History.ReplaceRange(results);
-            OnPropertyChanged(nameof(ResultsSummary));
+            var term = NormalizeSearchTerm(SearchText);
+            _searchCts?.Cancel();
+            var cts = new CancellationTokenSource();
+            _searchCts = cts;
+            IsFiltering = true;
+
+            try
+            {
+                var results = await Task.Run(() => BuildFilteredHistory(term, cts.Token), cts.Token);
+                if (cts.IsCancellationRequested)
+                    return;
+
+                var previousSelectionId = SelectedEntry?.RentalID;
+                History.ReplaceRange(results);
+                AppliedSearchText = term;
+                RestoreSelection(previousSelectionId);
+                NotifyHistoryViewChanged();
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("Rental history search canceled");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to filter rental history for term {SearchTerm}", term);
+                _dialogService.ShowInfo($"Failed to filter rental history: {ex.Message}", "Rental History Search");
+            }
+            finally
+            {
+                if (ReferenceEquals(_searchCts, cts))
+                {
+                    _searchCts = null;
+                    IsFiltering = false;
+                }
+                cts.Dispose();
+            }
         }
 
         void ClearSearch()
         {
+            ThrowIfDisposed();
+
+            _searchCts?.Cancel();
             SearchText = string.Empty;
-            History.ReplaceRange(_allHistory);
+            AppliedSearchText = string.Empty;
+            var previousSelectionId = SelectedEntry?.RentalID;
+            History.ReplaceRange(_allHistory.Select(r => r.Rental));
+            RestoreSelection(previousSelectionId);
+            NotifyHistoryViewChanged();
+        }
+
+        List<RentalModel> BuildFilteredHistory(string term, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(term))
+                return _allHistory.Select(r => r.Rental).ToList();
+
+            return _allHistory
+                .Where(r =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return r.Matches(term);
+                })
+                .Select(r => r.Rental)
+                .ToList();
+        }
+
+        void RestoreSelection(int? previousSelectionId)
+        {
+            SelectedEntry = previousSelectionId.HasValue
+                ? History.FirstOrDefault(r => r.RentalID == previousSelectionId.Value) ?? History.FirstOrDefault()
+                : History.FirstOrDefault();
+        }
+
+        void NotifyHistoryViewChanged()
+        {
             OnPropertyChanged(nameof(ResultsSummary));
+            OnPropertyChanged(nameof(SearchStatus));
+            OnPropertyChanged(nameof(HasNoResults));
+            OnPropertyChanged(nameof(CanExportHistory));
+            OnPropertyChanged(nameof(EmptyStateTitle));
+            OnPropertyChanged(nameof(EmptyStateMessage));
+            OnPropertyChanged(nameof(ExportSummary));
+            ExportCsvCommand.NotifyCanExecuteChanged();
         }
 
         void OpenDetails()
@@ -108,7 +239,7 @@ namespace InventoryManagementApp.ViewModels.Rental
             if (SelectedEntry == null)
                 return;
 
-            var returned = SelectedEntry.ReturnDate?.ToString("yyyy-MM-dd HH:mm") ?? "Not returned";
+            var returned = SelectedEntry.ReturnDate?.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) ?? "Not returned";
             var details = new StringBuilder()
                 .AppendLine($"Rental #: {SelectedEntry.RentalID}")
                 .AppendLine($"Item #: {SelectedEntry.ItemNumber}")
@@ -118,6 +249,8 @@ namespace InventoryManagementApp.ViewModels.Rental
                 .AppendLine($"Due back: {SelectedEntry.DueDate:yyyy-MM-dd HH:mm}")
                 .AppendLine($"Returned: {returned}")
                 .AppendLine($"Status: {SelectedEntry.Status}")
+                .AppendLine()
+                .AppendLine(SearchStatus)
                 .ToString();
 
             _dialogService.ShowInfo(details, "Rental History Details");
@@ -125,6 +258,9 @@ namespace InventoryManagementApp.ViewModels.Rental
 
         void ExportCsv()
         {
+            if (!CanExportHistory)
+                return;
+
             string? path = null;
 
             if (System.Windows.Application.Current != null)
@@ -134,7 +270,7 @@ namespace InventoryManagementApp.ViewModels.Rental
                     var dlg = new Microsoft.Win32.SaveFileDialog
                     {
                         Filter = "CSV Files|*.csv",
-                        FileName = "rental_history.csv"
+                        FileName = BuildExportFileName()
                     };
                     if (dlg.ShowDialog() == true)
                         path = dlg.FileName;
@@ -145,26 +281,28 @@ namespace InventoryManagementApp.ViewModels.Rental
                 }
             }
 
-            path ??= Path.Combine(Environment.CurrentDirectory, "rental_history.csv");
+            path ??= Path.Combine(Environment.CurrentDirectory, BuildExportFileName());
 
             var sb = new StringBuilder();
-            sb.AppendLine("RentalID,ItemNumber,ItemLocation,CustomerName,RentalDate,DueDate,ReturnDate,Status");
+            sb.AppendLine("RentalID,ItemNumber,ItemLocation,CustomerName,RentalDate,DueDate,ReturnDate,Status,FilteredView");
             foreach (var r in History)
             {
                 sb.AppendLine(string.Join(',',
-                    r.RentalID,
+                    r.RentalID.ToString(CultureInfo.InvariantCulture),
                     Escape(r.ItemNumber),
                     Escape(r.ItemLocation),
                     Escape(r.CustomerName),
-                    r.RentalDate.ToString("o"),
-                    r.DueDate.ToString("o"),
-                    r.ReturnDate?.ToString("o") ?? string.Empty,
-                    Escape(r.Status)));
+                    r.RentalDate.ToString("o", CultureInfo.InvariantCulture),
+                    r.DueDate.ToString("o", CultureInfo.InvariantCulture),
+                    r.ReturnDate?.ToString("o", CultureInfo.InvariantCulture) ?? string.Empty,
+                    Escape(r.Status),
+                    Escape(SearchStatus)));
             }
 
             try
             {
-                File.WriteAllText(path, sb.ToString());
+                File.WriteAllText(path, sb.ToString(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+                _dialogService.ShowInfo($"Exported {History.Count} rental record(s) to {path}.", "Rental History Export");
             }
             catch (Exception ex)
             {
@@ -172,6 +310,14 @@ namespace InventoryManagementApp.ViewModels.Rental
                 _dialogService.ShowInfo($"Failed to export rental history: {ex.Message}", "Error");
             }
         }
+
+        string BuildExportFileName()
+        {
+            var suffix = HasActiveSearch ? "_filtered" : string.Empty;
+            return $"rental_history{suffix}_{DateTime.Now:yyyyMMdd_HHmm}.csv";
+        }
+
+        static string NormalizeSearchTerm(string? value) => string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
 
         static string Escape(string? value)
         {
@@ -192,6 +338,47 @@ namespace InventoryManagementApp.ViewModels.Rental
                 .FirstOrDefault(w => w.DataContext == this);
             if (window != null)
                 window.Close();
+        }
+
+        void ThrowIfDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(RentalHistoryViewModel));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _searchCts?.Cancel();
+            _searchCts?.Dispose();
+            _disposed = true;
+        }
+
+        private sealed class RentalHistorySearchRow
+        {
+            public RentalHistorySearchRow(RentalModel rental)
+            {
+                Rental = rental;
+                SearchText = string.Join(' ',
+                    rental.RentalID.ToString(CultureInfo.InvariantCulture),
+                    rental.ItemNumber,
+                    rental.ItemLocation,
+                    rental.CustomerName,
+                    rental.Status,
+                    rental.RentalDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    rental.RentalDate.ToString("MMM d yyyy", CultureInfo.InvariantCulture),
+                    rental.DueDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    rental.DueDate.ToString("MMM d yyyy", CultureInfo.InvariantCulture),
+                    rental.ReturnDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    rental.ReturnDate?.ToString("MMM d yyyy", CultureInfo.InvariantCulture));
+            }
+
+            public RentalModel Rental { get; }
+            private string SearchText { get; }
+
+            public bool Matches(string term) => SearchText.Contains(term, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
@@ -50,7 +50,7 @@
                 <StackPanel>
                     <TextBlock Text="01 Current View" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding ResultsSummary}" Style="{StaticResource RentalHistoryMetricValue}"/>
-                    <TextBlock Text="Search and exported CSV use the same filtered record set." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding SearchStatus}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource RentalHistoryMetricCard}">
@@ -64,7 +64,7 @@
                 <StackPanel>
                     <TextBlock Text="03 Output" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Details and CSV" Style="{StaticResource RentalHistoryMetricValue}"/>
-                    <TextBlock Text="Export preserves the current search result for audit review." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding ExportSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
         </WrapPanel>
@@ -84,7 +84,7 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="Rental Records" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
-                        <TextBlock Grid.Column="1" Text="Double-click, press Details, or use the context menu to inspect a selected rental."
+                        <TextBlock Grid.Column="1" Text="Search runs off the UI path and matches rental #, item, customer, location, status, and rental dates."
                                    Style="{StaticResource CaptionTextBlock}"
                                    HorizontalAlignment="Right"
                                    TextWrapping="Wrap"
@@ -100,10 +100,10 @@
                                          MinWidth="220"
                                          Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                                          SearchCommand="{Binding SearchCommand}"
+                                         ClearCommand="{Binding ClearSearchCommand}"
                                          SearchLabel=""
                                          Margin="0,0,10,6"/>
-                        <TextBlock Text="{Binding ResultsSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="360" Margin="0,0,10,6"/>
-                        <Button Style="{StaticResource GhostButton}" MinWidth="82" Content="Clear" Command="{Binding ClearSearchCommand}" Margin="0,0,6,6"/>
+                        <TextBlock Text="{Binding SearchStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="360" Margin="0,0,10,6"/>
                         <Button Style="{StaticResource PrimaryButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" Margin="0,0,0,6"/>
                     </WrapPanel>
                 </Border>
@@ -152,20 +152,33 @@
                             <Style TargetType="Border" BasedOn="{StaticResource AdminHandoffCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding History.Count}" Value="0">
+                                    <DataTrigger Binding="{Binding HasNoResults}" Value="True">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
-                            <TextBlock Text="No rental history records" Style="{StaticResource SectionHeader}" TextAlignment="Center" TextWrapping="Wrap"/>
-                            <TextBlock Text="Adjust the search or clear the filter to review previous rental activity for this item."
+                            <TextBlock Text="{Binding EmptyStateTitle}" Style="{StaticResource SectionHeader}" TextAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding EmptyStateMessage}"
                                        Style="{StaticResource CaptionTextBlock}"
                                        TextWrapping="Wrap"
                                        TextAlignment="Center"
                                        Margin="0,4,0,0"/>
                         </StackPanel>
+                    </Border>
+                    <Border MaxWidth="300" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Top">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource AdminHandoffCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsFiltering}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock Text="{Binding SearchStatus}" Style="{StaticResource CaptionTextBlock}" TextAlignment="Center" TextWrapping="Wrap"/>
                     </Border>
                 </Grid>
             </Grid>


### PR DESCRIPTION
## What changed

- Moved Rental History search from a synchronous relay command to an async cancellable command so repeated searches do not queue stale UI-path filtering work.
- Cached per-row searchable text and expanded matching to rental id, item number, location, customer, status, checkout date, due date, and return date.
- Defaulted the history list to newest-first ordering and preserved/fell back selected rows after search or clear.
- Added professional filtered-view state: filtering status, applied search text, dynamic no-record/no-match empty messages, export availability, and export summary copy.
- Disabled CSV export while filtering or when no rows are visible, added filtered-view context to details and CSV, generated timestamped filtered/unfiltered filenames, wrote UTF-8 BOM CSV output, and added export success feedback.
- Wired the Rental History search control clear command and added a bounded filtering-state overlay.
- Updated responsive XAML contracts and added search-performance source contracts.
- Added a progress note for the completed workflow slice.

## Why this was highest value

Current source showed the Rental History dialog already had responsive layout work, but its search path still filtered the full record set synchronously, refreshed the whole observable collection on the UI path, searched only a subset of useful fields, and left export/detail feedback thin for filtered handoffs. This directly matches the recurring priority for loading speed, UI responsiveness, professional data display, and safer export workflows.

## Why this is real progress

This is a complete vertical slice across view-model filtering, UI states, CSV output, details handoff text, empty/loading display, source-contract coverage, and progress notes. It is not a cosmetic-only or one-line guard change.

## Validation

- GitHub connector compare/readback confirmed the branch is ahead of `master` by five commits and changes only:
  - `InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs`
  - `InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml`
  - `InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs`
  - `InventoryManagementApp.Tests/RentalHistorySearchPerformanceContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-rental-history-search-performance.md`
- Connector readback confirmed the new async search state and new source-contract test file are present on the branch.
- Connector status readback found no attached commit statuses for the branch head before merge.

## Could not check

- Local `pwsh -File scripts/run-full-validation.ps1`, build, tests, WPF runtime smoke tests, screenshots, scaling checks, and CSV export execution could not be run in this scheduled Linux environment because direct checkout is blocked (`CONNECT tunnel failed, response 403`) and `dotnet`/Windows WPF tooling are unavailable.

## Follow-up

- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
- Smoke test Rental History at 1366 x 768 and higher Windows scaling: repeated searches, clear, no-match empty state, details, context menu, and CSV export.