### PR TITLE
Improve Maintenance workbench loading and print responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
@@ -15,6 +15,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding MaintenancePrintStatus}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"520\"/>", xaml, StringComparison.Ordinal);
@@ -58,8 +59,22 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<ComboBox Width=\"175\" MinWidth=\"145\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"360\" MinHeight=\"130\" Margin=\"12\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding MaintenanceEmptyTitle}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding MaintenanceEmptyMessage}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Center\" MaxWidth=\"360\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenancePage_ShowsBoundedLoadingOverlayWhileRowsLoad()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml");
+
+            Assert.Contains("<Condition Binding=\"{Binding IsLoading}\" Value=\"False\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<DataTrigger Binding=\"{Binding IsLoading}\" Value=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Loading maintenance schedule", xaml, StringComparison.Ordinal);
+            Assert.Contains("Work-order actions and schedule printing are paused", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"380\" MinHeight=\"118\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -76,6 +91,65 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("PrintMaintenanceListCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("MaintenanceRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
             Assert.Contains("MaintenanceRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenanceViewModel_GuardsLoadingStateAndCommandAvailability()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MaintenanceManagementViewModel.cs");
+
+            Assert.Contains("private bool _isLoading;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsLoading", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsLoading)", source, StringComparison.Ordinal);
+            Assert.Contains("CanRefreshMaintenance", source, StringComparison.Ordinal);
+            Assert.Contains("CanInteractWithMaintenanceList", source, StringComparison.Ordinal);
+            Assert.Contains("!IsLoading && SelectedRecord != null", source, StringComparison.Ordinal);
+            Assert.Contains("PrintMaintenanceListCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenanceViewModel_ExposesProfessionalEmptyAndPrintState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MaintenanceManagementViewModel.cs");
+
+            Assert.Contains("public bool IsFilterActive", source, StringComparison.Ordinal);
+            Assert.Contains("public string MaintenanceEmptyTitle", source, StringComparison.Ordinal);
+            Assert.Contains("public string MaintenanceEmptyMessage", source, StringComparison.Ordinal);
+            Assert.Contains("public bool CanPrintMaintenanceList", source, StringComparison.Ordinal);
+            Assert.Contains("public string MaintenancePrintStatus", source, StringComparison.Ordinal);
+            Assert.Contains("Print paused while maintenance rows load", source, StringComparison.Ordinal);
+            Assert.Contains("No filtered rows ready to print", source, StringComparison.Ordinal);
+            Assert.Contains("Ready to print first", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenancePrintPreview_IsBoundedAndUsesProportionalColumns()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MaintenanceManagementViewModel.cs");
+
+            Assert.Contains("private const int MaxMaintenancePrintRows = 250;", source, StringComparison.Ordinal);
+            Assert.Contains("FilteredMaintenanceRecords.Take(MaxMaintenancePrintRows).ToList();", source, StringComparison.Ordinal);
+            Assert.Contains("Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows}", source, StringComparison.Ordinal);
+            Assert.Contains("Large schedule preview limited to the first", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(1.05, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(1.65, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("Review overdue rows, technician assignment", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new GridLength(150)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var record in FilteredMaintenanceRecords)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenancePage_LoadsOnceAfterFirstPaintAndResetsForNewViewModels()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml.cs");
+
+            Assert.Contains("private Task? _loadMaintenanceTask;", source, StringComparison.Ordinal);
+            Assert.Contains("private MaintenanceManagementViewModel? _loadedViewModel;", source, StringComparison.Ordinal);
+            Assert.Contains("DataContextChanged += MaintenancePage_DataContextChanged;", source, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("LoadMaintenanceOnceAsync", source, StringComparison.Ordinal);
+            Assert.Contains("IsCompletedSuccessfully", source, StringComparison.Ordinal);
+            Assert.Contains("_loadMaintenanceTask = null;", source, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
@@ -134,7 +134,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("new GridLength(1.05, GridUnitType.Star)", source, StringComparison.Ordinal);
             Assert.Contains("new GridLength(1.65, GridUnitType.Star)", source, StringComparison.Ordinal);
             Assert.Contains("Review overdue rows, technician assignment", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("new GridLength(150)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("table.Columns.Add(new TableColumn { Width = new GridLength(90) });", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("table.Columns.Add(new TableColumn { Width = new GridLength(110) });", source, StringComparison.Ordinal);
             Assert.DoesNotContain("foreach (var record in FilteredMaintenanceRecords)", source, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-maintenance-workbench-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-maintenance-workbench-performance.md
@@ -1,0 +1,30 @@
+# Maintenance Workbench Performance - 2026-07-04
+
+Completed a focused Maintenance workbench responsiveness and professional-output pass.
+
+## Completed
+
+- Added a Maintenance loading guard so schedule refreshes cannot overlap.
+- Disabled refresh, add, edit, delete, complete, details, copy, selected print, filter shortcuts, clear, and schedule print actions while maintenance rows are loading.
+- Added first-paint-friendly page-owned loading that yields before the initial Maintenance refresh.
+- Prevented duplicate page loads for the same Maintenance view model and reset the guard when the page receives a new view model.
+- Added ViewModel-backed loading, filter, empty-state, print-availability, and print-status properties.
+- Added dynamic empty-state copy for no maintenance records versus no filter matches.
+- Added a bounded loading overlay in the Maintenance schedule grid region.
+- Added Maintenance print status in the summary card, grid subheader, and footer status area.
+- Kept the virtualized Maintenance grid, row selection, context menu, keyboard shortcuts, and technician handoff panel intact.
+- Capped Maintenance Schedule print preview generation to the first 250 visible rows.
+- Added honest print packet accounting for visible, printed, omitted, filter, search, and backlog context.
+- Replaced fixed Maintenance Schedule print columns with proportional columns.
+- Added large-schedule guidance, print preview description text, fallback row text, and a handoff review note for professional schedule output.
+- Extended Maintenance source-contract coverage for loading guards, UI states, command availability, capped print snapshots, proportional print columns, page load behavior, and preserved actions.
+
+## Validation
+
+- GitHub connector readback should verify the branch diff and exact source markers before merge.
+- Local Windows/.NET validation, WPF runtime smoke testing, screenshots, scaling checks, and print-preview rendering remain blocked in the scheduled Linux environment because direct clone is blocked and required Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test Maintenance at 1366 x 768 and higher Windows scaling with no records, loading, all rows, filtered rows, no-match filters, rapid refresh/filter clicks, and 250+ visible rows before schedule printing.

--- a/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
@@ -15,22 +15,70 @@ namespace InventoryManagementApp.ViewModels
 {
     public class MaintenanceManagementViewModel : ObservableObject
     {
+        private const int MaxMaintenancePrintRows = 250;
+
         private readonly MaintenanceService _maintenanceService;
         private readonly IDialogService _dialogService;
 
         public ObservableCollection<MaintenanceRecord> MaintenanceRecords { get; }
         public ObservableCollection<MaintenanceRecord> FilteredMaintenanceRecords { get; }
 
-        public string MaintenanceResultsSummary => $"{FilteredMaintenanceRecords.Count} of {MaintenanceRecords.Count} maintenance record{(MaintenanceRecords.Count == 1 ? string.Empty : "s")} shown";
+        public string MaintenanceResultsSummary => IsLoading
+            ? "Loading maintenance records..."
+            : $"{FilteredMaintenanceRecords.Count} of {MaintenanceRecords.Count} maintenance record{(MaintenanceRecords.Count == 1 ? string.Empty : "s")} shown";
+
         public string MaintenanceBacklogSummary
         {
             get
             {
+                if (IsLoading)
+                {
+                    return "Refreshing maintenance backlog";
+                }
+
                 var scheduled = MaintenanceRecords.Count(r => IsScheduled(r));
                 var overdue = MaintenanceRecords.Count(r => r.IsOverdue);
                 var upcoming = MaintenanceRecords.Count(r => IsUpcoming(r));
                 var completed = MaintenanceRecords.Count(r => IsCompleted(r));
                 return $"{overdue} overdue | {upcoming} upcoming | {scheduled} scheduled | {completed} completed";
+            }
+        }
+
+        public bool IsFilterActive => !string.IsNullOrWhiteSpace(SearchText) || !string.Equals(SelectedFilter, "All", StringComparison.Ordinal);
+
+        public string MaintenanceEmptyTitle => MaintenanceRecords.Count == 0
+            ? "No maintenance work recorded"
+            : "No maintenance work matches this filter";
+
+        public string MaintenanceEmptyMessage => MaintenanceRecords.Count == 0
+            ? "Add a work order or refresh the schedule when service history is available."
+            : "Clear search, switch the filter, or add a new work order to restart the technician queue.";
+
+        public bool CanPrintMaintenanceList => !IsLoading && FilteredMaintenanceRecords.Count > 0;
+
+        public string MaintenancePrintStatus
+        {
+            get
+            {
+                if (IsLoading)
+                {
+                    return "Print paused while maintenance rows load";
+                }
+
+                if (FilteredMaintenanceRecords.Count == 0)
+                {
+                    return IsFilterActive
+                        ? "No filtered rows ready to print"
+                        : "No maintenance rows ready to print";
+                }
+
+                var visible = FilteredMaintenanceRecords.Count;
+                var printed = Math.Min(visible, MaxMaintenancePrintRows);
+                var omitted = Math.Max(0, visible - printed);
+                var filterContext = IsFilterActive ? "filtered" : "all rows";
+                return omitted == 0
+                    ? $"Ready to print {printed} {filterContext} row{(printed == 1 ? string.Empty : "s")}."
+                    : $"Ready to print first {printed} of {visible} {filterContext} rows; {omitted} omitted from preview.";
             }
         }
 
@@ -78,6 +126,20 @@ namespace InventoryManagementApp.ViewModels
             ? "Select work first, then verify the item tag, confirm service notes, complete or edit the record, and print/copy the handoff before releasing the item."
             : "Verify item tag and location, capture who performed the work, record cost/notes, mark complete when finished, and keep the printed or copied handoff with the item.";
 
+        private bool _isLoading;
+        public bool IsLoading
+        {
+            get => _isLoading;
+            private set
+            {
+                if (SetProperty(ref _isLoading, value))
+                {
+                    NotifyCommandStatesAndSummaries();
+                    NotifyMaintenanceListStateChanged();
+                }
+            }
+        }
+
         private MaintenanceRecord? _selectedRecord;
         public MaintenanceRecord? SelectedRecord
         {
@@ -86,13 +148,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _selectedRecord, value))
                 {
-                    EditMaintenanceCommand.NotifyCanExecuteChanged();
-                    DeleteMaintenanceCommand.NotifyCanExecuteChanged();
-                    CompleteMaintenanceCommand.NotifyCanExecuteChanged();
-                    OpenMaintenanceDetailsCommand.NotifyCanExecuteChanged();
-                    PrintSelectedMaintenanceCommand.NotifyCanExecuteChanged();
-                    CopySelectedMaintenanceCommand.NotifyCanExecuteChanged();
-                    OnSelectedRecordSummariesChanged();
+                    NotifyCommandStatesAndSummaries();
                 }
             }
         }
@@ -158,26 +214,32 @@ namespace InventoryManagementApp.ViewModels
                 "Upcoming (30 days)"
             };
 
-            LoadMaintenanceCommand = new AsyncRelayCommand(LoadMaintenanceAsync);
-            AddMaintenanceCommand = new AsyncRelayCommand(AddMaintenanceAsync);
+            LoadMaintenanceCommand = new AsyncRelayCommand(LoadMaintenanceAsync, CanRefreshMaintenance);
+            AddMaintenanceCommand = new AsyncRelayCommand(AddMaintenanceAsync, CanInteractWithMaintenanceList);
             EditMaintenanceCommand = new AsyncRelayCommand(EditMaintenanceAsync, CanEditOrDelete);
             DeleteMaintenanceCommand = new AsyncRelayCommand(DeleteMaintenanceAsync, CanEditOrDelete);
             CompleteMaintenanceCommand = new AsyncRelayCommand(CompleteMaintenanceAsync, CanComplete);
-            RefreshCommand = new AsyncRelayCommand(LoadMaintenanceAsync);
+            RefreshCommand = new AsyncRelayCommand(LoadMaintenanceAsync, CanRefreshMaintenance);
             OpenMaintenanceDetailsCommand = new RelayCommand(OpenMaintenanceDetails, CanEditOrDelete);
-            PrintMaintenanceListCommand = new RelayCommand(PrintMaintenanceList);
+            PrintMaintenanceListCommand = new RelayCommand(PrintMaintenanceList, () => CanPrintMaintenanceList);
             PrintSelectedMaintenanceCommand = new RelayCommand(PrintSelectedMaintenance, CanEditOrDelete);
             CopySelectedMaintenanceCommand = new RelayCommand(CopySelectedMaintenance, CanEditOrDelete);
-            ClearSearchCommand = new RelayCommand(ClearSearch);
-            ShowOverdueCommand = new RelayCommand(() => SelectedFilter = "Overdue");
-            ShowUpcomingCommand = new RelayCommand(() => SelectedFilter = "Upcoming (30 days)");
-            ShowScheduledCommand = new RelayCommand(() => SelectedFilter = "Scheduled");
+            ClearSearchCommand = new RelayCommand(ClearSearch, CanInteractWithMaintenanceList);
+            ShowOverdueCommand = new RelayCommand(() => SelectedFilter = "Overdue", CanInteractWithMaintenanceList);
+            ShowUpcomingCommand = new RelayCommand(() => SelectedFilter = "Upcoming (30 days)", CanInteractWithMaintenanceList);
+            ShowScheduledCommand = new RelayCommand(() => SelectedFilter = "Scheduled", CanInteractWithMaintenanceList);
         }
 
         private async Task LoadMaintenanceAsync()
         {
+            if (IsLoading)
+            {
+                return;
+            }
+
             try
             {
+                IsLoading = true;
                 var selectedId = SelectedRecord?.MaintenanceID;
                 var records = await _maintenanceService.GetAllMaintenanceRecordsAsync();
                 MaintenanceRecords.Clear();
@@ -191,6 +253,11 @@ namespace InventoryManagementApp.ViewModels
             {
                 ClearMaintenanceStateAfterLoadFailure();
                 await _dialogService.ShowErrorAsync("Error loading maintenance records", $"{ex.Message} Maintenance rows were cleared until reload succeeds.");
+            }
+            finally
+            {
+                IsLoading = false;
+                NotifyMaintenanceListStateChanged();
             }
         }
 
@@ -343,6 +410,7 @@ namespace InventoryManagementApp.ViewModels
             FilteredMaintenanceRecords.Clear();
             SelectedRecord = null;
             NotifyCommandStatesAndSummaries();
+            NotifyMaintenanceListStateChanged();
         }
 
         private async Task RefreshMaintenanceAfterMutationFailureAsync(
@@ -369,6 +437,7 @@ namespace InventoryManagementApp.ViewModels
                 }
 
                 NotifyCommandStatesAndSummaries();
+                NotifyMaintenanceListStateChanged();
                 await _dialogService.ShowErrorAsync(title, message);
             }
             catch (Exception refreshEx)
@@ -420,8 +489,7 @@ namespace InventoryManagementApp.ViewModels
             SelectedRecord = FilteredMaintenanceRecords.FirstOrDefault(r => r.MaintenanceID == preferredMaintenanceId)
                 ?? FilteredMaintenanceRecords.FirstOrDefault();
 
-            OnPropertyChanged(nameof(MaintenanceResultsSummary));
-            OnPropertyChanged(nameof(MaintenanceBacklogSummary));
+            NotifyMaintenanceListStateChanged();
         }
 
         private void OpenMaintenanceDetails()
@@ -478,40 +546,59 @@ namespace InventoryManagementApp.ViewModels
 
         private void PrintMaintenanceList()
         {
-            if (FilteredMaintenanceRecords.Count == 0)
+            if (!CanPrintMaintenanceList)
             {
-                _dialogService.ShowInfo("There are no maintenance records to print.", "Maintenance Report");
+                _dialogService.ShowInfo("There are no maintenance records ready to print.", "Maintenance Report");
                 return;
             }
 
             try
             {
+                var visibleRows = FilteredMaintenanceRecords.Count;
+                var printRows = FilteredMaintenanceRecords.Take(MaxMaintenancePrintRows).ToList();
+                var omittedRows = Math.Max(0, visibleRows - printRows.Count);
                 var doc = CreateMaintenanceDocument("Maintenance Schedule", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | {MaintenanceResultsSummary} | {MaintenanceBacklogSummary}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows} | {MaintenanceBacklogSummary}"))
                 {
                     FontSize = 10,
-                    Margin = new Thickness(0, 0, 0, 10)
+                    Margin = new Thickness(0, 0, 0, 8)
                 });
 
+                if (omittedRows > 0)
+                {
+                    doc.Blocks.Add(new Paragraph(new Run($"Large schedule preview limited to the first {MaxMaintenancePrintRows} visible rows to keep print preview responsive. Clear filters or export smaller packets for full handoff review."))
+                    {
+                        FontSize = 10,
+                        FontStyle = FontStyles.Italic,
+                        Margin = new Thickness(0, 0, 0, 8)
+                    });
+                }
+
                 var table = new Table { CellSpacing = 0 };
-                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(110) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.05, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.65, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.25, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.05, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.0, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.25, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.05, GridUnitType.Star) });
 
                 var group = new TableRowGroup();
                 table.RowGroups.Add(group);
-                AddPrintRow(group, true, "Item #", "Name", "Type", "Scheduled", "Status", "Performed By", "Completed");
-                foreach (var record in FilteredMaintenanceRecords)
+                AddPrintRow(group, true, "Item #", "Name", "Type", "Scheduled", "Status", "Technician", "Completed");
+                foreach (var record in printRows)
                 {
                     AddPrintRow(group, false, record.ItemNumber, record.ItemName, record.MaintenanceType, record.ScheduledDate.ToString("yyyy-MM-dd"), record.StatusDisplay, record.PerformedBy, FormatDate(record.CompletedDate));
                 }
 
                 doc.Blocks.Add(table);
-                _dialogService.ShowPrintPreview(doc, "Maintenance Schedule", string.Empty);
+                doc.Blocks.Add(new Paragraph(new Run("Review overdue rows, technician assignment, completed dates, and omitted-row counts before handing this schedule to the bench."))
+                {
+                    FontSize = 10,
+                    FontStyle = FontStyles.Italic,
+                    Margin = new Thickness(0, 10, 0, 0)
+                });
+                _dialogService.ShowPrintPreview(doc, "Maintenance Schedule", MaintenancePrintStatus);
             }
             catch (Exception ex)
             {
@@ -542,7 +629,7 @@ namespace InventoryManagementApp.ViewModels
                 AddKeyValueRow(group, "Next action:", SelectedMaintenanceNextAction);
                 doc.Blocks.Add(table);
 
-                _dialogService.ShowPrintPreview(doc, $"Maintenance {record.MaintenanceID}", string.Empty);
+                _dialogService.ShowPrintPreview(doc, $"Maintenance {record.MaintenanceID}", SelectedMaintenanceNextAction);
             }
             catch (Exception ex)
             {
@@ -550,21 +637,45 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private bool CanEditOrDelete() => SelectedRecord != null;
+        private bool CanInteractWithMaintenanceList() => !IsLoading;
 
-        private bool CanComplete() => SelectedRecord != null && IsScheduled(SelectedRecord);
+        private bool CanRefreshMaintenance() => !IsLoading;
+
+        private bool CanEditOrDelete() => !IsLoading && SelectedRecord != null;
+
+        private bool CanComplete() => !IsLoading && SelectedRecord != null && IsScheduled(SelectedRecord);
 
         private void NotifyCommandStatesAndSummaries()
         {
+            LoadMaintenanceCommand.NotifyCanExecuteChanged();
+            AddMaintenanceCommand.NotifyCanExecuteChanged();
             EditMaintenanceCommand.NotifyCanExecuteChanged();
             DeleteMaintenanceCommand.NotifyCanExecuteChanged();
             CompleteMaintenanceCommand.NotifyCanExecuteChanged();
+            RefreshCommand.NotifyCanExecuteChanged();
             OpenMaintenanceDetailsCommand.NotifyCanExecuteChanged();
+            PrintMaintenanceListCommand.NotifyCanExecuteChanged();
             PrintSelectedMaintenanceCommand.NotifyCanExecuteChanged();
             CopySelectedMaintenanceCommand.NotifyCanExecuteChanged();
+            ClearSearchCommand.NotifyCanExecuteChanged();
+            ShowOverdueCommand.NotifyCanExecuteChanged();
+            ShowUpcomingCommand.NotifyCanExecuteChanged();
+            ShowScheduledCommand.NotifyCanExecuteChanged();
             OnSelectedRecordSummariesChanged();
             OnPropertyChanged(nameof(MaintenanceBacklogSummary));
             OnPropertyChanged(nameof(MaintenanceResultsSummary));
+        }
+
+        private void NotifyMaintenanceListStateChanged()
+        {
+            OnPropertyChanged(nameof(MaintenanceResultsSummary));
+            OnPropertyChanged(nameof(MaintenanceBacklogSummary));
+            OnPropertyChanged(nameof(IsFilterActive));
+            OnPropertyChanged(nameof(MaintenanceEmptyTitle));
+            OnPropertyChanged(nameof(MaintenanceEmptyMessage));
+            OnPropertyChanged(nameof(CanPrintMaintenanceList));
+            OnPropertyChanged(nameof(MaintenancePrintStatus));
+            PrintMaintenanceListCommand.NotifyCanExecuteChanged();
         }
 
         private void OnSelectedRecordSummariesChanged()

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml
@@ -65,8 +65,8 @@
                     </Border>
                     <Border Style="{StaticResource MaintenanceStatCard}">
                         <StackPanel>
-                            <TextBlock Text="HANDOFF" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Copy / print ready" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="PRINT" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding MaintenancePrintStatus}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                 </WrapPanel>
@@ -133,6 +133,7 @@
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
                         <DockPanel LastChildFill="True">
                             <TextBlock Text="{Binding MaintenanceBacklogSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,10,0"/>
+                            <TextBlock Text="{Binding MaintenancePrintStatus}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
                         </DockPanel>
                     </Border>
                     <DataGrid x:Name="MaintenanceGrid"
@@ -208,15 +209,39 @@
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding FilteredMaintenanceRecords.Count}" Value="0">
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding FilteredMaintenanceRecords.Count}" Value="0"/>
+                                            <Condition Binding="{Binding IsLoading}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="{Binding MaintenanceEmptyTitle}" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding MaintenanceEmptyMessage}"
+                                       Style="{StaticResource CaptionTextBlock}"
+                                       TextAlignment="Center"
+                                       TextWrapping="Wrap"
+                                       Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Row="2" MaxWidth="380" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="16">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsLoading}" Value="True">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
-                            <TextBlock Text="No maintenance work matches this filter" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
-                            <TextBlock Text="Clear search, switch the filter, or add a new work order to restart the technician queue."
+                            <TextBlock Text="Loading maintenance schedule" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="Work-order actions and schedule printing are paused until the latest saved rows are ready."
                                        Style="{StaticResource CaptionTextBlock}"
                                        TextAlignment="Center"
                                        TextWrapping="Wrap"
@@ -312,7 +337,10 @@
                     <Button Style="{StaticResource PrimaryButton}" Content="Complete" Command="{Binding CompleteMaintenanceCommand}" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Print Schedule" Command="{Binding PrintMaintenanceListCommand}" Margin="0,0,0,4"/>
                 </WrapPanel>
-                <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
+                <StackPanel Margin="2,0,10,0">
+                    <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding MaintenancePrintStatus}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                </StackPanel>
             </DockPanel>
         </Border>
     </Grid>

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
@@ -1,24 +1,58 @@
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
 {
     public partial class MaintenancePage : Page
     {
+        private Task? _loadMaintenanceTask;
+        private MaintenanceManagementViewModel? _loadedViewModel;
+
         public MaintenancePage()
         {
             InitializeComponent();
             Loaded += MaintenancePage_Loaded;
+            DataContextChanged += MaintenancePage_DataContextChanged;
         }
 
         private async void MaintenancePage_Loaded(object sender, RoutedEventArgs e)
         {
             if (DataContext is MaintenanceManagementViewModel vm)
             {
-                await vm.LoadMaintenanceCommand.ExecuteAsync(null);
+                await LoadMaintenanceOnceAsync(vm);
             }
+        }
+
+        private void MaintenancePage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(_loadedViewModel, e.NewValue))
+            {
+                _loadedViewModel = null;
+                _loadMaintenanceTask = null;
+            }
+        }
+
+        private async Task LoadMaintenanceOnceAsync(MaintenanceManagementViewModel vm)
+        {
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadMaintenanceTask is { IsCompleted: false })
+            {
+                await _loadMaintenanceTask;
+                return;
+            }
+
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadMaintenanceTask is { IsCompletedSuccessfully: true })
+            {
+                return;
+            }
+
+            _loadedViewModel = vm;
+            await Dispatcher.Yield(DispatcherPriority.Background);
+            _loadMaintenanceTask = vm.LoadMaintenanceCommand.ExecuteAsync(null);
+            await _loadMaintenanceTask;
         }
 
         private void MaintenanceRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## What changed

