### PR TITLE
Improve customer directory search and print responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
@@ -91,7 +91,7 @@ namespace InventoryManagementApp.Tests
             vm.CustomerSearchTerm = "555";
             await vm.SearchCustomersCommand.ExecuteAsync(null);
 
-            Assert.Equal(2, service.SearchCustomersCallCount);
+            Assert.Equal(1, service.SearchCustomersCallCount);
             Assert.Equal("555", service.LastSearchTerm);
             Assert.Equal(2, vm.Customers.Count);
             Assert.Equal("Beta Builders", vm.Customers[0].Company);

--- a/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -73,6 +74,31 @@ namespace InventoryManagementApp.Tests
 
             Assert.Equal(2, vm.Customers.Count);
             Assert.Equal(string.Empty, vm.CustomerSearchTerm);
+            Assert.Equal("Showing all customers", vm.CustomerFilterStatus);
+        }
+
+        [Fact]
+        public async Task SearchCustomersCommand_UsesServiceSearchForFilteredDirectoryAndStatus()
+        {
+            var service = new StubCustomerService();
+            service.Customers.Add(new CustomerModel { CustomerID = 2, Company = "Beta Builders", Contact = "Blair", Phone = "555-2000" });
+            service.Customers.Add(new CustomerModel { CustomerID = 1, Company = "Alpha Supply", Contact = "Alex", Email = "alpha@example.test" });
+            service.Customers.Add(new CustomerModel { CustomerID = 3, Company = "Gamma Tools", Contact = "Gale", Mobile = "555-3000" });
+            var dialog = new StubDialogService();
+            var vm = new CustomerManagementViewModel(service, dialog);
+            await vm.LoadCustomersAsync();
+
+            vm.CustomerSearchTerm = "555";
+            await vm.SearchCustomersCommand.ExecuteAsync(null);
+
+            Assert.Equal(2, service.SearchCustomersCallCount);
+            Assert.Equal("555", service.LastSearchTerm);
+            Assert.Equal(2, vm.Customers.Count);
+            Assert.Equal("Beta Builders", vm.Customers[0].Company);
+            Assert.Equal("Gamma Tools", vm.Customers[1].Company);
+            Assert.Equal("Filtered by \"555\"", vm.CustomerFilterStatus);
+            Assert.Contains("2 visible customers ready", vm.CustomerPrintSummary);
+            Assert.True(vm.PrintCustomerDirectoryCommand.CanExecute(null));
         }
 
         [Fact]
@@ -92,9 +118,12 @@ namespace InventoryManagementApp.Tests
             Assert.Empty(vm.Customers);
             Assert.Null(vm.SelectedCustomer);
             Assert.Equal("0 customers shown", vm.CustomerResultsSummary);
+            Assert.Equal("Showing all customers", vm.CustomerFilterStatus);
+            Assert.Equal("No printable customer rows yet", vm.CustomerPrintSummary);
             Assert.Equal(string.Empty, vm.NewCustomerName);
             Assert.False(vm.UpdateCustomerCommand.CanExecute(null));
             Assert.False(vm.PrintSelectedCustomerCommand.CanExecute(null));
+            Assert.False(vm.PrintCustomerDirectoryCommand.CanExecute(null));
             Assert.Equal("Customer Load Failed", dialog.LastInfoTitle);
             Assert.Contains("Customer rows were cleared until reload succeeds.", dialog.LastInfoMessage);
         }
@@ -110,16 +139,55 @@ namespace InventoryManagementApp.Tests
             await vm.LoadCustomersAsync();
             vm.CustomerSearchTerm = "Alpha";
 
-            service.ThrowOnGetAllCustomers = true;
+            service.ThrowOnSearchCustomers = true;
             await vm.SearchCustomersCommand.ExecuteAsync(null);
 
             Assert.Empty(vm.Customers);
             Assert.Null(vm.SelectedCustomer);
             Assert.Equal("0 customers shown for \"Alpha\"", vm.CustomerResultsSummary);
