### PR TITLE
Improve Kits workbench loading and print responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
@@ -16,6 +16,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("KitStatValueText", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("{Binding KitFilterSummary}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{Binding KitPrintSummary}", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"520\"/>", xaml, StringComparison.Ordinal);
@@ -61,12 +63,30 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<TextBox Width=\"240\" MinWidth=\"190\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<ComboBox Width=\"140\" MinWidth=\"120\"", xaml, StringComparison.Ordinal);
             Assert.Equal(2, CountOccurrences(xaml, "MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\""));
+            Assert.Contains("Visibility=\"{Binding IsKitDirectoryEmptyVisible, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Visibility=\"{Binding IsKitItemsEmptyVisible, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("{Binding KitEmptyStateTitle}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{Binding KitItemsEmptyStateMessage}", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\" Padding=\"12\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"320\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Width=\"320\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<StackPanel DockPanel.Dock=\"Right\" Orientation=\"Horizontal\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitManagementPage_ShowsBoundedLoadingOverlaysForDirectoryAndMembership()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml");
+
+            Assert.Contains("Visibility=\"{Binding IsLoadingKits, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Visibility=\"{Binding IsLoadingKitItems, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(xaml, "MaxWidth=\"360\" MinHeight=\"118\" Margin=\"12\""));
+            Assert.Equal(2, CountOccurrences(xaml, "<ProgressBar IsIndeterminate=\"True\" Height=\"6\""));
+            Assert.Contains("Loading kit rows", xaml, StringComparison.Ordinal);
+            Assert.Contains("Loading kit membership", xaml, StringComparison.Ordinal);
+            Assert.Contains("{Binding KitItemLoadSummary}", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -81,6 +101,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("CopySelectedKitCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("PrintSelectedKitCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("PrintKitListCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding IsKitDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("DeleteKitCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("AddKitItemCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("EditKitItemCommand", xaml, StringComparison.Ordinal);
@@ -89,6 +110,54 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("KitRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
             Assert.Contains("KitItemRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
             Assert.Contains("DataGridRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitManagementViewModel_GuardsLoadingCommandsAndStaleMembershipRefreshes()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+
+            Assert.Contains("private const int MaxDirectoryPrintRows = 250;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsLoadingKits", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsLoadingKitItems", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsKitInteractionBusy => IsLoadingKits;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsKitItemInteractionBusy => IsLoadingKits || IsLoadingKitItems;", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsKitInteractionBusy)", source, StringComparison.Ordinal);
+            Assert.Contains("LoadKitsCommand = new AsyncRelayCommand(LoadKitsAsync, () => !IsKitInteractionBusy);", source, StringComparison.Ordinal);
+            Assert.Contains("RefreshCommand = new AsyncRelayCommand(LoadKitsAsync, () => !IsKitInteractionBusy);", source, StringComparison.Ordinal);
+            Assert.Contains("ClearSearchCommand = new RelayCommand(ClearSearch, () => !IsKitInteractionBusy", source, StringComparison.Ordinal);
+            Assert.Contains("var loadVersion = ++_kitItemLoadVersion;", source, StringComparison.Ordinal);
+            Assert.Contains("loadVersion != _kitItemLoadVersion || SelectedKit?.KitID != kitID", source, StringComparison.Ordinal);
+            Assert.Contains("if (loadVersion == _kitItemLoadVersion)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitManagementViewModel_CapsAndDescribesPrintPreviewOutput()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+
+            Assert.Contains("var printedKits = visibleKits.Take(MaxDirectoryPrintRows).ToList();", source, StringComparison.Ordinal);
+            Assert.Contains("var omittedCount = visibleKits.Count - printedKits.Count;", source, StringComparison.Ordinal);
+            Assert.Contains("Visible {visibleKits.Count} | Printed {printedKits.Count} | Omitted {omittedCount}", source, StringComparison.Ordinal);
+            Assert.Contains("Large filtered directories print the first 250 visible rows to keep preview responsive.", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(1.15, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.Contains("new GridLength(2.25, GridUnitType.Star)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new GridLength(120)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new GridLength(230)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitManagementPage_CodeBehindUsesFirstPaintLoadGuard()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs");
+
+            Assert.Contains("private KitManagementViewModel? _loadedViewModel;", source, StringComparison.Ordinal);
+            Assert.Contains("private Task? _loadKitsTask;", source, StringComparison.Ordinal);
+            Assert.Contains("DataContextChanged += KitManagementPage_DataContextChanged;", source, StringComparison.Ordinal);
+            Assert.Contains("LoadKitsOnceForViewModelAsync", source, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("vm.LoadKitsCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("ReferenceEquals(currentVm, vm)", source, StringComparison.Ordinal);
         }
 
         private static int CountOccurrences(string text, string value)

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-kits-workbench-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-kits-workbench-performance.md
@@ -1,0 +1,29 @@
+# Kits Workbench Loading and Print Responsiveness - 2026-07-04
+
+## Completed
+
+- Added a Kits directory loading guard so manual refresh and page-open loading cannot start overlapping kit list refreshes.
+- Added membership loading state so item-line actions, availability checks, details, copy, and kit-sheet printing pause while selected-kit rows are still loading.
+- Added stale membership-load protection so rapid selection changes do not let an older item-list response replace the currently selected kit's membership rows.
+- Added deterministic kit and kit-item ordering after refresh so grids stay stable while operators search, filter, reload, or return from edits.
+- Added ViewModel-backed directory loading, item loading, empty-state, filter-summary, print-summary, and print-availability properties.
+- Disabled add/edit/delete/details/copy/availability/refresh/clear/print commands while their underlying directory or membership data is loading.
+- Added bounded loading overlays for the Kits directory and kit membership grid regions.
+- Added dynamic no-record versus no-match empty-state copy for kits and selected-kit item lines.
+- Surfaced filter, membership, and print status in the summary cards, directory subheader, membership subheader, and footer.
+- Capped Kit Directory print preview generation to the first 250 visible rows.
+- Added honest print packet accounting for visible, printed, omitted, search, and status-filter context.
+- Replaced fixed Kit Directory and Kit Pick Sheet print table widths with proportional columns.
+- Added print-preview guidance so large filtered directories explain why rows may be omitted from the preview packet.
+- Added first-paint-friendly page-owned Kits loading with a dispatcher yield, duplicate-load prevention for the same view model, and reset behavior when the page gets a new view model.
+- Extended Kits source-contract coverage for loading guards, stale item-load protection, responsive overlays, command gating, capped print snapshots, proportional print columns, and page load behavior.
+
+## Validation
+
+- Connector readback confirmed the branch contains the intended Kits view model, page XAML, page code-behind, test, and progress-note changes.
+- Local Windows/.NET validation, WPF runtime smoke tests, screenshots, scaling checks, and print-preview rendering could not run in this scheduled Linux environment because direct checkout is blocked and the required Windows/.NET/WPF tools are unavailable.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test Kits at 1366 x 768 and higher Windows scaling with no kits, loading, all kits, active/inactive filters, no-match search, rapid selection changes, empty membership, populated membership, and 250+ visible rows before directory printing.

--- a/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
@@ -16,26 +16,148 @@ namespace InventoryManagementApp.ViewModels
 {
     public class KitManagementViewModel : ObservableObject
     {
+        private const int MaxDirectoryPrintRows = 250;
         private readonly KitService _kitService;
         private readonly IDialogService _dialogService;
+        private bool _isLoadingKits;
+        private bool _isLoadingKitItems;
+        private int _kitItemLoadVersion;
 
         public ObservableCollection<Kit> Kits { get; }
         public ObservableCollection<Kit> FilteredKits { get; }
         public ObservableCollection<KitItem> KitItems { get; }
 
-        public string KitResultsSummary => $"{FilteredKits.Count} kit{(FilteredKits.Count == 1 ? string.Empty : "s")} shown | {Kits.Count(k => k.IsActive)} active | {Kits.Count(k => !k.IsActive)} inactive";
+        public bool IsLoadingKits
+        {
+            get => _isLoadingKits;
+            private set
+            {
+                if (SetProperty(ref _isLoadingKits, value))
+                {
+                    RaiseDirectoryStateChanged();
+                    RaiseCommandStates();
+                }
+            }
+        }
+
+        public bool IsLoadingKitItems
+        {
+            get => _isLoadingKitItems;
+            private set
+            {
+                if (SetProperty(ref _isLoadingKitItems, value))
+                {
+                    RaiseKitItemStateChanged();
+                    RaiseCommandStates();
+                }
+            }
+        }
+
+        public bool IsKitInteractionBusy => IsLoadingKits;
+
+        public bool IsKitItemInteractionBusy => IsLoadingKits || IsLoadingKitItems;
+
+        public bool IsKitDirectoryEmptyVisible => !IsKitInteractionBusy && FilteredKits.Count == 0;
+
+        public bool IsKitItemsEmptyVisible => !IsKitItemInteractionBusy && SelectedKit != null && KitItems.Count == 0;
+
+        public bool IsKitDirectoryPrintAvailable => !IsKitInteractionBusy && FilteredKits.Count > 0;
+
+        public string KitResultsSummary
+        {
+            get
+            {
+                if (IsLoadingKits) return "Loading kit directory...";
+                var active = Kits.Count(k => k.IsActive);
+                var inactive = Kits.Count - active;
+                return $"{FilteredKits.Count} kit{(FilteredKits.Count == 1 ? string.Empty : "s")} shown | {active} active | {inactive} inactive";
+            }
+        }
+
+        public string KitFilterSummary
+        {
+            get
+            {
+                if (IsLoadingKits) return "Filter and search are paused while kit rows load.";
+
+                var status = SelectedFilter == "All" ? "all kits" : SelectedFilter.ToLowerInvariant() + " kits";
+                return string.IsNullOrWhiteSpace(SearchText)
+                    ? $"Showing {status}."
+                    : $"Showing {status} matching \"{SearchText.Trim()}\".";
+            }
+        }
+
+        public string KitPrintSummary
+        {
+            get
+            {
+                if (IsLoadingKits) return "Print is paused while kit rows are loading.";
+                if (FilteredKits.Count == 0) return "Print is available after kits are loaded or the filter has matches.";
+
+                var visible = FilteredKits.Count;
+                var printed = Math.Min(visible, MaxDirectoryPrintRows);
+                var omitted = visible - printed;
+                var suffix = omitted > 0 ? $" First {printed} will print; {omitted} omitted for preview speed." : string.Empty;
+                return $"Ready to print {visible} visible kit row{(visible == 1 ? string.Empty : "s")}.{suffix}";
+            }
+        }
+
+        public string KitEmptyStateTitle
+        {
+            get
+            {
+                if (Kits.Count == 0) return "No kits saved yet";
+                return string.IsNullOrWhiteSpace(SearchText) && SelectedFilter == "All"
+                    ? "No kits to show"
+                    : "No kits match this filter";
+            }
+        }
+
+        public string KitEmptyStateMessage
+        {
+            get
+            {
+                if (Kits.Count == 0)
+                {
+                    return "Add the first reusable kit so staff can stage grouped items, confirm availability, and print a pick sheet from one workflow.";
+                }
+
+                return "Clear the search, change the status filter, or add a kit that matches the current shop language.";
+            }
+        }
+
+        public string KitItemLoadSummary
+        {
+            get
+            {
+                if (SelectedKit == null) return "Select a kit to load required and optional item lines.";
+                if (IsLoadingKitItems) return $"Loading membership for {ValueOrNotRecorded(SelectedKit.KitNumber)}...";
+                if (KitItems.Count == 0) return "No item lines are assigned to this kit yet.";
+                return $"{KitItems.Count} item line{(KitItems.Count == 1 ? string.Empty : "s")} ready for availability review and pick-sheet printing.";
+            }
+        }
+
+        public string KitItemsEmptyStateTitle => SelectedKit == null
+            ? "No kit selected"
+            : "No items assigned to this kit";
+
+        public string KitItemsEmptyStateMessage => SelectedKit == null
+            ? "Choose a kit from the directory to load its membership lines."
+            : "Add required and optional item lines so availability checks and printed handoffs have enough detail.";
 
         public string SelectedKitSummary => SelectedKit == null
             ? "Select a kit to review membership, check availability, copy details, print a pick sheet, or maintain its item list."
-            : $"{ValueOrNotRecorded(SelectedKit.KitNumber)} | {ValueOrNotRecorded(SelectedKit.Name)} | {KitItems.Count} item line{(KitItems.Count == 1 ? string.Empty : "s")} | {(SelectedKit.IsActive ? "Active" : "Inactive")}";
+            : $"{ValueOrNotRecorded(SelectedKit.KitNumber)} | {ValueOrNotRecorded(SelectedKit.Name)} | {(IsLoadingKitItems ? "loading" : KitItems.Count.ToString())} item line{(KitItems.Count == 1 ? string.Empty : "s")} | {(SelectedKit.IsActive ? "Active" : "Inactive")}";
 
         public string SelectedKitDetail => SelectedKit == null
             ? "No kit selected. Choose a row from the directory to see the operational detail here."
-            : $"Kit # {ValueOrNotRecorded(SelectedKit.KitNumber)}\nName: {ValueOrNotRecorded(SelectedKit.Name)}\nCategory: {ValueOrNotRecorded(SelectedKit.Category)}\nStatus: {(SelectedKit.IsActive ? "Active" : "Inactive")}\nItems: {KitItems.Count}\nUpdated: {SelectedKit.UpdatedAt:yyyy-MM-dd HH:mm}\n\n{ValueOrNotRecorded(SelectedKit.Description)}";
+            : $"Kit # {ValueOrNotRecorded(SelectedKit.KitNumber)}\nName: {ValueOrNotRecorded(SelectedKit.Name)}\nCategory: {ValueOrNotRecorded(SelectedKit.Category)}\nStatus: {(SelectedKit.IsActive ? "Active" : "Inactive")}\nItems: {(IsLoadingKitItems ? "Loading" : KitItems.Count.ToString())}\nUpdated: {SelectedKit.UpdatedAt:yyyy-MM-dd HH:mm}\n\n{ValueOrNotRecorded(SelectedKit.Description)}";
 
         public string KitItemsSummary => SelectedKit == null
             ? "No kit selected"
-            : $"{KitItems.Count} item line{(KitItems.Count == 1 ? string.Empty : "s")} in {ValueOrNotRecorded(SelectedKit.KitNumber)} | {KitItems.Count(i => !i.IsOptional)} required | {KitItems.Count(i => i.IsOptional)} optional";
+            : IsLoadingKitItems
+                ? $"Loading item lines for {ValueOrNotRecorded(SelectedKit.KitNumber)}"
+                : $"{KitItems.Count} item line{(KitItems.Count == 1 ? string.Empty : "s")} in {ValueOrNotRecorded(SelectedKit.KitNumber)} | {KitItems.Count(i => !i.IsOptional)} required | {KitItems.Count(i => i.IsOptional)} optional";
 
         public string SelectedKitItemSummary => SelectedKitItem == null
             ? "Select a kit item to edit quantity, mark optional, or remove it from this kit."
@@ -43,7 +165,9 @@ namespace InventoryManagementApp.ViewModels
 
         public string SelectedKitAvailabilitySummary => SelectedKit == null
             ? "Availability check is ready once a kit is selected."
-            : "Use Check Availability before promising the kit; required item quantities are checked against current stock.";
+            : IsLoadingKitItems
+                ? "Membership is loading; availability checks are paused until item lines are ready."
+                : "Use Check Availability before promising the kit; required item quantities are checked against current stock.";
 
         private Kit? _selectedKit;
         public Kit? SelectedKit
@@ -53,18 +177,14 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _selectedKit, value))
                 {
-                    EditKitCommand.NotifyCanExecuteChanged();
-                    DeleteKitCommand.NotifyCanExecuteChanged();
-                    ViewKitItemsCommand.NotifyCanExecuteChanged();
-                    AddKitItemCommand.NotifyCanExecuteChanged();
-                    CheckAvailabilityCommand.NotifyCanExecuteChanged();
-                    OpenKitDetailsCommand.NotifyCanExecuteChanged();
-                    CopySelectedKitCommand.NotifyCanExecuteChanged();
-                    PrintSelectedKitCommand.NotifyCanExecuteChanged();
+                    RaiseCommandStates();
                     OnPropertyChanged(nameof(SelectedKitSummary));
                     OnPropertyChanged(nameof(SelectedKitDetail));
                     OnPropertyChanged(nameof(KitItemsSummary));
                     OnPropertyChanged(nameof(SelectedKitAvailabilitySummary));
+                    OnPropertyChanged(nameof(KitItemLoadSummary));
+                    OnPropertyChanged(nameof(KitItemsEmptyStateTitle));
+                    OnPropertyChanged(nameof(KitItemsEmptyStateMessage));
 
                     if (value != null)
                     {
@@ -72,6 +192,7 @@ namespace InventoryManagementApp.ViewModels
                     }
                     else
                     {
+                        _kitItemLoadVersion++;
                         ClearKitItemsForReload();
                     }
                 }
@@ -154,31 +275,36 @@ namespace InventoryManagementApp.ViewModels
                 "Inactive"
             };
 
-            LoadKitsCommand = new AsyncRelayCommand(LoadKitsAsync);
-            AddKitCommand = new AsyncRelayCommand(AddKitAsync);
+            LoadKitsCommand = new AsyncRelayCommand(LoadKitsAsync, () => !IsKitInteractionBusy);
+            AddKitCommand = new AsyncRelayCommand(AddKitAsync, () => !IsKitInteractionBusy);
             EditKitCommand = new AsyncRelayCommand(EditKitAsync, CanEditOrDelete);
             DeleteKitCommand = new AsyncRelayCommand(DeleteKitAsync, CanEditOrDelete);
             ViewKitItemsCommand = new AsyncRelayCommand(ViewKitItemsAsync, CanEditOrDelete);
-            AddKitItemCommand = new AsyncRelayCommand(AddKitItemAsync, CanEditOrDelete);
+            AddKitItemCommand = new AsyncRelayCommand(AddKitItemAsync, CanMaintainKitItems);
             EditKitItemCommand = new AsyncRelayCommand(EditKitItemAsync, CanEditOrRemoveKitItem);
             RemoveKitItemCommand = new AsyncRelayCommand(RemoveKitItemAsync, CanEditOrRemoveKitItem);
             CheckAvailabilityCommand = new AsyncRelayCommand(CheckAvailabilityAsync, CanEditOrDelete);
-            RefreshCommand = new AsyncRelayCommand(LoadKitsAsync);
-            ClearSearchCommand = new RelayCommand(ClearSearch);
+            RefreshCommand = new AsyncRelayCommand(LoadKitsAsync, () => !IsKitInteractionBusy);
+            ClearSearchCommand = new RelayCommand(ClearSearch, () => !IsKitInteractionBusy && (!string.IsNullOrWhiteSpace(SearchText) || SelectedFilter != "Active"));
             OpenKitDetailsCommand = new RelayCommand(OpenKitDetails, CanEditOrDelete);
             CopySelectedKitCommand = new RelayCommand(CopySelectedKit, CanEditOrDelete);
-            PrintKitListCommand = new RelayCommand(PrintKitList);
+            PrintKitListCommand = new RelayCommand(PrintKitList, () => IsKitDirectoryPrintAvailable);
             PrintSelectedKitCommand = new RelayCommand(PrintSelectedKit, CanEditOrDelete);
         }
 
         private async Task LoadKitsAsync()
         {
+            if (IsKitInteractionBusy)
+                return;
+
+            IsLoadingKits = true;
+
             try
             {
                 var kits = await _kitService.GetAllKitsAsync();
                 var previouslySelectedKitId = SelectedKit?.KitID;
                 Kits.Clear();
-                foreach (var kit in kits)
+                foreach (var kit in kits.OrderByDescending(k => k.IsActive).ThenBy(k => k.Name).ThenBy(k => k.KitNumber))
                 {
                     Kits.Add(kit);
                 }
@@ -188,6 +314,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 ClearKitStateAfterLoadFailure();
                 await _dialogService.ShowErrorAsync("Error loading kits", $"{ex.Message} Kit rows were cleared until reload succeeds.");
+            }
+            finally
+            {
+                IsLoadingKits = false;
             }
         }
 
@@ -199,20 +329,25 @@ namespace InventoryManagementApp.ViewModels
             SelectedKitItem = null;
             KitItems.Clear();
             RefreshKitItemSummaries();
-            OnPropertyChanged(nameof(KitResultsSummary));
+            RaiseDirectoryStateChanged();
             OnPropertyChanged(nameof(SelectedKitAvailabilitySummary));
             PrintKitListCommand.NotifyCanExecuteChanged();
         }
 
         private async Task LoadKitItemsAsync(int kitID)
         {
+            var loadVersion = ++_kitItemLoadVersion;
             var selectedKitItemId = SelectedKitItem?.KitItemID;
             ClearKitItemsForReload();
+            IsLoadingKitItems = true;
 
             try
             {
                 var items = await _kitService.GetKitItemsAsync(kitID);
-                foreach (var item in items)
+                if (loadVersion != _kitItemLoadVersion || SelectedKit?.KitID != kitID)
+                    return;
+
+                foreach (var item in items.OrderBy(i => i.IsOptional).ThenBy(i => i.ItemName).ThenBy(i => i.ItemNumber))
                 {
                     KitItems.Add(item);
                 }
@@ -221,8 +356,18 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
+                if (loadVersion != _kitItemLoadVersion)
+                    return;
+
                 ClearKitItemsForReload();
                 await _dialogService.ShowErrorAsync("Error loading kit items", $"{ex.Message} Kit item rows were cleared until reload succeeds.");
+            }
+            finally
+            {
+                if (loadVersion == _kitItemLoadVersion)
+                {
+                    IsLoadingKitItems = false;
+                }
             }
         }
 
@@ -231,6 +376,7 @@ namespace InventoryManagementApp.ViewModels
             KitItems.Clear();
             SelectedKitItem = null;
             RefreshKitItemSummaries();
+            RaiseKitItemStateChanged();
         }
 
         private async Task RefreshKitItemsAfterMutationFailureAsync(string title, string message)
@@ -258,7 +404,7 @@ namespace InventoryManagementApp.ViewModels
             var selectedKitItemId = SelectedKitItem?.KitItemID;
             ClearKitItemsForReload();
             var items = await _kitService.GetKitItemsAsync(kitID);
-            foreach (var item in items)
+            foreach (var item in items.OrderBy(i => i.IsOptional).ThenBy(i => i.ItemName).ThenBy(i => i.ItemNumber))
             {
                 KitItems.Add(item);
             }
@@ -268,6 +414,8 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task AddKitAsync()
         {
+            if (IsKitInteractionBusy) return;
+
             var newKit = new Kit
             {
                 KitNumber = $"KIT-{DateTime.Now:yyyyMMddHHmmss}",
@@ -295,7 +443,7 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task EditKitAsync()
         {
-            if (SelectedKit == null) return;
+            if (SelectedKit == null || IsKitInteractionBusy) return;
 
             var clone = new Kit
             {
@@ -330,7 +478,7 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task DeleteKitAsync()
         {
-            if (SelectedKit == null) return;
+            if (SelectedKit == null || IsKitInteractionBusy) return;
 
             var kitName = SelectedKit.Name;
             var confirmed = await _dialogService.ShowConfirmAsync(
@@ -356,13 +504,13 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task ViewKitItemsAsync()
         {
-            if (SelectedKit == null) return;
+            if (SelectedKit == null || IsKitInteractionBusy) return;
             await LoadKitItemsAsync(SelectedKit.KitID);
         }
 
         private async Task AddKitItemAsync()
         {
-            if (SelectedKit == null) return;
+            if (SelectedKit == null || IsKitItemInteractionBusy) return;
 
             var newKitItem = new KitItem
             {
@@ -392,7 +540,7 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task EditKitItemAsync()
         {
-            if (SelectedKitItem == null) return;
+            if (SelectedKitItem == null || IsKitItemInteractionBusy) return;
 
             var clone = new KitItem
             {
@@ -426,7 +574,7 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task RemoveKitItemAsync()
         {
-            if (SelectedKitItem == null) return;
+            if (SelectedKitItem == null || IsKitItemInteractionBusy) return;
 
             var itemName = ValueOrNotRecorded(SelectedKitItem.ItemName);
             var confirmed = await _dialogService.ShowConfirmAsync(
@@ -452,7 +600,7 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task CheckAvailabilityAsync()
         {
-            if (SelectedKit == null) return;
+            if (SelectedKit == null || IsKitItemInteractionBusy) return;
 
             try
             {
@@ -470,6 +618,8 @@ namespace InventoryManagementApp.ViewModels
 
         private void ClearSearch()
         {
+            if (IsKitInteractionBusy) return;
+
             SearchText = string.Empty;
             SelectedFilter = "Active";
             ApplyFilter();
@@ -477,7 +627,7 @@ namespace InventoryManagementApp.ViewModels
 
         private void OpenKitDetails()
         {
-            if (SelectedKit == null) return;
+            if (SelectedKit == null || IsKitInteractionBusy) return;
 
             var details = BuildSelectedKitDetails();
             _dialogService.ShowInfo(details, $"Kit Details - {ValueOrNotRecorded(SelectedKit.Name)}");
@@ -485,7 +635,7 @@ namespace InventoryManagementApp.ViewModels
 
         private void CopySelectedKit()
         {
-            if (SelectedKit == null) return;
+            if (SelectedKit == null || IsKitInteractionBusy) return;
 
             try
             {
@@ -500,6 +650,12 @@ namespace InventoryManagementApp.ViewModels
 
         private void PrintKitList()
         {
+            if (IsKitInteractionBusy)
+            {
+                _dialogService.ShowInfo("Kit directory printing is paused while rows are loading.", "Kit Directory");
+                return;
+            }
+
             if (FilteredKits.Count == 0)
             {
                 _dialogService.ShowInfo("There are no kits to print for the current filter.", "Kit Directory");
@@ -508,30 +664,42 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
+                var visibleKits = FilteredKits.ToList();
+                var printedKits = visibleKits.Take(MaxDirectoryPrintRows).ToList();
+                var omittedCount = visibleKits.Count - printedKits.Count;
+                var filterContext = string.IsNullOrWhiteSpace(SearchText)
+                    ? $"Status filter: {SelectedFilter}"
+                    : $"Status filter: {SelectedFilter} | Search: {SearchText.Trim()}";
+
                 var doc = CreateKitDocument("Kit Directory", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {KitResultsSummary}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Visible {visibleKits.Count} | Printed {printedKits.Count} | Omitted {omittedCount} | {filterContext}"))
+                {
+                    FontSize = 10,
+                    Margin = new Thickness(0, 0, 0, 8)
+                });
+                doc.Blocks.Add(new Paragraph(new Run("Review active status, category, and descriptions before staging grouped item sets. Large filtered directories print the first 250 visible rows to keep preview responsive."))
                 {
                     FontSize = 10,
                     Margin = new Thickness(0, 0, 0, 10)
                 });
 
                 var table = new Table { CellSpacing = 0 };
-                table.Columns.Add(new TableColumn { Width = new GridLength(120) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(210) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(230) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.15, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.85, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(1.25, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(0.8, GridUnitType.Star) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(2.25, GridUnitType.Star) });
 
                 var group = new TableRowGroup();
                 table.RowGroups.Add(group);
                 AddPrintRow(group, true, "Kit #", "Name", "Category", "Status", "Description");
-                foreach (var kit in FilteredKits)
+                foreach (var kit in printedKits)
                 {
                     AddPrintRow(group, false, kit.KitNumber, kit.Name, kit.Category, kit.IsActive ? "Active" : "Inactive", kit.Description);
                 }
 
                 doc.Blocks.Add(table);
-                _dialogService.ShowPrintPreview(doc, "Kit Directory", string.Empty);
+                _dialogService.ShowPrintPreview(doc, "Kit Directory", KitPrintSummary);
             }
             catch (Exception ex)
             {
@@ -541,7 +709,7 @@ namespace InventoryManagementApp.ViewModels
 
         private void PrintSelectedKit()
         {
-            if (SelectedKit == null) return;
+            if (SelectedKit == null || IsKitItemInteractionBusy) return;
 
             try
             {
@@ -564,10 +732,10 @@ namespace InventoryManagementApp.ViewModels
                 });
 
                 var itemTable = new Table { CellSpacing = 0 };
-                itemTable.Columns.Add(new TableColumn { Width = new GridLength(130) });
-                itemTable.Columns.Add(new TableColumn { Width = new GridLength(280) });
-                itemTable.Columns.Add(new TableColumn { Width = new GridLength(80) });
-                itemTable.Columns.Add(new TableColumn { Width = new GridLength(100) });
+                itemTable.Columns.Add(new TableColumn { Width = new GridLength(1.2, GridUnitType.Star) });
+                itemTable.Columns.Add(new TableColumn { Width = new GridLength(2.4, GridUnitType.Star) });
+                itemTable.Columns.Add(new TableColumn { Width = new GridLength(0.7, GridUnitType.Star) });
+                itemTable.Columns.Add(new TableColumn { Width = new GridLength(0.9, GridUnitType.Star) });
                 var itemGroup = new TableRowGroup();
                 itemTable.RowGroups.Add(itemGroup);
                 AddPrintRow(itemGroup, true, "Item #", "Item", "Qty", "Required");
@@ -577,7 +745,7 @@ namespace InventoryManagementApp.ViewModels
                 }
                 doc.Blocks.Add(itemTable);
 
-                _dialogService.ShowPrintPreview(doc, $"Kit {kit.KitNumber}", string.Empty);
+                _dialogService.ShowPrintPreview(doc, $"Kit {kit.KitNumber}", KitItemLoadSummary);
             }
             catch (Exception ex)
             {
@@ -601,7 +769,11 @@ namespace InventoryManagementApp.ViewModels
             details.AppendLine(ValueOrNotRecorded(kit.Description));
             details.AppendLine();
             details.AppendLine("Kit items:");
-            if (KitItems.Count == 0)
+            if (IsLoadingKitItems)
+            {
+                details.AppendLine("- Kit items are still loading.");
+            }
+            else if (KitItems.Count == 0)
             {
                 details.AppendLine("- No items assigned.");
             }
@@ -640,7 +812,7 @@ namespace InventoryManagementApp.ViewModels
                 _ => filtered
             };
 
-            foreach (var kit in filtered)
+            foreach (var kit in filtered.OrderByDescending(k => k.IsActive).ThenBy(k => k.Name).ThenBy(k => k.KitNumber))
             {
                 FilteredKits.Add(kit);
             }
@@ -650,11 +822,8 @@ namespace InventoryManagementApp.ViewModels
                 : FilteredKits.FirstOrDefault(k => SelectedKit != null && k.KitID == SelectedKit.KitID);
             SelectedKit = selectedKit ?? FilteredKits.FirstOrDefault();
 
-            OnPropertyChanged(nameof(KitResultsSummary));
-            OnPropertyChanged(nameof(SelectedKitSummary));
-            OnPropertyChanged(nameof(SelectedKitDetail));
-            OnPropertyChanged(nameof(SelectedKitAvailabilitySummary));
-            PrintKitListCommand.NotifyCanExecuteChanged();
+            RaiseDirectoryStateChanged();
+            RaiseCommandStates();
         }
 
         private void RefreshKitItemSummaries()
@@ -663,11 +832,58 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(SelectedKitSummary));
             OnPropertyChanged(nameof(SelectedKitDetail));
             OnPropertyChanged(nameof(SelectedKitItemSummary));
+            OnPropertyChanged(nameof(SelectedKitAvailabilitySummary));
+            OnPropertyChanged(nameof(KitItemLoadSummary));
+            OnPropertyChanged(nameof(IsKitItemsEmptyVisible));
         }
 
-        private bool CanEditOrDelete() => SelectedKit != null;
+        private void RaiseDirectoryStateChanged()
+        {
+            OnPropertyChanged(nameof(IsKitInteractionBusy));
+            OnPropertyChanged(nameof(IsKitDirectoryEmptyVisible));
+            OnPropertyChanged(nameof(IsKitDirectoryPrintAvailable));
+            OnPropertyChanged(nameof(KitResultsSummary));
+            OnPropertyChanged(nameof(KitFilterSummary));
+            OnPropertyChanged(nameof(KitPrintSummary));
+            OnPropertyChanged(nameof(KitEmptyStateTitle));
+            OnPropertyChanged(nameof(KitEmptyStateMessage));
+        }
 
-        private bool CanEditOrRemoveKitItem() => SelectedKitItem != null;
+        private void RaiseKitItemStateChanged()
+        {
+            OnPropertyChanged(nameof(IsKitItemInteractionBusy));
+            OnPropertyChanged(nameof(IsKitItemsEmptyVisible));
+            OnPropertyChanged(nameof(KitItemsSummary));
+            OnPropertyChanged(nameof(SelectedKitSummary));
+            OnPropertyChanged(nameof(SelectedKitDetail));
+            OnPropertyChanged(nameof(SelectedKitAvailabilitySummary));
+            OnPropertyChanged(nameof(KitItemLoadSummary));
+        }
+
+        private void RaiseCommandStates()
+        {
+            LoadKitsCommand.NotifyCanExecuteChanged();
+            AddKitCommand.NotifyCanExecuteChanged();
+            EditKitCommand.NotifyCanExecuteChanged();
+            DeleteKitCommand.NotifyCanExecuteChanged();
+            ViewKitItemsCommand.NotifyCanExecuteChanged();
+            AddKitItemCommand.NotifyCanExecuteChanged();
+            EditKitItemCommand.NotifyCanExecuteChanged();
+            RemoveKitItemCommand.NotifyCanExecuteChanged();
+            CheckAvailabilityCommand.NotifyCanExecuteChanged();
+            RefreshCommand.NotifyCanExecuteChanged();
+            ClearSearchCommand.NotifyCanExecuteChanged();
+            OpenKitDetailsCommand.NotifyCanExecuteChanged();
+            CopySelectedKitCommand.NotifyCanExecuteChanged();
+            PrintKitListCommand.NotifyCanExecuteChanged();
+            PrintSelectedKitCommand.NotifyCanExecuteChanged();
+        }
+
+        private bool CanEditOrDelete() => SelectedKit != null && !IsKitInteractionBusy && !IsLoadingKitItems;
+
+        private bool CanMaintainKitItems() => SelectedKit != null && !IsKitItemInteractionBusy;
+
+        private bool CanEditOrRemoveKitItem() => SelectedKitItem != null && !IsKitItemInteractionBusy;
 
         static bool Contains(string? source, string search) =>
             !string.IsNullOrWhiteSpace(source) && source.Contains(search, StringComparison.OrdinalIgnoreCase);

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
@@ -48,20 +48,20 @@
                     </Border>
                     <Border Style="{StaticResource KitStatCard}">
                         <StackPanel>
+                            <TextBlock Text="FILTER" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding KitFilterSummary}" Style="{StaticResource KitStatValueText}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource KitStatCard}">
+                        <StackPanel>
                             <TextBlock Text="MEMBERSHIP" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="{Binding KitItemsSummary}" Style="{StaticResource KitStatValueText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource KitStatCard}">
                         <StackPanel>
-                            <TextBlock Text="SELECTED" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedKit.KitNumber, TargetNullValue='No kit selected', FallbackValue='No kit selected'}" Style="{StaticResource KitStatValueText}"/>
-                        </StackPanel>
-                    </Border>
-                    <Border Style="{StaticResource KitStatCard}">
-                        <StackPanel>
-                            <TextBlock Text="AVAILABILITY" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="Check before promise" Style="{StaticResource KitStatValueText}"/>
+                            <TextBlock Text="PRINT" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding KitPrintSummary}" Style="{StaticResource KitStatValueText}"/>
                         </StackPanel>
                     </Border>
                 </WrapPanel>
@@ -83,7 +83,7 @@
                         <Button Style="{StaticResource PrimaryButton}" Content="Check Availability" Command="{Binding CheckAvailabilityCommand}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopySelectedKitCommand}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Print Kit" Command="{Binding PrintSelectedKitCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" IsEnabled="{Binding IsKitDirectoryPrintAvailable}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteKitCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
                 </DockPanel>
@@ -117,6 +117,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Border Style="{StaticResource DesktopPaneHeader}">
                         <DockPanel>
@@ -128,7 +129,10 @@
                         </DockPanel>
                     </Border>
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
-                        <TextBlock Text="Select a kit to load required and optional item lines, then check availability or print a handoff sheet." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        <DockPanel LastChildFill="True">
+                            <TextBlock Text="Select a kit to load required and optional item lines, then check availability or print a handoff sheet." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,10,0"/>
+                            <TextBlock Text="{Binding KitFilterSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </DockPanel>
                     </Border>
                     <DataGrid x:Name="KitsGrid" Grid.Row="2" ItemsSource="{Binding FilteredKits}" SelectedItem="{Binding SelectedKit}" AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single" SelectionUnit="FullRow" EnableRowVirtualization="True" EnableColumnVirtualization="True" ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.RowStyle>
@@ -173,19 +177,21 @@
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>
-                    <Border Grid.Row="2" MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
-                        <Border.Style>
-                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding FilteredKits.Count}" Value="0"><Setter Property="Visibility" Value="Visible"/></DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Border.Style>
+                    <Border Grid.Row="2" MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding IsKitDirectoryEmptyVisible, Converter={StaticResource BoolToVis}}" Style="{StaticResource DesktopNoteCard}">
                         <StackPanel>
-                            <TextBlock Text="No kits match this filter" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
-                            <TextBlock Text="Adjust the search or status filter, or add a new reusable kit." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding KitEmptyStateTitle}" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="{Binding KitEmptyStateMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
+                    </Border>
+                    <Border Grid.Row="2" MaxWidth="360" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding IsLoadingKits, Converter={StaticResource BoolToVis}}" Style="{StaticResource DesktopNoteCard}">
+                        <StackPanel>
+                            <ProgressBar IsIndeterminate="True" Height="6" Margin="0,0,0,10"/>
+                            <TextBlock Text="Loading kit rows" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="The directory is refreshing. Editing, filtering, and print actions resume when saved kits are ready." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Row="3" Style="{StaticResource DesktopPaneSubheader}" BorderThickness="0,1,0,0">
+                        <TextBlock Text="{Binding KitPrintSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                     </Border>
                 </Grid>
             </Border>
@@ -209,12 +215,15 @@
                         </DockPanel>
                     </Border>
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
-                        <WrapPanel>
-                            <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource PrimaryButton}" Content="Edit Item" Command="{Binding EditKitItemCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Remove Item" Command="{Binding RemoveKitItemCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Reload Items" Command="{Binding ViewKitItemsCommand}" Margin="0,0,0,4"/>
-                        </WrapPanel>
+                        <DockPanel LastChildFill="True">
+                            <WrapPanel DockPanel.Dock="Left">
+                                <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Edit Item" Command="{Binding EditKitItemCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Remove Item" Command="{Binding RemoveKitItemCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Reload Items" Command="{Binding ViewKitItemsCommand}" Margin="0,0,6,4"/>
+                            </WrapPanel>
+                            <TextBlock Text="{Binding KitItemLoadSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </DockPanel>
                     </Border>
                     <Grid Grid.Row="2">
                         <DataGrid x:Name="KitItemsGrid" ItemsSource="{Binding KitItems}" SelectedItem="{Binding SelectedKitItem}" AutoGenerateColumns="False" IsReadOnly="True" SelectionMode="Single" SelectionUnit="FullRow" EnableRowVirtualization="True" EnableColumnVirtualization="True" ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" Style="{StaticResource VirtualizedDataGridStyle}">
@@ -255,18 +264,17 @@
                                 </ContextMenu>
                             </DataGrid.ContextMenu>
                         </DataGrid>
-                        <Border MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
-                            <Border.Style>
-                                <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
-                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding KitItems.Count}" Value="0"><Setter Property="Visibility" Value="Visible"/></DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Border.Style>
+                        <Border MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding IsKitItemsEmptyVisible, Converter={StaticResource BoolToVis}}" Style="{StaticResource DesktopNoteCard}">
                             <StackPanel>
-                                <TextBlock Text="No items assigned to this kit" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
-                                <TextBlock Text="Add required and optional item lines so availability checks and printed handoffs have enough detail." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                <TextBlock Text="{Binding KitItemsEmptyStateTitle}" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                                <TextBlock Text="{Binding KitItemsEmptyStateMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </Border>
+                        <Border MaxWidth="360" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding IsLoadingKitItems, Converter={StaticResource BoolToVis}}" Style="{StaticResource DesktopNoteCard}">
+                            <StackPanel>
+                                <ProgressBar IsIndeterminate="True" Height="6" Margin="0,0,0,10"/>
+                                <TextBlock Text="Loading kit membership" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                                <TextBlock Text="Item-line actions, availability checks, and kit-sheet printing resume after membership rows are ready." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
                         </Border>
                     </Grid>
@@ -301,7 +309,7 @@
                             <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenKitDetailsCommand}" Margin="0,0,4,4"/>
                             <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopySelectedKitCommand}" Margin="0,0,4,4"/>
                             <Button Style="{StaticResource GhostButton}" Content="Print Kit" Command="{Binding PrintSelectedKitCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" IsEnabled="{Binding IsKitDirectoryPrintAvailable}" Margin="0,0,4,4"/>
                         </WrapPanel>
                     </Border>
                 </Grid>
@@ -312,7 +320,7 @@
             <DockPanel LastChildFill="True">
                 <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
                     <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" Margin="0,0,0,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" IsEnabled="{Binding IsKitDirectoryPrintAvailable}" Margin="0,0,0,4"/>
                 </WrapPanel>
                 <TextBlock Text="{Binding SelectedKitSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
             </DockPanel>

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
@@ -1,22 +1,60 @@
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
 {
     public partial class KitManagementPage : Page
     {
+        private KitManagementViewModel? _loadedViewModel;
+        private Task? _loadKitsTask;
+
         public KitManagementPage()
         {
             InitializeComponent();
             Loaded += KitManagementPage_Loaded;
+            DataContextChanged += KitManagementPage_DataContextChanged;
             PreviewKeyDown += KitManagementPage_PreviewKeyDown;
         }
 
         private async void KitManagementPage_Loaded(object sender, RoutedEventArgs e)
         {
             if (DataContext is KitManagementViewModel vm)
+            {
+                await LoadKitsOnceForViewModelAsync(vm);
+            }
+        }
+
+        private void KitManagementPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(e.NewValue, _loadedViewModel))
+            {
+                _loadedViewModel = null;
+                _loadKitsTask = null;
+            }
+        }
+
+        private async Task LoadKitsOnceForViewModelAsync(KitManagementViewModel vm)
+        {
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadKitsTask != null)
+            {
+                await _loadKitsTask;
+                return;
+            }
+
+            _loadedViewModel = vm;
+            _loadKitsTask = LoadKitsAfterFirstPaintAsync(vm);
+            await _loadKitsTask;
+        }
+
+        private async Task LoadKitsAfterFirstPaintAsync(KitManagementViewModel vm)
+        {
+            await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
+
+            if (DataContext is KitManagementViewModel currentVm && ReferenceEquals(currentVm, vm) && vm.LoadKitsCommand.CanExecute(null))
             {
                 await vm.LoadKitsCommand.ExecuteAsync(null);
             }


### PR DESCRIPTION
## What changed

- Added a Kits directory loading guard so page-open loading and manual refresh cannot overlap.
- Added membership loading state for selected-kit item rows.
- Protected selected-kit membership refreshes from stale responses when operators switch rows quickly.
- Disabled add, edit, delete, details, copy, availability, item maintenance, refresh, clear, selected print, and directory print commands while the relevant directory or membership data is loading.
- Added ViewModel-backed directory loading, item loading, empty-state, filter-summary, print-summary, and print-availability properties.
- Added dynamic no-record versus no-match empty copy for the kit directory and selected-kit membership rows.
- Surfaced filter, membership, and print status in summary cards, pane subheaders, and footer status text.
- Added bounded loading overlays for the kit directory and kit membership grid regions.
- Kept the virtualized kit and membership grids, row context menus, double-click actions, and keyboard shortcuts intact.
- Sorted kit and kit-item refresh results deterministically for stable scanning after reloads or edits.
- Added first-paint-friendly page-owned loading with a dispatcher yield, duplicate-load prevention for the same view model, and reset behavior when a new view model is attached.
- Capped Kit Directory print preview generation to the first 250 visible rows.
- Added visible/printed/omitted/search/status-filter print accounting and large-directory guidance.
- Replaced fixed Kit Directory and Kit Pick Sheet print columns with proportional columns.
- Extended Kits source-contract coverage for loading guards, stale membership-load protection, UI states, command availability, capped print snapshots, proportional print columns, and page load behavior.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-kits-workbench-performance.md`.

## Why this was highest value

Recent scheduled passes already covered Reservations, Calibration, Maintenance, Categories, Settings, Customers, Rental History, Activity Logs, Users, Reports, imports, and shell paths. The Kits workflow still had current evidence of a full vertical gap: overlapping list refreshes were possible, selected-kit item loads could race during rapid selection changes, action/print state did not reflect loading or empty data, and directory printing materialized every visible kit into fixed-width print columns. That directly affects loading speed, UI responsiveness, professional data display, and printed kit handoffs.

## Why this is real progress

This is a complete Kits workflow slice across ViewModel state and command gating, page loading behavior, grid loading/empty display, print-preview document generation, source-contract tests, and progress records. It includes more than ten focused improvements while staying inside the active WPF app.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by five focused commits, and limited to:
  - `InventoryManagementApp/ViewModels/KitManagementViewModel.cs`
  - `InventoryManagementApp/Views/Pages/KitManagementPage.xaml`
  - `InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs`
  - `InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-kits-workbench-performance.md`
- Connector readback confirmed the loading guard, stale membership load version checks, command state updates, dynamic filter/empty/print state, bounded loading overlays, first-paint page load guard, capped print snapshot, proportional print columns, and source-contract assertions.
- Connector status readback found no attached commit statuses on branch head `40697e6f836706d402bdd798dbb4858c47761339`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Kits at 1366 x 768 and higher Windows scaling with no kits, loading, all kits, active/inactive filters, no-match search, rapid selection changes, empty membership, populated membership, and 250+ visible rows before directory printing.