### PR TITLE
Improve Activity Logs filter and load responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
@@ -69,6 +69,73 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("SelectedLogHandoff", xaml, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ActivityLogsPage_DisablesRiskyActionsWhileRowsAreBusy()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml");
+
+            Assert.Contains("IsEnabled=\"{Binding CanUseSelectedLogActions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding CanPrintActivityRows}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding CanChangeActivityFilters}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"{Binding PrintStatusText}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("DataContext=\"{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsPage_ShowsDynamicBusyAndEmptyStates()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml");
+
+            Assert.Contains("CanShowActivityEmptyState", xaml, StringComparison.Ordinal);
+            Assert.Contains("ActivityEmptyStateTitle", xaml, StringComparison.Ordinal);
+            Assert.Contains("ActivityEmptyStateMessage", xaml, StringComparison.Ordinal);
+            Assert.Contains("<DataTrigger Binding=\"{Binding IsBusy}\" Value=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ProgressBar IsIndeterminate=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ActivityBusyMessage", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsPage_CodeBehindKeepsFirstPaintAndBusyGuards()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContextChanged += ActivityLogsPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ReferenceEquals(_loadedViewModel, vm)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContext is ActivityLogsViewModel { IsBusy: true }", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsBusy)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.PrintStatusText", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsViewModel_CoalescesFilteringAndKeepsRowsDuringRefreshFailure()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
+
+            Assert.Contains("const int FilterDebounceMilliseconds = 160;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("CancellationTokenSource? _filterRefreshCts", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Interlocked.Exchange(ref _filterRefreshCts, cts)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("await Task.Delay(FilterDebounceMilliseconds, cts.Token);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("await Task.Run(() => rows.Where", viewModel, StringComparison.Ordinal);
+            Assert.Contains("PreserveActivityLogRowsAfterLoadFailure", viewModel, StringComparison.Ordinal);
+            Assert.DoesNotContain("ClearActivityLogRowsAfterLoadFailure", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsViewModel_ExposesProfessionalDisplayAndPrintState()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
+
+            Assert.Contains("public bool IsBusy => IsLoading || IsFiltering;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanPrintActivityRows => !IsBusy && FilteredLogs.Count > 0;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanUseSelectedLogActions => !IsBusy && SelectedLog != null;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string ActivityEmptyStateTitle", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string ActivityEmptyStateMessage", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string PrintStatusText", viewModel, StringComparison.Ordinal);
+            Assert.Contains("log.UserID.ToString().Contains(search, StringComparison.OrdinalIgnoreCase)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OrderByDescending(log => log.Timestamp)", viewModel, StringComparison.Ordinal);
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-activity-logs-filter-load-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-activity-logs-filter-load-responsiveness.md
@@ -1,0 +1,26 @@
+# Activity Logs Filter And Load Responsiveness - 2026-07-04
+
+## Completed
+
+- Improved Activity Audit Workbench refresh behavior so successful loads replace rows only after the service returns, while failed refreshes keep the existing audit rows visible instead of clearing the directory.
+- Added cancellable, debounced filter application for search/user/action changes so rapid typing and filter switching coalesce into the latest result set.
+- Moved audit filtering work onto a background task over a snapshot of loaded rows, then applied the final filtered rows back to the UI collection after cancellation checks.
+- Sorted refreshed activity rows newest-first with deterministic user/action tie breakers for faster scanning and stable print previews.
+- Expanded audit search to include user ID in addition to user, action, action group, destination, and timestamp.
+- Added explicit loading, filtering, empty-state, action-availability, and print-availability properties to the Activity Logs view model.
+- Surfaced professional print readiness copy, dynamic no-record/no-match empty messages, and a bounded loading/filtering overlay in the Activity Logs page.
+- Disabled selected-row detail, related-page, copy, and print actions while the activity directory is loading or filtering.
+- Bound context-menu action availability to the page view model so right-click actions follow the same busy and print guards as toolbar buttons.
+- Added first-paint-friendly page loading with a dispatcher yield, duplicate-load prevention for the same view model, and DataContext reset handling.
+- Guarded code-behind detail, related-page, copy, and print handlers against busy-state invocations that bypass disabled buttons.
+- Extended source-contract coverage for busy action gating, dynamic empty/loading states, first-paint loading, cancellable background filtering, preserved rows after refresh failure, print state, deterministic sorting, and user-ID search.
+
+## Validation
+
+- Local Windows/.NET validation could not be run in this scheduled Linux environment because direct repository checkout is blocked by GitHub HTTP 403 and the environment does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.
+- GitHub connector readback and compare should be used before merge to confirm the PR remains focused to Activity Logs responsiveness files and this progress note.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test Activity Logs with a large audit trail, rapid typing, user/action filter changes, failed refresh behavior, context menus, and capped print preview output.

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,9 +16,13 @@ namespace InventoryManagementApp.ViewModels
     {
         const string AllUsersFilter = "All users";
         const string AllActionsFilter = "All actions";
+        const int FilterDebounceMilliseconds = 160;
+        const int MaxActivityPrintRows = 250;
 
         private readonly ActivityLogService _service;
         private readonly ILogger<ActivityLogsViewModel> _logger;
+        private CancellationTokenSource? _filterRefreshCts;
+        private bool _suppressFilterRefresh;
 
         public ObservableCollection<ActivityLog> Logs { get; } = new();
         public ObservableCollection<ActivityLog> FilteredLogs { get; } = new();
@@ -31,7 +36,7 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _searchText, value))
-                    ApplyFilters();
+                    QueueFilterRefresh();
             }
         }
 
@@ -42,7 +47,7 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _selectedUserFilter, string.IsNullOrWhiteSpace(value) ? AllUsersFilter : value))
-                    ApplyFilters();
+                    QueueFilterRefresh();
             }
         }
 