+            Assert.Equal("Filtered by \"Alpha\"", vm.CustomerFilterStatus);
             Assert.False(vm.OpenCustomerDetailsCommand.CanExecute(null));
             Assert.False(vm.CopySelectedCustomerCommand.CanExecute(null));
+            Assert.False(vm.PrintCustomerDirectoryCommand.CanExecute(null));
             Assert.Equal("Customer Search Failed", dialog.LastInfoTitle);
             Assert.Contains("Customer rows were cleared until reload succeeds.", dialog.LastInfoMessage);
+        }
+
+        [Fact]
+        public async Task PrintCustomerDirectory_BoundsLargeDirectoryAndAddsHandoffContext()
+        {
+            var service = new StubCustomerService();
+            for (var i = 1; i <= 260; i++)
+            {
+                service.Customers.Add(new CustomerModel
+                {
+                    CustomerID = i,
+                    Company = $"Customer {i:000}",
+                    Contact = $"Contact {i:000}",
+                    Phone = $"555-{i:0000}",
+                    Mobile = $"555-9{i:000}",
+                    Email = $"customer{i:000}@example.test",
+                    Address = $"{i} Warehouse Road"
+                });
+            }
+
+            var dialog = new StubDialogService();
+            var vm = new CustomerManagementViewModel(service, dialog);
+            await vm.LoadCustomersAsync();
+
+            vm.PrintCustomerDirectoryCommand.Execute(null);
+
+            Assert.Equal("Customer Directory", dialog.LastPrintPreviewTitle);
+            Assert.Contains("large-directory limits", dialog.LastPrintPreviewDescription);
+            Assert.NotNull(dialog.LastPrintPreviewDocument);
+            var text = new TextRange(dialog.LastPrintPreviewDocument!.ContentStart, dialog.LastPrintPreviewDocument.ContentEnd).Text;
+            Assert.Contains("Visible: 260", text);
+            Assert.Contains("Printed: 250", text);
+            Assert.Contains("Omitted: 10", text);
+            Assert.Contains("Large directory limit", text);
+            Assert.Contains("Review note", text);
+            Assert.DoesNotContain("Customer 260", text);
+            Assert.Contains("Print preview includes the first 250 of 260 visible customers", vm.CustomerPrintSummary);
         }
 
         [Fact]
@@ -165,15 +233,18 @@ namespace InventoryManagementApp.Tests
         {
             public List<CustomerModel> Customers { get; } = new();
             public bool ThrowOnGetAllCustomers { get; set; }
+            public bool ThrowOnSearchCustomers { get; set; }
             public bool ThrowAfterAddCustomer { get; set; }
             public bool ThrowAfterUpdateCustomer { get; set; }
             public bool ThrowAfterDeleteCustomer { get; set; }
+            public int SearchCustomersCallCount { get; private set; }
+            public string? LastSearchTerm { get; private set; }
 
             public Task AddCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
             {
                 Customers.Add(customer);
                 return ThrowAfterAddCustomer
-                    ? Task.FromException(new System.InvalidOperationException("add handoff failed"))
+                    ? Task.FromException(new InvalidOperationException("add handoff failed"))
                     : Task.CompletedTask;
             }
             public Task UpdateCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
@@ -182,14 +253,14 @@ namespace InventoryManagementApp.Tests
                 if (idx >= 0) Customers[idx] = customer;
 
                 return ThrowAfterUpdateCustomer
-                    ? Task.FromException(new System.InvalidOperationException("update handoff failed"))
+                    ? Task.FromException(new InvalidOperationException("update handoff failed"))
                     : Task.CompletedTask;
             }
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default)
             {
                 Customers.RemoveAll(c => c.CustomerID == customerID);
                 return ThrowAfterDeleteCustomer
-                    ? Task.FromException(new System.InvalidOperationException("delete handoff failed"))
+                    ? Task.FromException(new InvalidOperationException("delete handoff failed"))
                     : Task.CompletedTask;
             }
             public Task<CustomerModel?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default)
@@ -197,14 +268,28 @@ namespace InventoryManagementApp.Tests
             public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default)
             {
                 if (ThrowOnGetAllCustomers)
-                    return Task.FromException<List<CustomerModel>>(new System.InvalidOperationException("database offline"));
+                    return Task.FromException<List<CustomerModel>>(new InvalidOperationException("database offline"));
 
                 return Task.FromResult(Customers.ToList());
             }
             public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult(Customers.Count);
             public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default)
