### PR TITLE
Improve Calibration workbench loading and print responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
@@ -16,6 +16,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding CalibrationPrintStatus}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"520\"/>", xaml, StringComparison.Ordinal);
@@ -60,8 +61,22 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<ComboBox Width=\"175\" MinWidth=\"145\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"360\" MinHeight=\"130\" Margin=\"12\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding CalibrationEmptyTitle}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding CalibrationEmptyMessage}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Center\" MaxWidth=\"380\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPage_ShowsBoundedLoadingOverlayWhileRowsLoad()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml");
+
+            Assert.Contains("<Condition Binding=\"{Binding IsLoading}\" Value=\"False\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<DataTrigger Binding=\"{Binding IsLoading}\" Value=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Loading calibration register", xaml, StringComparison.Ordinal);
+            Assert.Contains("Certificate actions and due-report printing are paused", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"380\" MinHeight=\"118\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -80,6 +95,66 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("ShowCurrentCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("CalibrationRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
             Assert.Contains("CalibrationRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationViewModel_GuardsLoadingStateAndCommandAvailability()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");
+
+            Assert.Contains("private bool _isLoading;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsLoading", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsLoading)", source, StringComparison.Ordinal);
+            Assert.Contains("CanRefreshCalibration", source, StringComparison.Ordinal);
+            Assert.Contains("CanInteractWithCalibrationList", source, StringComparison.Ordinal);
+            Assert.Contains("!IsLoading && SelectedRecord != null", source, StringComparison.Ordinal);
+            Assert.Contains("PrintCalibrationListCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationViewModel_ExposesProfessionalEmptyAndPrintState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");
+
+            Assert.Contains("public bool IsFilterActive", source, StringComparison.Ordinal);
+            Assert.Contains("public string CalibrationEmptyTitle", source, StringComparison.Ordinal);
+            Assert.Contains("public string CalibrationEmptyMessage", source, StringComparison.Ordinal);
+            Assert.Contains("public bool CanPrintCalibrationList", source, StringComparison.Ordinal);
+            Assert.Contains("public string CalibrationPrintStatus", source, StringComparison.Ordinal);
+            Assert.Contains("Print paused while calibration rows load", source, StringComparison.Ordinal);
+            Assert.Contains("No filtered certificate rows ready to print", source, StringComparison.Ordinal);
+            Assert.Contains("Ready to print first", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPrintPreview_IsBoundedAndUsesProportionalColumns()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");
+
+            Assert.Contains("private const int MaxCalibrationPrintRows = 250;", source, StringComparison.Ordinal);
+            Assert.Contains("FilteredCalibrationRecords.Take(MaxCalibrationPrintRows).ToList();", source, StringComparison.Ordinal);
+            Assert.Contains("Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows}", source, StringComparison.Ordinal);
+            Assert.Contains("Large calibration preview limited to the first", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(1.05, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(1.65, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("Review overdue rows, due-soon certificates", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("table.Columns.Add(new TableColumn { Width = new GridLength(90) });", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("table.Columns.Add(new TableColumn { Width = new GridLength(150) });", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var record in FilteredCalibrationRecords)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPage_LoadsOnceAfterFirstPaintAndResetsForNewViewModels()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml.cs");
+
+            Assert.Contains("private Task? _loadCalibrationTask;", source, StringComparison.Ordinal);
+            Assert.Contains("private CalibrationManagementViewModel? _loadedViewModel;", source, StringComparison.Ordinal);
+            Assert.Contains("DataContextChanged += CalibrationPage_DataContextChanged;", source, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("LoadCalibrationOnceAsync", source, StringComparison.Ordinal);
+            Assert.Contains("IsCompletedSuccessfully", source, StringComparison.Ordinal);
+            Assert.Contains("_loadCalibrationTask = null;", source, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-calibration-workbench-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-calibration-workbench-performance.md
@@ -1,0 +1,30 @@
+# Calibration Workbench Performance - 2026-07-04
+
+Completed a focused Calibration workbench responsiveness and professional-output pass.
+
+## Completed
+
+- Added a Calibration loading guard so register refreshes cannot overlap.
+- Disabled refresh, add, edit, delete, details, copy, selected print, filter shortcuts, clear, and due-report print actions while calibration rows are loading.
+- Added first-paint-friendly page-owned loading that yields before the initial Calibration refresh.
+- Prevented duplicate page loads for the same Calibration view model and reset the guard when the page receives a new view model.
+- Added ViewModel-backed loading, filter, empty-state, print-availability, and print-status properties.
+- Added dynamic empty-state copy for no calibration records versus no filter matches.
+- Added a bounded loading overlay in the Calibration register grid region.
+- Added Calibration print status in the summary card, grid subheader, and footer status area.
+- Kept the virtualized Calibration grid, row selection, context menu, double-click details, and certificate handoff panel intact.
+- Capped Calibration Due Report print preview generation to the first 250 visible rows.
+- Added honest print packet accounting for visible, printed, omitted, filter, search, and due-state context.
+- Replaced fixed Calibration Due Report print columns with proportional columns.
+- Added large-register guidance, print preview description text, fallback row text, and a release-review note for professional certificate output.
+- Extended Calibration source-contract coverage for loading guards, UI states, command availability, capped print snapshots, proportional print columns, page load behavior, and preserved actions.
+
+## Validation
+
+- GitHub connector readback should verify the branch diff and exact source markers before merge.
+- Local Windows/.NET validation, WPF runtime smoke testing, screenshots, scaling checks, and print-preview rendering remain blocked in the scheduled Linux environment because direct clone is blocked and required Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test Calibration at 1366 x 768 and higher Windows scaling with no records, loading, all rows, filtered rows, no-match filters, rapid refresh/filter clicks, and 250+ visible rows before due-report printing.

--- a/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
@@ -15,21 +15,69 @@ namespace InventoryManagementApp.ViewModels
 {
     public class CalibrationManagementViewModel : ObservableObject
     {
+        private const int MaxCalibrationPrintRows = 250;
+
         private readonly CalibrationService _calibrationService;
         private readonly IDialogService _dialogService;
 
         public ObservableCollection<CalibrationRecord> CalibrationRecords { get; }
         public ObservableCollection<CalibrationRecord> FilteredCalibrationRecords { get; }
 
-        public string CalibrationResultsSummary => $"{FilteredCalibrationRecords.Count} of {CalibrationRecords.Count} calibration record{(CalibrationRecords.Count == 1 ? string.Empty : "s")} shown";
+        public string CalibrationResultsSummary => IsLoading
+            ? "Loading calibration records..."
+            : $"{FilteredCalibrationRecords.Count} of {CalibrationRecords.Count} calibration record{(CalibrationRecords.Count == 1 ? string.Empty : "s")} shown";
+
         public string CalibrationBacklogSummary
         {
             get
             {
+                if (IsLoading)
+                {
+                    return "Refreshing calibration due state";
+                }
+
                 var overdue = CalibrationRecords.Count(r => r.IsOverdue);
                 var dueSoon = CalibrationRecords.Count(r => r.IsDueSoon);
                 var current = CalibrationRecords.Count(r => IsCurrent(r));
                 return $"{overdue} overdue | {dueSoon} due soon | {current} current";
+            }
+        }
+
+        public bool IsFilterActive => !string.IsNullOrWhiteSpace(SearchText) || !string.Equals(SelectedFilter, "All", StringComparison.Ordinal);
+
+        public string CalibrationEmptyTitle => CalibrationRecords.Count == 0
+            ? "No calibration records found"
+            : "No calibration records match this filter";
+
+        public string CalibrationEmptyMessage => CalibrationRecords.Count == 0
+            ? "Add a certificate record or refresh when calibration history is available."
+            : "Clear search, switch the due-state filter, or add a certificate record to rebuild the calibration queue.";
+
+        public bool CanPrintCalibrationList => !IsLoading && FilteredCalibrationRecords.Count > 0;
+
+        public string CalibrationPrintStatus
+        {
+            get
+            {
+                if (IsLoading)
+                {
+                    return "Print paused while calibration rows load";
+                }
+
+                if (FilteredCalibrationRecords.Count == 0)
+                {
+                    return IsFilterActive
+                        ? "No filtered certificate rows ready to print"
+                        : "No certificate rows ready to print";
+                }
+
+                var visible = FilteredCalibrationRecords.Count;
+                var printed = Math.Min(visible, MaxCalibrationPrintRows);
+                var omitted = Math.Max(0, visible - printed);
+                var filterContext = IsFilterActive ? "filtered" : "all rows";
+                return omitted == 0
+                    ? $"Ready to print {printed} {filterContext} certificate row{(printed == 1 ? string.Empty : "s")}."
+                    : $"Ready to print first {printed} of {visible} {filterContext} certificate rows; {omitted} omitted from preview.";
             }
         }
 
@@ -72,6 +120,20 @@ namespace InventoryManagementApp.ViewModels
             ? "Select a certificate first, then verify the item tag, certificate number, due date, result, and shelf release status before the item is issued."
             : "Verify item tag and location, confirm certificate number and standard, check due date/result, update missing notes if needed, and keep the printed or copied handoff with the item.";
 
+        private bool _isLoading;
+        public bool IsLoading
+        {
+            get => _isLoading;
+            private set
+            {
+                if (SetProperty(ref _isLoading, value))
+                {
+                    NotifyCommandStatesAndSummaries();
+                    NotifyCalibrationListStateChanged();
+                }
+            }
+        }
+
         private CalibrationRecord? _selectedRecord;
         public CalibrationRecord? SelectedRecord
         {
@@ -80,12 +142,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _selectedRecord, value))
                 {
-                    EditCalibrationCommand.NotifyCanExecuteChanged();
-                    DeleteCalibrationCommand.NotifyCanExecuteChanged();
-                    OpenCalibrationDetailsCommand.NotifyCanExecuteChanged();
-                    PrintSelectedCalibrationCommand.NotifyCanExecuteChanged();
-                    CopySelectedCalibrationCommand.NotifyCanExecuteChanged();
-                    OnSelectedRecordSummariesChanged();
+                    NotifyCommandStatesAndSummaries();
                 }
             }
         }
@@ -149,25 +206,31 @@ namespace InventoryManagementApp.ViewModels
                 "Overdue"
             };
 
-            LoadCalibrationCommand = new AsyncRelayCommand(LoadCalibrationAsync);
-            AddCalibrationCommand = new AsyncRelayCommand(AddCalibrationAsync);
+            LoadCalibrationCommand = new AsyncRelayCommand(LoadCalibrationAsync, CanRefreshCalibration);
+            AddCalibrationCommand = new AsyncRelayCommand(AddCalibrationAsync, CanInteractWithCalibrationList);
             EditCalibrationCommand = new AsyncRelayCommand(EditCalibrationAsync, CanEditOrDelete);
             DeleteCalibrationCommand = new AsyncRelayCommand(DeleteCalibrationAsync, CanEditOrDelete);
-            RefreshCommand = new AsyncRelayCommand(LoadCalibrationAsync);
+            RefreshCommand = new AsyncRelayCommand(LoadCalibrationAsync, CanRefreshCalibration);
             OpenCalibrationDetailsCommand = new RelayCommand(OpenCalibrationDetails, CanEditOrDelete);
-            PrintCalibrationListCommand = new RelayCommand(PrintCalibrationList);
+            PrintCalibrationListCommand = new RelayCommand(PrintCalibrationList, () => CanPrintCalibrationList);
             PrintSelectedCalibrationCommand = new RelayCommand(PrintSelectedCalibration, CanEditOrDelete);
             CopySelectedCalibrationCommand = new RelayCommand(CopySelectedCalibration, CanEditOrDelete);
-            ClearSearchCommand = new RelayCommand(ClearSearch);
-            ShowOverdueCommand = new RelayCommand(() => SelectedFilter = "Overdue");
-            ShowDueSoonCommand = new RelayCommand(() => SelectedFilter = "Due Soon");
-            ShowCurrentCommand = new RelayCommand(() => SelectedFilter = "Current");
+            ClearSearchCommand = new RelayCommand(ClearSearch, CanInteractWithCalibrationList);
+            ShowOverdueCommand = new RelayCommand(() => SelectedFilter = "Overdue", CanInteractWithCalibrationList);
+            ShowDueSoonCommand = new RelayCommand(() => SelectedFilter = "Due Soon", CanInteractWithCalibrationList);
+            ShowCurrentCommand = new RelayCommand(() => SelectedFilter = "Current", CanInteractWithCalibrationList);
         }
 
         private async Task LoadCalibrationAsync()
         {
+            if (IsLoading)
+            {
+                return;
+            }
+
             try
             {
+                IsLoading = true;
                 var selectedId = SelectedRecord?.CalibrationID;
                 var records = await _calibrationService.GetAllCalibrationRecordsAsync();
                 CalibrationRecords.Clear();
@@ -181,6 +244,11 @@ namespace InventoryManagementApp.ViewModels
             {
                 ClearCalibrationStateAfterLoadFailure();
                 await _dialogService.ShowErrorAsync("Error loading calibration records", $"{ex.Message} Calibration rows were cleared until reload succeeds.");
+            }
+            finally
+            {
+                IsLoading = false;
+                NotifyCalibrationListStateChanged();
             }
         }
 
@@ -299,6 +367,7 @@ namespace InventoryManagementApp.ViewModels
             FilteredCalibrationRecords.Clear();
             SelectedRecord = null;
             NotifyCommandStatesAndSummaries();
+            NotifyCalibrationListStateChanged();
         }
 
         private async Task RefreshCalibrationAfterMutationFailureAsync(
@@ -325,6 +394,7 @@ namespace InventoryManagementApp.ViewModels
                 }
 
                 NotifyCommandStatesAndSummaries();
+                NotifyCalibrationListStateChanged();
                 await _dialogService.ShowErrorAsync(title, message);
             }
             catch (Exception refreshEx)
@@ -376,8 +446,7 @@ namespace InventoryManagementApp.ViewModels
             SelectedRecord = FilteredCalibrationRecords.FirstOrDefault(r => r.CalibrationID == preferredCalibrationId)
                 ?? FilteredCalibrationRecords.FirstOrDefault();
 
-            OnPropertyChanged(nameof(CalibrationResultsSummary));
-            OnPropertyChanged(nameof(CalibrationBacklogSummary));
+            NotifyCalibrationListStateChanged();
         }
 
         private void OpenCalibrationDetails()
@@ -436,40 +505,59 @@ namespace InventoryManagementApp.ViewModels
 
         private void PrintCalibrationList()
         {
-            if (FilteredCalibrationRecords.Count == 0)
+            if (!CanPrintCalibrationList)
             {
-                _dialogService.ShowInfo("There are no calibration records to print.", "Calibration Report");
+                _dialogService.ShowInfo("There are no calibration records ready to print.", "Calibration Report");
                 return;
             }
 
             try
             {
+                var visibleRows = FilteredCalibrationRecords.Count;
+                var printRows = FilteredCalibrationRecords.Take(MaxCalibrationPrintRows).ToList();
+                var omittedRows = Math.Max(0, visibleRows - printRows.Count);
                 var doc = CreateCalibrationDocument("Calibration Due Report", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | {CalibrationResultsSummary} | {CalibrationBacklogSummary}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows} | {CalibrationBacklogSummary}"))
                 {
                     FontSize = 10,
-                    Margin = new Thickness(0, 0, 0, 10)
+                    Margin = new Thickness(0, 0, 0, 8)
                 });
 
+                if (omittedRows > 0)
+                {
+                    doc.Blocks.Add(new Paragraph(new Run($"Large calibration preview limited to the first {MaxCalibrationPrintRows} visible rows to keep print preview responsive. Clear filters or print smaller certificate packets for full handoff review."))
+                    {
+                        FontSize = 10,
+                        FontStyle = FontStyles.Italic,
+                        Margin = new Thickness(0, 0, 0, 8)
+                    });
+                }
+
                 var table = new Table { CellSpacing = 0 };
-                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(105) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(105) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(80) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.05, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.65, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.05, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.05, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.2, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.35, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.1, GridUnitType.Star) });
 
                 var group = new TableRowGroup();
                 table.RowGroups.Add(group);
-                AddPrintRow(group, true, "Item #", "Name", "Calibrated", "Next Due", "By", "Certificate", "Status");
-                foreach (var record in FilteredCalibrationRecords)
+                AddPrintRow(group, true, "Item #", "Name", "Calibrated", "Next Due", "Calibrated By", "Certificate", "Status");
+                foreach (var record in printRows)
                 {
                     AddPrintRow(group, false, record.ItemNumber, record.ItemName, record.CalibrationDate.ToString("yyyy-MM-dd"), record.NextCalibrationDue.ToString("yyyy-MM-dd"), record.CalibratedBy, record.CertificateNumber, record.StatusDisplay);
                 }
 
                 doc.Blocks.Add(table);
-                _dialogService.ShowPrintPreview(doc, "Calibration Due Report", string.Empty);
+                doc.Blocks.Add(new Paragraph(new Run("Review overdue rows, due-soon certificates, missing certificate numbers, calibration standard, and omitted-row counts before releasing items to the shelf."))
+                {
+                    FontSize = 10,
+                    FontStyle = FontStyles.Italic,
+                    Margin = new Thickness(0, 10, 0, 0)
+                });
+                _dialogService.ShowPrintPreview(doc, "Calibration Due Report", CalibrationPrintStatus);
             }
             catch (Exception ex)
             {
@@ -501,7 +589,7 @@ namespace InventoryManagementApp.ViewModels
                 AddKeyValueRow(group, "Next action:", SelectedCalibrationNextAction);
                 doc.Blocks.Add(table);
 
-                _dialogService.ShowPrintPreview(doc, $"Calibration {record.CalibrationID}", string.Empty);
+                _dialogService.ShowPrintPreview(doc, $"Calibration {record.CalibrationID}", SelectedCalibrationNextAction);
             }
             catch (Exception ex)
             {
@@ -509,18 +597,42 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private bool CanEditOrDelete() => SelectedRecord != null;
+        private bool CanInteractWithCalibrationList() => !IsLoading;
+
+        private bool CanRefreshCalibration() => !IsLoading;
+
+        private bool CanEditOrDelete() => !IsLoading && SelectedRecord != null;
 
         private void NotifyCommandStatesAndSummaries()
         {
+            LoadCalibrationCommand.NotifyCanExecuteChanged();
+            AddCalibrationCommand.NotifyCanExecuteChanged();
             EditCalibrationCommand.NotifyCanExecuteChanged();
             DeleteCalibrationCommand.NotifyCanExecuteChanged();
+            RefreshCommand.NotifyCanExecuteChanged();
             OpenCalibrationDetailsCommand.NotifyCanExecuteChanged();
+            PrintCalibrationListCommand.NotifyCanExecuteChanged();
             PrintSelectedCalibrationCommand.NotifyCanExecuteChanged();
             CopySelectedCalibrationCommand.NotifyCanExecuteChanged();
+            ClearSearchCommand.NotifyCanExecuteChanged();
+            ShowOverdueCommand.NotifyCanExecuteChanged();
+            ShowDueSoonCommand.NotifyCanExecuteChanged();
+            ShowCurrentCommand.NotifyCanExecuteChanged();
             OnSelectedRecordSummariesChanged();
             OnPropertyChanged(nameof(CalibrationBacklogSummary));
             OnPropertyChanged(nameof(CalibrationResultsSummary));
+        }
+
+        private void NotifyCalibrationListStateChanged()
+        {
+            OnPropertyChanged(nameof(CalibrationResultsSummary));
+            OnPropertyChanged(nameof(CalibrationBacklogSummary));
+            OnPropertyChanged(nameof(IsFilterActive));
+            OnPropertyChanged(nameof(CalibrationEmptyTitle));
+            OnPropertyChanged(nameof(CalibrationEmptyMessage));
+            OnPropertyChanged(nameof(CanPrintCalibrationList));
+            OnPropertyChanged(nameof(CalibrationPrintStatus));
+            PrintCalibrationListCommand.NotifyCanExecuteChanged();
         }
 
         private void OnSelectedRecordSummariesChanged()

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
@@ -57,8 +57,8 @@
                     </Border>
                     <Border Style="{StaticResource CalibrationMetricCard}">
                         <StackPanel>
-                            <TextBlock Text="RELEASE" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Verify before issue" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="PRINT" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding CalibrationPrintStatus}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                 </WrapPanel>
@@ -118,12 +118,13 @@
                                 <TextBlock Text="01 Calibration Register" Style="{StaticResource SectionHeader}" Margin="0"/>
                                 <TextBlock Text="Prioritizes overdue and due-soon certificates before current shelf-ready items" Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0"/>
                             </StackPanel>
-                            <TextBlock Text="{Binding CalibrationResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding CalibrationResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
                         </DockPanel>
                     </Border>
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
                         <DockPanel LastChildFill="True">
                             <TextBlock Text="{Binding CalibrationBacklogSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,10,0"/>
+                            <TextBlock Text="{Binding CalibrationPrintStatus}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
                         </DockPanel>
                     </Border>
                     <DataGrid x:Name="CalibrationGrid"
@@ -207,15 +208,39 @@
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding FilteredCalibrationRecords.Count}" Value="0">
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding FilteredCalibrationRecords.Count}" Value="0"/>
+                                            <Condition Binding="{Binding IsLoading}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="{Binding CalibrationEmptyTitle}" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding CalibrationEmptyMessage}"
+                                       Style="{StaticResource CaptionTextBlock}"
+                                       TextAlignment="Center"
+                                       TextWrapping="Wrap"
+                                       Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Row="2" MaxWidth="380" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="16">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsLoading}" Value="True">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
-                            <TextBlock Text="No calibration records match this filter" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
-                            <TextBlock Text="Clear search, switch the due-state filter, or add a certificate record to rebuild the calibration queue."
+                            <TextBlock Text="Loading calibration register" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="Certificate actions and due-report printing are paused until the latest saved rows are ready."
                                        Style="{StaticResource CaptionTextBlock}"
                                        TextAlignment="Center"
                                        TextWrapping="Wrap"
