### PR TITLE
Improve Reservations workbench loading and print responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace InventoryManagementApp.Tests
@@ -17,6 +18,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("ReservationStatValueText", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.85*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding ReservationPrintStatus}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"540\"/>", xaml, StringComparison.Ordinal);
@@ -29,7 +31,7 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("<ColumnDefinition Width=\"1.55*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<GridSplitter Grid.Column=\"1\"\n                          Width=\"6\"", xaml, StringComparison.Ordinal);
+            Assert.Matches(new Regex("<GridSplitter[^>]*Grid\\.Column=\"1\"[^>]*Width=\"6\"", RegexOptions.Singleline), xaml);
             Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border Grid.Column=\"2\" Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2.45*\" MinWidth=\"620\"/>", xaml, StringComparison.Ordinal);
@@ -61,8 +63,22 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Border Grid.Row=\"2\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Center\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\" Padding=\"16\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<StackPanel Margin=\"12,12,12,4\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding ReservationEmptyTitle}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding ReservationEmptyMessage}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("MaxWidth=\"370\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationPage_ShowsBoundedLoadingOverlayWhileRowsLoad()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml");
+
+            Assert.Contains("<Condition Binding=\"{Binding IsLoading}\" Value=\"False\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<DataTrigger Binding=\"{Binding IsLoading}\" Value=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Loading reservation directory", xaml, StringComparison.Ordinal);
+            Assert.Contains("Hold actions and directory printing are paused", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"380\" MinHeight=\"118\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -93,6 +109,66 @@ namespace InventoryManagementApp.Tests
 
             foreach (var contract in requiredContracts)
                 Assert.Contains(contract, xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationViewModel_GuardsLoadingStateAndCommandAvailability()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");
+
+            Assert.Contains("private bool _isLoading;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsLoading", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsLoading)", source, StringComparison.Ordinal);
+            Assert.Contains("CanRefreshReservations", source, StringComparison.Ordinal);
+            Assert.Contains("CanInteractWithReservations", source, StringComparison.Ordinal);
+            Assert.Contains("!IsLoading && SelectedReservation != null", source, StringComparison.Ordinal);
+            Assert.Contains("PrintReservationDirectoryCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationViewModel_ExposesProfessionalEmptyAndPrintState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");
+
+            Assert.Contains("public bool IsFilterActive", source, StringComparison.Ordinal);
+            Assert.Contains("public string ReservationEmptyTitle", source, StringComparison.Ordinal);
+            Assert.Contains("public string ReservationEmptyMessage", source, StringComparison.Ordinal);
+            Assert.Contains("public bool CanPrintReservationDirectory", source, StringComparison.Ordinal);
+            Assert.Contains("public string ReservationPrintStatus", source, StringComparison.Ordinal);
+            Assert.Contains("Print paused while reservation rows load", source, StringComparison.Ordinal);
+            Assert.Contains("No filtered hold rows ready to print", source, StringComparison.Ordinal);
+            Assert.Contains("Ready to print first", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationPrintPreview_IsBoundedAndUsesProportionalColumns()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");
+
+            Assert.Contains("private const int MaxReservationPrintRows = 250;", source, StringComparison.Ordinal);
+            Assert.Contains("FilteredReservations.Take(MaxReservationPrintRows).ToList();", source, StringComparison.Ordinal);
+            Assert.Contains("Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows}", source, StringComparison.Ordinal);
+            Assert.Contains("Large reservation preview limited to the first", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(0.85, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(1.65, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("Review pending, confirmed, upcoming", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("table.Columns.Add(new TableColumn { Width = new GridLength(80) });", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("table.Columns.Add(new TableColumn { Width = new GridLength(165) });", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var reservation in FilteredReservations)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationPage_LoadsOnceAfterFirstPaintAndResetsForNewViewModels()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml.cs");
+
+            Assert.Contains("private Task? _loadReservationsTask;", source, StringComparison.Ordinal);
+            Assert.Contains("private ReservationManagementViewModel? _loadedViewModel;", source, StringComparison.Ordinal);
+            Assert.Contains("DataContextChanged += ReservationPage_DataContextChanged;", source, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("LoadReservationsOnceAsync", source, StringComparison.Ordinal);
+            Assert.Contains("IsCompletedSuccessfully", source, StringComparison.Ordinal);
+            Assert.Contains("_loadReservationsTask = null;", source, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-reservations-workbench-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-reservations-workbench-performance.md
@@ -1,0 +1,24 @@
+# 2026-07-04 Reservations workbench performance
+
+## Completed
+
+- Added a Reservations loading guard so page load and manual refresh cannot overlap while the hold directory is already loading.
+- Disabled add, edit, delete, confirm, cancel, fulfill, details, copy, selected handoff print, quick-filter, clear, refresh, and directory print commands while reservation rows load.
+- Added ViewModel-backed loading, filter, empty-state, print-availability, and print-status properties for the Reservations Workbench.
+- Added dynamic empty-state title and message text that distinguishes no saved holds from no filter/search matches.
+- Added a bounded loading overlay in the hold directory grid region so operators can see why actions and printing are paused.
+- Added Reservation print status in the summary card, hold-directory subheader, and footer status area.
+- Preserved the virtualized reservation grid, row selection, context menu, keyboard shortcuts, double-click details, and pickup handoff panel.
+- Added first-paint-friendly page-owned loading with a dispatcher yield before the initial reservation refresh.
+- Prevented duplicate page loads for the same Reservations view model and reset the page load guard when a new view model is attached.
+- Capped Reservation Directory print preview generation to the first 250 visible rows.
+- Added honest print packet accounting for visible, printed, omitted, filter, search, and result summary context.
+- Replaced fixed Reservation Directory print columns with proportional columns for more professional print-preview layout.
+- Added large-directory guidance, print preview description text, fallback row text, and a shelf-pick review note for reservation handoff output.
+- Extended `ReservationPageResponsiveContractTests` for loading guards, UI states, command availability, capped print snapshots, proportional print columns, first-paint page load behavior, and preserved actions.
+- Replaced the brittle GridSplitter source-contract assertion with a whitespace-tolerant regex while preserving the same layout contract.
+
+## Validation
+
+- GitHub connector readback and compare should be used for this scheduled run because the environment cannot clone the repository directly and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
+- Full Windows validation still needs to run with `pwsh -File scripts/run-full-validation.ps1`.

--- a/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
@@ -15,6 +15,8 @@ namespace InventoryManagementApp.ViewModels
 {
     public class ReservationManagementViewModel : ObservableObject
     {
+        private const int MaxReservationPrintRows = 250;
+
         private readonly ReservationService _reservationService;
         private readonly IDialogService _dialogService;
 
@@ -25,12 +27,55 @@ namespace InventoryManagementApp.ViewModels
         {
             get
             {
+                if (IsLoading)
+                {
+                    return "Loading reservations...";
+                }
+
                 var activeCount = Reservations.Count(r => r.IsActive);
                 var shown = $"{FilteredReservations.Count} of {Reservations.Count} reservation{(Reservations.Count == 1 ? string.Empty : "s")} shown";
                 var active = $"{activeCount} active";
                 return string.IsNullOrWhiteSpace(SearchText)
                     ? $"{shown} | {active} | filter: {SelectedFilter}"
                     : $"{shown} for \"{SearchText.Trim()}\" | {active} | filter: {SelectedFilter}";
+            }
+        }
+
+        public bool IsFilterActive => !string.IsNullOrWhiteSpace(SearchText) || !string.Equals(SelectedFilter, "Active", StringComparison.Ordinal);
+
+        public string ReservationEmptyTitle => Reservations.Count == 0
+            ? "No reservations found"
+            : "No reservations match this filter";
+
+        public string ReservationEmptyMessage => Reservations.Count == 0
+            ? "Add a hold or refresh when reservation records are available."
+            : "Clear search, switch the status filter, or add a new hold to restart the reservation queue.";
+
+        public bool CanPrintReservationDirectory => !IsLoading && FilteredReservations.Count > 0;
+
+        public string ReservationPrintStatus
+        {
+            get
+            {
+                if (IsLoading)
+                {
+                    return "Print paused while reservation rows load";
+                }
+
+                if (FilteredReservations.Count == 0)
+                {
+                    return IsFilterActive
+                        ? "No filtered hold rows ready to print"
+                        : "No hold rows ready to print";
+                }
+
+                var visible = FilteredReservations.Count;
+                var printed = Math.Min(visible, MaxReservationPrintRows);
+                var omitted = Math.Max(0, visible - printed);
+                var filterContext = IsFilterActive ? "filtered" : "active";
+                return omitted == 0
+                    ? $"Ready to print {printed} {filterContext} hold row{(printed == 1 ? string.Empty : "s")}."
+                    : $"Ready to print first {printed} of {visible} {filterContext} hold rows; {omitted} omitted from preview.";
             }
         }
 
@@ -77,6 +122,20 @@ namespace InventoryManagementApp.ViewModels
             ? "Select a reservation to confirm, cancel, fulfill, print, copy, edit, or delete."
             : $"Ready: #{SelectedReservation.ReservationID} | {ValueOrNotRecorded(SelectedReservation.CustomerName)} | {ValueOrNotRecorded(SelectedReservation.ItemName)} | {SelectedReservation.StartDate:yyyy-MM-dd} to {SelectedReservation.EndDate:yyyy-MM-dd} | {SelectedReservation.StatusDisplay}";
 
+        private bool _isLoading;
+        public bool IsLoading
+        {
+            get => _isLoading;
+            private set
+            {
+                if (SetProperty(ref _isLoading, value))
+                {
+                    NotifyCommandStatesAndSummaries();
+                    NotifyReservationListStateChanged();
+                }
+            }
+        }
+
         private Reservation? _selectedReservation;
         public Reservation? SelectedReservation
         {
@@ -85,7 +144,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _selectedReservation, value))
                 {
-                    NotifySelectionChanged();
+                    NotifyCommandStatesAndSummaries();
                 }
             }
         }
@@ -156,29 +215,35 @@ namespace InventoryManagementApp.ViewModels
                 "Upcoming (7 days)"
             };
 
-            LoadReservationsCommand = new AsyncRelayCommand(LoadReservationsAsync);
-            AddReservationCommand = new AsyncRelayCommand(AddReservationAsync);
+            LoadReservationsCommand = new AsyncRelayCommand(LoadReservationsAsync, CanRefreshReservations);
+            AddReservationCommand = new AsyncRelayCommand(AddReservationAsync, CanInteractWithReservations);
             EditReservationCommand = new AsyncRelayCommand(EditReservationAsync, CanEdit);
             DeleteReservationCommand = new AsyncRelayCommand(DeleteReservationAsync, CanDelete);
             ConfirmReservationCommand = new AsyncRelayCommand(ConfirmReservationAsync, CanConfirm);
             CancelReservationCommand = new AsyncRelayCommand(CancelReservationAsync, CanCancel);
             FulfillReservationCommand = new AsyncRelayCommand(FulfillReservationAsync, CanFulfill);
-            RefreshCommand = new AsyncRelayCommand(LoadReservationsAsync);
-            OpenReservationDetailsCommand = new RelayCommand(OpenReservationDetails, () => SelectedReservation != null);
-            CopyReservationHandoffCommand = new RelayCommand(CopyReservationHandoff, () => SelectedReservation != null);
-            PrintReservationHandoffCommand = new RelayCommand(PrintReservationHandoff, () => SelectedReservation != null);
-            PrintReservationDirectoryCommand = new RelayCommand(PrintReservationDirectory);
-            ClearReservationSearchCommand = new RelayCommand(ClearReservationSearch);
-            ShowActiveReservationsCommand = new RelayCommand(() => SelectedFilter = "Active");
-            ShowPendingReservationsCommand = new RelayCommand(() => SelectedFilter = "Pending");
-            ShowConfirmedReservationsCommand = new RelayCommand(() => SelectedFilter = "Confirmed");
-            ShowUpcomingReservationsCommand = new RelayCommand(() => SelectedFilter = "Upcoming (7 days)");
+            RefreshCommand = new AsyncRelayCommand(LoadReservationsAsync, CanRefreshReservations);
+            OpenReservationDetailsCommand = new RelayCommand(OpenReservationDetails, CanUseSelectedReservation);
+            CopyReservationHandoffCommand = new RelayCommand(CopyReservationHandoff, CanUseSelectedReservation);
+            PrintReservationHandoffCommand = new RelayCommand(PrintReservationHandoff, CanUseSelectedReservation);
+            PrintReservationDirectoryCommand = new RelayCommand(PrintReservationDirectory, () => CanPrintReservationDirectory);
+            ClearReservationSearchCommand = new RelayCommand(ClearReservationSearch, CanInteractWithReservations);
+            ShowActiveReservationsCommand = new RelayCommand(() => SelectedFilter = "Active", CanInteractWithReservations);
+            ShowPendingReservationsCommand = new RelayCommand(() => SelectedFilter = "Pending", CanInteractWithReservations);
+            ShowConfirmedReservationsCommand = new RelayCommand(() => SelectedFilter = "Confirmed", CanInteractWithReservations);
+            ShowUpcomingReservationsCommand = new RelayCommand(() => SelectedFilter = "Upcoming (7 days)", CanInteractWithReservations);
         }
 
         private async Task LoadReservationsAsync()
         {
+            if (IsLoading)
+            {
+                return;
+            }
+
             try
             {
+                IsLoading = true;
                 var preferredReservationId = SelectedReservation?.ReservationID;
                 var reservations = await _reservationService.GetAllReservationsAsync();
                 Reservations.Clear();
@@ -190,11 +255,13 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                Reservations.Clear();
-                FilteredReservations.Clear();
-                SelectedReservation = null;
-                OnPropertyChanged(nameof(ReservationResultsSummary));
+                ClearReservationStateAfterLoadFailure();
                 await _dialogService.ShowErrorAsync("Error loading reservations", $"{ex.Message} The reservation list has been cleared until reload succeeds.");
+            }
+            finally
+            {
+                IsLoading = false;
+                NotifyReservationListStateChanged();
             }
         }
 
@@ -209,14 +276,13 @@ namespace InventoryManagementApp.ViewModels
                     Reservations.Add(reservation);
                 }
                 ApplyFilter(preferredReservationId);
+                NotifyCommandStatesAndSummaries();
+                NotifyReservationListStateChanged();
                 return true;
             }
             catch
             {
-                Reservations.Clear();
-                FilteredReservations.Clear();
-                SelectedReservation = null;
-                OnPropertyChanged(nameof(ReservationResultsSummary));
+                ClearReservationStateAfterLoadFailure();
                 return false;
             }
         }
@@ -430,7 +496,7 @@ namespace InventoryManagementApp.ViewModels
             }
 
             SelectBestReservationAfterRefresh(preferredReservationId);
-            OnPropertyChanged(nameof(ReservationResultsSummary));
+            NotifyReservationListStateChanged();
         }
 
         private void ClearReservationSearch()
@@ -438,6 +504,15 @@ namespace InventoryManagementApp.ViewModels
             SearchText = string.Empty;
             SelectedFilter = "Active";
             ApplyFilter();
+        }
+
+        private void ClearReservationStateAfterLoadFailure()
+        {
+            Reservations.Clear();
+            FilteredReservations.Clear();
+            SelectedReservation = null;
+            NotifyCommandStatesAndSummaries();
+            NotifyReservationListStateChanged();
         }
 
         private void OpenReservationDetails()
@@ -496,35 +571,48 @@ namespace InventoryManagementApp.ViewModels
 
         private void PrintReservationDirectory()
         {
-            if (FilteredReservations.Count == 0)
+            if (!CanPrintReservationDirectory)
             {
-                _dialogService.ShowInfo("There are no reservations to print for the current filter.", "Reservation Directory");
+                _dialogService.ShowInfo("There are no reservations ready to print for the current filter.", "Reservation Directory");
                 return;
             }
 
             try
             {
+                var visibleRows = FilteredReservations.Count;
+                var printRows = FilteredReservations.Take(MaxReservationPrintRows).ToList();
+                var omittedRows = Math.Max(0, visibleRows - printRows.Count);
                 var doc = CreateReservationDocument("Reservation Directory", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {ReservationResultsSummary}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows} | {ReservationResultsSummary}"))
                 {
                     FontSize = 10,
-                    Margin = new Thickness(0, 0, 0, 10)
+                    Margin = new Thickness(0, 0, 0, 8)
                 });
 
+                if (omittedRows > 0)
+                {
+                    doc.Blocks.Add(new Paragraph(new Run($"Large reservation preview limited to the first {MaxReservationPrintRows} visible rows to keep print preview responsive. Narrow the status filter or search before printing a full shelf-pick packet."))
+                    {
+                        FontSize = 10,
+                        FontStyle = FontStyles.Italic,
+                        Margin = new Thickness(0, 0, 0, 8)
+                    });
+                }
+
                 var table = new Table { CellSpacing = 0 };
-                table.Columns.Add(new TableColumn { Width = new GridLength(80) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(110) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(165) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(165) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(0.85, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.1, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.65, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.65, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.0, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.0, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.05, GridUnitType.Star) });
 
                 var group = new TableRowGroup();
                 table.RowGroups.Add(group);
                 AddPrintRow(group, true, "Hold #", "Item #", "Item", "Customer", "Start", "End", "Status");
 
-                foreach (var reservation in FilteredReservations)
+                foreach (var reservation in printRows)
                 {
                     AddPrintRow(
                         group,
@@ -539,7 +627,13 @@ namespace InventoryManagementApp.ViewModels
                 }
 
                 doc.Blocks.Add(table);
-                _dialogService.ShowPrintPreview(doc, "Reservation Directory", string.Empty);
+                doc.Blocks.Add(new Paragraph(new Run("Review pending, confirmed, upcoming, fulfilled, cancelled, linked Rental ID, and omitted-row counts before shelf pickup or customer handoff."))
+                {
+                    FontSize = 10,
+                    FontStyle = FontStyles.Italic,
+                    Margin = new Thickness(0, 10, 0, 0)
+                });
+                _dialogService.ShowPrintPreview(doc, "Reservation Directory", ReservationPrintStatus);
             }
             catch (Exception ex)
             {
@@ -560,16 +654,42 @@ namespace InventoryManagementApp.ViewModels
                 : FilteredReservations.FirstOrDefault();
         }
 
-        private void NotifySelectionChanged()
+        private void NotifyCommandStatesAndSummaries()
         {
+            LoadReservationsCommand.NotifyCanExecuteChanged();
+            AddReservationCommand.NotifyCanExecuteChanged();
             EditReservationCommand.NotifyCanExecuteChanged();
             DeleteReservationCommand.NotifyCanExecuteChanged();
             ConfirmReservationCommand.NotifyCanExecuteChanged();
             CancelReservationCommand.NotifyCanExecuteChanged();
             FulfillReservationCommand.NotifyCanExecuteChanged();
+            RefreshCommand.NotifyCanExecuteChanged();
             OpenReservationDetailsCommand.NotifyCanExecuteChanged();
             CopyReservationHandoffCommand.NotifyCanExecuteChanged();
             PrintReservationHandoffCommand.NotifyCanExecuteChanged();
+            PrintReservationDirectoryCommand.NotifyCanExecuteChanged();
+            ClearReservationSearchCommand.NotifyCanExecuteChanged();
+            ShowActiveReservationsCommand.NotifyCanExecuteChanged();
+            ShowPendingReservationsCommand.NotifyCanExecuteChanged();
+            ShowConfirmedReservationsCommand.NotifyCanExecuteChanged();
+            ShowUpcomingReservationsCommand.NotifyCanExecuteChanged();
+            NotifySelectionSummariesChanged();
+            OnPropertyChanged(nameof(ReservationResultsSummary));
+        }
+
+        private void NotifyReservationListStateChanged()
+        {
+            OnPropertyChanged(nameof(ReservationResultsSummary));
+            OnPropertyChanged(nameof(IsFilterActive));
+            OnPropertyChanged(nameof(ReservationEmptyTitle));
+            OnPropertyChanged(nameof(ReservationEmptyMessage));
+            OnPropertyChanged(nameof(CanPrintReservationDirectory));
+            OnPropertyChanged(nameof(ReservationPrintStatus));
+            PrintReservationDirectoryCommand.NotifyCanExecuteChanged();
+        }
+
+        private void NotifySelectionSummariesChanged()
+        {
             OnPropertyChanged(nameof(SelectedReservationTitle));
             OnPropertyChanged(nameof(SelectedReservationSubtitle));
             OnPropertyChanged(nameof(SelectedReservationTiming));
@@ -676,14 +796,20 @@ namespace InventoryManagementApp.ViewModels
         private static string ValueOrNotRecorded(string? value) =>
             string.IsNullOrWhiteSpace(value) ? "Not recorded" : value.Trim();
 
-        private bool CanEdit() => SelectedReservation != null && SelectedReservation.Status != "Fulfilled";
+        private bool CanInteractWithReservations() => !IsLoading;
 
-        private bool CanDelete() => SelectedReservation != null;
+        private bool CanRefreshReservations() => !IsLoading;
 
-        private bool CanConfirm() => SelectedReservation != null && SelectedReservation.Status == "Pending";
+        private bool CanUseSelectedReservation() => !IsLoading && SelectedReservation != null;
 
-        private bool CanCancel() => SelectedReservation != null && SelectedReservation.IsActive;
+        private bool CanEdit() => !IsLoading && SelectedReservation != null && SelectedReservation.Status != "Fulfilled";
 
-        private bool CanFulfill() => SelectedReservation != null && SelectedReservation.Status == "Confirmed";
+        private bool CanDelete() => !IsLoading && SelectedReservation != null;
+
+        private bool CanConfirm() => !IsLoading && SelectedReservation != null && SelectedReservation.Status == "Pending";
+
+        private bool CanCancel() => !IsLoading && SelectedReservation != null && SelectedReservation.IsActive;
+
+        private bool CanFulfill() => !IsLoading && SelectedReservation != null && SelectedReservation.Status == "Confirmed";
     }
 }

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml
@@ -72,8 +72,8 @@
                     </Border>
                     <Border Style="{StaticResource ReservationStatCard}">
                         <StackPanel>
-                            <TextBlock Text="HANDOFF" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Copy / print ready" Style="{StaticResource ReservationStatValueText}"/>
+                            <TextBlock Text="PRINT" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding ReservationPrintStatus}" Style="{StaticResource ReservationStatValueText}"/>
                         </StackPanel>
                     </Border>
                 </WrapPanel>
