### PR TITLE
Improve Manage Rentals startup and shortcut responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
@@ -101,6 +101,36 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ManageRentalsPage_LoadsOncePerViewModelAfterFirstPaintAndResetsOnDataContextChange()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
+
+            Assert.Contains("ManageRentalsViewModel? _loadedViewModel;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContextChanged += ManageRentalsPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SearchTextBox.Focus();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("UpdateCompactHeightMode();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (DataContext is ManageRentalsViewModel vm && !ReferenceEquals(_loadedViewModel, vm))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadedViewModel = vm;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("await vm.LoadRentalsAsync();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!ReferenceEquals(e.NewValue, _loadedViewModel))", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (DataContext is ManageRentalsViewModel vm)\n            {\n                await vm.LoadRentalsAsync();\n            }", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageRentalsPage_KeyboardShortcutsRespectCommandAvailabilityBeforePrinting()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
+
+            Assert.Contains("e.Key == Key.P && vm.PrintSearchResultsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Key == Key.P && vm.PrintCheckedOutCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Key == Key.R && vm.PrintRequestsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)\n            {\n                UiActionGuard.Run(this, \"Rentals\", () => vm.PrintSearchResultsCommand.Execute(null));", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
+            Assert.DoesNotContain("if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P)\n            {\n                UiActionGuard.Run(this, \"Rentals\", () => vm.PrintCheckedOutCommand.Execute(null));", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
+            Assert.DoesNotContain("if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.R)\n            {\n                UiActionGuard.Run(this, \"Rentals\", () => vm.PrintRequestsCommand.Execute(null));", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ManageRentalsPage_PreservesRentalAndRequestCommandsAndRowHandlers()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml");
@@ -131,6 +161,8 @@ namespace InventoryManagementApp.Tests
             foreach (var contract in requiredContracts)
                 Assert.Contains(contract, xaml, StringComparison.Ordinal);
         }
+
+        private static string NormalizeNewlines(string value) => value.Replace("\r\n", "\n", StringComparison.Ordinal);
 
         private static string ReadRepoFile(params string[] parts)
         {

--- a/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
@@ -111,7 +111,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("UpdateCompactHeightMode();", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (DataContext is ManageRentalsViewModel vm && !ReferenceEquals(_loadedViewModel, vm))", codeBehind, StringComparison.Ordinal);
             Assert.Contains("_loadedViewModel = vm;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("await Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
             Assert.Contains("await vm.LoadRentalsAsync();", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (!ReferenceEquals(e.NewValue, _loadedViewModel))", codeBehind, StringComparison.Ordinal);
             Assert.DoesNotContain("if (DataContext is ManageRentalsViewModel vm)\n            {\n                await vm.LoadRentalsAsync();\n            }", NormalizeNewlines(codeBehind), StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-manage-rentals-startup-shortcut-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-manage-rentals-startup-shortcut-performance.md
@@ -1,0 +1,27 @@
+# Manage Rentals Startup And Shortcut Responsiveness - 2026-07-04
+
+## Completed
+
+- Prevented the Manage Rentals page from rerunning its initial rental/request refresh every time the same page/view-model pair receives another `Loaded` event.
+- Reset the page-owned load guard when a different `ManageRentalsViewModel` is attached, preserving correct reload behavior for real navigation/context changes.
+- Moved search focus, selection, and compact-height layout setup ahead of the rental refresh so the page can paint and accept layout before the data call begins.
+- Yielded to the WPF dispatcher before the first rental refresh to reduce first-paint blocking on screen open.
+- Guarded Ctrl+P, Ctrl+Shift+P, and Ctrl+Shift+R print shortcuts with each print command's `CanExecute` state before dispatching print-preview work.
+- Extended Manage Rentals source-contract coverage for the page-owned load guard, first-paint yield, data-context reset, and shortcut command availability checks.
+
+## Why It Matters
+
+Manage Rentals is a high-traffic operational desk for active checkouts, returns, request routing, and documents. The page already had responsive layout work, but the code-behind could still trigger redundant startup reloads after WPF reloaded the same visual tree and keyboard shortcuts could dispatch print workflows without checking command availability first. This pass reduces unnecessary refresh work and keeps shortcut-triggered preview generation aligned with command state.
+
+## Validation
+
+- Source readback confirmed the code-behind now tracks the loaded view model, resets that guard on data-context changes, yields through the dispatcher before first data refresh, and checks print command availability before keyboard print shortcuts execute.
+- Source-contract tests were updated to guard those behaviors.
+
+## Not Run Here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- .NET restore/build/test
+- WPF runtime smoke tests, screenshots, scaling checks, or print-preview rendering
+
+Those remain unavailable in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is not present.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -12,11 +12,13 @@ namespace InventoryManagementApp.Views.Pages
     {
         const double CompactHeightThreshold = 650;
         bool _isCompactHeight;
+        ManageRentalsViewModel? _loadedViewModel;
 
         public ManageRentalsPage()
         {
             InitializeComponent();
             Loaded += ManageRentalsPage_Loaded;
+            DataContextChanged += ManageRentalsPage_DataContextChanged;
             SizeChanged += ManageRentalsPage_SizeChanged;
             PreviewKeyDown += ManageRentalsPage_PreviewKeyDown;
         }
@@ -24,14 +26,22 @@ namespace InventoryManagementApp.Views.Pages
         private async void ManageRentalsPage_Loaded(object sender, RoutedEventArgs e)
         {
             Focus();
-            if (DataContext is ManageRentalsViewModel vm)
-            {
-                await vm.LoadRentalsAsync();
-            }
-
             SearchTextBox.Focus();
             SearchTextBox.SelectAll();
             UpdateCompactHeightMode();
+
+            if (DataContext is ManageRentalsViewModel vm && !ReferenceEquals(_loadedViewModel, vm))
+            {
+                _loadedViewModel = vm;
+                await Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
+                await vm.LoadRentalsAsync();
+            }
+        }
+
+        private void ManageRentalsPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(e.NewValue, _loadedViewModel))
+                _loadedViewModel = null;
         }
 
         private void ManageRentalsPage_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -98,21 +108,21 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && vm.PrintSearchResultsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Rentals", () => vm.PrintSearchResultsCommand.Execute(null));
                 e.Handled = true;
                 return;
             }
 
-            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P)
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P && vm.PrintCheckedOutCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Rentals", () => vm.PrintCheckedOutCommand.Execute(null));
                 e.Handled = true;
                 return;
             }
 
-            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.R)
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.R && vm.PrintRequestsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Rentals", () => vm.PrintRequestsCommand.Execute(null));
                 e.Handled = true;

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -33,7 +33,7 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is ManageRentalsViewModel vm && !ReferenceEquals(_loadedViewModel, vm))
             {
                 _loadedViewModel = vm;
-                await Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
+                await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
                 await vm.LoadRentalsAsync();
             }
         }


### PR DESCRIPTION
## What changed

- Added a page-owned Manage Rentals startup load guard so repeated WPF `Loaded` events for the same view model do not rerun the rental/request refresh.
- Reset the load guard when a different `ManageRentalsViewModel` is attached, preserving correct reload behavior for real context changes.
- Moved search focus, text selection, and compact-height layout setup ahead of the first data refresh.
- Yielded to the WPF dispatcher before the first rentals refresh so the page can paint before data loading begins.
- Guarded Ctrl+P, Ctrl+Shift+P, and Ctrl+Shift+R print shortcuts with the associated print command's `CanExecute` state before dispatching print-preview work.
- Extended Manage Rentals source-contract coverage for startup load gating, data-context reset, first-paint yield, and keyboard print shortcut command availability.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-manage-rentals-startup-shortcut-performance.md`.

## Why this was highest value

Recent merged work already covered Categories, Maintenance, Calibration, Reservations, Users, Activity Logs, Reports, shell responsiveness, and several print paths. Manage Rentals still had a concrete responsiveness gap in current source evidence: the page could rerun its initial refresh when the same visual tree loaded again, and print shortcuts dispatched work without checking command availability first. This affects a high-traffic workflow for returns, request routing, and documents.

## Why this is real progress

This is a focused workflow-level improvement across page load behavior, keyboard workflow safety, tests, and progress records. It reduces unnecessary data refresh work and prevents shortcut-triggered print paths from bypassing command state while staying inside the existing WPF/MVVM structure.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by five focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs`
  - `InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-manage-rentals-startup-shortcut-performance.md`
- Connector readback confirmed the page-owned view-model load guard, data-context reset, dispatcher first-paint yield, shortcut `CanExecute` checks, and updated source-contract assertions.
- Connector status readback found no attached commit statuses on head `0fd1fea4b4a77ac3c5e6df7fe98d7bfb52d8f9c7`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Manage Rentals with repeated navigation, tab switching, compact height, rapid shortcut use, loading states, and print shortcut behavior while data is still refreshing.