### PR TITLE
Guard Dashboard startup and row actions while loading

### DIFF
--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -98,6 +98,52 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void DashboardPage_GatesStartupLoadsForSameViewModelAndResetsOnContextChange()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("private DashboardViewModel? _loadedDashboardViewModel;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private bool _hasLoadedDashboardForViewModel;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContextChanged += DashboardPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ReferenceEquals(_loadedDashboardViewModel, vm) && _hasLoadedDashboardForViewModel", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadedDashboardViewModel = vm;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_hasLoadedDashboardForViewModel = true;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void DashboardPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadedDashboardViewModel = e.NewValue as DashboardViewModel;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_hasLoadedDashboardForViewModel = false;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DashboardLoadRetryButton_Click", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_BlocksKeyboardPrintAndNavigationActionsWhileLoading()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("if (!_isLoadingDashboard && vm.PrintDashboardSnapshotCommand.CanExecute(null))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!_isLoadingDashboard && vm.PrintCheckedOutItemsCommand.CanExecute(null))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (_isLoadingDashboard)\n                return;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (vm.OpenItemsCommand.CanExecute(null))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (vm.OpenRentalsCommand.CanExecute(null))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("UiActionGuard.Run(this, \"Dashboard\", () => OpenFocusedRow(vm));", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_BlocksRowActionsAndSelectionRetargetingWhileLoading()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Equal(5, CountOccurrences(codeBehind, "if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm."));
+            Assert.Contains("!vm.OpenSelectedCommonItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("!vm.OpenSelectedCheckedOutItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("!vm.OpenSelectedRentalCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("!vm.OpenActivityDestinationCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("!vm.OpenSelectedIncompleteItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void DashboardGrid_PreviewMouseRightButtonDown", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (_isLoadingDashboard)\n                return;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void DashboardPage_PreservesPrimaryDashboardActionsAndRowHandoff()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-dashboard-loading-action-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-dashboard-loading-action-guards.md
@@ -1,0 +1,28 @@
+# Dashboard loading action guards - 2026-07-04
+
+## Completed
+
+- Added a page-owned Dashboard startup load guard so repeated WPF `Loaded` events for the same view model do not rerun the full dashboard refresh.
+- Reset the startup load guard when a different `DashboardViewModel` is attached.
+- Kept manual retry available by clearing the startup guard before a user-triggered refresh.
+- Preserved the existing first-paint dispatcher yield before dashboard data work starts.
+- Guarded Ctrl+P dashboard snapshot printing while dashboard rows are loading.
+- Guarded Ctrl+Shift+P checked-out item printing while dashboard rows are loading.
+- Guarded Ctrl+I and Ctrl+R keyboard navigation through the commands' `CanExecute` state.
+- Guarded Enter row handoff while dashboard data is loading.
+- Guarded double-click row actions for common items, checked-out items, active rentals, recent activity, and incomplete items while loading.
+- Guarded row double-clicks through the selected commands' `CanExecute` state so stale selections do not bypass command availability.
+- Guarded right-click row retargeting while the dashboard refresh is active.
+- Guarded focused-row fallback routing through `CanExecute` before opening related workflows.
+- Extended Dashboard source-contract coverage for startup load gating, DataContext reset behavior, keyboard loading guards, row-action loading guards, and preserved dashboard actions.
+
+## Validation
+
+- Source-contract coverage was updated for the changed Dashboard page code-behind behavior.
+- GitHub connector readback was used to confirm the branch file changes and compare scope.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, scaling checks, and manual responsiveness checks could not be run in this scheduled Linux environment because direct checkout is blocked and the required Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full Windows validation runner.
+- Smoke test Dashboard initial open, repeated navigation back to the page, manual retry after a simulated load failure, keyboard shortcuts during load, row double-clicks during load, right-click context selection during load, and normal actions after loading completes.

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
@@ -15,23 +15,45 @@ namespace InventoryManagementApp.Views.Pages
     {
         private CancellationTokenSource? _loadCts;
         private bool _isLoadingDashboard;
+        private DashboardViewModel? _loadedDashboardViewModel;
+        private bool _hasLoadedDashboardForViewModel;
 
         public DashboardPage()
         {
             InitializeComponent();
             Loaded += DashboardPage_Loaded;
             Unloaded += DashboardPage_Unloaded;
+            DataContextChanged += DashboardPage_DataContextChanged;
             PreviewKeyDown += DashboardPage_PreviewKeyDown;
         }
 
         private async void DashboardPage_Loaded(object sender, RoutedEventArgs e)
         {
             Focus();
+
+            if (DataContext is not DashboardViewModel vm)
+                return;
+
+            if (ReferenceEquals(_loadedDashboardViewModel, vm) && _hasLoadedDashboardForViewModel)
+                return;
+
+            _loadedDashboardViewModel = vm;
+            _hasLoadedDashboardForViewModel = true;
             await LoadDashboardAsync("Loading dashboard data...");
+        }
+
+        private void DashboardPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(_loadedDashboardViewModel, e.NewValue))
+            {
+                _loadedDashboardViewModel = e.NewValue as DashboardViewModel;
+                _hasLoadedDashboardForViewModel = false;
+            }
         }
 
         private async void DashboardLoadRetryButton_Click(object sender, RoutedEventArgs e)
         {
+            _hasLoadedDashboardForViewModel = false;
             await LoadDashboardAsync("Refreshing dashboard data...");
         }
 
@@ -98,28 +120,35 @@ namespace InventoryManagementApp.Views.Pages
 
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)
             {
-                UiActionGuard.RunAsync(this, "Dashboard", async () => await vm.PrintDashboardSnapshotCommand.ExecuteAsync(null));
+                if (!_isLoadingDashboard && vm.PrintDashboardSnapshotCommand.CanExecute(null))
+                    UiActionGuard.RunAsync(this, "Dashboard", async () => await vm.PrintDashboardSnapshotCommand.ExecuteAsync(null));
                 e.Handled = true;
                 return;
             }
 
             if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P)
             {
-                UiActionGuard.RunAsync(this, "Dashboard", async () => await vm.PrintCheckedOutItemsCommand.ExecuteAsync(null));
+                if (!_isLoadingDashboard && vm.PrintCheckedOutItemsCommand.CanExecute(null))
+                    UiActionGuard.RunAsync(this, "Dashboard", async () => await vm.PrintCheckedOutItemsCommand.ExecuteAsync(null));
                 e.Handled = true;
                 return;
             }
 
+            if (_isLoadingDashboard)
+                return;
+
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.I)
             {
-                UiActionGuard.Run(this, "Dashboard", () => vm.OpenItemsCommand.Execute(null));
+                if (vm.OpenItemsCommand.CanExecute(null))
+                    UiActionGuard.Run(this, "Dashboard", () => vm.OpenItemsCommand.Execute(null));
                 e.Handled = true;
                 return;
             }
 
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R)
             {
-                UiActionGuard.Run(this, "Dashboard", () => vm.OpenRentalsCommand.Execute(null));
+                if (vm.OpenRentalsCommand.CanExecute(null))
+                    UiActionGuard.Run(this, "Dashboard", () => vm.OpenRentalsCommand.Execute(null));
                 e.Handled = true;
                 return;
             }