@@ -153,6 +153,7 @@
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
                         <DockPanel LastChildFill="True">
                             <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,10,0"/>
+                            <TextBlock Text="{Binding ReservationPrintStatus}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
                         </DockPanel>
                     </Border>
 
@@ -244,15 +245,39 @@
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding FilteredReservations.Count}" Value="0">
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding FilteredReservations.Count}" Value="0"/>
+                                            <Condition Binding="{Binding IsLoading}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="{Binding ReservationEmptyTitle}" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding ReservationEmptyMessage}"
+                                       Style="{StaticResource CaptionTextBlock}"
+                                       TextAlignment="Center"
+                                       TextWrapping="Wrap"
+                                       Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Row="2" MaxWidth="380" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="16">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsLoading}" Value="True">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
-                            <TextBlock Text="No reservations match this filter" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
-                            <TextBlock Text="Clear search, switch the status filter, or add a new hold to restart the reservation queue."
+                            <TextBlock Text="Loading reservation directory" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="Hold actions and directory printing are paused until the latest saved rows are ready."
                                        Style="{StaticResource CaptionTextBlock}"
                                        TextAlignment="Center"
                                        TextWrapping="Wrap"
@@ -348,7 +373,10 @@
                     <Button Style="{StaticResource PrimaryButton}" Content="Add Hold" Command="{Binding AddReservationCommand}" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Print List" Command="{Binding PrintReservationDirectoryCommand}" Margin="0,0,0,4"/>
                 </WrapPanel>