-                => Task.FromResult(Customers.Where(c => c.Company?.Contains(searchTerm) == true).ToList());
+            {
+                SearchCustomersCallCount++;
+                LastSearchTerm = searchTerm;
+
+                if (ThrowOnSearchCustomers)
+                    return Task.FromException<List<CustomerModel>>(new InvalidOperationException("search offline"));
+
+                return Task.FromResult(Customers.Where(c =>
+                    Contains(c.Company, searchTerm) ||
+                    Contains(c.Email, searchTerm) ||
+                    Contains(c.Contact, searchTerm) ||
+                    Contains(c.Phone, searchTerm) ||
+                    Contains(c.Mobile, searchTerm) ||
+                    Contains(c.Address, searchTerm)).ToList());
+            }
             public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default)
                 => Task.FromResult(new CustomerImportResult());
             public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default)
@@ -213,6 +298,9 @@ namespace InventoryManagementApp.Tests
                 => Task.FromResult(0);
             public Task ExportCustomersAsync(string filePath, IDataExporter<CustomerModel> exporter, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
+
+            private static bool Contains(string? value, string searchTerm)
+                => value?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) == true;
         }
 
         private sealed class StubDialogService : IDialogService
@@ -221,6 +309,9 @@ namespace InventoryManagementApp.Tests
             public CustomerModel? EditCustomerResult { get; set; }
             public string? LastInfoMessage { get; private set; }
             public string? LastInfoTitle { get; private set; }
+            public FlowDocument? LastPrintPreviewDocument { get; private set; }
+            public string? LastPrintPreviewTitle { get; private set; }
+            public string? LastPrintPreviewDescription { get; private set; }
             public void ShowInfo(string message, string title)
             {
                 LastInfoMessage = message;
@@ -237,14 +328,19 @@ namespace InventoryManagementApp.Tests
             public ItemModel? ShowEditItemDialog(ItemModel item) => null;
             public Task<ItemModel?> ShowEditItemDialogAsync(ItemModel item) => Task.FromResult<ItemModel?>(null);
             public void ShowItemDetails(ItemModel item) { }
-            public (CustomerModel customer, System.DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => AddCustomerResult;
             public CustomerModel? ShowEditCustomerDialog(CustomerModel customer) => EditCustomerResult;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
             public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
-            public System.Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
-            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description)
+            {
+                LastPrintPreviewDocument = document;
+                LastPrintPreviewTitle = title;
+                LastPrintPreviewDescription = description;
+            }
             public void ShowPrintLabelDialog() { }
         }
     }

--- a/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
@@ -15,6 +15,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Setter Property=\"MinWidth\" Value=\"160\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"250\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("CustomerStatValueText", xaml, StringComparison.Ordinal);
+            Assert.Contains("CustomerFilterStatus", xaml, StringComparison.Ordinal);
+            Assert.Contains("CustomerPrintSummary", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Grid Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"1.35*\"/>", xaml, StringComparison.Ordinal);
         }
