### PR TITLE
Improve Reports print and action responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
@@ -103,6 +103,25 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Wait for the report to finish generating before opening print preview.", codeBehind, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ReportsPage_BoundsPrintPreviewRowsAndReportsOmittedRows()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
+
+            Assert.Contains("private const int MaxReportPrintRows = 250;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var totalLineCount = vm.ReportLines.Count;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var printRows = vm.ReportLines.Take(MaxReportPrintRows).ToList();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, printRows, totalLineCount)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Large reports print the first 250 rows so preview stays responsive.", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("BuildSummarySection(safeTitle, summary, lastRunText, totalLineCount, printedLineCount, omittedLineCount)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Total Action Rows\", totalLineCount.ToString())", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Printed Action Rows\", printedLineCount.ToString())", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Omitted Action Rows\"", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("AddKeyValueRow(group, \"Large Report Limit\"", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Review each destination, source-page route, next action, and omitted-row count", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, vm.ReportLines.ToList())", codeBehind, StringComparison.Ordinal);
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;

--- a/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
@@ -59,6 +59,9 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("MinHeight=\"130\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MaxHeight=\"260\"", xaml, StringComparison.Ordinal);
             Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<MultiDataTrigger>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Condition Binding=\"{Binding IsBusy}\" Value=\"False\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Generating report\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"360\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("MinHeight=\"150\"", xaml, StringComparison.Ordinal);
         }
@@ -76,6 +79,28 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("ReportGrid_MouseDoubleClick", xaml, StringComparison.Ordinal);
             Assert.Contains("ReportGrid_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedLineHandoff", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReportsPage_DisablesRowAndPrintActionsWhileReportsGenerate()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReportsViewModel.cs");
+
+            Assert.Contains("public bool CanUseReportRows => !IsBusy && ReportLines.Count > 0;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanPrintCurrentReport => !IsBusy && LastRunAt.HasValue", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CanPrintCurrentReport));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CanUseReportRows));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding CanUseReportRows}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding CanPrintCurrentReport}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("DataContext=\"{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ReportsViewModel { CanUseReportRows: true }", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ReportsViewModel { IsBusy: true }", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Wait for the report to finish generating before opening a source page.", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Wait for the report to finish generating before copying a handoff.", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Wait for the report to finish generating before opening print preview.", codeBehind, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-reports-print-action-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-reports-print-action-responsiveness.md
@@ -1,0 +1,28 @@
+# Reports print action responsiveness - 2026-07-04
+
+## Completed
+
+- Added a ViewModel-backed `CanUseReportRows` state so Reports row actions can be disabled whenever a report is still generating or no rows are available.
+- Tightened `CanPrintCurrentReport` so print preview is unavailable while report generation is active.
+- Raised print and row-action availability notifications when busy state changes, report rows load, report rows clear, report failures occur, or a report selection clears stale output.
+- Disabled Open Source, Copy Handoff, and Print Report buttons from the toolbar and handoff pane until report rows are ready.
+- Bound the report grid context menu to the page ViewModel so context-menu Open, Copy, and Print actions use the same availability state.
+- Added a bounded loading overlay for report generation so the empty state no longer competes with active work.
+- Guarded report row double-clicks so destination routing cannot fire while a report is generating.
+- Guarded report grid right-click selection retargeting while report generation is active.
+- Guarded Open Source, Copy Handoff, and Print Report click handlers with clear operator messages when a report is still generating.
+- Capped Reports print preview generation to the first 250 action rows instead of materializing every generated row into a preview packet.
+- Added total, printed, omitted, and large-report-limit summary rows to the printed report handoff document.
+- Updated print-preview description and footer guidance so operators know large reports are capped for responsiveness and must review omitted-row counts.
+- Extended Reports source-contract coverage for loading overlays, action availability, row gesture guards, context-menu bindings, bounded print packets, and omitted-row accounting.
+
+## Validation
+
+- Source-contract coverage was updated for the changed Reports ViewModel, XAML, and code-behind behavior.
+- GitHub connector readback and compare were used to confirm the branch file changes and diff scope.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, scaling checks, and print-preview rendering could not be run in this scheduled Linux environment because direct checkout is blocked and the required Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full Windows validation runner.
+- Smoke test Reports with a long report, a failed report, an empty report, row double-clicks during generation, right-click context menus during generation, and print preview for capped output.

--- a/InventoryManagementApp/ViewModels/ReportsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReportsViewModel.cs
@@ -87,7 +87,11 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _isBusy, value))
+                {
                     RunReportCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(CanPrintCurrentReport));