@@ -133,36 +162,49 @@ namespace InventoryManagementApp.Views.Pages
 
         private void CommonItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is DashboardViewModel vm)
-                UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedCommonItemCommand.Execute(null));
+            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenSelectedCommonItemCommand.CanExecute(null))
+                return;
+
+            UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedCommonItemCommand.Execute(null));
         }
 
         private void CheckedOutItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is DashboardViewModel vm)
-                UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedCheckedOutItemCommand.Execute(null));
+            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenSelectedCheckedOutItemCommand.CanExecute(null))
+                return;
+
+            UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedCheckedOutItemCommand.Execute(null));
         }
 
         private void RentedItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is DashboardViewModel vm)
-                UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedRentalCommand.Execute(null));
+            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenSelectedRentalCommand.CanExecute(null))
+                return;
+
+            UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedRentalCommand.Execute(null));
         }
 
         private void RecentActivityGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is DashboardViewModel vm)
-                UiActionGuard.Run(this, "Dashboard", () => vm.OpenActivityDestinationCommand.Execute(null));
+            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenActivityDestinationCommand.CanExecute(null))
+                return;
+
+            UiActionGuard.Run(this, "Dashboard", () => vm.OpenActivityDestinationCommand.Execute(null));
         }
 
         private void IncompleteItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is DashboardViewModel vm)
-                UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedIncompleteItemCommand.Execute(null));
+            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenSelectedIncompleteItemCommand.CanExecute(null))
+                return;
+
+            UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedIncompleteItemCommand.Execute(null));
         }
 
         private void DashboardGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (_isLoadingDashboard)
+                return;
+
             var row = GridContextMenuSelection.SelectRow(sender, e);
             if (row == null || DataContext is not DashboardViewModel vm)
                 return;