@@ -53,7 +58,7 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _selectedActionFilter, string.IsNullOrWhiteSpace(value) ? AllActionsFilter : value))
-                    ApplyFilters();
+                    QueueFilterRefresh();
             }
         }
 
@@ -74,6 +79,7 @@ namespace InventoryManagementApp.ViewModels
                     OnPropertyChanged(nameof(SelectedLogNextAction));
                     OnPropertyChanged(nameof(SelectedLogHandoff));
                     OnPropertyChanged(nameof(SelectedLogOperatorPath));
+                    NotifyActivityStateChanged();
                 }
             }
         }
@@ -103,20 +109,79 @@ namespace InventoryManagementApp.ViewModels
             private set
             {
                 if (SetProperty(ref _isLoading, value))
+                {
                     RefreshCommand.NotifyCanExecuteChanged();
+                    ClearFiltersCommand.NotifyCanExecuteChanged();
+                    NotifyActivityStateChanged();
+                }
+            }
+        }
+
+        private bool _isFiltering;
+        public bool IsFiltering
+        {
+            get => _isFiltering;
+            private set
+            {
+                if (SetProperty(ref _isFiltering, value))
+                    NotifyActivityStateChanged();
             }
         }
 
         public string LastLoadedText => LastLoadedAt.HasValue ? LastLoadedAt.Value.ToString("g") : "Not loaded";
         public int TotalLogCount => Logs.Count;
         public int FilteredLogCount => FilteredLogs.Count;
