### PR TITLE
Guard Manage Rentals actions while loading

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
@@ -131,6 +131,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ManageRentalsPage_LoadingStateBlocksCodeBehindActionBypasses()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
+
+            Assert.Contains("!vm.IsLoading && vm.OpenRentalDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("!vm.IsLoading && vm.OpenRequestDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsLoading)\n                return;", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
+            Assert.Contains("if (DataContext is ManageRentalsViewModel { IsLoading: true })", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n                return;", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
+            Assert.DoesNotContain("DataContext is ManageRentalsViewModel vm && vm.OpenRentalDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("DataContext is ManageRentalsViewModel vm && vm.OpenRequestDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ManageRentalsPage_PreservesRentalAndRequestCommandsAndRowHandlers()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml");

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-manage-rentals-loading-action-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-manage-rentals-loading-action-guards.md
@@ -1,0 +1,24 @@
+# Manage Rentals Loading Action Guards - 2026-07-04
+
+## Completed
+
+- Guarded rental-row double-click details so it cannot open while the rental desk is loading.
+- Guarded request-row double-click details so it cannot open while open request data is loading.
+- Added a shared loading early-return in the keyboard action path after Ctrl+F focus handling.
+- Prevented Ctrl+P search-results printing while the rental desk is loading.
+- Prevented Ctrl+Shift+P checked-out printing while the rental desk is loading.
+- Prevented Ctrl+Shift+R request-queue printing while the rental desk is loading.
+- Prevented Ctrl+D and Enter detail routing from launching during loading.
+- Prevented Ctrl+H history, Ctrl+I check-in, Ctrl+E extend, Ctrl+R request, and Delete actions from launching during loading.
+- Blocked right-click row selection while the rental desk is loading so context-menu actions do not retarget rows mid-refresh.
+- Kept Ctrl+F search focus available during loading so operators can prepare the next search without starting data actions.
+- Extended Manage Rentals source-contract coverage for the loading-state code-behind guards while preserving existing virtualization, layout, and shortcut contracts.
+
+## Why it matters
+
+Manage Rentals is a high-traffic workflow for returns, extensions, request handoffs, history, and rental documents. The current page already had first-paint loading protection, but code-behind paths could still bypass loading state through double-click, right-click selection, keyboard shortcuts, and print shortcuts. These guards reduce accidental work during refresh and keep the UI responsive and predictable while rental rows are loading.
+
+## Validation
+
+- GitHub connector readback and compare should be used for this scheduled run.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET test execution, WPF runtime checks, screenshots, and print-preview rendering remain unavailable in this Linux scheduled environment.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -71,7 +71,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void RentalRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is ManageRentalsViewModel vm && vm.OpenRentalDetailsCommand.CanExecute(null))
+            if (DataContext is ManageRentalsViewModel vm && !vm.IsLoading && vm.OpenRentalDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Rentals", () => vm.OpenRentalDetailsCommand.Execute(null));
             }
@@ -84,7 +84,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void RequestRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is ManageRentalsViewModel vm && vm.OpenRequestDetailsCommand.CanExecute(null))
+            if (DataContext is ManageRentalsViewModel vm && !vm.IsLoading && vm.OpenRequestDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Rentals", () => vm.OpenRequestDetailsCommand.Execute(null));
             }
@@ -107,6 +107,9 @@ namespace InventoryManagementApp.Views.Pages
                 e.Handled = true;
                 return;
             }
+
+            if (vm.IsLoading)
+                return;
 
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && vm.PrintSearchResultsCommand.CanExecute(null))
             {
@@ -180,6 +183,9 @@ namespace InventoryManagementApp.Views.Pages
 
         private void OpenFocusedDetails(ManageRentalsViewModel vm)
         {
+            if (vm.IsLoading)
+                return;
+
             UiActionGuard.Run(this, "Rentals", () =>
             {
                 if (Keyboard.FocusedElement is DependencyObject focusedElement && GridContextMenuSelection.FindAncestor<System.Windows.Controls.DataGrid>(focusedElement) is System.Windows.Controls.DataGrid grid)
@@ -200,6 +206,12 @@ namespace InventoryManagementApp.Views.Pages
 
         private void SelectRowForContextMenu(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is ManageRentalsViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
             var row = GridContextMenuSelection.SelectRow(sender, e);
             if (row == null)
                 return;


### PR DESCRIPTION
## What changed

- Guarded rental-row double-click details so it cannot open while the rental desk is loading.
- Guarded request-row double-click details so it cannot open while open request data is loading.
- Added a loading early-return in the keyboard action path after Ctrl+F focus handling.
- Kept Ctrl+F search focus available during loading so operators can prepare the next search without launching data work.
- Prevented Ctrl+P search-results printing while rental rows are loading.
- Prevented Ctrl+Shift+P checked-out printing while rental rows are loading.
- Prevented Ctrl+Shift+R request-queue printing while request data is loading.
- Prevented Ctrl+D and Enter detail routing from launching during loading.
- Prevented Ctrl+H history, Ctrl+I check-in, Ctrl+E extend, Ctrl+R request, and Delete actions from launching during loading.
- Blocked right-click row selection while loading so context-menu actions do not retarget rows mid-refresh.
- Extended Manage Rentals source-contract coverage for the loading-state code-behind guards while preserving existing virtualization, layout, and shortcut contracts.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-manage-rentals-loading-action-guards.md`.

## Why this was highest value

The repo’s current focus is loading speed, UI responsiveness, and professional workflow behavior. Recent work gave Manage Rentals a first-paint startup guard, but current source evidence still showed code-behind action paths that could bypass loading state through double-click, right-click row selection, keyboard shortcuts, and print shortcuts. Manage Rentals is a high-traffic desk for returns, extensions, requests, history, and documents, so preventing actions during refresh reduces accidental work and keeps the screen predictable under load.

## Why this is real progress

This is a focused workflow-level reliability and responsiveness slice across page action routing, context-menu selection behavior, keyboard shortcuts, tests, and progress notes. It protects more than ten user action paths without changing unrelated workflows or inventing new modules.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by three focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs`
  - `InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-manage-rentals-loading-action-guards.md`
- Connector readback confirmed the loading checks on double-click handlers, keyboard action routing, focused detail routing, right-click row selection, and the source-contract assertions.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `c20916da3496237b7ac1d5125b2649ea039cfc7f`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and the WPF runtime are unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Manage Rentals with initial load, rapid repeated navigation, right-click while loading, double-click while loading, keyboard shortcuts during loading, and print shortcuts after loading completes.