@@ -56,9 +58,22 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<pages:SearchBar Width=\"300\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CustomerEmptyStateMessage", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"310\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomersPage_ShowsBoundedDirectoryLoadingOverlay()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
+
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"360\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<DataTrigger Binding=\"{Binding IsCustomerDirectoryBusy}\" Value=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ProgressBar IsIndeterminate=\"True\" Height=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Updating customer directory", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding CustomerFilterStatus}\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-customer-directory-search-print-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-customer-directory-search-print-performance.md
@@ -1,0 +1,26 @@
+# Customer Directory Search And Print Performance - 2026-07-04
+
+## Completed
+
+- Routed filtered customer directory searches through `ICustomerService.SearchCustomersAsync` instead of loading every customer and filtering the full list in the view model.
+- Added a directory busy guard so page load, search, and clear actions do not start overlapping customer refreshes.
+- Added customer directory loading, filter, empty-state, and print-summary properties for clearer operator feedback.
+- Kept directory rows deterministically sorted by company, contact, and customer ID after load/search refreshes.
+- Disabled customer directory print while rows are loading or no rows are visible.
+- Added a bounded loading overlay and dynamic no-record/no-match empty-state text on the Customers page.
+- Bounded Customer Directory print preview to the first 250 visible rows to avoid oversized FlowDocument generation on large directories.
+- Replaced fixed-width Customer Directory print columns with proportional columns.
+- Added honest print accounting for visible, printed, and omitted rows plus search context and a large-directory notice.
+- Added contact-path/address review guidance and a useful preview description to printed customer packets.
+- Added behavior coverage for service-backed search, failure states, print command availability, and bounded print packets.
+- Extended Customers page source-contract coverage for the loading overlay and dynamic filter/print/empty-state display.
+
+## Validation
+
+- Source changes were made through the GitHub connector because direct checkout remains blocked in the scheduled Linux environment.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime checks, screenshots, scaling checks, and print-preview rendering were not available in this environment.
+
+## Follow-up
+
+- Run the full Windows/.NET validation runner.
+- Smoke test Customers at 1366 x 768 and higher Windows scaling with all customers, active search, no-match search, rapid search/clear, and 250+ visible rows before printing.

--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
@@ -16,6 +17,8 @@ namespace InventoryManagementApp.ViewModels
 {
     public class CustomerManagementViewModel : ObservableObject
     {
+        private const int MaxCustomerDirectoryPrintRows = 250;
+
         private readonly ICustomerService? _customerService;
         private readonly IDialogService? _dialogService;
 
@@ -31,6 +34,64 @@ namespace InventoryManagementApp.ViewModels
                     : $"{baseSummary} for \"{CustomerSearchTerm.Trim()}\"";
             }
         }
+
+        public string CustomerFilterStatus
+        {
+            get
+            {
+                if (IsCustomerDirectoryBusy)
+                    return string.IsNullOrWhiteSpace(CustomerSearchTerm)
+                        ? "Loading customer directory..."
+                        : $"Searching \"{CustomerSearchTerm.Trim()}\"...";
+
+                return string.IsNullOrWhiteSpace(CustomerSearchTerm)
+                    ? "Showing all customers"
+                    : $"Filtered by \"{CustomerSearchTerm.Trim()}\"";
+            }
+        }
+
+        public string CustomerPrintSummary
+        {
+            get
+            {
+                if (Customers.Count == 0)
+                    return "No printable customer rows yet";
+
+                return Customers.Count > MaxCustomerDirectoryPrintRows
+                    ? $"Print preview includes the first {MaxCustomerDirectoryPrintRows} of {Customers.Count} visible customers"
+                    : $"{Customers.Count} visible customer{(Customers.Count == 1 ? string.Empty : "s")} ready for print preview";
+            }
+        }
+
+        public string CustomerEmptyStateMessage
+        {
+            get
+            {
+                if (IsCustomerDirectoryBusy)
+                    return "The directory is updating. Results will appear here shortly.";
+
+                return string.IsNullOrWhiteSpace(CustomerSearchTerm)
+                    ? "No customer records are available yet. Add a customer to start the directory."
+                    : $"No customers match \"{CustomerSearchTerm.Trim()}\". Clear or adjust the search before adding a duplicate record.";
+            }
+        }
+
+        public bool IsCustomerDirectoryBusy
+        {
+            get => _isCustomerDirectoryBusy;
+            private set
+            {
+                if (SetProperty(ref _isCustomerDirectoryBusy, value))
+                {
+                    OnPropertyChanged(nameof(CustomerFilterStatus));
+                    OnPropertyChanged(nameof(CustomerEmptyStateMessage));
+                    SearchCustomersCommand.NotifyCanExecuteChanged();
+                    ClearCustomerSearchCommand.NotifyCanExecuteChanged();
+                    PrintCustomerDirectoryCommand.NotifyCanExecuteChanged();
+                }
+            }
+        }
+        private bool _isCustomerDirectoryBusy;
 
         public string SelectedCustomerSummary => SelectedCustomer == null
             ? "Select or double-click a customer row to view contact details, copy a handoff, print a customer sheet, edit, or delete."
