### PR TITLE
Guard reservation add shortcut while loading

### DIFF
--- a/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
@@ -169,6 +169,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("LoadReservationsOnceAsync", source, StringComparison.Ordinal);
             Assert.Contains("IsCompletedSuccessfully", source, StringComparison.Ordinal);
             Assert.Contains("_loadReservationsTask = null;", source, StringComparison.Ordinal);
+            Assert.Contains("Key == Key.N && vm.AddReservationCommand.CanExecute(null)", source, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
@@ -86,7 +86,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N)
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N && vm.AddReservationCommand.CanExecute(null))
             {
                 UiActionGuard.RunAsync(this, "Reservations", async () => await vm.AddReservationCommand.ExecuteAsync(null));
                 e.Handled = true;


### PR DESCRIPTION
## What changed

- Updated the Reservations Ctrl+N add-hold shortcut to check `AddReservationCommand.CanExecute(null)` before invoking the command.
- Added source-contract coverage so the shortcut stays aligned with the same loading guard used by toolbar/button command state.
- Also restored trailing newlines in the touched Reservations page code-behind and source-contract test files.

## Why this was highest value

PR #1516 intentionally paused reservation mutations while the hold directory is loading, but readback showed Ctrl+N still invoked the add-hold command path without checking command availability. This is a small but real regression risk in the new loading guard workflow, so it was safer to fix immediately before ending the scheduled run.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, ahead by two focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs`
  - `InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs`
- Connector readback confirmed the Ctrl+N path now requires `vm.AddReservationCommand.CanExecute(null)` and the test asserts that contract.
- Connector status readback found no attached commit statuses on branch head `e75804fcb3a2c67278598ebc0b0c4fc76bce1ae0`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime keyboard shortcut smoke tests

Those remain blocked in this scheduled Linux environment because direct checkout is blocked and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.