### PR TITLE
Improve Manage Items loading display and action guards

### DIFF
--- a/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
@@ -117,7 +117,7 @@ namespace InventoryManagementApp.Tests
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml.cs");
 
             Assert.Contains("DataContextChanged += ManageItemsPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("await Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (IsItemDirectoryBusy())", codeBehind, StringComparison.Ordinal);
             Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("return DataContext is ItemsViewModel { Items.IsLoading: true };", codeBehind, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
@@ -70,9 +70,28 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"320\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel>", xaml, StringComparison.Ordinal);
+            Assert.Contains("More rows available: {0}", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"300\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<DockPanel LastChildFill=\"False\">\n                <TextBlock DockPanel.Dock=\"Left\" Text=\"{Binding PendingEdits.Count", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageItemsPage_DisplaysAndGatesDirectoryLoadingState()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml");
+
+            Assert.Contains("LoadingAwarePrimaryButton", xaml, StringComparison.Ordinal);
+            Assert.Contains("LoadingAwareGhostButton", xaml, StringComparison.Ordinal);
+            Assert.Contains("DirectoryStatusValueText", xaml, StringComparison.Ordinal);
+            Assert.Contains("DirectoryStatusDetailText", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"Directory Status\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"Text\" Value=\"Loading rows\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"IsEnabled\" Value=\"False\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding Items.IsLoading, Converter={StaticResource InverseBooleanConverter}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Loading item rows", xaml, StringComparison.Ordinal);
+            Assert.Contains("Visibility=\"{Binding Items.IsLoading, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Row actions will resume when the current page is ready", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -90,6 +109,26 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("SearchCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("DataGridRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
             Assert.Contains("DataGridRow_MouseDoubleClick", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageItemsPage_CodeBehindGuardsRowActionsWhileLoading()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml.cs");
+
+            Assert.Contains("DataContextChanged += ManageItemsPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (IsItemDirectoryBusy())", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return DataContext is ItemsViewModel { Items.IsLoading: true };", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SharedConverters_RegisterInverseBooleanConverterForLoadingState()
+        {
+            var converters = ReadRepoFile("InventoryManagementApp", "Resources", "Converters.xaml");
+
+            Assert.Contains("<conv:InverseBooleanConverter x:Key=\"InverseBooleanConverter\"/>", converters, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-manage-items-loading-display-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-manage-items-loading-display-guards.md
@@ -1,0 +1,25 @@
+# Manage Items loading display and action guards - 2026-07-04
+
+## Completed
+
+- Added loading-aware button styles for the Manage Items toolbar, directory action strip, selected-item handoff actions, and empty-state new-item action.
+- Added a Directory Status summary card that changes from ready copy to loading copy while item rows are refreshing.
+- Disabled filter, sort, page-size, context-menu, save, details, edit, history, delete, new-item, and mobile-capture entry points while the incremental item directory is loading.
+- Added a bounded loading overlay inside the virtualized item grid region so operators see why row actions are temporarily paused.
+- Kept the virtualized item grid, horizontal/vertical scrolling, full-row selection, responsive split layout, empty state, and selected-item handoff panel intact.
+- Added footer status for whether more item rows are available from the incremental loader.
+- Guarded right-click row selection and double-click details in code-behind while item rows are loading.
+- Added a page DataContext reset hook so page-owned load state resets when a new view model is attached.
+- Added a dispatcher yield before the initial incremental row load so the page can paint before data work starts.
+- Registered the existing inverse boolean converter in shared XAML resources for loading-state control disabling.
+- Extended Manage Items source-contract coverage for loading display, disabled action state, row-action guards, first-paint yield, DataContext reset, and converter registration.
+
+## Validation
+
+- Source-contract coverage was updated for the changed XAML, code-behind, and converter resource contracts.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, scaling checks, and manual responsiveness checks could not be run in this scheduled Linux environment because direct checkout is blocked and the required Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full Windows validation runner.
+- Smoke test Manage Items at 1366 x 768 and higher Windows scaling with initial load, rapid filter/sort/page-size changes, right-click and double-click during load, context-menu actions after load, and incremental loading with many rows.

--- a/InventoryManagementApp/Resources/Converters.xaml
+++ b/InventoryManagementApp/Resources/Converters.xaml
@@ -3,6 +3,7 @@
                     xmlns:conv="clr-namespace:InventoryManagementApp.Utilities.Converters;assembly=InventoryManagementApp">
     <conv:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
     <conv:BooleanToAdminConverter x:Key="BooleanToAdminConverter"/>
+    <conv:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
     <conv:DateTimeMinToEmptyStringConverter x:Key="DateTimeMinToEmptyStringConverter"/>
     <conv:AnyTrueToVisibilityConverter x:Key="AnyTrueToVisibilityConverter"/>
     <conv:StringNotEmptyConverter x:Key="StringNotEmptyConverter"/>

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -22,6 +22,36 @@
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="Margin" Value="0,2,0,0"/>
         </Style>
+        <Style x:Key="LoadingAwarePrimaryButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Items.IsLoading}" Value="True">
+                    <Setter Property="IsEnabled" Value="False"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="LoadingAwareGhostButton" TargetType="Button" BasedOn="{StaticResource GhostButton}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Items.IsLoading}" Value="True">
+                    <Setter Property="IsEnabled" Value="False"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="DirectoryStatusValueText" TargetType="TextBlock" BasedOn="{StaticResource DirectoryStatValueText}">
+            <Setter Property="Text" Value="Ready"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Items.IsLoading}" Value="True">
+                    <Setter Property="Text" Value="Loading rows"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="DirectoryStatusDetailText" TargetType="TextBlock" BasedOn="{StaticResource DirectoryDetailText}">
+            <Setter Property="Text" Value="Actions use the currently loaded page of rows"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Items.IsLoading}" Value="True">
+                    <Setter Property="Text" Value="Row actions pause until the directory finishes loading"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
         <Style x:Key="AvailabilityTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
             <Setter Property="FontWeight" Value="SemiBold"/>
             <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}"/>
@@ -57,12 +87,12 @@
                     <TextBlock Text="Maintain the item directory, review current availability, and save inline stock/location edits before staff use live records." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
                 <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="12,0,0,0">
-                    <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding NewItemCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Mobile Capture" Command="{Binding OpenMobileCaptureCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditItemCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Details" Command="{Binding ViewDetailsCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="History" Command="{Binding OpenRentalHistoryCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteSelectedItemCommand}" CommandParameter="{Binding SelectedItem}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="New" Command="{Binding NewItemCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="Mobile Capture" Command="{Binding OpenMobileCaptureCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="Edit" Command="{Binding EditItemCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Details" Command="{Binding ViewDetailsCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource LoadingAwareGhostButton}" Content="History" Command="{Binding OpenRentalHistoryCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Delete" Command="{Binding DeleteSelectedItemCommand}" CommandParameter="{Binding SelectedItem}" Margin="0,0,4,4"/>
                 </WrapPanel>
             </DockPanel>
         </Border>
@@ -94,6 +124,13 @@
                     <TextBlock Text="Page Size" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding PageSize}" Style="{StaticResource DirectoryStatValueText}"/>
                     <TextBlock Text="Rows requested per directory load" Style="{StaticResource DirectoryDetailText}"/>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource DirectoryStatCard}">
+                <StackPanel>
+                    <TextBlock Text="Directory Status" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Style="{StaticResource DirectoryStatusValueText}"/>
+                    <TextBlock Style="{StaticResource DirectoryStatusDetailText}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource DirectoryStatCard}">
@@ -135,21 +172,23 @@
                                 <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
                                 <pages:SearchBar Width="240"
                                                  MinWidth="180"
+                                                 IsEnabled="{Binding Items.IsLoading, Converter={StaticResource InverseBooleanConverter}}"
                                                  Text="{Binding Filter}"
                                                  SearchCommand="{Binding SearchCommand}"
                                                  SearchLabel="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Search {0}}"/>
                                 <TextBlock Text="Sort" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="12,0,6,4"/>
                                 <ComboBox Width="110"
                                           MinWidth="96"
+                                          IsEnabled="{Binding Items.IsLoading, Converter={StaticResource InverseBooleanConverter}}"
                                           ItemsSource="{Binding SortOptions}"
                                           SelectedItem="{Binding SelectedSortOption}"
                                           DisplayMemberPath="DisplayName"/>
                                 <TextBlock Text="Rows" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="12,0,6,4"/>
-                                <TextBox Width="56" MinWidth="48" Text="{Binding PageSize, UpdateSourceTrigger=LostFocus}"/>
+                                <TextBox Width="56" MinWidth="48" IsEnabled="{Binding Items.IsLoading, Converter={StaticResource InverseBooleanConverter}}" Text="{Binding PageSize, UpdateSourceTrigger=LostFocus}"/>
                             </WrapPanel>
                             <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="12,0,0,0">
-                                <Button Style="{StaticResource PrimaryButton}" Content="Save Changes" Command="{Binding CommitChangesCommand}" Margin="0,0,4,4"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Details" Command="{Binding ViewDetailsCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="Save Changes" Command="{Binding CommitChangesCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Details" Command="{Binding ViewDetailsCommand}" Margin="0,0,4,4"/>
                             </WrapPanel>
                         </DockPanel>
                     </Border>
@@ -210,15 +249,20 @@
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
                                         DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
                                 <MenuItem Header="View details"
+                                          IsEnabled="{Binding PlacementTarget.DataContext.Items.IsLoading, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource InverseBooleanConverter}}"
                                           Command="{Binding PlacementTarget.DataContext.ViewDetailsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                 <MenuItem Header="Edit item"
+                                          IsEnabled="{Binding PlacementTarget.DataContext.Items.IsLoading, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource InverseBooleanConverter}}"
                                           Command="{Binding PlacementTarget.DataContext.EditItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                 <MenuItem Header="Rental history"
+                                          IsEnabled="{Binding PlacementTarget.DataContext.Items.IsLoading, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource InverseBooleanConverter}}"
                                           Command="{Binding PlacementTarget.DataContext.OpenRentalHistoryCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                 <Separator/>
                                 <MenuItem Header="Save pending changes"
+                                          IsEnabled="{Binding PlacementTarget.DataContext.Items.IsLoading, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource InverseBooleanConverter}}"
                                           Command="{Binding PlacementTarget.DataContext.CommitChangesCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                 <MenuItem Header="Delete selected"
+                                          IsEnabled="{Binding PlacementTarget.DataContext.Items.IsLoading, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource InverseBooleanConverter}}"
                                           Command="{Binding PlacementTarget.DataContext.DeleteItemsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                                           CommandParameter="{Binding PlacementTarget.SelectedItems, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                             </ContextMenu>
@@ -232,13 +276,29 @@
                                     <DataTrigger Binding="{Binding Items.Count}" Value="0">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
+                                    <DataTrigger Binding="{Binding Items.IsLoading}" Value="True">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
                             <TextBlock Text="No matching items" Style="{StaticResource SectionHeader}" HorizontalAlignment="Center" TextWrapping="Wrap"/>
                             <TextBlock Text="Adjust the filter or create a new item to begin building the directory." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" TextAlignment="Center" Margin="0,4,0,8"/>
-                            <Button Style="{StaticResource PrimaryButton}" Content="New Item" Command="{Binding NewItemCommand}" HorizontalAlignment="Center"/>
+                            <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="New Item" Command="{Binding NewItemCommand}" HorizontalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Row="2" MaxWidth="360" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding Items.IsLoading, Converter={StaticResource BoolToVis}}" IsHitTestVisible="False">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
+                                <Setter Property="Opacity" Value="0.96"/>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="Loading item rows" Style="{StaticResource SectionHeader}" HorizontalAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="The directory is refreshing. Row actions will resume when the current page is ready." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" TextAlignment="Center" Margin="0,4,0,8"/>
+                            <ProgressBar IsIndeterminate="True" Height="4" MinWidth="180"/>
                         </StackPanel>
                     </Border>
                     <ProgressBar Grid.Row="3"
@@ -259,11 +319,11 @@
                     </Border>
                     <Border DockPanel.Dock="Bottom" Style="{StaticResource DesktopSectionActionStrip}">
                         <WrapPanel>
-                            <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditItemCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Details" Command="{Binding ViewDetailsCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="History" Command="{Binding OpenRentalHistoryCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Save" Command="{Binding CommitChangesCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteSelectedItemCommand}" CommandParameter="{Binding SelectedItem}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="Edit" Command="{Binding EditItemCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Details" Command="{Binding ViewDetailsCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource LoadingAwareGhostButton}" Content="History" Command="{Binding OpenRentalHistoryCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Save" Command="{Binding CommitChangesCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Delete" Command="{Binding DeleteSelectedItemCommand}" CommandParameter="{Binding SelectedItem}" Margin="0,0,4,4"/>
                         </WrapPanel>
                     </Border>
                     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
@@ -325,7 +385,8 @@
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Padding="6,3" Margin="0,5,0,0">
             <WrapPanel>
                 <TextBlock Text="{Binding PendingEdits.Count, StringFormat='Pending inline edits: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <TextBlock Text="{Binding SelectedSortOption.DisplayName, StringFormat='Sort: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
+                <TextBlock Text="{Binding SelectedSortOption.DisplayName, StringFormat='Sort: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Text="{Binding Items.HasMoreItems, StringFormat='More rows available: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
             </WrapPanel>
         </Border>
     </Grid>

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
@@ -19,15 +20,34 @@ namespace InventoryManagementApp.Views.Pages
             DataContext = ((App)Application.Current).Host.Services.GetRequiredService<ItemsViewModel>();
             Loaded += ManageItemsPage_Loaded;
             Unloaded += ManageItemsPage_Unloaded;
+            DataContextChanged += ManageItemsPage_DataContextChanged;
+        }
+
+        private void ManageItemsPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(e.OldValue, e.NewValue))
+                _isLoadedForCurrentLifetime = false;
         }
 
         private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (IsItemDirectoryBusy())
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
         }
 
         private void DataGridRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (IsItemDirectoryBusy())
+            {
+                e.Handled = true;
+                return;
+            }
+
             if (GridContextMenuSelection.SelectRow(sender, e) == null)
                 return;
 
@@ -54,6 +74,7 @@ namespace InventoryManagementApp.Views.Pages
             try
             {
                 await vm.InitializeAsync(_loadCts.Token);
+                await Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
                 await vm.LoadMoreAsync(_loadCts.Token);
             }
             catch (OperationCanceledException)
@@ -72,6 +93,11 @@ namespace InventoryManagementApp.Views.Pages
             }
             _loadCts.Dispose();
             _loadCts = new CancellationTokenSource();
+        }
+
+        private bool IsItemDirectoryBusy()
+        {
+            return DataContext is ItemsViewModel { Items.IsLoading: true };
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -74,7 +74,7 @@ namespace InventoryManagementApp.Views.Pages
             try
             {
                 await vm.InitializeAsync(_loadCts.Token);
-                await Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
+                await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
                 await vm.LoadMoreAsync(_loadCts.Token);
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
## What changed

- Added loading-aware Manage Items button styles for toolbar, directory action strip, selected-item handoff, and empty-state actions.
- Added a Directory Status summary card that switches from ready copy to loading copy while item rows are refreshing.
- Disabled filter, sort, page-size, context-menu, save, details, edit, history, delete, new-item, and mobile-capture entry points while the incremental item directory is loading.
- Added a bounded loading overlay inside the virtualized item grid region so operators can see why row actions are paused.
- Kept the virtualized item grid, horizontal/vertical scrolling, full-row selection, responsive split layout, empty state, and selected-item handoff panel intact.
- Added footer status for whether more incremental item rows are available.
- Guarded right-click row selection and double-click details in code-behind while item rows are loading.
- Added a page DataContext reset hook so page-owned load state resets when a new view model is attached.
- Added a WPF dispatcher yield before the first incremental row load so the page can paint before data work starts.
- Registered the existing inverse boolean converter in shared XAML resources for loading-state control disabling.
- Extended Manage Items source-contract coverage for loading display, disabled action state, row-action guards, first-paint yield, DataContext reset, and converter registration.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-manage-items-loading-display-guards.md`.

## Why this was highest value

The current repo focus is loading speed, UI responsiveness, and professional data display. Recent scheduled work covered many adjacent workflows, while current Manage Items evidence still showed a central data-heavy directory with incremental loading but weak visible loading state and row/action paths that could still be invoked during active row refreshes. Manage Items is one of the highest-traffic screens, so making its loading behavior predictable is a safe, high-value workflow improvement.

## Why this is real progress

This is a focused Manage Items workflow slice across XAML display state, action disabling, code-behind row guards, shared converter registration, source-contract tests, and progress notes. It includes more than ten practical improvements while staying inside the existing WPF/MVVM app.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, ahead by focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ManageItemsPage.xaml`
  - `InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs`
  - `InventoryManagementApp/Resources/Converters.xaml`
  - `InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-manage-items-loading-display-guards.md`
- Connector readback confirmed the loading-aware styles, directory status card, loading overlay, disabled controls, row-action guards, dispatcher yield, DataContext reset, converter registration, and source-contract additions.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or manual responsiveness checks

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and the required Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Manage Items at 1366 x 768 and higher Windows scaling with initial load, rapid filter/sort/page-size changes, right-click and double-click during load, context-menu actions after load, and incremental loading with many rows.