### PR TITLE
Improve Categories directory responsiveness and print output

### DIFF
--- a/InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs
@@ -16,6 +16,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("CategoryStatValueText", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("PRINT", xaml, StringComparison.Ordinal);
+            Assert.Contains("CategoryPrintSummary", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"520\"/>", xaml, StringComparison.Ordinal);
@@ -51,17 +53,69 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void CategoriesPage_BoundsInputsEmptyStateAndHandoffScrolling()
+        public void CategoriesPage_BoundsInputsEmptyStateLoadingStateAndHandoffScrolling()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
 
             Assert.Contains("<TextBox x:Name=\"CategoryNameBox\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Width=\"250\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MinWidth=\"190\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Visibility=\"{Binding IsCategoryEmptyStateVisible, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CategoryEmptyStateTitle", xaml, StringComparison.Ordinal);
+            Assert.Contains("CategoryEmptyStateMessage", xaml, StringComparison.Ordinal);
+            Assert.Contains("Visibility=\"{Binding IsCategoryInteractionBusy, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Loading category rows", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"340\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_DisablesDirectoryPrintWhileRowsAreNotReady()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
+
+            Assert.Contains("Content=\"Print Directory\" Click=\"PrintCategories_Click\" IsEnabled=\"{Binding IsDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Print Current Directory\" Click=\"PrintCategories_Click\" IsEnabled=\"{Binding IsDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CategoryPrintSummary", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoryViewModel_GuardsLoadingCommandsAndProfessionalDirectoryState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+
+            Assert.Contains("public bool IsCategoryInteractionBusy => IsBusy;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FilteredCategories.Count > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FilteredCategories.Count == 0;", source, StringComparison.Ordinal);
+            Assert.Contains("CategoryPrintSummary", source, StringComparison.Ordinal);
+            Assert.Contains("CategoryEmptyStateTitle", source, StringComparison.Ordinal);
+            Assert.Contains("CategoryEmptyStateMessage", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsBusy)", source, StringComparison.Ordinal);
+            Assert.Contains("Category refresh is already running.", source, StringComparison.Ordinal);
+            Assert.Contains("_refreshCommand = new AsyncCommand(LoadAsync, () => !IsCategoryInteractionBusy && SelectedInventoryId > 0);", source, StringComparison.Ordinal);
+            Assert.Contains("_clearSearchCommand = new AsyncCommand(ClearSearchAsync, () => !IsCategoryInteractionBusy && !string.IsNullOrWhiteSpace(SearchText));", source, StringComparison.Ordinal);
+            Assert.Contains("RaiseCommandStates();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_BoundsDirectoryPrintPreviewAndUsesFlexibleColumns()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+
+            Assert.Contains("private const int MaxDirectoryPrintRows = 250;", source, StringComparison.Ordinal);
+            Assert.Contains("!vm.IsDirectoryPrintAvailable", source, StringComparison.Ordinal);
+            Assert.Contains("vm.FilteredCategories.Take(MaxDirectoryPrintRows).ToList()", source, StringComparison.Ordinal);
+            Assert.Contains("Rows visible: {visibleRowCount}. Rows printed: {printedRowCount}. Rows omitted: {omittedRowCount}.", source, StringComparison.Ordinal);
+            Assert.Contains("Review note: verify category names, item assignments, search/filter coverage, and any omitted rows", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(0.7, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(1.6, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(2.4, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("ValueOrNotRecorded", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("vm.FilteredCategories.ToList()", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new GridLength(90)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new GridLength(220)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new GridLength(280)", source, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-categories-directory-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-categories-directory-performance.md
@@ -1,0 +1,32 @@
+# Categories Directory Performance
+
+Completed on 2026-07-04.
+
+## What changed
+
+- Added a category directory busy guard so refresh requests do not overlap while rows are already loading.
+- Disabled create, save, delete, refresh, clear-filter, and directory print actions while category rows are busy.
+- Added ViewModel-backed print availability so directory print is only offered when visible rows are ready.
+- Added dynamic print status text for all rows, filtered rows, empty rows, and loading states.
+- Added dynamic empty-state title and message text that distinguishes no linked categories from no filter matches.
+- Added a bounded loading overlay in the Categories directory so operators see why grid actions are paused.
+- Preserved the existing virtualized category grid, selection, context menu, keyboard shortcuts, and setup handoff panel.
+- Capped Category Directory print-preview generation to the first 250 visible rows.
+- Added honest print packet accounting for visible, printed, omitted, total, and filter context.
+- Replaced fixed Category Directory print table widths with proportional columns.
+- Added directory labels, fallback row text, review guidance, and an extra selected-sheet checklist item for professional handoff output.
+- Extended source-contract coverage for loading guards, UI state, print availability, capped print snapshots, proportional print columns, and preserved actions.
+
+## Validation
+
+- Source inspection confirmed Categories ViewModel commands now respect `IsCategoryInteractionBusy` and directory print state.
+- Source inspection confirmed Categories page print actions bind to `IsDirectoryPrintAvailable`, loading/empty states are ViewModel-backed, and the print preview caps rows with proportional columns.
+- Source-contract tests were updated to guard the new Categories loading, empty, print, and preserved-action contracts.
+
+## Could not run here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- .NET restore/build/test
+- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering
+
+The scheduled Linux environment still blocks direct checkout and does not provide the Windows/.NET/WPF validation stack.

--- a/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
@@ -38,7 +38,7 @@ namespace InventoryManagementApp.ViewModels
                 if (_selectedInventoryId == value) return;
                 _selectedInventoryId = value;
                 OnPropertyChanged();
-                _addCommand.RaiseCanExecuteChanged();
+                RaiseCommandStates();
                 if (_schemaInitialized)
                 {
                     LoadCategoriesAsync();
@@ -56,8 +56,7 @@ namespace InventoryManagementApp.ViewModels
                 OnPropertyChanged();
                 CategoryName = value?.Name ?? "";
                 RaiseSelectedCategoryProperties();
-                _saveCommand.RaiseCanExecuteChanged();
-                _deleteCommand.RaiseCanExecuteChanged();
+                RaiseCommandStates();
             }
         }
 
@@ -71,8 +70,7 @@ namespace InventoryManagementApp.ViewModels
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(CategoryNameStatus));
                 OnPropertyChanged(nameof(SelectedCategoryNextAction));
-                _addCommand.RaiseCanExecuteChanged();
-                _saveCommand.RaiseCanExecuteChanged();
+                RaiseCommandStates();
             }
         }
 
@@ -85,7 +83,7 @@ namespace InventoryManagementApp.ViewModels
                 _searchText = value;
                 OnPropertyChanged();
                 ApplyFilter();
-                _clearSearchCommand.RaiseCanExecuteChanged();
+                RaiseCommandStates();
             }
         }
 
@@ -108,8 +106,17 @@ namespace InventoryManagementApp.ViewModels
                 if (_isBusy == value) return;
                 _isBusy = value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(IsCategoryInteractionBusy));
+                RaiseDirectoryProperties();
+                RaiseCommandStates();
             }
         }
+
+        public bool IsCategoryInteractionBusy => IsBusy;
+
+        public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FilteredCategories.Count > 0;
+
+        public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FilteredCategories.Count == 0;
 
         public string CategoryResultsSummary => string.IsNullOrWhiteSpace(SearchText)
             ? $"{FilteredCategories.Count} {(FilteredCategories.Count == 1 ? "category" : "categories")} shown"
@@ -122,6 +129,44 @@ namespace InventoryManagementApp.ViewModels
         public string CategoryFilterSummary => string.IsNullOrWhiteSpace(SearchText)
             ? "Showing every linked category."
             : $"Filter active: \"{SearchText.Trim()}\".";
+
+        public string CategoryPrintSummary
+        {
+            get
+            {
+                if (IsCategoryInteractionBusy) return "Print is paused while category rows are loading.";
+                if (FilteredCategories.Count == 0) return "Print is available after categories are loaded or the filter has matches.";
+                return string.IsNullOrWhiteSpace(SearchText)
+                    ? $"Ready to print {FilteredCategories.Count} category row{(FilteredCategories.Count == 1 ? "" : "s")}."
+                    : $"Ready to print {FilteredCategories.Count} filtered category row{(FilteredCategories.Count == 1 ? "" : "s")}.";
+            }
+        }
+
+        public string CategoryEmptyStateTitle
+        {
+            get
+            {
+                if (Categories.Count == 0) return "No categories linked yet";
+                return string.IsNullOrWhiteSpace(SearchText)
+                    ? "No categories to show"
+                    : "No categories match this filter";
+            }
+        }
+
+        public string CategoryEmptyStateMessage
+        {
+            get
+            {
+                if (Categories.Count == 0)
+                {
+                    return "Create the first category for this inventory area so item setup, advisor search, and printed directories have a controlled vocabulary.";
+                }
+
+                return string.IsNullOrWhiteSpace(SearchText)
+                    ? "Refresh the directory or create a category name that matches how staff ask for tools."
+                    : "Clear the search, adjust the filter, or create a category name that matches how staff ask for tools.";
+            }
+        }
 
         public string CategoryNameStatus
         {
@@ -201,11 +246,11 @@ namespace InventoryManagementApp.ViewModels
         {
             _service = service;
             _logger = logger ?? NullLogger<CategoryManagementViewModel>.Instance;
-            _addCommand = new AsyncCommand(AddAsync, () => !string.IsNullOrWhiteSpace(CategoryName) && SelectedInventoryId > 0);
-            _saveCommand = new AsyncCommand(SaveAsync, () => SelectedCategory != null && !string.IsNullOrWhiteSpace(CategoryName));
-            _deleteCommand = new AsyncCommand(DeleteAsync, () => SelectedCategory != null);
-            _refreshCommand = new AsyncCommand(LoadAsync);
-            _clearSearchCommand = new AsyncCommand(ClearSearchAsync, () => !string.IsNullOrWhiteSpace(SearchText));
+            _addCommand = new AsyncCommand(AddAsync, () => !IsCategoryInteractionBusy && !string.IsNullOrWhiteSpace(CategoryName) && SelectedInventoryId > 0);
+            _saveCommand = new AsyncCommand(SaveAsync, () => !IsCategoryInteractionBusy && SelectedCategory != null && !string.IsNullOrWhiteSpace(CategoryName));
+            _deleteCommand = new AsyncCommand(DeleteAsync, () => !IsCategoryInteractionBusy && SelectedCategory != null);
+            _refreshCommand = new AsyncCommand(LoadAsync, () => !IsCategoryInteractionBusy && SelectedInventoryId > 0);
+            _clearSearchCommand = new AsyncCommand(ClearSearchAsync, () => !IsCategoryInteractionBusy && !string.IsNullOrWhiteSpace(SearchText));
         }
 
         private async void LoadCategoriesAsync()
@@ -237,13 +282,25 @@ namespace InventoryManagementApp.ViewModels
             await LoadAsync();
         }
 
-        private async Task LoadAsync()
+        private Task LoadAsync()
+        {
+            if (SelectedInventoryId <= 0) return Task.CompletedTask;
+            if (IsBusy)
+            {
+                StatusMessage = "Category refresh is already running.";
+                return Task.CompletedTask;
+            }
+
+            return LoadCategoryDirectoryAsync();
+        }
+
+        private async Task LoadCategoryDirectoryAsync(int? preferredSelectedId = null)
         {
             if (SelectedInventoryId <= 0) return;
             IsBusy = true;
             try
             {
-                var selectedId = SelectedCategory?.CategoryID;
+                var selectedId = preferredSelectedId ?? SelectedCategory?.CategoryID;
                 var list = await _service.GetCategoriesForInventoryAsync(SelectedInventoryId);
                 Categories.Clear();
                 foreach (var c in list) Categories.Add(new CategoryItem { CategoryID = c.CategoryID, Name = c.Name });
@@ -323,12 +380,12 @@ namespace InventoryManagementApp.ViewModels
                 : FilteredCategories.FirstOrDefault();
 
             RaiseDirectoryProperties();
+            RaiseSelectedCategoryProperties();
         }
 
         private async Task ClearSearchAsync()
         {
             SearchText = "";
-            ApplyFilter();
             StatusMessage = "Category filter cleared.";
             await Task.CompletedTask;
         }
@@ -354,7 +411,7 @@ namespace InventoryManagementApp.ViewModels
                     _logger.LogInformation(ex, "Category {CategoryId} was already linked to inventory {InventoryId}", id, SelectedInventoryId);
                 }
 
-                await LoadAsync();
+                await LoadCategoryDirectoryAsync(id);
                 SelectedCategory = FilteredCategories.FirstOrDefault(x => x.CategoryID == id)
                     ?? Categories.FirstOrDefault(x => x.CategoryID == id);
                 StatusMessage = $"Category '{name}' is ready for item assignment.";
@@ -460,6 +517,11 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CategoryResultsSummary));
             OnPropertyChanged(nameof(CategorySetupSummary));
             OnPropertyChanged(nameof(CategoryFilterSummary));