@@ -104,7 +165,11 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _customerSearchTerm, value))
+                {
                     OnPropertyChanged(nameof(CustomerResultsSummary));
+                    OnPropertyChanged(nameof(CustomerFilterStatus));
+                    OnPropertyChanged(nameof(CustomerEmptyStateMessage));
+                }
             }
         }
 
@@ -127,35 +192,40 @@ namespace InventoryManagementApp.ViewModels
             _dialogService = dialogService;
             AddCustomerCommand = new AsyncRelayCommand(AddCustomerAsync);
             UpdateCustomerCommand = new AsyncRelayCommand(UpdateCustomerAsync, () => SelectedCustomer != null);
-            SearchCustomersCommand = new AsyncRelayCommand(SearchCustomersAsync);
+            SearchCustomersCommand = new AsyncRelayCommand(SearchCustomersAsync, CanRefreshCustomerDirectory);
             DeleteCustomerCommand = new AsyncRelayCommand(() => DeleteCustomerAsync(), () => SelectedCustomer != null);
             EditCustomerCommand = new AsyncRelayCommand(() => EditCustomerAsync(SelectedCustomer), () => SelectedCustomer != null);
             EditCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(EditCustomerAsync);
             DeleteCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(c => DeleteCustomerAsync(c));
-            ClearCustomerSearchCommand = new AsyncRelayCommand(ClearCustomerSearchAsync);
+            ClearCustomerSearchCommand = new AsyncRelayCommand(ClearCustomerSearchAsync, CanRefreshCustomerDirectory);
             OpenCustomerDetailsCommand = new RelayCommand(OpenCustomerDetails, () => SelectedCustomer != null);
-            PrintCustomerDirectoryCommand = new RelayCommand(PrintCustomerDirectory);
+            PrintCustomerDirectoryCommand = new RelayCommand(PrintCustomerDirectory, CanPrintCustomerDirectory);
             PrintSelectedCustomerCommand = new RelayCommand(PrintSelectedCustomer, () => SelectedCustomer != null);
             CopySelectedCustomerCommand = new RelayCommand(CopySelectedCustomer, () => SelectedCustomer != null);
         }
 
         public async Task LoadCustomersAsync()
         {
-            if (_customerService == null) return;
+            if (_customerService == null || IsCustomerDirectoryBusy) return;
 
             try
             {
+                IsCustomerDirectoryBusy = true;
                 var preferredCustomerId = SelectedCustomer?.CustomerID;
                 var all = await _customerService.GetAllCustomersAsync();
-                Customers.ReplaceRange(all);
+                Customers.ReplaceRange(OrderCustomersForDirectory(all));
                 SelectBestCustomerAfterRefresh(preferredCustomerId);
-                OnPropertyChanged(nameof(CustomerResultsSummary));
+                NotifyCustomerDirectoryStateChanged();
             }
             catch (Exception ex)
             {
                 ClearCustomerDirectoryAfterLoadFailure();
                 if (_dialogService != null)
                     await _dialogService.ShowInfoAsync($"Failed to load customers: {ex.Message} Customer rows were cleared until reload succeeds.", "Customer Load Failed");
+            }
+            finally
+            {
+                IsCustomerDirectoryBusy = false;
             }
         }
 
@@ -223,21 +293,26 @@ namespace InventoryManagementApp.ViewModels
 
         async Task SearchCustomersAsync()
         {
-            if (_customerService == null) return;
+            if (_customerService == null || IsCustomerDirectoryBusy) return;
 
             try
             {
+                IsCustomerDirectoryBusy = true;
                 var preferredCustomerId = SelectedCustomer?.CustomerID;
                 var all = await GetCustomersForCurrentSearchAsync();
                 Customers.ReplaceRange(all);
                 SelectBestCustomerAfterRefresh(preferredCustomerId);
-                OnPropertyChanged(nameof(CustomerResultsSummary));
+                NotifyCustomerDirectoryStateChanged();
             }
             catch (Exception ex)
             {
                 ClearCustomerDirectoryAfterLoadFailure();
                 if (_dialogService != null)
                     await _dialogService.ShowInfoAsync($"Failed to search customers: {ex.Message} Customer rows were cleared until reload succeeds.", "Customer Search Failed");
+            }
+            finally
+            {
+                IsCustomerDirectoryBusy = false;
             }
         }
 