-                <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
+                <StackPanel Margin="2,0,10,0">
+                    <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding ReservationPrintStatus}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                </StackPanel>
             </DockPanel>
         </Border>
     </Grid>

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
@@ -1,18 +1,24 @@
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
 {
     public partial class ReservationPage : Page
     {
+        private Task? _loadReservationsTask;
+        private ReservationManagementViewModel? _loadedViewModel;
+
         public ReservationPage()
         {
             InitializeComponent();
             Loaded += ReservationPage_Loaded;
+            DataContextChanged += ReservationPage_DataContextChanged;
             PreviewKeyDown += ReservationPage_PreviewKeyDown;
         }
 
@@ -21,10 +27,38 @@ namespace InventoryManagementApp.Views.Pages
             Focus();
             if (DataContext is ReservationManagementViewModel vm)
             {
-                await vm.LoadReservationsCommand.ExecuteAsync(null);
+                await LoadReservationsOnceAsync(vm);
             }
 
             FocusFirstSearchBox();
+        }
+
+        private void ReservationPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(_loadedViewModel, e.NewValue))
+            {
+                _loadedViewModel = null;
+                _loadReservationsTask = null;
+            }
+        }
+
+        private async Task LoadReservationsOnceAsync(ReservationManagementViewModel vm)
+        {
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadReservationsTask is { IsCompleted: false })
+            {
+                await _loadReservationsTask;
+                return;
+            }
+
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadReservationsTask is { IsCompletedSuccessfully: true })
+            {
+                return;
+            }
+
+            _loadedViewModel = vm;
+            await Dispatcher.Yield(DispatcherPriority.Background);
+            _loadReservationsTask = vm.LoadReservationsCommand.ExecuteAsync(null);
+            await _loadReservationsTask;
         }
 
         private void ReservationRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -59,7 +93,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && vm.PrintReservationDirectoryCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Reservations", () => vm.PrintReservationDirectoryCommand.Execute(null));
                 e.Handled = true;