+            OnPropertyChanged(nameof(CategoryPrintSummary));
+            OnPropertyChanged(nameof(IsDirectoryPrintAvailable));
+            OnPropertyChanged(nameof(IsCategoryEmptyStateVisible));
+            OnPropertyChanged(nameof(CategoryEmptyStateTitle));
+            OnPropertyChanged(nameof(CategoryEmptyStateMessage));
             OnPropertyChanged(nameof(CategoryNameStatus));
         }
 
@@ -472,6 +534,15 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(SelectedCategorySummary));
             OnPropertyChanged(nameof(SelectedCategoryChecklist));
             OnPropertyChanged(nameof(SelectedCategoryHandoff));
+        }
+
+        private void RaiseCommandStates()
+        {
+            _addCommand.RaiseCanExecuteChanged();
+            _saveCommand.RaiseCanExecuteChanged();
+            _deleteCommand.RaiseCanExecuteChanged();
+            _refreshCommand.RaiseCanExecuteChanged();
+            _clearSearchCommand.RaiseCanExecuteChanged();
         }
 
         private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
@@ -73,8 +73,8 @@
                     </Border>
                     <Border Style="{StaticResource CategoryStatCard}">
                         <StackPanel>
-                            <TextBlock Text="SETUP" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding CategoryNameStatus}" Style="{StaticResource CategoryStatValueText}"/>
+                            <TextBlock Text="PRINT" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding CategoryPrintSummary}" Style="{StaticResource CategoryStatValueText}"/>
                         </StackPanel>
                     </Border>
                 </WrapPanel>