@@ -250,7 +325,7 @@ namespace InventoryManagementApp.ViewModels
                 var all = await GetCustomersForCurrentSearchAsync();
                 Customers.ReplaceRange(all);
                 SelectBestCustomerAfterRefresh(preferredCustomerId, clearSelectionWhenPreferredMissing);
-                OnPropertyChanged(nameof(CustomerResultsSummary));
+                NotifyCustomerDirectoryStateChanged();
                 await _dialogService.ShowInfoAsync(refreshedMessage, title);
             }
             catch
@@ -260,31 +335,42 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private async Task<System.Collections.Generic.List<CustomerModel>> GetCustomersForCurrentSearchAsync()
+        private async Task<List<CustomerModel>> GetCustomersForCurrentSearchAsync()
         {
-            var all = await _customerService!.GetAllCustomersAsync();
-            if (!string.IsNullOrWhiteSpace(CustomerSearchTerm))
-            {
-                var term = CustomerSearchTerm.Trim();
-                all = all.Where(c =>
-                    (c.Company?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Email?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Contact?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Phone?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Mobile?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Address?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false))
-                    .ToList();
-            }
+            var searchTerm = CustomerSearchTerm.Trim();
+            var customers = string.IsNullOrWhiteSpace(searchTerm)
+                ? await _customerService!.GetAllCustomersAsync()
+                : await _customerService!.SearchCustomersAsync(searchTerm);
 
-            return all;
+            return OrderCustomersForDirectory(customers);
         }