+        public bool IsBusy => IsLoading || IsFiltering;
+        public bool HasActiveFilters => HasActiveFilter();
+        public bool CanChangeActivityFilters => !IsLoading;
+        public bool CanUseSelectedLogActions => !IsBusy && SelectedLog != null;
+        public bool CanPrintActivityRows => !IsBusy && FilteredLogs.Count > 0;
+        public bool CanShowActivityEmptyState => !IsBusy && FilteredLogs.Count == 0;
+        public string ActivityBusyMessage => IsLoading
+            ? "Refreshing recent audit rows without blocking the rest of the screen."
+            : "Applying the current search and filter choices to the loaded audit rows.";
+
+        public string ActivityEmptyStateTitle => Logs.Count == 0
+            ? "No activity rows loaded"
+            : HasActiveFilter()
+                ? "No activity rows match"
+                : "No activity rows available";
+
+        public string ActivityEmptyStateMessage => Logs.Count == 0
+            ? "Refresh the audit trail to review recent operations, account changes, imports, rentals, and item events."
+            : "Clear or adjust the current search, user, and action filters to review more of the audit trail.";
+
+        public string PrintStatusText
+        {
+            get
+            {
+                if (IsLoading)
+                    return "Print preview will be available after the latest activity rows finish loading.";
+                if (IsFiltering)
+                    return "Print preview will be available after the current filters finish applying.";
+                if (FilteredLogs.Count == 0)
+                    return "No activity rows are ready to print.";
+                if (FilteredLogs.Count > MaxActivityPrintRows)
+                    return $"Print preview will include the first {MaxActivityPrintRows} of {FilteredLogs.Count} visible row(s).";
+
+                return $"Print preview ready for {FilteredLogs.Count} visible activity row(s).";
+            }
+        }
 
         public string ActivitySummary
         {
             get
             {
+                if (IsLoading)
+                    return Logs.Count == 0
+                        ? "Loading recent activity rows."
+                        : $"Refreshing activity rows; {FilteredLogs.Count} previously visible row(s) remain on screen.";
+                if (IsFiltering)
+                    return $"Filtering {Logs.Count} loaded activity row(s).";
                 if (FilteredLogs.Count == 0)
-                    return "No matching activity rows. Clear filters or refresh to review recent operations.";
+                    return Logs.Count == 0
+                        ? "No activity rows loaded yet. Refresh to review recent operations."
+                        : "No matching activity rows. Clear filters or refine the audit search.";
 
                 var groups = FilteredLogs
                     .GroupBy(log => ClassifyAction(log.Action))
@@ -189,29 +254,38 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 IsLoading = true;
-                StatusMessage = "Loading recent activity...";
-                Logs.Clear();
+                StatusMessage = Logs.Count == 0
+                    ? "Loading recent activity..."
+                    : $"Refreshing recent activity while keeping {FilteredLogs.Count} visible row(s) on screen...";
+
                 var result = await _service.GetRecentLogsAsync();
                 if (!result.Success || result.Value == null)
                 {
                     _logger.LogError("Failed to load activity logs: {Error}", result.ErrorMessage);
-                    ClearActivityLogRowsAfterLoadFailure("Activity logs could not be loaded. Activity rows were cleared until refresh succeeds.");
+                    PreserveActivityLogRowsAfterLoadFailure("Activity logs could not be loaded. Existing activity rows were kept on screen until refresh succeeds.");
                     return false;
                 }
 
-                foreach (var log in result.Value)
+                var refreshedRows = result.Value
+                    .OrderByDescending(log => log.Timestamp)
+                    .ThenBy(log => SafeText(log.UserName, "Unknown user"), StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(log => SafeText(log.Action), StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                Logs.Clear();
+                foreach (var log in refreshedRows)
                     Logs.Add(log);
 
                 LastLoadedAt = DateTime.Now;
                 RebuildFilterLists();
-                ApplyFilters();
+                await ApplyFiltersAsync(false);
                 StatusMessage = $"Loaded {Logs.Count} recent activity row(s).";
                 return true;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load activity logs");
-                ClearActivityLogRowsAfterLoadFailure("Activity logs could not be loaded. Activity rows were cleared until refresh succeeds.");
+                PreserveActivityLogRowsAfterLoadFailure("Activity logs could not be loaded. Existing activity rows were kept on screen until refresh succeeds.");
                 return false;
             }
             finally
@@ -220,40 +294,43 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private void ClearActivityLogRowsAfterLoadFailure(string message)
+        private void PreserveActivityLogRowsAfterLoadFailure(string message)
         {
-            Logs.Clear();
-            FilteredLogs.Clear();
-            SelectedLog = null;
-            LastLoadedAt = null;
-            RebuildFilterLists();
-            OnPropertyChanged(nameof(TotalLogCount));
-            OnPropertyChanged(nameof(FilteredLogCount));
-            OnPropertyChanged(nameof(ActivitySummary));
-            ClearFiltersCommand.NotifyCanExecuteChanged();
+            if (Logs.Count == 0)
+            {
+                FilteredLogs.Clear();
+                SelectedLog = null;
+                LastLoadedAt = null;
+                RebuildFilterLists();
+            }
+
+            NotifyActivityStateChanged();
             StatusMessage = message;
         }
 
         private void ClearFilters()
         {
+            _suppressFilterRefresh = true;
             SearchText = string.Empty;
             SelectedUserFilter = AllUsersFilter;
             SelectedActionFilter = AllActionsFilter;
-            ApplyFilters();
+            _suppressFilterRefresh = false;
+            _ = ApplyFiltersAsync(false);
         }
 
         private bool HasActiveFilter()
         {
-            return !string.IsNullOrWhiteSpace(SearchText)
+            return !IsLoading &&
+                (!string.IsNullOrWhiteSpace(SearchText)
                 || SelectedUserFilter != AllUsersFilter
-                || SelectedActionFilter != AllActionsFilter;
+                || SelectedActionFilter != AllActionsFilter);
         }
 
         private void RebuildFilterLists()
         {
             UserFilters.Clear();
             UserFilters.Add(AllUsersFilter);
-            foreach (var userName in Logs.Select(l => l.UserName).Where(u => !string.IsNullOrWhiteSpace(u)).Distinct().OrderBy(u => u))
+            foreach (var userName in Logs.Select(l => l.UserName).Where(u => !string.IsNullOrWhiteSpace(u)).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(u => u))
                 UserFilters.Add(userName);
 
             ActionFilters.Clear();
@@ -262,43 +339,105 @@ namespace InventoryManagementApp.ViewModels
                 ActionFilters.Add(actionGroup);
 
             if (!UserFilters.Contains(SelectedUserFilter))
-                SelectedUserFilter = AllUsersFilter;
+            {
+                _selectedUserFilter = AllUsersFilter;
+                OnPropertyChanged(nameof(SelectedUserFilter));
+            }
+
             if (!ActionFilters.Contains(SelectedActionFilter))
-                SelectedActionFilter = AllActionsFilter;
+            {
+                _selectedActionFilter = AllActionsFilter;
+                OnPropertyChanged(nameof(SelectedActionFilter));
+            }
         }
 
-        private void ApplyFilters()
+        private void QueueFilterRefresh()
         {
-            var previousSelection = SelectedLog;
-            var search = SearchText?.Trim() ?? string.Empty;
+            if (_suppressFilterRefresh)
+                return;
 
-            var filtered = Logs.Where(log =>
-                (SelectedUserFilter == AllUsersFilter || string.Equals(log.UserName, SelectedUserFilter, StringComparison.OrdinalIgnoreCase)) &&
-                (SelectedActionFilter == AllActionsFilter || string.Equals(ClassifyAction(log.Action), SelectedActionFilter, StringComparison.OrdinalIgnoreCase)) &&
-                (string.IsNullOrWhiteSpace(search) ||
-                    SafeText(log.UserName).Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                    SafeText(log.Action).Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                    ClassifyAction(log.Action).Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                    BuildDestinationName(BuildDestinationKey(log.Action)).Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                    log.Timestamp.ToString("g").Contains(search, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
+            _ = ApplyFiltersAsync(true);
+        }
 
-            FilteredLogs.Clear();
-            foreach (var log in filtered)
-                FilteredLogs.Add(log);
+        private async Task ApplyFiltersAsync(bool debounce)
+        {
+            var cts = new CancellationTokenSource();
+            var previousCts = Interlocked.Exchange(ref _filterRefreshCts, cts);
+            previousCts?.Cancel();
+            previousCts?.Dispose();
 
-            SelectedLog = previousSelection != null && FilteredLogs.Contains(previousSelection)
-                ? previousSelection
-                : FilteredLogs.FirstOrDefault();
+            try
+            {
+                IsFiltering = true;
+                StatusMessage = "Filtering loaded activity rows...";
 
+                if (debounce)
+                    await Task.Delay(FilterDebounceMilliseconds, cts.Token);
+
+                var search = SearchText?.Trim() ?? string.Empty;
+                var selectedUserFilter = SelectedUserFilter;
+                var selectedActionFilter = SelectedActionFilter;
+                var previousSelection = SelectedLog;
+                var rows = Logs.ToList();
+
+                var filtered = await Task.Run(() => rows.Where(log =>
+                    (selectedUserFilter == AllUsersFilter || string.Equals(log.UserName, selectedUserFilter, StringComparison.OrdinalIgnoreCase)) &&
+                    (selectedActionFilter == AllActionsFilter || string.Equals(ClassifyAction(log.Action), selectedActionFilter, StringComparison.OrdinalIgnoreCase)) &&
+                    (string.IsNullOrWhiteSpace(search) ||
+                        SafeText(log.UserName).Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                        SafeText(log.Action).Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                        ClassifyAction(log.Action).Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                        BuildDestinationName(BuildDestinationKey(log.Action)).Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                        log.UserID.ToString().Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                        log.Timestamp.ToString("g").Contains(search, StringComparison.OrdinalIgnoreCase)))
+                    .ToList(), cts.Token);
+
+                cts.Token.ThrowIfCancellationRequested();
+                FilteredLogs.Clear();
+                foreach (var log in filtered)
+                    FilteredLogs.Add(log);
+
+                SelectedLog = previousSelection != null && FilteredLogs.Contains(previousSelection)
+                    ? previousSelection
+                    : FilteredLogs.FirstOrDefault();
+
+                NotifyActivityStateChanged();
+                StatusMessage = HasActiveFilter()
+                    ? $"{FilteredLogs.Count} of {Logs.Count} activity row(s) match the current filters."
+                    : $"{Logs.Count} recent activity row(s) visible.";
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                if (ReferenceEquals(_filterRefreshCts, cts))
+                {
+                    _filterRefreshCts = null;
+                    IsFiltering = false;
+                    NotifyActivityStateChanged();
+                }
+
+                cts.Dispose();
+            }
+        }
+
+        private void NotifyActivityStateChanged()
+        {
             OnPropertyChanged(nameof(TotalLogCount));
             OnPropertyChanged(nameof(FilteredLogCount));
+            OnPropertyChanged(nameof(IsBusy));
+            OnPropertyChanged(nameof(HasActiveFilters));
+            OnPropertyChanged(nameof(CanChangeActivityFilters));
+            OnPropertyChanged(nameof(CanUseSelectedLogActions));
+            OnPropertyChanged(nameof(CanPrintActivityRows));
+            OnPropertyChanged(nameof(CanShowActivityEmptyState));
+            OnPropertyChanged(nameof(ActivityBusyMessage));
+            OnPropertyChanged(nameof(ActivityEmptyStateTitle));
+            OnPropertyChanged(nameof(ActivityEmptyStateMessage));
+            OnPropertyChanged(nameof(PrintStatusText));
             OnPropertyChanged(nameof(ActivitySummary));
             ClearFiltersCommand.NotifyCanExecuteChanged();
-
-            StatusMessage = HasActiveFilter()
-                ? $"{FilteredLogs.Count} of {Logs.Count} activity row(s) match the current filters."
-                : $"{Logs.Count} recent activity row(s) visible.";
         }
 
         public static string ClassifyAction(string? action)
@@ -380,7 +519,7 @@ namespace InventoryManagementApp.ViewModels
 
         private static string SafeText(string? text, string fallback = "")
         {
-            return string.IsNullOrWhiteSpace(text) ? fallback : text;
+            return string.IsNullOrWhiteSpace(text) ? fallback : text.Trim();
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -241,7 +241,7 @@ namespace InventoryManagementApp.ViewModels
             _service = service;
             _logger = logger ?? NullLogger<ActivityLogsViewModel>.Instance;
             RefreshCommand = new AsyncRelayCommand(LoadLogsAsync, () => !IsLoading);
-            ClearFiltersCommand = new RelayCommand(ClearFilters, HasActiveFilter);
+            ClearFiltersCommand = new RelayCommand(ClearFilters, () => !IsLoading && HasActiveFilter());
             UserFilters.Add(AllUsersFilter);
             ActionFilters.Add(AllActionsFilter);
         }
@@ -320,10 +320,9 @@ namespace InventoryManagementApp.ViewModels
 
         private bool HasActiveFilter()
         {
-            return !IsLoading &&
-                (!string.IsNullOrWhiteSpace(SearchText)
+            return !string.IsNullOrWhiteSpace(SearchText)
                 || SelectedUserFilter != AllUsersFilter
-                || SelectedActionFilter != AllActionsFilter);
+                || SelectedActionFilter != AllActionsFilter;
         }
 
         private void RebuildFilterLists()

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
@@ -76,8 +76,8 @@
                     </Border>
                     <Border Style="{StaticResource ActivityStatCard}">
                         <StackPanel>
-                            <TextBlock Text="DESTINATION" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedLogDestinationName}"
+                            <TextBlock Text="PRINT" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding PrintStatusText}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
                                        TextWrapping="Wrap"
@@ -100,16 +100,19 @@
                         <TextBox MinWidth="180"
                                  Width="250"
                                  Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
-                                 ToolTip="Filter by user, action, type, destination, or timestamp"
+                                 IsEnabled="{Binding CanChangeActivityFilters}"
+                                 ToolTip="Filter by user, action, type, destination, user ID, or timestamp"
                                  Margin="0,0,6,4"/>
                         <ComboBox ItemsSource="{Binding UserFilters}"
                                   SelectedItem="{Binding SelectedUserFilter}"
+                                  IsEnabled="{Binding CanChangeActivityFilters}"
                                   MinWidth="150"
                                   Width="170"
                                   ToolTip="Filter by user"
                                   Margin="0,0,6,4"/>
                         <ComboBox ItemsSource="{Binding ActionFilters}"
                                   SelectedItem="{Binding SelectedActionFilter}"
+                                  IsEnabled="{Binding CanChangeActivityFilters}"
                                   MinWidth="165"
                                   Width="185"
                                   ToolTip="Filter by action group"
@@ -121,10 +124,10 @@
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
                     <TextBlock Text="Audit actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Open Related" Click="OpenRelatedPage_Click" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Open Detail" Click="OpenSelectedLog_Click" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedLog_Click" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Results" Click="PrintLogs_Click" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="Open Related" Click="OpenRelatedPage_Click" IsEnabled="{Binding CanUseSelectedLogActions}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Open Detail" Click="OpenSelectedLog_Click" IsEnabled="{Binding CanUseSelectedLogActions}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedLog_Click" IsEnabled="{Binding CanUseSelectedLogActions}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Print Results" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintActivityRows}" Margin="0,0,4,4"/>
                         <TextBlock Text="{Binding ActivitySummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="6,1,0,4"/>
                     </WrapPanel>
                 </DockPanel>
@@ -185,13 +188,13 @@
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.ContextMenu>
-                            <ContextMenu>
-                                <MenuItem Header="Open Activity Detail" Click="OpenSelectedLog_Click"/>
-                                <MenuItem Header="Open Related Page" Click="OpenRelatedPage_Click"/>
-                                <MenuItem Header="Copy Handoff" Click="CopySelectedLog_Click"/>
+                            <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open Activity Detail" Click="OpenSelectedLog_Click" IsEnabled="{Binding CanUseSelectedLogActions}"/>
+                                <MenuItem Header="Open Related Page" Click="OpenRelatedPage_Click" IsEnabled="{Binding CanUseSelectedLogActions}"/>
+                                <MenuItem Header="Copy Handoff" Click="CopySelectedLog_Click" IsEnabled="{Binding CanUseSelectedLogActions}"/>
                                 <Separator/>
-                                <MenuItem Header="Print Current Results" Click="PrintLogs_Click"/>
-                                <MenuItem Header="Refresh" Click="RefreshLogs_Click"/>
+                                <MenuItem Header="Print Current Results" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintActivityRows}"/>
+                                <MenuItem Header="Refresh" Click="RefreshLogs_Click" IsEnabled="{Binding CanChangeActivityFilters}"/>
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                         <DataGrid.Columns>
@@ -224,21 +227,39 @@
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding FilteredLogCount}" Value="0">
+                                    <DataTrigger Binding="{Binding CanShowActivityEmptyState}" Value="True">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
-                            <TextBlock Text="No activity rows match" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
-                            <TextBlock Text="Clear the filters or refresh the audit trail to review recent operations, account changes, imports, rentals, and item events." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding ActivityEmptyStateTitle}" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="{Binding ActivityEmptyStateMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Grid.Row="2" MaxWidth="380" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <ProgressBar IsIndeterminate="True" Height="6" Margin="0,0,0,10"/>
+                            <TextBlock Text="Updating activity directory" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="{Binding ActivityBusyMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
 
                     <Border Grid.Row="3" Style="{StaticResource DesktopPaneSubheader}" BorderThickness="0,1,0,0">
                         <DockPanel LastChildFill="True">
-                            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Left" TextWrapping="Wrap" Margin="0,0,10,0"/>
+                            <TextBlock Text="{Binding PrintStatusText}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Left" TextWrapping="Wrap" Margin="0,0,10,0"/>
                             <Button Style="{StaticResource GhostButton}" Content="Clear Filters" Command="{Binding ClearFiltersCommand}" HorizontalAlignment="Right"/>
                         </DockPanel>
                     </Border>
@@ -301,10 +322,10 @@
 
                             <Border Style="{StaticResource DesktopInsetCard}" Padding="10" Margin="0,0,0,8">
                                 <WrapPanel>
-                                    <Button Style="{StaticResource PrimaryButton}" Content="Open Related" Click="OpenRelatedPage_Click" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Open Detail" Click="OpenSelectedLog_Click" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedLog_Click" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Print" Click="PrintLogs_Click" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Open Related" Click="OpenRelatedPage_Click" IsEnabled="{Binding CanUseSelectedLogActions}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Open Detail" Click="OpenSelectedLog_Click" IsEnabled="{Binding CanUseSelectedLogActions}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedLog_Click" IsEnabled="{Binding CanUseSelectedLogActions}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Print" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintActivityRows}" Margin="0,0,4,4"/>
                                 </WrapPanel>
                             </Border>
                         </StackPanel>

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Threading;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Views.Windows;
@@ -16,18 +17,37 @@ namespace InventoryManagementApp.Views.Pages
     {
         private const int MaxActivityPrintRows = 250;
         private bool _hasLoadedLogs;
+        private ActivityLogsViewModel? _loadedViewModel;
 
         public ActivityLogsPage()
         {
             InitializeComponent();
             Loaded += ActivityLogsPage_Loaded;
+            DataContextChanged += ActivityLogsPage_DataContextChanged;
         }
 
         private async void ActivityLogsPage_Loaded(object sender, RoutedEventArgs e)
         {
-            if (!_hasLoadedLogs && DataContext is ActivityLogsViewModel vm)
+            if (DataContext is not ActivityLogsViewModel vm)
+                return;
+
+            if (_hasLoadedLogs && ReferenceEquals(_loadedViewModel, vm))
+                return;
+
+            await Dispatcher.Yield(DispatcherPriority.Background);
+            if (!ReferenceEquals(DataContext, vm))
+                return;
+
+            _loadedViewModel = vm;
+            _hasLoadedLogs = await vm.LoadLogsAsync();
+        }
+
+        private void ActivityLogsPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(e.NewValue, _loadedViewModel))
             {
-                _hasLoadedLogs = await vm.LoadLogsAsync();
+                _hasLoadedLogs = false;
+                _loadedViewModel = e.NewValue as ActivityLogsViewModel;
             }
         }
 