@@ -95,7 +95,7 @@
                         <Button Style="{StaticResource GhostButton}" Content="Open" Click="OpenCategoryDetail_Click" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopyCategory_Click" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintCategories_Click" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintCategories_Click" IsEnabled="{Binding IsDirectoryPrintAvailable}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
                 </DockPanel>
@@ -184,7 +184,7 @@
                                 <MenuItem Header="Save Rename" Command="{Binding SaveCommand}"/>
                                 <MenuItem Header="Delete Category" Command="{Binding DeleteCommand}"/>
                                 <Separator/>
-                                <MenuItem Header="Print Current Directory" Click="PrintCategories_Click"/>
+                                <MenuItem Header="Print Current Directory" Click="PrintCategories_Click" IsEnabled="{Binding IsDirectoryPrintAvailable}"/>
                                 <MenuItem Header="Clear Filter" Command="{Binding ClearSearchCommand}"/>
                                 <MenuItem Header="Refresh" Command="{Binding RefreshCommand}"/>
                             </ContextMenu>
@@ -214,20 +214,18 @@
                         </DataGrid.Columns>
                     </DataGrid>
 
-                    <Border Grid.Row="2" MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
-                        <Border.Style>
-                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding FilteredCategories.Count}" Value="0">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Border.Style>
+                    <Border Grid.Row="2" MaxWidth="340" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding IsCategoryEmptyStateVisible, Converter={StaticResource BoolToVis}}" Style="{StaticResource DesktopNoteCard}">
                         <StackPanel>