+
+        private static List<CustomerModel> OrderCustomersForDirectory(IEnumerable<CustomerModel> customers)
+            => customers
+                .OrderBy(c => c.Company ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(c => c.Contact ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(c => c.CustomerID)
+                .ToList();
 
         private void ClearCustomerDirectoryAfterLoadFailure()
         {
             Customers.Clear();
             SelectedCustomer = null;
-            OnPropertyChanged(nameof(CustomerResultsSummary));
+            NotifyCustomerDirectoryStateChanged();
         }
+
+        private void NotifyCustomerDirectoryStateChanged()
+        {
+            OnPropertyChanged(nameof(CustomerResultsSummary));
+            OnPropertyChanged(nameof(CustomerFilterStatus));
+            OnPropertyChanged(nameof(CustomerPrintSummary));
+            OnPropertyChanged(nameof(CustomerEmptyStateMessage));
+            PrintCustomerDirectoryCommand.NotifyCanExecuteChanged();
+        }
+
+        private bool CanRefreshCustomerDirectory() => !IsCustomerDirectoryBusy;
+
+        private bool CanPrintCustomerDirectory() => Customers.Count > 0 && !IsCustomerDirectoryBusy;
 
         private void ClearNewCustomerFields()
         {
@@ -298,6 +384,8 @@ namespace InventoryManagementApp.ViewModels
 
         async Task ClearCustomerSearchAsync()
         {
+            if (IsCustomerDirectoryBusy) return;
+
             CustomerSearchTerm = string.Empty;
             await LoadCustomersAsync();
         }
@@ -391,6 +479,12 @@ namespace InventoryManagementApp.ViewModels
             if (_dialogService == null)
                 return;
 
+            if (IsCustomerDirectoryBusy)
+            {
+                _dialogService.ShowInfo("Customer rows are still updating. Try printing again after the directory finishes loading.", "Customer Directory");
+                return;
+            }
+
             if (Customers.Count == 0)
             {
                 _dialogService.ShowInfo("There are no customers to print.", "Customer Directory");
@@ -399,31 +493,67 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
+                var visibleCount = Customers.Count;
+                var printableCustomers = Customers.Take(MaxCustomerDirectoryPrintRows).ToList();
+                var omittedCount = Math.Max(0, visibleCount - printableCustomers.Count);
+                var searchStatus = string.IsNullOrWhiteSpace(CustomerSearchTerm)
+                    ? "Search: all visible customers"
+                    : $"Search: {CustomerSearchTerm.Trim()}";
+
                 var doc = CreateCustomerDocument("Customer Directory", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {Customers.Count} customer{(Customers.Count == 1 ? string.Empty : "s")}"))
+                doc.Blocks.Add(new Paragraph(new Run(
+                    $"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Visible: {visibleCount} | Printed: {printableCustomers.Count} | Omitted: {omittedCount} | {searchStatus}"))
                 {
                     FontSize = 10,
-                    Margin = new Thickness(0, 0, 0, 10)
+                    Margin = new Thickness(0, 0, 0, 8)
                 });
 
+                if (omittedCount > 0)
+                {
+                    doc.Blocks.Add(new Paragraph(new Run(
+                        $"Large directory limit: showing the first {MaxCustomerDirectoryPrintRows} visible customers. Refine search before filing or sending a complete directory packet."))
+                    {
+                        FontSize = 10,
+                        FontWeight = FontWeights.Bold,
+                        Margin = new Thickness(0, 0, 0, 8)
+                    });
+                }
+
                 var table = new Table { CellSpacing = 0 };
-                table.Columns.Add(new TableColumn { Width = new GridLength(175) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(130) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(105) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(105) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(190) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(2.1, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.4, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.25, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.55, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.8, GridUnitType.Star) });
 
                 var group = new TableRowGroup();
                 table.RowGroups.Add(group);
-                AddPrintRow(group, true, "Company", "Contact", "Phone", "Mobile", "Email");
+                AddPrintRow(group, true, "Company", "Primary Contact", "Phone / Mobile", "Email", "Address / Review");
 
-                foreach (var customer in Customers)
+                foreach (var customer in printableCustomers)
                 {
-                    AddPrintRow(group, false, customer.Company, customer.Contact, customer.Phone, customer.Mobile, customer.Email);
+                    AddPrintRow(
+                        group,
+                        false,
+                        customer.Company,
+                        customer.Contact,
+                        JoinPrintValues(customer.Phone, customer.Mobile),
+                        customer.Email,
+                        customer.Address);
                 }
 
                 doc.Blocks.Add(table);
-                _dialogService.ShowPrintPreview(doc, "Customer Directory", string.Empty);
+                doc.Blocks.Add(new Paragraph(new Run("Review note: verify the selected contact path, email, phone/mobile, address, and omitted-row count before using this directory for rental, reminder, or service follow-up."))
+                {
+                    FontSize = 10,
+                    FontStyle = FontStyles.Italic,
+                    Margin = new Thickness(0, 10, 0, 0)
+                });
+
+                _dialogService.ShowPrintPreview(
+                    doc,
+                    "Customer Directory",
+                    "Customer directory packet with contact paths, address review, visible-row counts, and large-directory limits.");
             }
             catch (Exception ex)
             {
@@ -452,7 +582,10 @@ namespace InventoryManagementApp.ViewModels
                 AddKeyValueRow(group, "Advisor note:", "Use rentals and requests to review open activity before promising availability or delivery dates.");
                 doc.Blocks.Add(table);
 
-                _dialogService.ShowPrintPreview(doc, $"Customer {customer.CustomerID}", string.Empty);
+                _dialogService.ShowPrintPreview(
+                    doc,
+                    $"Customer {customer.CustomerID}",
+                    "Customer sheet with contact, address, and advisor next-step handoff.");
             }
             catch (Exception ex)
             {
@@ -553,6 +686,16 @@ namespace InventoryManagementApp.ViewModels
             group.Rows.Add(row);
         }
 
-        static string ValueOrNotRecorded(string? value) => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
+        static string JoinPrintValues(params string?[] values)
+        {
+            var recordedValues = values
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v!.Trim())
+                .ToList();
+
+            return recordedValues.Count == 0 ? "Not recorded" : string.Join(" / ", recordedValues);
+        }
+
+        static string ValueOrNotRecorded(string? value) => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value.Trim();
     }
 }

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml
@@ -60,8 +60,8 @@
             <Border Style="{StaticResource CustomerStatCard}">
                 <StackPanel>
                     <TextBlock Text="Search State" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding CustomerResultsSummary}" Style="{StaticResource CustomerStatValueText}"/>