@@ -314,7 +339,10 @@
                     <Button Style="{StaticResource PrimaryButton}" Content="Copy Handoff" Command="{Binding CopySelectedCalibrationCommand}" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Print Due" Command="{Binding PrintCalibrationListCommand}" Margin="0,0,0,4"/>
                 </WrapPanel>
-                <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
+                <StackPanel Margin="2,0,10,0">
+                    <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding CalibrationPrintStatus}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                </StackPanel>
             </DockPanel>
         </Border>
     </Grid>

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
@@ -1,24 +1,58 @@
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
 {
     public partial class CalibrationPage : Page
     {
+        private Task? _loadCalibrationTask;
+        private CalibrationManagementViewModel? _loadedViewModel;
+
         public CalibrationPage()
         {
             InitializeComponent();
             Loaded += CalibrationPage_Loaded;
+            DataContextChanged += CalibrationPage_DataContextChanged;
         }
 
         private async void CalibrationPage_Loaded(object sender, RoutedEventArgs e)
         {
             if (DataContext is CalibrationManagementViewModel vm)
             {
-                await vm.LoadCalibrationCommand.ExecuteAsync(null);
+                await LoadCalibrationOnceAsync(vm);
             }
+        }
+
+        private void CalibrationPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(_loadedViewModel, e.NewValue))
+            {
+                _loadedViewModel = null;
+                _loadCalibrationTask = null;
+            }
+        }
+
+        private async Task LoadCalibrationOnceAsync(CalibrationManagementViewModel vm)
+        {
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadCalibrationTask is { IsCompleted: false })
+            {
+                await _loadCalibrationTask;
+                return;
+            }
+
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadCalibrationTask is { IsCompletedSuccessfully: true })
+            {
+                return;
+            }
+
+            _loadedViewModel = vm;
+            await Dispatcher.Yield(DispatcherPriority.Background);
+            _loadCalibrationTask = vm.LoadCalibrationCommand.ExecuteAsync(null);
+            await _loadCalibrationTask;
         }
 
         private void CalibrationRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## What changed