### PR DESCRIPTION
## What changed

- Added a Reservations workbench loading guard so hold-directory refreshes cannot overlap.
- Disabled add, edit, delete, confirm, cancel, fulfill, details, copy, selected handoff print, quick-filter, clear, refresh, and directory print actions while reservation rows are loading.
- Added ViewModel-backed loading, filter, empty-state, print-availability, and print-status properties.
- Added dynamic empty-state copy for no saved holds versus no search/filter matches.
- Added a bounded loading overlay in the hold-directory grid region.
- Added Reservation print status in the summary card, hold-directory subheader, and footer status area.
- Preserved the virtualized reservation grid, row selection, context menu, keyboard shortcuts, double-click details, and pickup handoff panel.
- Added first-paint-friendly page-owned loading that yields before the initial Reservations refresh.
- Prevented duplicate page loads for the same Reservations view model and reset the page load guard when a new view model is attached.
- Capped Reservation Directory print preview generation to the first 250 visible rows.
- Added honest print packet accounting for visible, printed, omitted, filter, search, and result summary context.
- Replaced fixed Reservation Directory print columns with proportional columns.
- Added large-directory guidance, print preview description text, fallback row text, and a shelf-pick review note for professional reservation handoff output.
- Extended source-contract coverage for loading guards, UI states, command availability, capped print snapshots, proportional print columns, page load behavior, and preserved actions.
- Replaced the brittle GridSplitter source-contract assertion with a whitespace-tolerant regex while preserving the same layout contract.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-reservations-workbench-performance.md`.

## Why this was highest value

Recent merged work already covered Categories, Maintenance, Calibration, Settings, Customers, Rental History, Activity Logs, Users, Reports, imports, and shell responsiveness. Current Reservations evidence still showed a concrete workflow gap: the grid was virtualized, but page load/manual refresh could overlap, action and print state did not reflect loading or empty data, and directory printing materialized every visible hold into fixed-width print columns. That directly affects loading speed, UI responsiveness, professional data display, and shelf-pick handoff output.

## Why this is real progress

This is a complete Reservations workflow slice across ViewModel command state, page load behavior, grid loading/empty display, print-preview document generation, source-contract tests, and progress records. It includes more than ten focused improvements while staying inside the active WPF app.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by five focused commits, and limited to:
  - `InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs`
  - `InventoryManagementApp/Views/Pages/ReservationPage.xaml`
  - `InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs`
  - `InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-reservations-workbench-performance.md`
- Connector readback confirmed the loading guard, command can-execute gating, dynamic loading/empty/print status, bounded loading overlay, first-paint page load guard, capped print snapshot, proportional print columns, shelf-pick review note, and updated source-contract assertions.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `ad1d9e24d7160165d5ca2e8a9776027a6fa96dee`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Reservations at 1366 x 768 and higher Windows scaling with no records, loading, all rows, filtered rows, no-match filters, rapid refresh/filter clicks, keyboard shortcuts, and 250+ visible rows before directory printing.