@@ -46,6 +66,8 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is ActivityLogsViewModel vm)
             {
                 await vm.LoadLogsAsync();
+                _hasLoadedLogs = true;
+                _loadedViewModel = vm;
             }
         }
 
@@ -53,6 +75,12 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Activity Logs", () =>
             {
+                if (DataContext is ActivityLogsViewModel { IsBusy: true })
+                {
+                    WpfMessageBox.Show("Wait for the activity directory to finish updating before opening details.", "Activity Logs", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
                 var log = GetSelectedActivityLogForAction();
                 if (log == null)
                 {
@@ -75,6 +103,12 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Activity Logs", () =>
             {
+                if (DataContext is ActivityLogsViewModel { IsBusy: true })
+                {
+                    WpfMessageBox.Show("Wait for the activity directory to finish updating before opening the related page.", "Activity Logs", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
                 var log = GetSelectedActivityLogForAction();
                 if (log == null)
                 {
@@ -128,6 +162,12 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Activity Logs", () =>
             {
+                if (DataContext is ActivityLogsViewModel { IsBusy: true })
+                {
+                    WpfMessageBox.Show("Wait for the activity directory to finish updating before copying a handoff.", "Activity Logs", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
                 var log = GetSelectedActivityLogForAction();
                 if (log == null)
                 {
@@ -149,9 +189,15 @@ namespace InventoryManagementApp.Views.Pages
                     return;
                 }
 
+                if (vm.IsBusy)
+                {
+                    WpfMessageBox.Show("Wait for the activity directory to finish updating before opening print preview.", "Activity Logs", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
                 var totalFilteredCount = vm.FilteredLogs.Count;
                 var printRows = vm.FilteredLogs.Take(MaxActivityPrintRows).ToList();
-                var document = BuildPrintDocument(printRows, totalFilteredCount, vm.StatusMessage, vm.ActivitySummary);
+                var document = BuildPrintDocument(printRows, totalFilteredCount, vm.PrintStatusText, vm.ActivitySummary);
                 new PrintPreviewWindow().ShowPreview(
                     document,
                     "Activity Logs",


### PR DESCRIPTION
## What changed

- Improved Activity Logs refresh behavior so a failed refresh keeps existing audit rows visible instead of clearing the directory.
- Added cancellable, debounced filtering for search/user/action changes so rapid input coalesces to the latest filter request.
- Moved audit filtering over a snapshot of loaded rows to background work, then applies the final result after cancellation checks.
- Added newest-first deterministic sorting for refreshed rows and expanded search to include user ID.
- Added ViewModel-backed loading, filtering, empty-state, selected-action availability, and print-readiness properties.
- Added a bounded loading/filtering overlay, dynamic no-record/no-match empty copy, and visible print status in the Activity Logs page.
- Disabled selected-row detail, related-page, copy, and print actions while rows are loading/filtering, including context-menu actions and code-behind bypasses.
- Added first-paint-friendly page loading with a dispatcher yield, duplicate-load prevention for the same view model, and DataContext reset handling.
- Extended source-contract coverage for the Activity Logs responsiveness and display contracts.
- Added a progress note for future scheduled runs.

## Why this was highest value

The repo’s current focus is loading speed, UI responsiveness, and professional data display. Activity Logs already had responsive layout and grid virtualization, but filtering still ran synchronously on every property change and refresh failures cleared the directory. That made a busy audit trail vulnerable to visible churn, stale action use, and sluggish search/filter interactions.

## Scope and progress size

This is a complete workflow slice across the Activity Logs ViewModel, XAML display, page code-behind, source-contract tests, and progress notes. It avoids repeating the recently merged Kits, Reservations, Calibration, Maintenance, Categories, Settings, Customers, and Rental History work.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, ahead by 6 commits, and limited to Activity Logs responsiveness files plus the progress note.
- Connector readback spot-checked the changed ViewModel state/filtering code and source-contract additions.

Could not run local validation: this scheduled Linux environment cannot clone the repo directly because GitHub HTTP access returns `CONNECT tunnel failed, response 403`, and it does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime. That blocks `pwsh -File scripts/run-full-validation.ps1`, WPF smoke testing, screenshots, scaling checks, and print-preview rendering.

## Known follow-up

- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
- Smoke test Activity Logs with a large audit trail, rapid search typing, filter changes, failed refresh behavior, context-menu actions, and capped print preview output.