- Added a Calibration workbench loading guard so register refreshes cannot overlap.
- Disabled refresh, add, edit, delete, details, copy, selected print, filter shortcuts, clear, and due-report print actions while calibration rows are loading.
- Added first-paint-friendly page-owned loading that yields before the initial Calibration refresh.
- Prevented duplicate page loads for the same Calibration view model and reset the page load guard when a new view model is attached.
- Added ViewModel-backed loading, filter, empty-state, print-availability, and print-status properties.
- Added dynamic empty-state copy for no calibration records versus no filter matches.
- Added a bounded loading overlay in the Calibration register grid region.
- Added Calibration print status in the summary card, register subheader, and footer status area.
- Preserved the virtualized Calibration grid, row selection, context menu, double-click details, and certificate handoff panel.
- Capped Calibration Due Report print preview generation to the first 250 visible rows.
- Added honest print packet accounting for visible, printed, omitted, filter, search, and due-state context.
- Replaced fixed Calibration Due Report print columns with proportional columns.
- Added large-register guidance, print preview description text, fallback row text, and a release-review note for professional certificate output.
- Extended Calibration source-contract coverage for loading guards, UI states, command availability, capped print snapshots, proportional print columns, page load behavior, and preserved actions.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-calibration-workbench-performance.md`.

## Why this was highest value

Recent merged work already covered Settings, Customers, Categories, Maintenance, Rental History, Activity Logs, Users, Item Search, Reports, imports, and shared shell paths. Current Calibration evidence still showed the same concrete workflow gap Maintenance had before the latest pass: the grid was virtualized, but repeated load/refresh could overlap, action and print state did not reflect loading or empty data, and due-report printing materialized every visible row into fixed-width print columns. That directly affects loading speed, UI responsiveness, professional data display, and certificate handoff output.

## Why this is real progress

This is a complete Calibration workflow slice across ViewModel command state, page load behavior, grid loading/empty display, print-preview document generation, source-contract tests, and progress records. It includes more than ten focused improvements while staying inside the active WPF app.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by five focused commits, and limited to:
  - `InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs`
  - `InventoryManagementApp/Views/Pages/CalibrationPage.xaml`
  - `InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs`
  - `InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-calibration-workbench-performance.md`
- Connector readback confirmed the loading guard, command can-execute gating, dynamic loading/empty/print status, bounded loading overlay, first-paint page load guard, capped print snapshot, proportional print columns, release review note, and updated source-contract assertions.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `847c95b4993e6886e1026c5b24afc4239161bfbd`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Calibration at 1366 x 768 and higher Windows scaling with no records, loading, all rows, filtered rows, no-match filters, rapid refresh/filter clicks, and 250+ visible rows before due-report printing.