+                    OnPropertyChanged(nameof(CanUseReportRows));
+                }
             }
         }
 
@@ -107,7 +111,8 @@ namespace InventoryManagementApp.ViewModels
 
         public string LastRunText => LastRunAt.HasValue ? LastRunAt.Value.ToString("g") : "Not run";
         public int ReportLineCount => ReportLines.Count;
-        public bool CanPrintCurrentReport => LastRunAt.HasValue && ReportLines.Count > 0 && !string.Equals(ReportStatus, "Report failed.", StringComparison.Ordinal);
+        public bool CanPrintCurrentReport => !IsBusy && LastRunAt.HasValue && ReportLines.Count > 0 && !string.Equals(ReportStatus, "Report failed.", StringComparison.Ordinal);
+        public bool CanUseReportRows => !IsBusy && ReportLines.Count > 0;
         public string ReportOperatorPath => string.IsNullOrWhiteSpace(SelectedReport)
             ? "Choose a report, run it, then open the source page from any row that needs follow-up."
             : $"Run {SelectedReport}, select a row, then open {BuildDestinationName(SelectedReport, SelectedReportLine?.Category)} to continue the workflow.";
@@ -202,6 +207,7 @@ namespace InventoryManagementApp.ViewModels
                 LastRunAt = null;
                 OnPropertyChanged(nameof(ReportLineCount));
                 OnPropertyChanged(nameof(CanPrintCurrentReport));
+                OnPropertyChanged(nameof(CanUseReportRows));
                 OnPropertyChanged(nameof(ReportOperatorPath));
                 ClearReportCommand.NotifyCanExecuteChanged();
             }
@@ -247,6 +253,7 @@ namespace InventoryManagementApp.ViewModels
                 SelectedReportLine = ReportLines[0];
             OnPropertyChanged(nameof(ReportLineCount));
             OnPropertyChanged(nameof(CanPrintCurrentReport));
+            OnPropertyChanged(nameof(CanUseReportRows));
             OnPropertyChanged(nameof(ReportOperatorPath));
             ClearReportCommand.NotifyCanExecuteChanged();
         }
@@ -265,6 +272,7 @@ namespace InventoryManagementApp.ViewModels
             LastRunAt = null;
             OnPropertyChanged(nameof(ReportLineCount));
             OnPropertyChanged(nameof(CanPrintCurrentReport));
+            OnPropertyChanged(nameof(CanUseReportRows));
             OnPropertyChanged(nameof(ReportOperatorPath));
             ClearReportCommand.NotifyCanExecuteChanged();
         }
@@ -280,6 +288,7 @@ namespace InventoryManagementApp.ViewModels
             LastRunAt = null;
             OnPropertyChanged(nameof(ReportLineCount));
             OnPropertyChanged(nameof(CanPrintCurrentReport));
+            OnPropertyChanged(nameof(CanUseReportRows));
             OnPropertyChanged(nameof(ReportOperatorPath));
             ClearReportCommand.NotifyCanExecuteChanged();
         }

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml
@@ -105,15 +105,15 @@
                                   ToolTip="Choose the report to run"
                                   Margin="0,0,6,4"/>
                         <Button Style="{StaticResource PrimaryButton}" Content="Run Report" Command="{Binding RunReportCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Open Source Page" Click="OpenSourcePage_Click" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Open Source Page" Click="OpenSourcePage_Click" IsEnabled="{Binding CanUseReportRows}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearReportCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
                 </DockPanel>
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
                     <TextBlock Text="Output actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Print Report" Click="PrintReport_Click" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedRow_Click" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="Print Report" Click="PrintReport_Click" IsEnabled="{Binding CanPrintCurrentReport}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedRow_Click" IsEnabled="{Binding CanUseReportRows}" Margin="0,0,4,4"/>
                         <TextBlock Text="{Binding ReportStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="6,1,0,4"/>
                     </WrapPanel>
                 </DockPanel>
@@ -171,10 +171,10 @@
                               PreviewMouseRightButtonDown="ReportGrid_PreviewMouseRightButtonDown"
                               Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.ContextMenu>
-                            <ContextMenu>
-                                <MenuItem Header="Open Source Page" Click="OpenSourcePage_Click"/>
-                                <MenuItem Header="Copy Handoff" Click="CopySelectedRow_Click"/>
-                                <MenuItem Header="Print Report" Click="PrintReport_Click"/>
+                            <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open Source Page" Click="OpenSourcePage_Click" IsEnabled="{Binding CanUseReportRows}"/>
+                                <MenuItem Header="Copy Handoff" Click="CopySelectedRow_Click" IsEnabled="{Binding CanUseReportRows}"/>
+                                <MenuItem Header="Print Report" Click="PrintReport_Click" IsEnabled="{Binding CanPrintCurrentReport}"/>
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                         <DataGrid.Columns>
@@ -208,15 +208,40 @@
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding ReportLineCount}" Value="0">
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding ReportLineCount}" Value="0"/>
+                                            <Condition Binding="{Binding IsBusy}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
                                         <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