@@ -193,25 +235,26 @@ namespace InventoryManagementApp.Views.Pages
             {
                 switch (grid.Name)
                 {
-                    case nameof(CommonItemsGrid):
+                    case nameof(CommonItemsGrid) when vm.OpenSelectedCommonItemCommand.CanExecute(null):
                         vm.OpenSelectedCommonItemCommand.Execute(null);
                         return;
-                    case nameof(CheckedOutItemsGrid):
+                    case nameof(CheckedOutItemsGrid) when vm.OpenSelectedCheckedOutItemCommand.CanExecute(null):
                         vm.OpenSelectedCheckedOutItemCommand.Execute(null);
                         return;
-                    case nameof(RentedItemsGrid):
+                    case nameof(RentedItemsGrid) when vm.OpenSelectedRentalCommand.CanExecute(null):
                         vm.OpenSelectedRentalCommand.Execute(null);
                         return;
-                    case nameof(IncompleteItemsGrid):
+                    case nameof(IncompleteItemsGrid) when vm.OpenSelectedIncompleteItemCommand.CanExecute(null):
                         vm.OpenSelectedIncompleteItemCommand.Execute(null);
                         return;
-                    case nameof(RecentActivityGrid):
+                    case nameof(RecentActivityGrid) when vm.OpenActivityDestinationCommand.CanExecute(null):
                         vm.OpenActivityDestinationCommand.Execute(null);
                         return;
                 }
             }
 
-            vm.OpenItemsCommand.Execute(null);
+            if (vm.OpenItemsCommand.CanExecute(null))
+                vm.OpenItemsCommand.Execute(null);
         }
     }
 }


### PR DESCRIPTION
## What changed

- Added a page-owned Dashboard startup load guard so repeated WPF `Loaded` events for the same view model do not rerun the full dashboard refresh.
- Reset the startup load guard when a different `DashboardViewModel` is attached.
- Kept manual retry available by clearing the startup guard before user-triggered refresh.
- Preserved the existing first-paint dispatcher yield before dashboard data work starts.
- Guarded Ctrl+P dashboard snapshot printing while dashboard rows are loading.
- Guarded Ctrl+Shift+P checked-out item printing while dashboard rows are loading.
- Guarded Ctrl+I and Ctrl+R keyboard navigation through command `CanExecute` checks.
- Guarded Enter row handoff while dashboard data is loading.
- Guarded double-click row actions for common items, checked-out items, active rentals, recent activity, and incomplete items while loading.
- Guarded double-click row actions through selected-command `CanExecute` checks.
- Guarded right-click row retargeting while the dashboard refresh is active.
- Guarded focused-row fallback routing through `CanExecute` before opening related workflows.
- Extended Dashboard source-contract coverage for startup load gating, DataContext reset behavior, keyboard loading guards, row-action loading guards, and preserved dashboard actions.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-dashboard-loading-action-guards.md`.

## Why this was highest value

The current repo focus is loading speed, UI responsiveness, and professional data display. Recent scheduled work covered Manage Items, Manage Rentals, Import / Export, Activity Logs, Kits, Reservations, Categories, Maintenance, Calibration, Reports, and Users. Dashboard still had current source evidence of a first-paint load path but no same-view-model startup guard and several keyboard, double-click, Enter, and right-click paths that could act while a refresh was active. Dashboard is a first-stop operational screen, so preventing repeated loads and stale row actions is a safe workflow-level responsiveness improvement.

## Why this is real progress

This is a focused Dashboard workflow slice across startup load behavior, retry behavior, keyboard shortcuts, row double-clicks, right-click row selection, focused-row routing, source-contract coverage, and progress notes. It improves more than ten user-facing action paths without introducing unrelated modules or touching recently completed workstreams.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by three focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs`
  - `InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-dashboard-loading-action-guards.md`
- Connector readback confirmed the startup load guard, DataContext reset, retry reset, keyboard loading guards, command `CanExecute` checks, row double-click loading guards, right-click loading guard, focused-row command checks, and source-contract assertions.
- Connector workflow readback found no attached workflow runs on branch head `c674f47ece7d635d74bbfd2f839efbed2bfbdffc`.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or print-preview rendering

Those remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and the required Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Dashboard initial open, repeated navigation back to Dashboard, manual retry after simulated load failure, Ctrl+P/Ctrl+Shift+P during load, Ctrl+I/Ctrl+R during load, Enter/double-click/right-click during load, and normal row actions after loading completes.