### PR TITLE
Improve Import Export operation responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
@@ -83,6 +83,58 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ImportExportViewModel_GatesAllDataOperationsThroughSharedBusyState()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("private int _activeDataOperationCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool IsDataOperationBusy => _activeDataOperationCount > 0;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool IsDataOperationReady => !IsDataOperationBusy;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string DataOperationStatus => IsDataOperationBusy", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string DataOperationSummary => IsDataOperationBusy", viewModel, StringComparison.Ordinal);
+            Assert.Contains("bool TryBeginDataOperation(string operationName)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("void EndDataOperation()", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ImportItemsCommand = new AsyncRelayCommand(ct => ImportItemsAsync(ct), CanStartDataOperation);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ExportItemsCommand = new AsyncRelayCommand(ct => ExportItemsAsync(ct), CanStartDataOperation);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ImportCustomersCommand = new AsyncRelayCommand(ct => ImportCustomersAsync(ct), CanStartDataOperation);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct), CanStartDataOperation);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("BackupDatabaseCommand = new AsyncRelayCommand(ct => BackupDatabaseAsync(ct), CanStartDataOperation);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("RestoreBackupCommand = new AsyncRelayCommand(ct => RestoreBackupAsync(ct), CanStartDataOperation);", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_UpdatesLogActionAvailabilityDuringBusyState()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("public bool CanReviewSelectedLog => !IsDataOperationBusy && !string.IsNullOrWhiteSpace(SelectedImportExportLog);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanPrintImportExportLogs => !IsDataOperationBusy && HasLogEntries;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("new RelayCommand(ClearImportExportLogs, () => HasLogEntries && !IsDataOperationBusy)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (IsDataOperationBusy)\n                return;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CanReviewSelectedLog));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CanPrintImportExportLogs));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ClearImportExportLogsCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportPage_CodeBehindGuardsLogActionsAndCapsPrintRows()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
+
+            Assert.Contains("private const int MaxPrintedLogRows = 250;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private bool IsDataOperationBusy() =>", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.IsDataOperationBusy", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Wait for the current import, export, backup, or restore operation to finish before opening log details.", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Wait for the current import, export, backup, or restore operation to finish before copying log details.", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Wait for the current import, export, backup, or restore operation to finish before generating a print preview.", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var printedLogs = safeLogs.Take(MaxPrintedLogRows).ToList();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var omittedLogCount = Math.Max(0, safeLogs.Count - printedLogs.Count);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Visible Log Rows", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Printed Log Rows", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Omitted Log Rows", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ImportExportPage_PreservesDataCommandsAndLogRowHandlers()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-import-export-operation-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-import-export-operation-responsiveness.md
@@ -1,0 +1,23 @@
+# Import / Export Operation Responsiveness - 2026-07-04
+
+## Completed
+
+- Added a shared Import / Export data-operation busy state so item import, item export, customer import, customer export, full backup, and restore backup cannot be started on top of one another.
+- Added ViewModel-backed readiness, busy/status, review, and print availability properties for the data desk workflow.
+- Updated Import / Export commands to use the shared busy guard and refresh related command availability when long-running data work starts or finishes.
+- Kept clear-log actions from running while an import/export/backup/restore operation is active.
+- Guarded double-click, context-menu, copy, and print log actions in code-behind while data work is active, preventing bypasses around command state.
+- Capped Import / Export run-log print preview generation to the first 250 printable rows.
+- Added visible, printed, and omitted log-row accounting to the run-log print packet.
+- Added operator guidance when oversized run logs are trimmed from print preview.
+- Preserved the existing virtualized run-log grid, selected-row detail workflow, context menu, copy action, print preview route, and empty-state display.
+- Extended source-contract coverage for shared operation gating, log action availability, busy-path code-behind guards, and bounded print output.
+
+## Validation
+
+- GitHub connector readback and PR compare were used to inspect the changed source because direct local checkout is blocked in this scheduled environment.
+- Local `dotnet` restore/build/test, `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, scaling checks, and print-preview rendering still need to be run on a Windows/.NET-capable checkout.
+
+## Follow-up
+
+- Smoke test Import / Export with a long item import, export, customer import/export, full backup, restore cancellation, rapid command clicks, log copy/open while busy, and 250+ log rows before printing.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -29,6 +29,8 @@ namespace InventoryManagementApp.ViewModels
         private readonly ILogger<ImportExportViewModel> _logger;
         private readonly IUserContext _userContext;
         private readonly RentalConfigurationService? _rentalConfigService;
+        private int _activeDataOperationCount;
+        private string? _currentDataOperation;
 
         public IAsyncRelayCommand ImportItemsCommand { get; }
         public IRelayCommand CancelImportItemsCommand { get; }
@@ -41,6 +43,16 @@ namespace InventoryManagementApp.ViewModels
         public bool CanImportImages => _userContext.IsAdmin || _userContext.CurrentUser?.HasPermission(User.PermissionImportExport) == true;
         public bool IsCurrentUserAdmin => CanImportImages;
         public bool HasLogEntries => ImportExportLogs.Count > 0;
+        public bool IsDataOperationBusy => _activeDataOperationCount > 0;
+        public bool IsDataOperationReady => !IsDataOperationBusy;
+        public bool CanReviewSelectedLog => !IsDataOperationBusy && !string.IsNullOrWhiteSpace(SelectedImportExportLog);
+        public bool CanPrintImportExportLogs => !IsDataOperationBusy && HasLogEntries;
+        public string DataOperationStatus => IsDataOperationBusy
+            ? $"{ValueOrDefault(_currentDataOperation, "Data operation")} running"
+            : "Data desk ready";
+        public string DataOperationSummary => IsDataOperationBusy
+            ? "Finish or cancel the current data operation before starting another import, export, backup, restore, copy, or print handoff."
+            : "Ready for the next import, export, backup, restore, image mapping, copy, or print handoff.";
         public string LogSummary => HasLogEntries
             ? $"{ImportExportLogs.Count} operation log entr{(ImportExportLogs.Count == 1 ? "y" : "ies")} recorded this session."
             : "No import, export, image, or backup operations have been run in this session.";
@@ -68,6 +80,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     OnPropertyChanged(nameof(SelectedLogTitle));
                     OnPropertyChanged(nameof(SelectedLogDetail));
+                    OnPropertyChanged(nameof(CanReviewSelectedLog));
                 }
             }
         }
@@ -127,6 +140,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 OnPropertyChanged(nameof(HasLogEntries));
                 OnPropertyChanged(nameof(LogSummary));
+                OnPropertyChanged(nameof(CanPrintImportExportLogs));
             };
             
             // Initialize importers and exporters
@@ -153,14 +167,14 @@ namespace InventoryManagementApp.ViewModels
                 new CustomerXmlExporter()
             };
             
-            ImportItemsCommand = new AsyncRelayCommand(ct => ImportItemsAsync(ct));
-            CancelImportItemsCommand = new RelayCommand(() => ImportItemsCommand.Cancel());
-            ExportItemsCommand = new AsyncRelayCommand(ct => ExportItemsAsync(ct));
-            ImportCustomersCommand = new AsyncRelayCommand(ct => ImportCustomersAsync(ct));
-            ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct));
-            BackupDatabaseCommand = new AsyncRelayCommand(ct => BackupDatabaseAsync(ct));
-            RestoreBackupCommand = new AsyncRelayCommand(ct => RestoreBackupAsync(ct));
-            ClearImportExportLogsCommand = new RelayCommand(ClearImportExportLogs, () => HasLogEntries);
+            ImportItemsCommand = new AsyncRelayCommand(ct => ImportItemsAsync(ct), CanStartDataOperation);
+            CancelImportItemsCommand = new RelayCommand(() => ImportItemsCommand.Cancel(), () => ImportItemsCommand.IsRunning);
+            ExportItemsCommand = new AsyncRelayCommand(ct => ExportItemsAsync(ct), CanStartDataOperation);
+            ImportCustomersCommand = new AsyncRelayCommand(ct => ImportCustomersAsync(ct), CanStartDataOperation);
+            ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct), CanStartDataOperation);
+            BackupDatabaseCommand = new AsyncRelayCommand(ct => BackupDatabaseAsync(ct), CanStartDataOperation);
+            RestoreBackupCommand = new AsyncRelayCommand(ct => RestoreBackupAsync(ct), CanStartDataOperation);
+            ClearImportExportLogsCommand = new RelayCommand(ClearImportExportLogs, () => HasLogEntries && !IsDataOperationBusy);
         }
 
         private sealed class DummyUserContext : IUserContext
@@ -183,6 +197,48 @@ namespace InventoryManagementApp.ViewModels
             public string Role => string.Empty;
         }
 
+        bool CanStartDataOperation() => !IsDataOperationBusy;
+
+        bool TryBeginDataOperation(string operationName)
+        {
+            if (IsDataOperationBusy)
+                return false;
+
+            _activeDataOperationCount++;
+            _currentDataOperation = operationName;
+            NotifyDataOperationStateChanged();
+            return true;
+        }
+
+        void EndDataOperation()
+        {
+            if (_activeDataOperationCount > 0)
+                _activeDataOperationCount--;
+
+            if (_activeDataOperationCount == 0)
+                _currentDataOperation = null;
+
+            NotifyDataOperationStateChanged();
+        }
+
+        void NotifyDataOperationStateChanged()
+        {
+            OnPropertyChanged(nameof(IsDataOperationBusy));
+            OnPropertyChanged(nameof(IsDataOperationReady));
+            OnPropertyChanged(nameof(CanReviewSelectedLog));
+            OnPropertyChanged(nameof(CanPrintImportExportLogs));
+            OnPropertyChanged(nameof(DataOperationStatus));
+            OnPropertyChanged(nameof(DataOperationSummary));
+            ImportItemsCommand.NotifyCanExecuteChanged();
+            CancelImportItemsCommand.NotifyCanExecuteChanged();
+            ExportItemsCommand.NotifyCanExecuteChanged();
+            ImportCustomersCommand.NotifyCanExecuteChanged();
+            ExportCustomersCommand.NotifyCanExecuteChanged();
+            BackupDatabaseCommand.NotifyCanExecuteChanged();
+            RestoreBackupCommand.NotifyCanExecuteChanged();
+            ClearImportExportLogsCommand.NotifyCanExecuteChanged();
+        }
+
         void AddLog(string message)
         {
             ImportExportLogs.Add(message);
@@ -192,6 +248,9 @@ namespace InventoryManagementApp.ViewModels
 
         void ClearImportExportLogs()
         {
+            if (IsDataOperationBusy)
+                return;
+
             ImportExportLogs.Clear();
             SelectedImportExportLog = null;
             ClearImportExportLogsCommand.NotifyCanExecuteChanged();
@@ -205,270 +264,310 @@ namespace InventoryManagementApp.ViewModels
 
         async Task ImportItemsAsync(CancellationToken cancellationToken)
         {
-            // Build combined file filter for all supported formats
-            // Note: CSV is handled separately from _itemImporters because it requires
-            // an interactive mapping dialog, whereas JSON/XML use direct import
-            var filters = new List<string> { "CSV Files|*.csv" };
-            filters.AddRange(_itemImporters.Select(i => i.FileFilter));
-            var combinedFilter = string.Join("|", filters) + "|All Files|*.*";
-            
-            var path = _fileDialogService.OpenFile(combinedFilter, AppContext.BaseDirectory);
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                var plural = LabelProvider.Instance.ItemLabelPlural;
-                await CancelFileSelectionAsync($"{plural} import file selection was cancelled.", $"Import {plural}");
+            if (!TryBeginDataOperation($"{LabelProvider.Instance.ItemLabelPlural} import"))
                 return;
-            }
-            
+
             try
             {
-                var extension = Path.GetExtension(path).ToLowerInvariant();
-                var plural = LabelProvider.Instance.ItemLabelPlural;
+                // Build combined file filter for all supported formats
+                // Note: CSV is handled separately from _itemImporters because it requires
+                // an interactive mapping dialog, whereas JSON/XML use direct import
+                var filters = new List<string> { "CSV Files|*.csv" };
+                filters.AddRange(_itemImporters.Select(i => i.FileFilter));
+                var combinedFilter = string.Join("|", filters) + "|All Files|*.*";
                 
-                List<int> skippedRows;
-                
-                // Check if it's CSV (requires mapping) or other format (direct import)
-                if (extension == ".csv")
+                var path = _fileDialogService.OpenFile(combinedFilter, AppContext.BaseDirectory);
+                if (string.IsNullOrWhiteSpace(path))
                 {
-                    // Use existing CSV import with mapping
-                    var headers = await CsvHelperUtil.ReadHeadersAsync(path);
-                    var properties = typeof(ItemImportDto).GetProperties().Select(p => p.Name);
-                    var map = _dialogService.ShowImportMapping(
-                        headers,
-                        properties,
-                        new[] { nameof(ItemImportDto.ItemNumber), nameof(ItemImportDto.Name) });
-                    if (map == null)
+                    var plural = LabelProvider.Instance.ItemLabelPlural;
+                    await CancelFileSelectionAsync($"{plural} import file selection was cancelled.", $"Import {plural}");
+                    return;
+                }
+
+                try
+                {
+                    var extension = Path.GetExtension(path).ToLowerInvariant();
+                    var plural = LabelProvider.Instance.ItemLabelPlural;
+                    
+                    List<int> skippedRows;
+                    
+                    // Check if it's CSV (requires mapping) or other format (direct import)
+                    if (extension == ".csv")
                     {
-                        var message = $"{plural} import mapping was cancelled.";
-                        AddLog(message);
-                        await _dialogService.ShowInfoAsync(message, $"Import {plural}");
-                        return;
+                        // Use existing CSV import with mapping
+                        var headers = await CsvHelperUtil.ReadHeadersAsync(path);
+                        var properties = typeof(ItemImportDto).GetProperties().Select(p => p.Name);
+                        var map = _dialogService.ShowImportMapping(
+                            headers,
+                            properties,
+                            new[] { nameof(ItemImportDto.ItemNumber), nameof(ItemImportDto.Name) });
+                        if (map == null)
+                        {
+                            var message = $"{plural} import mapping was cancelled.";
+                            AddLog(message);
+                            await _dialogService.ShowInfoAsync(message, $"Import {plural}");
+                            return;
+                        }
+                        
+                        if (!map.TryGetValue(nameof(ItemImportDto.ItemNumber), out var itemNumberHeader) || string.IsNullOrWhiteSpace(itemNumberHeader))
+                        {
+                            var singular = LabelProvider.Instance.ItemLabelSingular;
+                            var errorMessage = $"Mapping for {singular} number is required.";
+                            AddLog(errorMessage);
+                            _logger.LogWarning("Import aborted: missing {ItemLabelSingular} number mapping", singular);
+                            await _dialogService.ShowInfoAsync(errorMessage, $"Import {plural}");
+                            return;
+                        }
+                        
+                        await _dialogService.ShowInfoAsync($"Importing {plural}...", $"Import {plural}");
+                        skippedRows = await _itemService.ImportItemsFromCsvAsync(path, map, cancellationToken);
+                    }
+                    else
+                    {
+                        // Find appropriate importer
+                        var importer = _itemImporters.FirstOrDefault(i => i.FileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase));
+                        if (importer == null)
+                        {
+                            var errorMessage = $"No importer found for file type: {extension}";
+                            AddLog(errorMessage);
+                            await _dialogService.ShowInfoAsync(errorMessage, $"Import {plural}");
+                            return;
+                        }
+                        
+                        await _dialogService.ShowInfoAsync($"Importing {plural} from {importer.FormatName}...", $"Import {plural}");
+                        skippedRows = await _itemService.ImportItemsAsync(path, importer, cancellationToken);
                     }
                     
-                    if (!map.TryGetValue(nameof(ItemImportDto.ItemNumber), out var itemNumberHeader) || string.IsNullOrWhiteSpace(itemNumberHeader))
+                    var successMessage = $"Successfully imported {plural} from {path}.";
+                    AddLog(successMessage);
+                    if (skippedRows.Any())
                     {
-                        var singular = LabelProvider.Instance.ItemLabelSingular;
-                        var errorMessage = $"Mapping for {singular} number is required.";
-                        AddLog(errorMessage);
-                        _logger.LogWarning("Import aborted: missing {ItemLabelSingular} number mapping", singular);
-                        await _dialogService.ShowInfoAsync(errorMessage, $"Import {plural}");
-                        return;
+                        var skippedMessage = $"Skipped rows: {string.Join(", ", skippedRows)}";
+                        AddLog(skippedMessage);
+                        successMessage += $" {skippedMessage}";
                     }
-                    
-                    await _dialogService.ShowInfoAsync($"Importing {plural}...", $"Import {plural}");
-                    skippedRows = await _itemService.ImportItemsFromCsvAsync(path, map, cancellationToken);
+                    await _dialogService.ShowInfoAsync(successMessage, $"Import {plural}");
                 }
-                else
+                catch (OperationCanceledException)
                 {
-                    // Find appropriate importer
-                    var importer = _itemImporters.FirstOrDefault(i => i.FileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase));
-                    if (importer == null)
-                    {
-                        var errorMessage = $"No importer found for file type: {extension}";
-                        AddLog(errorMessage);
-                        await _dialogService.ShowInfoAsync(errorMessage, $"Import {plural}");
-                        return;
-                    }
-                    
-                    await _dialogService.ShowInfoAsync($"Importing {plural} from {importer.FormatName}...", $"Import {plural}");
-                    skippedRows = await _itemService.ImportItemsAsync(path, importer, cancellationToken);
+                    var plural = LabelProvider.Instance.ItemLabelPlural;
+                    AddLog($"{plural} import was cancelled.");
+                    await _dialogService.ShowInfoAsync($"{plural} import was cancelled.", $"Import {plural}");
                 }
-                
-                var successMessage = $"Successfully imported {plural} from {path}.";
-                AddLog(successMessage);
-                if (skippedRows.Any())
+                catch (Exception ex)
                 {
-                    var skippedMessage = $"Skipped rows: {string.Join(", ", skippedRows)}";
-                    AddLog(skippedMessage);
-                    successMessage += $" {skippedMessage}";
+                    var plural = LabelProvider.Instance.ItemLabelPlural;
+                    _logger.LogError(ex, "Failed to import {ItemLabelPlural} from {Path}", plural, path);
+                    AddLog($"Failed to import {plural} from {path}: {ex.Message}");
+                    await _dialogService.ShowInfoAsync($"Failed to import {plural} from {path}: {ex.Message}", $"Import {plural}");
                 }
-                await _dialogService.ShowInfoAsync(successMessage, $"Import {plural}");
             }
-            catch (OperationCanceledException)
+            finally
             {
-                var plural = LabelProvider.Instance.ItemLabelPlural;
-                AddLog($"{plural} import was cancelled.");
-                await _dialogService.ShowInfoAsync($"{plural} import was cancelled.", $"Import {plural}");
-            }
-            catch (Exception ex)
-            {
-                var plural = LabelProvider.Instance.ItemLabelPlural;
-                _logger.LogError(ex, "Failed to import {ItemLabelPlural} from {Path}", plural, path);
-                AddLog($"Failed to import {plural} from {path}: {ex.Message}");
-                await _dialogService.ShowInfoAsync($"Failed to import {plural} from {path}: {ex.Message}", $"Import {plural}");
+                EndDataOperation();
             }
         }
 
         async Task ExportItemsAsync(CancellationToken cancellationToken)
         {
-            // Build combined file filter for all supported formats
-            var filters = _itemExporters.Select(e => e.FileFilter);
-            var combinedFilter = string.Join("|", filters);
-            
-            var path = _fileDialogService.SaveFile(combinedFilter);
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                var plural = LabelProvider.Instance.ItemLabelPlural;
-                await CancelFileSelectionAsync($"{plural} export destination selection was cancelled.", $"Export {plural}");
+            if (!TryBeginDataOperation($"{LabelProvider.Instance.ItemLabelPlural} export"))
                 return;
-            }
-            
+
             try
             {
-                var extension = Path.GetExtension(path).ToLowerInvariant();
-                var plural = LabelProvider.Instance.ItemLabelPlural;
+                // Build combined file filter for all supported formats
+                var filters = _itemExporters.Select(e => e.FileFilter);
+                var combinedFilter = string.Join("|", filters);
                 
-                // Find appropriate exporter
-                var exporter = _itemExporters.FirstOrDefault(e => e.FileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase));
-                if (exporter == null)
+                var path = _fileDialogService.SaveFile(combinedFilter);
+                if (string.IsNullOrWhiteSpace(path))
                 {
-                    var errorMessage = $"No exporter found for file type: {extension}";
-                    AddLog(errorMessage);
-                    await _dialogService.ShowInfoAsync(errorMessage, $"Export {plural}");
+                    var plural = LabelProvider.Instance.ItemLabelPlural;
+                    await CancelFileSelectionAsync($"{plural} export destination selection was cancelled.", $"Export {plural}");
                     return;
                 }
-                
-                await _itemService.ExportItemsAsync(path, exporter, cancellationToken);
-                var successMessage = $"Successfully exported {plural} to {path} ({exporter.FormatName} format).";
-                AddLog(successMessage);
-                await _dialogService.ShowInfoAsync(successMessage, $"Export {plural}");
+
+                try
+                {
+                    var extension = Path.GetExtension(path).ToLowerInvariant();
+                    var plural = LabelProvider.Instance.ItemLabelPlural;
+                    
+                    // Find appropriate exporter
+                    var exporter = _itemExporters.FirstOrDefault(e => e.FileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase));
+                    if (exporter == null)
+                    {
+                        var errorMessage = $"No exporter found for file type: {extension}";
+                        AddLog(errorMessage);
+                        await _dialogService.ShowInfoAsync(errorMessage, $"Export {plural}");
+                        return;
+                    }
+                    
+                    await _itemService.ExportItemsAsync(path, exporter, cancellationToken);
+                    var successMessage = $"Successfully exported {plural} to {path} ({exporter.FormatName} format).";
+                    AddLog(successMessage);
+                    await _dialogService.ShowInfoAsync(successMessage, $"Export {plural}");
+                }
+                catch (OperationCanceledException)
+                {
+                    var plural = LabelProvider.Instance.ItemLabelPlural;
+                    var message = $"{plural} export was cancelled.";
+                    AddLog(message);
+                    await _dialogService.ShowInfoAsync(message, $"Export {plural}");
+                }
+                catch (Exception ex)
+                {
+                    var plural = LabelProvider.Instance.ItemLabelPlural;
+                    _logger.LogError(ex, "Failed to export {ItemLabelPlural} to {Path}", plural, path);
+                    var failureMessage = $"Failed to export {plural} to {path}: {ex.Message}";
+                    AddLog(failureMessage);
+                    await _dialogService.ShowInfoAsync(failureMessage, $"Export {plural}");
+                }
             }
-            catch (OperationCanceledException)
+            finally
             {
-                var plural = LabelProvider.Instance.ItemLabelPlural;
-                var message = $"{plural} export was cancelled.";
-                AddLog(message);
-                await _dialogService.ShowInfoAsync(message, $"Export {plural}");
-            }
-            catch (Exception ex)
-            {
-                var plural = LabelProvider.Instance.ItemLabelPlural;
-                _logger.LogError(ex, "Failed to export {ItemLabelPlural} to {Path}", plural, path);
-                var failureMessage = $"Failed to export {plural} to {path}: {ex.Message}";
-                AddLog(failureMessage);
-                await _dialogService.ShowInfoAsync(failureMessage, $"Export {plural}");
+                EndDataOperation();
             }
         }
 
         async Task ImportCustomersAsync(CancellationToken cancellationToken)
         {
-            // Build combined file filter for all supported formats
-            // Note: CSV is handled separately from _customerImporters because it requires
-            // an interactive mapping dialog, whereas JSON/XML use direct import
-            var filters = new List<string> { "CSV Files|*.csv" };
-            filters.AddRange(_customerImporters.Select(i => i.FileFilter));
-            var combinedFilter = string.Join("|", filters) + "|All Files|*.*";
-            
-            var path = _fileDialogService.OpenFile(combinedFilter, AppContext.BaseDirectory);
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                await CancelFileSelectionAsync("Customer import file selection was cancelled.", "Import Customers");
+            if (!TryBeginDataOperation("Customer import"))
                 return;
-            }
-            
+
             try
             {
-                var extension = Path.GetExtension(path).ToLowerInvariant();
+                // Build combined file filter for all supported formats
+                // Note: CSV is handled separately from _customerImporters because it requires
+                // an interactive mapping dialog, whereas JSON/XML use direct import
+                var filters = new List<string> { "CSV Files|*.csv" };
+                filters.AddRange(_customerImporters.Select(i => i.FileFilter));
+                var combinedFilter = string.Join("|", filters) + "|All Files|*.*";
                 
-                if (extension == ".csv")
+                var path = _fileDialogService.OpenFile(combinedFilter, AppContext.BaseDirectory);
+                if (string.IsNullOrWhiteSpace(path))
                 {
-                    // Use existing CSV import with mapping
-                    var headers = await CsvHelperUtil.ReadHeadersAsync(path);
-                    var properties = typeof(CustomerImportDto).GetProperties().Select(p => p.Name);
-                    var map = _dialogService.ShowImportMapping(headers, properties);
-                    if (map == null)
-                    {
-                        const string message = "Customer import mapping was cancelled.";
-                        AddLog(message);
-                        await _dialogService.ShowInfoAsync(message, "Import Customers");
-                        return;
-                    }
-                    var result = await _customerService.ImportCustomersFromCsvAsync(path, map, cancellationToken);
-                    var successMessage = $"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.";
-                    AddLog(successMessage);
-                    if (result.SkippedRows.Any())
-                        successMessage += $" {result.SkippedRows.Count} skipped row{(result.SkippedRows.Count == 1 ? "" : "s")} were recorded in the run log.";
-                    foreach (var msg in result.SkippedRows)
-                        AddLog($"Skipped {msg}");
-                    await _dialogService.ShowInfoAsync(successMessage, "Import Customers");
+                    await CancelFileSelectionAsync("Customer import file selection was cancelled.", "Import Customers");
+                    return;
                 }
-                else
+
+                try
                 {
-                    // Find appropriate importer
-                    var importer = _customerImporters.FirstOrDefault(i => i.FileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase));
-                    if (importer == null)
-                    {
-                        var errorMessage = $"No importer found for file type: {extension}";
-                        AddLog(errorMessage);
-                        await _dialogService.ShowInfoAsync(errorMessage, "Import Customers");
-                        return;
-                    }
+                    var extension = Path.GetExtension(path).ToLowerInvariant();
                     
-                    var importedCount = await _customerService.ImportCustomersAsync(path, importer, cancellationToken);
-                    var successMessage = $"Successfully imported {importedCount} customers from {path} ({importer.FormatName} format).";
-                    AddLog(successMessage);
-                    await _dialogService.ShowInfoAsync(successMessage, "Import Customers");
+                    if (extension == ".csv")
+                    {
+                        // Use existing CSV import with mapping
+                        var headers = await CsvHelperUtil.ReadHeadersAsync(path);
+                        var properties = typeof(CustomerImportDto).GetProperties().Select(p => p.Name);
+                        var map = _dialogService.ShowImportMapping(headers, properties);
+                        if (map == null)
+                        {
+                            const string message = "Customer import mapping was cancelled.";
+                            AddLog(message);
+                            await _dialogService.ShowInfoAsync(message, "Import Customers");
+                            return;
+                        }
+                        var result = await _customerService.ImportCustomersFromCsvAsync(path, map, cancellationToken);
+                        var successMessage = $"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.";
+                        AddLog(successMessage);
+                        if (result.SkippedRows.Any())
+                            successMessage += $" {result.SkippedRows.Count} skipped row{(result.SkippedRows.Count == 1 ? "" : "s")} were recorded in the run log.";
+                        foreach (var msg in result.SkippedRows)
+                            AddLog($"Skipped {msg}");
+                        await _dialogService.ShowInfoAsync(successMessage, "Import Customers");
+                    }
+                    else
+                    {
+                        // Find appropriate importer
+                        var importer = _customerImporters.FirstOrDefault(i => i.FileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase));
+                        if (importer == null)
+                        {
+                            var errorMessage = $"No importer found for file type: {extension}";
+                            AddLog(errorMessage);
+                            await _dialogService.ShowInfoAsync(errorMessage, "Import Customers");
+                            return;
+                        }
+                        
+                        var importedCount = await _customerService.ImportCustomersAsync(path, importer, cancellationToken);
+                        var successMessage = $"Successfully imported {importedCount} customers from {path} ({importer.FormatName} format).";
+                        AddLog(successMessage);
+                        await _dialogService.ShowInfoAsync(successMessage, "Import Customers");
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    const string message = "Customer import was cancelled.";
+                    AddLog(message);
+                    await _dialogService.ShowInfoAsync(message, "Import Customers");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to import customers from {Path}", path);
+                    var failureMessage = $"Failed to import customers from {path}: {ex.Message}";
+                    AddLog(failureMessage);
+                    await _dialogService.ShowInfoAsync(failureMessage, "Import Customers");
                 }
             }
-            catch (OperationCanceledException)
+            finally
             {
-                const string message = "Customer import was cancelled.";
-                AddLog(message);
-                await _dialogService.ShowInfoAsync(message, "Import Customers");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to import customers from {Path}", path);
-                var failureMessage = $"Failed to import customers from {path}: {ex.Message}";
-                AddLog(failureMessage);
-                await _dialogService.ShowInfoAsync(failureMessage, "Import Customers");
+                EndDataOperation();
             }
         }
 
         async Task ExportCustomersAsync(CancellationToken cancellationToken)
         {
-            // Build combined file filter for all supported formats
-            var filters = _customerExporters.Select(e => e.FileFilter);
-            var combinedFilter = string.Join("|", filters);
-            
-            var path = _fileDialogService.SaveFile(combinedFilter);
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                await CancelFileSelectionAsync("Customer export destination selection was cancelled.", "Export Customers");
+            if (!TryBeginDataOperation("Customer export"))
                 return;
-            }
-            
+
             try
             {
-                var extension = Path.GetExtension(path).ToLowerInvariant();
+                // Build combined file filter for all supported formats
+                var filters = _customerExporters.Select(e => e.FileFilter);
+                var combinedFilter = string.Join("|", filters);
                 
-                // Find appropriate exporter
-                var exporter = _customerExporters.FirstOrDefault(e => e.FileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase));
-                if (exporter == null)
+                var path = _fileDialogService.SaveFile(combinedFilter);
+                if (string.IsNullOrWhiteSpace(path))
                 {
-                    var errorMessage = $"No exporter found for file type: {extension}";
-                    AddLog(errorMessage);
-                    await _dialogService.ShowInfoAsync(errorMessage, "Export Customers");
+                    await CancelFileSelectionAsync("Customer export destination selection was cancelled.", "Export Customers");
                     return;
                 }
-                
-                await _customerService.ExportCustomersAsync(path, exporter, cancellationToken);
-                var successMessage = $"Successfully exported customers to {path} ({exporter.FormatName} format).";
-                AddLog(successMessage);
-                await _dialogService.ShowInfoAsync(successMessage, "Export Customers");
+
+                try
+                {
+                    var extension = Path.GetExtension(path).ToLowerInvariant();
+                    
+                    // Find appropriate exporter
+                    var exporter = _customerExporters.FirstOrDefault(e => e.FileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase));
+                    if (exporter == null)
+                    {
+                        var errorMessage = $"No exporter found for file type: {extension}";
+                        AddLog(errorMessage);
+                        await _dialogService.ShowInfoAsync(errorMessage, "Export Customers");
+                        return;
+                    }
+                    
+                    await _customerService.ExportCustomersAsync(path, exporter, cancellationToken);
+                    var successMessage = $"Successfully exported customers to {path} ({exporter.FormatName} format).";
+                    AddLog(successMessage);
+                    await _dialogService.ShowInfoAsync(successMessage, "Export Customers");
+                }
+                catch (OperationCanceledException)
+                {
+                    const string message = "Customer export was cancelled.";
+                    AddLog(message);
+                    await _dialogService.ShowInfoAsync(message, "Export Customers");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to export customers to {Path}", path);
+                    var failureMessage = $"Failed to export customers to {path}: {ex.Message}";
+                    AddLog(failureMessage);
+                    await _dialogService.ShowInfoAsync(failureMessage, "Export Customers");
+                }
             }
-            catch (OperationCanceledException)
+            finally
             {
-                const string message = "Customer export was cancelled.";
-                AddLog(message);
-                await _dialogService.ShowInfoAsync(message, "Export Customers");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to export customers to {Path}", path);
-                var failureMessage = $"Failed to export customers to {path}: {ex.Message}";
-                AddLog(failureMessage);
-                await _dialogService.ShowInfoAsync(failureMessage, "Export Customers");
+                EndDataOperation();
             }
         }
 
@@ -482,90 +581,113 @@ namespace InventoryManagementApp.ViewModels
         /// <returns>A <see cref="Task"/> representing the asynchronous backup operation.</returns>
         async Task BackupDatabaseAsync(CancellationToken cancellationToken)
         {
-            string? path = null;
+            if (!TryBeginDataOperation("Full backup"))
+                return;
 
             try
             {
-                var initialDirectory = _rentalConfigService == null
-                    ? null
-                    : await _rentalConfigService.GetBackupDirectoryAsync(cancellationToken).ConfigureAwait(false);
-                path = _fileDialogService.SaveFile("Inventory Backup Package|*.inventory-backup.zip|Zip Files|*.zip", initialDirectory);
-                if (string.IsNullOrWhiteSpace(path))
-                {
-                    await CancelFileSelectionAsync("Full backup destination selection was cancelled.", "Full Backup");
-                    return;
-                }
+                string? path = null;
 
-                await _databaseService.BackupApplicationAsync(path, cancellationToken);
-                var successMessage = $"Successfully created full backup package at {path}.";
-                AddLog(successMessage);
-                await _dialogService.ShowInfoAsync(successMessage, "Full Backup");
+                try
+                {
+                    var initialDirectory = _rentalConfigService == null
+                        ? null
+                        : await _rentalConfigService.GetBackupDirectoryAsync(cancellationToken).ConfigureAwait(false);
+                    path = _fileDialogService.SaveFile("Inventory Backup Package|*.inventory-backup.zip|Zip Files|*.zip", initialDirectory);
+                    if (string.IsNullOrWhiteSpace(path))
+                    {
+                        await CancelFileSelectionAsync("Full backup destination selection was cancelled.", "Full Backup");
+                        return;
+                    }
+
+                    await _databaseService.BackupApplicationAsync(path, cancellationToken);
+                    var successMessage = $"Successfully created full backup package at {path}.";
+                    AddLog(successMessage);
+                    await _dialogService.ShowInfoAsync(successMessage, "Full Backup");
+                }
+                catch (OperationCanceledException)
+                {
+                    const string message = "Full backup was cancelled.";
+                    AddLog(message);
+                    await _dialogService.ShowInfoAsync(message, "Full Backup");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to create full backup package at {Path}", path);
+                    var failureMessage = string.IsNullOrWhiteSpace(path)
+                        ? $"Failed to start full backup: {ex.Message}"
+                        : $"Failed to create full backup package at {path}: {ex.Message}";
+                    AddLog(failureMessage);
+                    await _dialogService.ShowInfoAsync(failureMessage, "Full Backup");
+                }
             }
-            catch (OperationCanceledException)
+            finally
             {
-                const string message = "Full backup was cancelled.";
-                AddLog(message);
-                await _dialogService.ShowInfoAsync(message, "Full Backup");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to create full backup package at {Path}", path);
-                var failureMessage = string.IsNullOrWhiteSpace(path)
-                    ? $"Failed to start full backup: {ex.Message}"
-                    : $"Failed to create full backup package at {path}: {ex.Message}";
-                AddLog(failureMessage);
-                await _dialogService.ShowInfoAsync(failureMessage, "Full Backup");
+                EndDataOperation();
             }
         }
 
         async Task RestoreBackupAsync(CancellationToken cancellationToken)
         {
-            string? path = null;
+            if (!TryBeginDataOperation("Restore backup"))
+                return;
 
             try
             {
-                var initialDirectory = _rentalConfigService == null
-                    ? null
-                    : await _rentalConfigService.GetBackupDirectoryAsync(cancellationToken).ConfigureAwait(false);
-                path = _fileDialogService.OpenFile("Inventory Backup Package|*.inventory-backup.zip;*.zip|All Files|*.*", initialDirectory);
-                if (string.IsNullOrWhiteSpace(path))
-                {
-                    await CancelFileSelectionAsync("Backup package selection was cancelled.", "Restore Backup");
-                    return;
-                }
+                string? path = null;
 
-                var confirmed = await _dialogService.ShowConfirmationAsync(
-                    "Restoring a backup will replace the current database and app assets. A safety backup of the current data will be created first. Continue?",
-                    "Restore Backup").ConfigureAwait(false);
-                if (!confirmed)
+                try
                 {
-                    const string cancelledMessage = "Restore backup was cancelled before changes were made.";
-                    AddLog(cancelledMessage);
-                    await _dialogService.ShowInfoAsync(cancelledMessage, "Restore Backup").ConfigureAwait(false);
-                    return;
-                }
+                    var initialDirectory = _rentalConfigService == null
+                        ? null
+                        : await _rentalConfigService.GetBackupDirectoryAsync(cancellationToken).ConfigureAwait(false);
+                    path = _fileDialogService.OpenFile("Inventory Backup Package|*.inventory-backup.zip;*.zip|All Files|*.*", initialDirectory);
+                    if (string.IsNullOrWhiteSpace(path))
+                    {
+                        await CancelFileSelectionAsync("Backup package selection was cancelled.", "Restore Backup");
+                        return;
+                    }
 
-                var safetyBackupDirectory = initialDirectory ?? Path.GetDirectoryName(path) ?? AppContext.BaseDirectory;
-                var safetyBackupPath = await _databaseService.RestoreApplicationBackupAsync(path, safetyBackupDirectory, cancellationToken).ConfigureAwait(false);
-                var successMessage = $"Successfully restored backup package from {path}. Safety backup created at {safetyBackupPath}. Restart the app before continuing work.";
-                AddLog(successMessage);
-                await _dialogService.ShowInfoAsync(successMessage, "Restore Backup").ConfigureAwait(false);
+                    var confirmed = await _dialogService.ShowConfirmationAsync(
+                        "Restoring a backup will replace the current database and app assets. A safety backup of the current data will be created first. Continue?",
+                        "Restore Backup").ConfigureAwait(false);
+                    if (!confirmed)
+                    {
+                        const string cancelledMessage = "Restore backup was cancelled before changes were made.";
+                        AddLog(cancelledMessage);
+                        await _dialogService.ShowInfoAsync(cancelledMessage, "Restore Backup").ConfigureAwait(false);
+                        return;
+                    }
+
+                    var safetyBackupDirectory = initialDirectory ?? Path.GetDirectoryName(path) ?? AppContext.BaseDirectory;
+                    var safetyBackupPath = await _databaseService.RestoreApplicationBackupAsync(path, safetyBackupDirectory, cancellationToken).ConfigureAwait(false);
+                    var successMessage = $"Successfully restored backup package from {path}. Safety backup created at {safetyBackupPath}. Restart the app before continuing work.";
+                    AddLog(successMessage);
+                    await _dialogService.ShowInfoAsync(successMessage, "Restore Backup").ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    const string message = "Restore backup was cancelled.";
+                    AddLog(message);
+                    await _dialogService.ShowInfoAsync(message, "Restore Backup").ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to restore backup package from {Path}", path);
+                    var failureMessage = string.IsNullOrWhiteSpace(path)
+                        ? $"Failed to start backup restore: {ex.Message}"
+                        : $"Failed to restore backup package from {path}: {ex.Message}";
+                    AddLog(failureMessage);
+                    await _dialogService.ShowInfoAsync(failureMessage, "Restore Backup").ConfigureAwait(false);
+                }
             }
-            catch (OperationCanceledException)
+            finally
             {
-                const string message = "Restore backup was cancelled.";
-                AddLog(message);
-                await _dialogService.ShowInfoAsync(message, "Restore Backup").ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to restore backup package from {Path}", path);
-                var failureMessage = string.IsNullOrWhiteSpace(path)
-                    ? $"Failed to start backup restore: {ex.Message}"
-                    : $"Failed to restore backup package from {path}: {ex.Message}";
-                AddLog(failureMessage);
-                await _dialogService.ShowInfoAsync(failureMessage, "Restore Backup").ConfigureAwait(false);
+                EndDataOperation();
             }
         }
+
+        private static string ValueOrDefault(string? value, string fallback) =>
+            string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
     }
 }

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -14,6 +14,8 @@ namespace InventoryManagementApp.Views.Pages
 {
     public partial class ImportExportPage : Page
     {
+        private const int MaxPrintedLogRows = 250;
+
         public ImportExportPage()
         {
             InitializeComponent();
@@ -33,6 +35,12 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Import / Export", () =>
             {
+                if (IsDataOperationBusy())
+                {
+                    WpfMessageBox.Show("Wait for the current import, export, backup, or restore operation to finish before opening log details.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
                 var log = GetSelectedLogForAction();
                 if (string.IsNullOrWhiteSpace(log))
                 {
@@ -55,6 +63,12 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Import / Export", () =>
             {
+                if (IsDataOperationBusy())
+                {
+                    WpfMessageBox.Show("Wait for the current import, export, backup, or restore operation to finish before copying log details.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
                 var log = GetSelectedLogForAction();
                 if (string.IsNullOrWhiteSpace(log))
                 {
@@ -76,10 +90,19 @@ namespace InventoryManagementApp.Views.Pages
                 : string.Empty;
         }
 
+        private bool IsDataOperationBusy() =>
+            DataContext is ImportExportViewModel vm && vm.IsDataOperationBusy;
+
         private void PrintLogs_Click(object sender, RoutedEventArgs e)
         {
             UiActionGuard.Run(this, "Import / Export", () =>
             {
+                if (IsDataOperationBusy())
+                {
+                    WpfMessageBox.Show("Wait for the current import, export, backup, or restore operation to finish before generating a print preview.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
                 var selectedLog = GetSelectedLogForAction();
                 if (!string.IsNullOrWhiteSpace(selectedLog))
                 {
@@ -108,6 +131,8 @@ namespace InventoryManagementApp.Views.Pages
             string title = "Import / Export Operation Log")
         {
             var safeLogs = logs?.Where(log => !string.IsNullOrWhiteSpace(log)).ToList() ?? new List<string>();
+            var printedLogs = safeLogs.Take(MaxPrintedLogRows).ToList();
+            var omittedLogCount = Math.Max(0, safeLogs.Count - printedLogs.Count);
             var document = new FlowDocument
             {
                 FontFamily = new FontFamily("Segoe UI"),
@@ -129,9 +154,9 @@ namespace InventoryManagementApp.Views.Pages
                 Margin = new Thickness(0, 0, 0, 2)
             });
 
-            document.Blocks.Add(BuildSummarySection(title, summary, safeLogs.Count));
+            document.Blocks.Add(BuildSummarySection(title, summary, safeLogs.Count, printedLogs.Count, omittedLogCount));
 
-            if (safeLogs.Count == 0)
+            if (printedLogs.Count == 0)
             {
                 document.Blocks.Add(new Paragraph(new Run("No import/export operation results were available when this packet was prepared."))
                 {
@@ -158,7 +183,7 @@ namespace InventoryManagementApp.Views.Pages
             AddCell(header, "Operation Result", true);
 
             var number = 1;
-            foreach (var log in safeLogs)
+            foreach (var log in printedLogs)
             {
                 var row = new TableRow();
                 rowGroup.Rows.Add(row);
@@ -168,7 +193,17 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             document.Blocks.Add(table);
-            document.Blocks.Add(new Paragraph(new Run("Review skipped rows, failures, backup paths, and restore notices before clearing the in-app run log."))
+            if (omittedLogCount > 0)
+            {
+                document.Blocks.Add(new Paragraph(new Run($"{omittedLogCount} additional log rows were omitted from this preview. Narrow the session handoff or print a selected row when the full run log is very large."))
+                {
+                    FontSize = 10,
+                    FontStyle = FontStyles.Italic,
+                    Margin = new Thickness(0, 10, 0, 0)
+                });
+            }
+
+            document.Blocks.Add(new Paragraph(new Run("Review skipped rows, failures, backup paths, restore notices, and omitted-row counts before clearing the in-app run log."))
             {
                 FontSize = 10,
                 FontStyle = FontStyles.Italic,
@@ -177,7 +212,7 @@ namespace InventoryManagementApp.Views.Pages
             return document;
         }
 
-        private static Section BuildSummarySection(string title, string summary, int logCount)
+        private static Section BuildSummarySection(string title, string summary, int logCount, int printedLogCount, int omittedLogCount)
         {
             var section = new Section
             {
@@ -199,7 +234,9 @@ namespace InventoryManagementApp.Views.Pages
             var group = new TableRowGroup();
             table.RowGroups.Add(group);
             AddKeyValueRow(group, "Packet", title);
-            AddKeyValueRow(group, "Result Count", logCount.ToString());
+            AddKeyValueRow(group, "Visible Log Rows", logCount.ToString());
+            AddKeyValueRow(group, "Printed Log Rows", printedLogCount.ToString());
+            AddKeyValueRow(group, "Omitted Log Rows", omittedLogCount.ToString());
             AddKeyValueRow(group, "Session Summary", ValueOrNotRecorded(summary));
 
             section.Blocks.Add(table);


### PR DESCRIPTION
## What changed

- Added a shared Import / Export data-operation busy state so item import, item export, customer import, customer export, full backup, and restore backup cannot start on top of one another.
- Added ViewModel-backed ready/busy/status, selected-log review, and print availability properties for the data desk workflow.
- Routed all long-running Import / Export commands through the shared busy guard and refreshed related command availability when work starts or finishes.
- Kept clear-log actions from running while data work is active.
- Guarded double-click, context-menu, copy, and print log actions in code-behind while data work is active so those paths cannot bypass command state.
- Capped Import / Export run-log print preview generation to the first 250 printable rows.
- Added visible, printed, and omitted log-row accounting to the run-log print packet.
- Added operator guidance when oversized run logs are trimmed from print preview.
- Preserved the existing virtualized run-log grid, selected-row detail workflow, context menu, copy action, print preview route, and empty-state display.
- Extended source-contract coverage for shared operation gating, log action availability, busy-path code-behind guards, bounded print output, and preserved commands.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-import-export-operation-responsiveness.md`.

## Why this was highest value

The repo’s active focus is loading speed, UI responsiveness, and professional data display. Recent scheduled runs covered many workbench pages, while current Import / Export evidence still showed a workflow gap: only item import exposed running/cancel state, and other import/export/backup/log actions could still be triggered while long-running data work was active. Large run logs also printed every row without bounded preview accounting.

## Why this is real progress

This is a focused Import / Export workflow slice across ViewModel command state, code-behind action guards, bounded print-preview generation, source-contract tests, and progress notes. It improves a real data-movement workflow without adding unrelated modules or repeating the latest Activity Logs/Categories/Kits/Reservations work.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by four focused commits, and limited to:
  - `InventoryManagementApp/ViewModels/ImportExportViewModel.cs`
  - `InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs`
  - `InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-import-export-operation-responsiveness.md`
- Connector readback confirmed the shared busy state, command can-execute gating, clear-log guard, code-behind busy guards, 250-row print cap, print accounting, and source-contract assertions.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `387608d5100ed7742372839124ce140bbfc1b0e5`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout/raw GitHub access is blocked by HTTP 403, and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Import / Export with long item import, export, customer import/export, full backup, restore cancellation, rapid command clicks, log copy/open while busy, and 250+ log rows before printing.