+                                    </MultiDataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
                             <TextBlock Text="No report rows are ready" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
                             <TextBlock Text="Choose a report, run it, then use this list to open source pages, copy handoffs, or print a report packet." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Grid.Row="2" MaxWidth="380" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="16">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="Generating report" FontSize="14" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="Report row routing, copying, and print preview are paused until the latest generated rows are ready."
+                                       Style="{StaticResource CaptionTextBlock}"
+                                       TextAlignment="Center"
+                                       TextWrapping="Wrap"
+                                       Margin="0,4,0,0"/>
                         </StackPanel>
                     </Border>
 
@@ -284,9 +309,9 @@
 
                             <Border Style="{StaticResource DesktopInsetCard}" Padding="10" Margin="0,0,0,8">
                                 <WrapPanel>
-                                    <Button Style="{StaticResource PrimaryButton}" Content="Open Source" Click="OpenSourcePage_Click" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedRow_Click" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Print Report" Click="PrintReport_Click" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Open Source" Click="OpenSourcePage_Click" IsEnabled="{Binding CanUseReportRows}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedRow_Click" IsEnabled="{Binding CanUseReportRows}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Print Report" Click="PrintReport_Click" IsEnabled="{Binding CanPrintCurrentReport}" Margin="0,0,4,4"/>
                                 </WrapPanel>
                             </Border>
                         </StackPanel>

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -14,6 +14,8 @@ namespace InventoryManagementApp.Views.Pages
 {
     public partial class ReportsPage : Page
     {
+        private const int MaxReportPrintRows = 250;
+
         public ReportsPage()
         {
             InitializeComponent();
@@ -21,7 +23,10 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ReportGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            UiActionGuard.Run(this, "Reports", OpenSelectedDestination);
+            if (DataContext is ReportsViewModel { CanUseReportRows: true })
+            {
+                UiActionGuard.Run(this, "Reports", OpenSelectedDestination);
+            }
         }
 
         private void OpenSourcePage_Click(object sender, RoutedEventArgs e)
@@ -31,6 +36,12 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ReportGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is ReportsViewModel { IsBusy: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
         }
 
@@ -38,6 +49,12 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Reports", () =>
             {
+                if (DataContext is ReportsViewModel { IsBusy: true })
+                {
+                    WpfMessageBox.Show("Wait for the report to finish generating before copying a handoff.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
                 var line = GetSelectedReportLineForAction();
                 if (line == null)
                 {
@@ -53,22 +70,42 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Reports", () =>
             {
-                if (DataContext is not ReportsViewModel vm || !vm.CanPrintCurrentReport)
+                if (DataContext is not ReportsViewModel vm)
                 {
                     WpfMessageBox.Show("Run a report before printing.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
                 }
 
-                var document = BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, vm.ReportLines.ToList());
+                if (vm.IsBusy)
+                {
+                    WpfMessageBox.Show("Wait for the report to finish generating before opening print preview.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
+                if (!vm.CanPrintCurrentReport)
+                {
+                    WpfMessageBox.Show("Run a report before printing.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
+                var totalLineCount = vm.ReportLines.Count;
+                var printRows = vm.ReportLines.Take(MaxReportPrintRows).ToList();
+                var document = BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, printRows, totalLineCount);
                 new PrintPreviewWindow().ShowPreview(
                     document,
                     vm.ReportTitle,
-                    "Review the report summary, destination routing, and next-action handoff before printing.");
+                    "Review the report summary, destination routing, next-action handoff, and any omitted rows before printing. Large reports print the first 250 rows so preview stays responsive.");
             });
         }
 
         private void OpenSelectedDestination()
         {
+            if (DataContext is ReportsViewModel { IsBusy: true })
+            {
+                WpfMessageBox.Show("Wait for the report to finish generating before opening a source page.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
             var line = GetSelectedReportLineForAction();
             if (line == null || string.IsNullOrWhiteSpace(line.DestinationKey))
             {
@@ -134,10 +171,12 @@ namespace InventoryManagementApp.Views.Pages
                    $"Destination: {line.DestinationName}";
         }
 
-        private static FlowDocument BuildReportDocument(string title, string summary, string lastRunText, IReadOnlyCollection<ReportLine> lines)
+        private static FlowDocument BuildReportDocument(string title, string summary, string lastRunText, IReadOnlyCollection<ReportLine> lines, int totalLineCount)
         {
             var safeLines = lines?.Where(line => line != null).ToList() ?? new List<ReportLine>();
             var safeTitle = ValueOrNotRecorded(title);
+            var printedLineCount = safeLines.Count;
+            var omittedLineCount = Math.Max(0, totalLineCount - printedLineCount);
             var document = new FlowDocument
             {
                 FontFamily = new FontFamily("Segoe UI"),
@@ -166,7 +205,7 @@ namespace InventoryManagementApp.Views.Pages
                 Margin = new Thickness(0, 0, 0, 2)
             });
 
-            document.Blocks.Add(BuildSummarySection(safeTitle, summary, lastRunText, safeLines.Count));
+            document.Blocks.Add(BuildSummarySection(safeTitle, summary, lastRunText, totalLineCount, printedLineCount, omittedLineCount));
 
             if (safeLines.Count == 0)
             {
@@ -220,7 +259,7 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             document.Blocks.Add(table);
-            document.Blocks.Add(new Paragraph(new Run("Review each destination, source-page route, and next action before closing the report packet or assigning follow-up work."))
+            document.Blocks.Add(new Paragraph(new Run("Review each destination, source-page route, next action, and omitted-row count before closing the report packet or assigning follow-up work."))
             {
                 FontSize = 10,
                 FontStyle = FontStyles.Italic,
@@ -229,7 +268,7 @@ namespace InventoryManagementApp.Views.Pages
             return document;
         }
 
-        private static Section BuildSummarySection(string title, string summary, string lastRunText, int lineCount)
+        private static Section BuildSummarySection(string title, string summary, string lastRunText, int totalLineCount, int printedLineCount, int omittedLineCount)
         {
             var section = new Section
             {
@@ -251,7 +290,10 @@ namespace InventoryManagementApp.Views.Pages
             var group = new TableRowGroup();
             table.RowGroups.Add(group);
             AddKeyValueRow(group, "Report", title);
-            AddKeyValueRow(group, "Action Rows", lineCount.ToString());
+            AddKeyValueRow(group, "Total Action Rows", totalLineCount.ToString());
+            AddKeyValueRow(group, "Printed Action Rows", printedLineCount.ToString());
+            AddKeyValueRow(group, "Omitted Action Rows", omittedLineCount == 0 ? "None" : $"{omittedLineCount} rows omitted to keep preview responsive");
+            AddKeyValueRow(group, "Large Report Limit", $"First {MaxReportPrintRows} action rows");
             AddKeyValueRow(group, "Last Run", ValueOrNotRecorded(lastRunText));
             AddKeyValueRow(group, "Summary", ValueOrNotRecorded(summary));
 


### PR DESCRIPTION
## What changed

- Added Reports row-action availability state so Open Source, Copy Handoff, context-menu actions, and row double-click routing are disabled while a report is generating or no generated rows exist.
- Tightened report print availability so Print Report is unavailable while generation is active.
- Added a loading overlay for active report generation so the empty state does not compete with in-progress work.
- Guarded double-click, right-click selection retargeting, Open Source, Copy Handoff, and Print Report handlers with clear operator messages during report generation.
- Capped Reports print-preview packets to the first 250 action rows and added total/printed/omitted/limit accounting to the printed report summary.
- Added source-contract coverage and a progress note for the workflow.

## Why this was highest value

Recent work already improved many workbench screens. Reports still had evidence of a hot path where code-behind could materialize every generated line into print preview and row gestures could run while report generation was active. This directly affects loading speed, UI responsiveness, professional data display, and print-preview stability.

## Why this is real progress

This is a vertical Reports workflow slice across ViewModel state, XAML availability, code-behind guards, print document output, source-contract coverage, and progress tracking. It improves report generation, tabulated result triage, context menus, row routing, copying, and printing together rather than changing one isolated control.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master` and focused to Reports ViewModel, Reports page XAML/code-behind, Reports source-contract tests, and one progress note.
- Source-contract coverage was updated for loading overlays, action availability, gesture guards, context-menu binding, bounded print packets, and omitted-row accounting.

## Could not check

- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, scaling checks, and print-preview rendering could not be run because this scheduled Linux environment cannot clone the repo directly and does not provide Windows/.NET/WPF tooling.

## Follow-up

- Run full Windows validation and smoke test Reports with long, empty, failed, and in-progress report states.