-                            <TextBlock Text="No categories match this filter" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
-                            <TextBlock Text="Clear the search, refresh the directory, or create a category name that matches how staff ask for tools." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding CategoryEmptyStateTitle}" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="{Binding CategoryEmptyStateMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Grid.Row="2" MaxWidth="360" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding IsCategoryInteractionBusy, Converter={StaticResource BoolToVis}}" Style="{StaticResource DesktopNoteCard}">
+                        <StackPanel>
+                            <ProgressBar IsIndeterminate="True" Height="6" Margin="0,0,0,10"/>
+                            <TextBlock Text="Loading category rows" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="The directory is refreshing. Actions and print are paused until the saved category list is ready." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
 
@@ -317,13 +315,14 @@
             <DockPanel LastChildFill="True">
                 <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
                     <Button Style="{StaticResource PrimaryButton}" Content="Open" Click="OpenCategoryDetail_Click" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintCategories_Click" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintCategories_Click" IsEnabled="{Binding IsDirectoryPrintAvailable}" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Clear Filter" Command="{Binding ClearSearchCommand}" Margin="0,0,0,4"/>
                 </WrapPanel>
                 <StackPanel MinWidth="0">
                     <TextBlock Text="{Binding SelectedCategorySummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="2,0,10,0"/>
                     <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="2,2,10,0"/>