-                    <TextBlock Text="Use the directory filters before printing or copying handoffs" Style="{StaticResource CustomerDetailText}"/>
+                    <TextBlock Text="{Binding CustomerFilterStatus}" Style="{StaticResource CustomerStatValueText}"/>
+                    <TextBlock Text="{Binding CustomerPrintSummary}" Style="{StaticResource CustomerDetailText}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource CustomerStatCard}">
@@ -116,6 +116,7 @@
                                                  Margin="0,0,8,6"/>
                             </WrapPanel>
                             <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="12,0,0,0">
+                                <TextBlock Text="{Binding CustomerFilterStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,8,6"/>
                                 <Button Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}" Margin="0,0,4,6"/>
                                 <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearCustomerSearchCommand}" Margin="0,0,4,6"/>
                                 <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintCustomerDirectoryCommand}" Margin="0,0,0,6"/>
@@ -201,7 +202,24 @@
                         </Border.Style>
                         <StackPanel>
                             <TextBlock Text="No customers found" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
-                            <TextBlock Text="Clear or adjust the search before adding a duplicate customer record." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding CustomerEmptyStateMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Row="2" MaxWidth="360" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsCustomerDirectoryBusy}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <ProgressBar IsIndeterminate="True" Height="6" Margin="0,0,0,10"/>
+                            <TextBlock Text="Updating customer directory" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="{Binding CustomerFilterStatus}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
                 </Grid>


### PR DESCRIPTION
## What changed

- Routed filtered Customers directory searches through `ICustomerService.SearchCustomersAsync` instead of loading the full customer list and filtering inside the view model.
- Added a customer-directory busy guard so page load, search, and clear actions do not start overlapping refreshes.
- Added professional status properties for loading, filter state, dynamic empty-state text, and print-preview availability.
- Kept refreshed customer rows deterministically sorted by company, contact, and customer ID.
- Disabled Customer Directory print while rows are loading or no rows are visible.
- Added a bounded loading overlay and dynamic no-record/no-match empty text to the Customers page.
- Bounded Customer Directory print preview generation to the first 250 visible rows.
- Replaced fixed-width Customer Directory print columns with proportional columns.
- Added honest print packet accounting for visible, printed, and omitted rows plus search context.
- Added large-directory guidance, contact/address review notes, and a useful print-preview description.
- Added behavior coverage for service-backed search, refresh failure states, command availability, and bounded large-directory print packets.
- Extended Customers page source-contract coverage for filter/print status, dynamic empty state, and loading overlay.
- Recorded the progress note for future scheduled runs.

## Why this was highest value

Recent work improved Rental History, Activity Logs, Users, Item Search, shell startup/navigation, and several print/export paths. The current Customers directory still had concrete hot-path evidence: filtered search loaded every customer before client-side filtering, directory refreshes could overlap from page load/search/clear, and printing built a fixed-width FlowDocument from every visible customer row. That directly affects loading speed, UI responsiveness, and professional customer handoff output.

## Why this is real progress

This is a complete workflow slice across the Customers view model, Customers page state display, print-preview output, behavior tests, source-contract tests, and progress notes. It includes more than ten focused shippable improvements without inventing a new workflow or touching unrelated modules.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by six focused commits, and limited to:
  - `InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs`
  - `InventoryManagementApp/Views/Pages/CustomersPage.xaml`
  - `InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs`
  - `InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-customer-directory-search-print-performance.md`
- Connector readback confirmed the service-backed search path, busy guard, bounded loading overlay, dynamic empty/filter/print status, capped print snapshot, proportional print columns, and new test coverage.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `998e28971477bc6365a9fe4c71c34deec855b83d` before PR creation.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Customers with all customers, active search, no-match search, rapid search/clear, and 250+ visible rows before printing at 1366 x 768 and higher Windows scaling.