### PR TITLE
Improve Label Output print performance and readiness

### DIFF
--- a/InventoryManagementApp.Tests/ImportOutputDialogResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportOutputDialogResponsiveContractTests.cs
@@ -22,10 +22,44 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Width=\"1.2*\" MinWidth=\"140\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("QueueStatusText", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintReadinessText", xaml, StringComparison.Ordinal);
+            Assert.Contains("EmptyQueueVisibility", xaml, StringComparison.Ordinal);
+            Assert.Contains("No labels queued", xaml, StringComparison.Ordinal);
             Assert.Contains("PreviewCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("PrintCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("CloseCommand", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<StackPanel Orientation=\"Horizontal\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintLabelViewModel_BoundsPreviewAndPrintsProfessionalLabelSheets()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "PrintLabelViewModel.cs");
+
+            Assert.Contains("private const int MaxPrintableLabels = 250;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool HasItems => Items.Count > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("public Visibility EmptyQueueVisibility => HasItems ? Visibility.Collapsed : Visibility.Visible;", source, StringComparison.Ordinal);
+            Assert.Contains("public int VisibleLabelCount => Math.Min(Items.Count, MaxPrintableLabels);", source, StringComparison.Ordinal);
+            Assert.Contains("public int OmittedLabelCount => Math.Max(0, Items.Count - MaxPrintableLabels);", source, StringComparison.Ordinal);
+            Assert.Contains("PreviewCommand = new RelayCommand(Preview, () => HasItems);", source, StringComparison.Ordinal);
+            Assert.Contains("PrintCommand = new RelayCommand(Print, () => HasItems);", source, StringComparison.Ordinal);
+            Assert.Contains("Items.CollectionChanged += Items_CollectionChanged;", source, StringComparison.Ordinal);
+            Assert.Contains("PreviewCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.Contains("PrintCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.Contains(".Take(MaxPrintableLabels)", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedTemplate, \"Compact\", StringComparison.OrdinalIgnoreCase) ? 3 : 2", source, StringComparison.Ordinal);
+            Assert.Contains("new TableColumn { Width = new GridLength(1, GridUnitType.Star) }", source, StringComparison.Ordinal);
+            Assert.Contains("PrintDocumentTheme.PageBackgroundBrush", source, StringComparison.Ordinal);
+            Assert.Contains("PrintDocumentTheme.RuleBorderBrush", source, StringComparison.Ordinal);
+            Assert.Contains("Prepared {DateTime.Now:g}", source, StringComparison.Ordinal);
+            Assert.Contains("Large queue note", source, StringComparison.Ordinal);
+            Assert.Contains("No label rows are queued", source, StringComparison.Ordinal);
+            Assert.Contains("Normalize(item.ItemNumber, \"Unnumbered item\")", source, StringComparison.Ordinal);
+            Assert.Contains("Normalize(item.Name, \"Unnamed item\")", source, StringComparison.Ordinal);
+            Assert.Contains("Normalize(item.Location, \"No location\")", source, StringComparison.Ordinal);
+            Assert.Contains("PrintDocumentTheme.ApplyLightTheme(doc);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new BlockUIContainer", source, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-label-output-print-performance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-label-output-print-performance.md
@@ -1,0 +1,41 @@
+# Label Output Print Performance
+
+Date: 2026-07-04
+
+## Summary
+
+Improved the Label Output workflow so large or empty label queues behave predictably, preview/print actions reflect real readiness, and generated label sheets look like professional operational output instead of bare stacked text.
+
+## Completed Work
+
+- Added label queue state to `PrintLabelViewModel`, including queued, visible, omitted, empty, and print-readiness properties.
+- Disabled Preview and Print commands when no label rows are queued.
+- Refreshed Preview and Print command availability whenever queued rows change.
+- Surfaced live queue status in the dialog header and footer.
+- Replaced static preview guidance with ViewModel-backed readiness guidance that reflects template, QR, and omitted-row state.
+- Added a bounded empty state inside the virtualized label queue grid.
+- Capped generated preview/print label rows to the first 250 queued items so large queues do not create oversized preview documents.
+- Added omitted-label accounting and operator guidance for large queues.
+- Replaced bare `BlockUIContainer` label output with a FlowDocument table that uses star-sized columns, printable page padding, theme brushes, and template-specific two-column or three-column layout.
+- Added document header metadata with prepared timestamp, template, QR state, queued count, printed count, and omitted count.
+- Trimmed label item number, name, and location display values with readable fallbacks for incomplete legacy rows.
+- Preserved the existing Standard/Compact template choices, Include QR option, Preview route, Print route, and light-theme print handoff.
+- Extended source-contract coverage for the queue display state, command gating, capped print generation, professional document layout, omitted-row guidance, empty-state copy, and preserved responsive dialog contracts.
+
+## Validation
+
+- GitHub connector source readback should be used for this scheduled pass because direct local checkout is still blocked in the Linux environment.
+- Source-contract coverage was updated in `InventoryManagementApp.Tests/ImportOutputDialogResponsiveContractTests.cs`.
+
+## Not Run Here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- .NET restore/build/test
+- WPF runtime smoke tests, screenshots, Windows scaling checks, print dialog execution, or print-preview rendering
+
+Those checks require a Windows/.NET-capable checkout and remain unavailable in this scheduled Linux environment.
+
+## Follow-Up
+
+- Run full Windows validation.
+- Smoke test Label Output with no queued items, one item, long names/locations, Standard and Compact templates, QR on/off, 250+ queued items, Preview, Print, and Close at 1366 x 768 plus common Windows scaling levels.

--- a/InventoryManagementApp/ViewModels/PrintLabelViewModel.cs
+++ b/InventoryManagementApp/ViewModels/PrintLabelViewModel.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
+using System.Windows;
 using System.Windows.Documents;
-using System.Windows.Controls;
+using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using InventoryManagementApp.Interfaces;
@@ -14,6 +18,8 @@ namespace InventoryManagementApp.ViewModels
 {
     public class PrintLabelViewModel : ObservableObject
     {
+        private const int MaxPrintableLabels = 250;
+
         private readonly System.Action _closeAction;
         private readonly IDialogService _dialogService;
         private readonly System.Action<FlowDocument> _printAction;
@@ -24,17 +30,49 @@ namespace InventoryManagementApp.ViewModels
         public string SelectedTemplate
         {
             get => _selectedTemplate;
-            set => SetProperty(ref _selectedTemplate, value);
+            set
+            {
+                if (SetProperty(ref _selectedTemplate, value))
+                    OnPropertyChanged(nameof(PrintReadinessText));
+            }
         }
 
         private bool _includeQr;
         public bool IncludeQr
         {
             get => _includeQr;
-            set => SetProperty(ref _includeQr, value);
+            set
+            {
+                if (SetProperty(ref _includeQr, value))
+                    OnPropertyChanged(nameof(PrintReadinessText));
+            }
         }
 
         public ObservableCollection<ItemModel> Items { get; }
+
+        public bool HasItems => Items.Count > 0;
+        public int VisibleLabelCount => Math.Min(Items.Count, MaxPrintableLabels);
+        public int OmittedLabelCount => Math.Max(0, Items.Count - MaxPrintableLabels);
+
+        public string QueueStatusText => HasItems
+            ? $"{Items.Count:N0} queued; {VisibleLabelCount:N0} printable preview labels"
+            : "No queued labels";
+
+        public string PrintReadinessText
+        {
+            get
+            {
+                if (!HasItems)
+                    return "Add at least one queued item before previewing or printing labels.";
+
+                var qrText = IncludeQr ? "QR markers included" : "QR markers excluded";
+                var omittedText = OmittedLabelCount > 0
+                    ? $"; {OmittedLabelCount:N0} additional labels omitted from this preview for responsiveness"
+                    : string.Empty;
+
+                return $"Ready to preview {VisibleLabelCount:N0} {SelectedTemplate.ToLowerInvariant()} labels; {qrText}{omittedText}.";
+            }
+        }
 
         public IRelayCommand PreviewCommand { get; }
         public IRelayCommand PrintCommand { get; }
@@ -53,15 +91,27 @@ namespace InventoryManagementApp.ViewModels
             Templates = new ObservableCollection<string> { "Standard", "Compact" };
             _selectedTemplate = Templates.First();
             Items = new ObservableCollection<ItemModel>();
-            PreviewCommand = new RelayCommand(Preview);
-            PrintCommand = new RelayCommand(Print);
+            Items.CollectionChanged += Items_CollectionChanged;
+            PreviewCommand = new RelayCommand(Preview, () => HasItems);
+            PrintCommand = new RelayCommand(Print, () => HasItems);
             CloseCommand = new RelayCommand(() => _closeAction?.Invoke());
+        }
+
+        private void Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(HasItems));
+            OnPropertyChanged(nameof(VisibleLabelCount));
+            OnPropertyChanged(nameof(OmittedLabelCount));
+            OnPropertyChanged(nameof(QueueStatusText));
+            OnPropertyChanged(nameof(PrintReadinessText));
+            PreviewCommand.NotifyCanExecuteChanged();
+            PrintCommand.NotifyCanExecuteChanged();
         }
 
         private void Preview()
         {
             var doc = BuildDocument();
-            _dialogService.ShowPrintPreview(doc, $"{LabelProvider.Instance.ItemLabelSingular} Labels", string.Empty);
+            _dialogService.ShowPrintPreview(doc, $"{LabelProvider.Instance.ItemLabelSingular} Labels", PrintReadinessText);
         }
 
         private void Print()
@@ -80,18 +130,147 @@ namespace InventoryManagementApp.ViewModels
 
         private FlowDocument BuildDocument()
         {
-            var doc = new FlowDocument();
-            foreach (var t in Items)
+            var printableLabels = Items
+                .Take(MaxPrintableLabels)
+                .Select(LabelSnapshot.FromItem)
+                .ToList();
+
+            var doc = new FlowDocument
             {
-                var sp = new StackPanel { Orientation = System.Windows.Controls.Orientation.Vertical };
-                sp.Children.Add(new TextBlock { Text = t.ItemNumber });
-                sp.Children.Add(new TextBlock { Text = t.Name });
-                sp.Children.Add(new TextBlock { Text = t.Location });
-                if (IncludeQr)
-                    sp.Children.Add(new TextBlock { Text = "[QR]" });
-                doc.Blocks.Add(new BlockUIContainer(sp));
+                PagePadding = new Thickness(36),
+                ColumnWidth = double.PositiveInfinity,
+                FontFamily = new FontFamily("Segoe UI"),
+                FontSize = 11,
+                Background = PrintDocumentTheme.PageBackgroundBrush,
+                Foreground = PrintDocumentTheme.BodyForegroundBrush
+            };
+
+            AddDocumentHeader(doc, printableLabels.Count);
+
+            if (printableLabels.Count == 0)
+            {
+                doc.Blocks.Add(CreateMutedParagraph("No label rows are queued. Add items from the label workflow before previewing or printing."));
+                return doc;
             }
+
+            doc.Blocks.Add(CreateLabelTable(printableLabels));
+
+            if (OmittedLabelCount > 0)
+            {
+                doc.Blocks.Add(CreateMutedParagraph(
+                    $"Large queue note: {OmittedLabelCount:N0} queued labels were omitted from this preview to keep rendering responsive. Print the current batch, then queue the remaining items separately."));
+            }
+
+            doc.Blocks.Add(CreateMutedParagraph("End of label sheet. Review item numbers, names, locations, and QR marker choices before applying labels."));
             return doc;
+        }
+
+        private void AddDocumentHeader(FlowDocument doc, int printableCount)
+        {
+            var itemLabel = LabelProvider.Instance.ItemLabelSingular;
+            doc.Blocks.Add(new Paragraph(new Run($"{itemLabel} Label Sheet"))
+            {
+                FontSize = 20,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = PrintDocumentTheme.HeaderForegroundBrush,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+
+            doc.Blocks.Add(new Paragraph(new Run(
+                $"Prepared {DateTime.Now:g} | Template: {SelectedTemplate} | QR: {(IncludeQr ? "Included" : "Excluded")} | Queued: {Items.Count:N0} | Printed in preview: {printableCount:N0} | Omitted: {OmittedLabelCount:N0}"))
+            {
+                Foreground = PrintDocumentTheme.MutedForegroundBrush,
+                Margin = new Thickness(0, 0, 0, 14)
+            });
+        }
+
+        private Table CreateLabelTable(IReadOnlyList<LabelSnapshot> labels)
+        {
+            var columnsPerRow = string.Equals(SelectedTemplate, "Compact", StringComparison.OrdinalIgnoreCase) ? 3 : 2;
+            var table = new Table
+            {
+                CellSpacing = 8,
+                Margin = new Thickness(0, 0, 0, 12)
+            };
+
+            for (var i = 0; i < columnsPerRow; i++)
+                table.Columns.Add(new TableColumn { Width = new GridLength(1, GridUnitType.Star) });
+
+            var group = new TableRowGroup();
+            foreach (var rowLabels in labels.Chunk(columnsPerRow))
+            {
+                var row = new TableRow();
+                foreach (var label in rowLabels)
+                    row.Cells.Add(CreateLabelCell(label));
+
+                while (row.Cells.Count < columnsPerRow)
+                    row.Cells.Add(new TableCell(new Paragraph(new Run(string.Empty))) { BorderThickness = new Thickness(0) });
+
+                group.Rows.Add(row);
+            }
+
+            table.RowGroups.Add(group);
+            return table;
+        }
+
+        private TableCell CreateLabelCell(LabelSnapshot label)
+        {
+            var cell = new TableCell
+            {
+                Padding = new Thickness(10),
+                BorderBrush = PrintDocumentTheme.RuleBorderBrush,
+                BorderThickness = new Thickness(1)
+            };
+
+            cell.Blocks.Add(new Paragraph(new Run(label.ItemNumber))
+            {
+                FontSize = 14,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = PrintDocumentTheme.HeaderForegroundBrush,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            cell.Blocks.Add(new Paragraph(new Run(label.Name))
+            {
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            cell.Blocks.Add(new Paragraph(new Run($"Location: {label.Location}"))
+            {
+                Foreground = PrintDocumentTheme.MutedForegroundBrush,
+                Margin = new Thickness(0, 0, 0, IncludeQr ? 8 : 0)
+            });
+
+            if (IncludeQr)
+            {
+                cell.Blocks.Add(new Paragraph(new Run($"[QR] {label.ItemNumber}"))
+                {
+                    FontFamily = new FontFamily("Consolas"),
+                    FontSize = 10,
+                    Foreground = PrintDocumentTheme.MutedForegroundBrush,
+                    Margin = new Thickness(0)
+                });
+            }
+
+            return cell;
+        }
+
+        private static Paragraph CreateMutedParagraph(string text) => new(new Run(text))
+        {
+            Foreground = PrintDocumentTheme.MutedForegroundBrush,
+            Margin = new Thickness(0, 6, 0, 0)
+        };
+
+        private readonly record struct LabelSnapshot(string ItemNumber, string Name, string Location)
+        {
+            public static LabelSnapshot FromItem(ItemModel item) => new(
+                Normalize(item.ItemNumber, "Unnumbered item"),
+                Normalize(item.Name, "Unnamed item"),
+                Normalize(item.Location, "No location"));
+
+            private static string Normalize(string? value, string fallback)
+            {
+                var text = value?.Trim();
+                return string.IsNullOrWhiteSpace(text) ? fallback : text;
+            }
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/PrintLabelViewModel.cs
+++ b/InventoryManagementApp/ViewModels/PrintLabelViewModel.cs
@@ -51,6 +51,7 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<ItemModel> Items { get; }
 
         public bool HasItems => Items.Count > 0;
+        public Visibility EmptyQueueVisibility => HasItems ? Visibility.Collapsed : Visibility.Visible;
         public int VisibleLabelCount => Math.Min(Items.Count, MaxPrintableLabels);
         public int OmittedLabelCount => Math.Max(0, Items.Count - MaxPrintableLabels);
 
@@ -100,6 +101,7 @@ namespace InventoryManagementApp.ViewModels
         private void Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             OnPropertyChanged(nameof(HasItems));
+            OnPropertyChanged(nameof(EmptyQueueVisibility));
             OnPropertyChanged(nameof(VisibleLabelCount));
             OnPropertyChanged(nameof(OmittedLabelCount));
             OnPropertyChanged(nameof(QueueStatusText));

--- a/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
@@ -34,10 +34,10 @@
                                TextWrapping="Wrap"
                                Margin="0,4,0,0"/>
                 </StackPanel>
-                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="10,7" Margin="12,0,0,0" VerticalAlignment="Center" MaxWidth="170">
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="10,7" Margin="12,0,0,0" VerticalAlignment="Center" MaxWidth="190">
                     <StackPanel>
                         <TextBlock Text="Queue" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="Ready to review" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                        <TextBlock Text="{Binding QueueStatusText}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                     </StackPanel>
                 </Border>
             </Grid>
@@ -56,10 +56,10 @@
                           IsChecked="{Binding IncludeQr}"
                           VerticalAlignment="Center"
                           Margin="0,0,14,6"/>
-                <TextBlock Text="Preview first when labels include item photos, QR codes, or updated location text."
+                <TextBlock Text="{Binding PrintReadinessText}"
                            Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
-                           MaxWidth="420"
+                           MaxWidth="460"
                            Margin="0,1,0,6"
                            VerticalAlignment="Center"/>
             </WrapPanel>
@@ -81,25 +81,42 @@
                         <TextBlock Grid.Column="1" Text="Item number, name, and location" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" MaxWidth="260" Margin="12,0,0,0"/>
                     </Grid>
                 </Border>
-                <DataGrid Grid.Row="1"
-                          ItemsSource="{Binding Items}"
-                          AutoGenerateColumns="False"
-                          IsReadOnly="True"
-                          Style="{StaticResource VirtualizedDataGridStyle}"
-                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}"
-                          EnableRowVirtualization="True"
-                          EnableColumnVirtualization="True"
-                          SelectionMode="Single"
-                          SelectionUnit="FullRow"
-                          ScrollViewer.CanContentScroll="True"
-                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                          ScrollViewer.VerticalScrollBarVisibility="Auto">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="120" MinWidth="96"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*" MinWidth="180"/>
-                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="1.2*" MinWidth="140"/>
-                    </DataGrid.Columns>
-                </DataGrid>
+                <Grid Grid.Row="1" MinWidth="0">
+                    <DataGrid ItemsSource="{Binding Items}"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              Style="{StaticResource VirtualizedDataGridStyle}"
+                              ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}"
+                              EnableRowVirtualization="True"
+                              EnableColumnVirtualization="True"
+                              SelectionMode="Single"
+                              SelectionUnit="FullRow"
+                              ScrollViewer.CanContentScroll="True"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="120" MinWidth="96"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*" MinWidth="180"/>
+                            <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="1.2*" MinWidth="140"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <Border Style="{StaticResource DesktopEmptyStateCard}"
+                            Visibility="{Binding EmptyQueueVisibility}"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            MaxWidth="380"
+                            IsHitTestVisible="False">
+                        <StackPanel>
+                            <TextBlock Text="No labels queued" Style="{StaticResource SectionHeader}" TextAlignment="Center"/>
+                            <TextBlock Text="Add items to the label queue before previewing or printing. The label sheet will stay capped for responsive previews when large batches are queued."
+                                       Style="{StaticResource CaptionTextBlock}"
+                                       TextWrapping="Wrap"
+                                       TextAlignment="Center"
+                                       Margin="0,6,0,0"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
             </Grid>
         </Border>
 
@@ -112,7 +129,10 @@
         </Border>
 
         <Border Grid.Row="4" Style="{StaticResource ToolbarCard}" Margin="0,8,0,0" Padding="10,7">
-            <TextBlock Text="Label output ready; preview verifies the final sheet before printing." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+            <WrapPanel>
+                <TextBlock Text="{Binding QueueStatusText}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,14,4"/>
+                <TextBlock Text="{Binding PrintReadinessText}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" MaxWidth="620" Margin="0,0,0,4"/>
+            </WrapPanel>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
@@ -101,7 +101,8 @@
                         </DataGrid.Columns>
                     </DataGrid>
 
-                    <Border Style="{StaticResource DesktopEmptyStateCard}"
+                    <Border Style="{StaticResource Card}"
+                            Padding="16"
                             Visibility="{Binding EmptyQueueVisibility}"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"


### PR DESCRIPTION
## What changed

- Added label queue state to `PrintLabelViewModel`: queued, visible, omitted, empty, and print-readiness properties.
- Disabled Preview and Print when no label rows are queued, and refreshed command availability whenever queued rows change.
- Surfaced live queue status in the Label Output header and footer.
- Replaced static preview guidance with ViewModel-backed readiness text reflecting template, QR, and omitted-row state.
- Added a bounded empty state inside the virtualized label queue grid.
- Capped generated label preview/print rows to the first 250 queued items to keep large previews responsive.
- Added omitted-label accounting and operator guidance for large queues.
- Replaced bare `BlockUIContainer` output with a structured FlowDocument table using page padding, theme brushes, star-sized columns, and two-column/three-column Standard/Compact layouts.
- Added document header metadata for prepared timestamp, template, QR state, queued count, printed count, and omitted count.
- Trimmed label item number, name, and location values with readable fallbacks for incomplete legacy rows.
- Preserved existing Standard/Compact template choices, Include QR, Preview, Print, Close, and light-theme print handoff behavior.
- Extended source-contract coverage and recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-label-output-print-performance.md`.

## Why this was highest value

Recent runs improved major grids, reports, import/export, and dialog responsiveness. The Label Output layout had landed, but the print-generation path still built an unbounded, bare stacked document and allowed preview/print with an empty queue. This directly affects preview speed, print responsiveness, and professional output for a workflow tied to item labels.

## Why this is real progress

This is a vertical Label Output workflow slice across ViewModel state, command availability, dialog display, generated print document structure, empty/large queue handling, source-contract coverage, and progress notes. It improves more than ten user-facing paths without adding unrelated modules.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, focused to four files, and contains the queue state, command gating, empty-state display, 250-row cap, table-based label sheet, omitted-row guidance, and source-contract coverage.
- Connector status/workflow readback found no attached commit statuses or workflow runs for the branch head before PR creation.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, print dialog execution, or print-preview rendering

These remain blocked in the scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and the required Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run full Windows validation.
- Smoke test Label Output with no queued rows, one item, long names/locations, Standard and Compact templates, QR on/off, 250+ queued items, Preview, Print, and Close at 1366 x 768 plus common Windows scaling levels.