+                    <TextBlock Text="{Binding CategoryPrintSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="2,2,10,0"/>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -331,6 +330,6 @@
         <ProgressBar Grid.Row="4"
                      IsIndeterminate="True"
                      Margin="0,4,0,0"
-                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+                     Visibility="{Binding IsCategoryInteractionBusy, Converter={StaticResource BoolToVis}}"/>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
@@ -16,6 +16,7 @@ namespace InventoryManagementApp.Views.Pages
 {
     public partial class CategoriesPage : Page
     {
+        private const int MaxDirectoryPrintRows = 250;
         private bool _hasInitialized;
 
         public CategoriesPage(int inventoryId)
@@ -138,13 +139,21 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Category Directory", () =>
             {
-                if (DataContext is not CategoryManagementViewModel vm || vm.FilteredCategories.Count == 0)
+                if (DataContext is not CategoryManagementViewModel vm || !vm.IsDirectoryPrintAvailable)
                 {
-                    WpfMessageBox.Show("There are no categories to print.", "Category Directory", MessageBoxButton.OK, MessageBoxImage.Information);
+                    WpfMessageBox.Show("There are no categories ready to print. Wait for loading to finish or clear the filter.", "Category Directory", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
                 }
 
-                var document = BuildDirectoryPrintDocument(vm.FilteredCategories.ToList(), vm.CategoryResultsSummary, vm.CategorySetupSummary);
+                var visibleRowCount = vm.FilteredCategories.Count;
+                var snapshot = vm.FilteredCategories.Take(MaxDirectoryPrintRows).ToList();
+                var document = BuildDirectoryPrintDocument(
+                    snapshot,
+                    visibleRowCount,
+                    vm.Categories.Count,
+                    vm.SearchText,
+                    vm.CategoryResultsSummary,
+                    vm.CategorySetupSummary);
                 ShowPrintPreview(document, "Category Directory");
             });
         }
@@ -182,14 +191,25 @@ namespace InventoryManagementApp.Views.Pages
         private static string FormatCategoryDetail(CategoryManagementViewModel.CategoryItem category)
         {
             return $"Category #: {category.CategoryID}{Environment.NewLine}" +
-                   $"Name: {category.Name}{Environment.NewLine}" +
-                   $"Directory label: {category.DirectoryLabel}{Environment.NewLine}{Environment.NewLine}" +
+                   $"Name: {ValueOrNotRecorded(category.Name)}{Environment.NewLine}" +
+                   $"Directory label: {ValueOrNotRecorded(category.DirectoryLabel)}{Environment.NewLine}{Environment.NewLine}" +
                    "Admin handoff: confirm the category name matches staff language, assign matching inventory records, review search/filter coverage, and remove obsolete duplicates.";
         }
 
-        private static FlowDocument BuildDirectoryPrintDocument(IReadOnlyCollection<CategoryManagementViewModel.CategoryItem> categories, string summary, string setupSummary)
+        private static FlowDocument BuildDirectoryPrintDocument(
+            IReadOnlyCollection<CategoryManagementViewModel.CategoryItem> categories,
+            int visibleRowCount,
+            int totalRowCount,
+            string searchText,
+            string summary,
+            string setupSummary)
         {
             var document = CreateBaseDocument();
+            var printedRowCount = categories.Count;
+            var omittedRowCount = Math.Max(0, visibleRowCount - printedRowCount);
+            var filterText = string.IsNullOrWhiteSpace(searchText)
+                ? "No filter applied"
+                : $"Filter: {searchText.Trim()}";
 
             document.Blocks.Add(new Paragraph(new Run("Category Directory"))
             {
@@ -200,13 +220,34 @@ namespace InventoryManagementApp.Views.Pages
             document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - {summary}. {setupSummary}"))
             {
                 FontSize = 10,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            document.Blocks.Add(new Paragraph(new Run($"Rows visible: {visibleRowCount}. Rows printed: {printedRowCount}. Rows omitted: {omittedRowCount}. Total linked categories: {totalRowCount}. {filterText}."))
+            {
+                FontSize = 10,
+                Margin = new Thickness(0, 0, 0, 8)
+            });
+            document.Blocks.Add(new Paragraph(new Run("Review note: verify category names, item assignments, search/filter coverage, and any omitted rows before using this packet for setup cleanup."))
+            {
+                FontSize = 10,
+                FontStyle = FontStyles.Italic,
                 Margin = new Thickness(0, 0, 0, 10)
             });
 
+            if (printedRowCount == 0)
+            {
+                document.Blocks.Add(new Paragraph(new Run("No category rows were available for this directory packet."))
+                {
+                    Margin = new Thickness(0, 0, 0, 10)
+                });
+                return document;
+            }
+
             var table = new Table { CellSpacing = 0 };
-            table.Columns.Add(new TableColumn { Width = new GridLength(90) });
-            table.Columns.Add(new TableColumn { Width = new GridLength(220) });
-            table.Columns.Add(new TableColumn { Width = new GridLength(280) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(0.7, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(1.6, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(2.4, GridUnitType.Star) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(1.8, GridUnitType.Star) });
 
             var rowGroup = new TableRowGroup();
             table.RowGroups.Add(rowGroup);
@@ -215,6 +256,7 @@ namespace InventoryManagementApp.Views.Pages
             rowGroup.Rows.Add(header);
             AddCell(header, "ID");
             AddCell(header, "Category");
+            AddCell(header, "Directory Label");
             AddCell(header, "Admin Handoff");
 
             foreach (var category in categories)
@@ -222,7 +264,8 @@ namespace InventoryManagementApp.Views.Pages
                 var row = new TableRow();
                 rowGroup.Rows.Add(row);
                 AddCell(row, category.CategoryID.ToString());
-                AddCell(row, category.Name);
+                AddCell(row, ValueOrNotRecorded(category.Name));
+                AddCell(row, ValueOrNotRecorded(category.DirectoryLabel));
                 AddCell(row, "Verify item assignment and search/filter coverage.");
             }
 
@@ -234,7 +277,7 @@ namespace InventoryManagementApp.Views.Pages
         {
             var document = CreateBaseDocument();
 
-            document.Blocks.Add(new Paragraph(new Run($"Category Sheet - {category.Name}"))
+            document.Blocks.Add(new Paragraph(new Run($"Category Sheet - {ValueOrNotRecorded(category.Name)}"))
             {
                 FontSize = 16,
                 FontWeight = FontWeights.SemiBold,
@@ -259,6 +302,7 @@ namespace InventoryManagementApp.Views.Pages
             document.Blocks.Add(new Paragraph(new Run("[ ] Matching inventory records are assigned")) { Margin = new Thickness(0, 0, 0, 2) });
             document.Blocks.Add(new Paragraph(new Run("[ ] Search and filter coverage has been checked")) { Margin = new Thickness(0, 0, 0, 2) });
             document.Blocks.Add(new Paragraph(new Run("[ ] Duplicate or obsolete categories have been removed")) { Margin = new Thickness(0, 0, 0, 2) });
+            document.Blocks.Add(new Paragraph(new Run("[ ] Printed directory totals were reviewed if this category appears in a filtered packet")) { Margin = new Thickness(0, 0, 0, 2) });
             return document;
         }
 
@@ -269,6 +313,11 @@ namespace InventoryManagementApp.Views.Pages
                 FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
                 FontSize = 10
             };
+        }
+
+        private static string ValueOrNotRecorded(string? value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? "Not recorded" : value.Trim();
         }
 
         private static void AddCell(TableRow row, string text)


### PR DESCRIPTION
## What changed

- Added a Categories directory busy guard so refresh requests do not overlap while rows are already loading.
- Disabled create, save, delete, refresh, clear-filter, and directory print actions while the category directory is busy.
- Added ViewModel-backed directory print availability so print is only offered when visible rows are ready.
- Added dynamic print status text for all rows, filtered rows, empty rows, and loading states.
- Added dynamic empty-state title/message text that distinguishes no linked categories from no filter matches.
- Added a bounded loading overlay in the Categories grid area so operators understand why actions are paused.
- Preserved the virtualized category grid, row selection, context menu, keyboard shortcuts, and setup handoff panel.
- Capped Category Directory print preview generation to the first 250 visible rows.
- Added honest print packet accounting for visible, printed, omitted, total, and filter context.
- Replaced fixed Category Directory print table widths with proportional columns.
- Added directory labels, fallback row text, review guidance, and an extra selected-sheet checklist item for professional handoff output.
- Extended source-contract coverage for loading guards, UI state, print availability, capped print snapshots, proportional print columns, and preserved actions.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-categories-directory-performance.md`.

## Why this was highest value

Recent merged work has already covered Settings, Customers, Rental History, Activity Logs, Users, Item Search, Reports print output, shell startup/layout, exporters, and several dialogs. Current Categories evidence still showed a concrete workflow gap: refresh actions could be requested while rows were already loading, action/print state did not reflect loading or empty data, and directory printing materialized every visible row into fixed-width print columns. This directly matches the recurring focus on loading speed, UI responsiveness, professional data display, and print/preview safety without reworking the same recent areas.

## Why this is real progress

This is a complete Categories workflow slice across ViewModel command state, grid loading/empty display, directory print availability, print-preview document generation, source-contract tests, and progress records. It includes more than ten focused improvements while staying inside the active WPF app.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by five focused commits, and limited to:
  - `InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs`
  - `InventoryManagementApp/Views/Pages/CategoriesPage.xaml`
  - `InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs`
  - `InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-categories-directory-performance.md`
- Connector readback confirmed the busy guard, command can-execute gating, print availability state, loading/empty UI state, capped print snapshot, proportional print columns, review note, fallback row text, and updated source-contract assertions.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `c5c55e8c4affedb16c861f3dad8a0c0e5bcbb720`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Categories at 1366 x 768 and higher Windows scaling with empty, loading, filtered, no-match, short, and 250+ row directories before printing.