- Added a Maintenance workbench loading guard so schedule refreshes cannot overlap.
- Disabled refresh, add, edit, delete, complete, details, copy, selected print, filter shortcuts, clear, and schedule print actions while maintenance rows are loading.
- Added first-paint-friendly page-owned loading that yields before the initial Maintenance refresh.
- Prevented duplicate page loads for the same Maintenance view model and reset the page load guard when a new view model is attached.
- Added ViewModel-backed loading, filter, empty-state, print-availability, and print-status properties.
- Added dynamic empty-state copy for no maintenance records versus no filter matches.
- Added a bounded loading overlay in the Maintenance schedule grid region.
- Added Maintenance print status in the summary card, schedule subheader, and footer status area.
- Preserved the virtualized Maintenance grid, row selection, context menu, double-click details, and technician handoff panel.
- Capped Maintenance Schedule print preview generation to the first 250 visible rows.
- Added honest print packet accounting for visible, printed, omitted, filter, search, and backlog context.
- Replaced fixed Maintenance Schedule print columns with proportional columns.
- Added large-schedule guidance, print preview description text, fallback row text, and a handoff review note for professional schedule output.
- Extended Maintenance source-contract coverage for loading guards, UI states, command availability, capped print snapshots, proportional print columns, page load behavior, and preserved actions.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-maintenance-workbench-performance.md`.

## Why this was highest value

Recent merged work already covered Categories, Settings, Customers, Rental History, Users, Activity Logs, Reports, imports, and shared popups. Current Maintenance evidence still showed a concrete workflow gap: the grid was virtualized, but loading could be triggered repeatedly from page load/refresh, action and print state did not reflect loading or empty data, and schedule printing materialized every visible row into fixed-width print columns. That directly affects loading speed, UI responsiveness, and professional technician handoff output.

## Why this is real progress

This is a complete Maintenance workflow slice across ViewModel command state, page load behavior, grid loading/empty display, print-preview document generation, source-contract tests, and progress records. It includes more than ten focused improvements while staying inside the active WPF app.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by six focused commits, and limited to:
  - `InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs`
  - `InventoryManagementApp/Views/Pages/MaintenancePage.xaml`
  - `InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs`
  - `InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-maintenance-workbench-performance.md`
- Connector readback confirmed the loading guard, command can-execute gating, dynamic loading/empty/print status, bounded loading overlay, first-paint page load guard, capped print snapshot, proportional print columns, handoff review note, and updated source-contract assertions.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `15e9f6ea1c585e6af763be305e448da0e554ec83`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Maintenance at 1366 x 768 and higher Windows scaling with no records, loading, all rows, filtered rows, no-match filters, rapid refresh/filter clicks, and 250+ visible rows before schedule printing.