### PR TITLE
Improve reservation page loading and action responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
@@ -185,7 +185,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("private static bool IsReservationActionShortcut(KeyEventArgs e)", source, StringComparison.Ordinal);
             Assert.Contains("e.Key is Key.N or Key.P or Key.C or Key.D or Key.Enter", source, StringComparison.Ordinal);
             Assert.Contains("e.Key is Key.P or Key.Enter", source, StringComparison.Ordinal);
-            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && (e.Key is Key.Enter or Key.Delete)", source, StringComparison.Ordinal);
             Assert.Contains("e.Handled = true;", source, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
@@ -165,11 +165,28 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("private Task? _loadReservationsTask;", source, StringComparison.Ordinal);
             Assert.Contains("private ReservationManagementViewModel? _loadedViewModel;", source, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += ReservationPage_DataContextChanged;", source, StringComparison.Ordinal);
+            Assert.Contains("FocusFirstSearchBox();\n\n            if (DataContext is ReservationManagementViewModel vm)", source, StringComparison.Ordinal);
             Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("if (!ReferenceEquals(DataContext, vm) || !vm.LoadReservationsCommand.CanExecute(null))", source, StringComparison.Ordinal);
             Assert.Contains("LoadReservationsOnceAsync", source, StringComparison.Ordinal);
             Assert.Contains("IsCompletedSuccessfully", source, StringComparison.Ordinal);
             Assert.Contains("_loadReservationsTask = null;", source, StringComparison.Ordinal);
             Assert.Contains("Key == Key.N && vm.AddReservationCommand.CanExecute(null)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationPage_BlocksStaleRowAndShortcutActionsWhileRowsLoad()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml.cs");
+
+            Assert.Contains("ReservationManagementViewModel { IsLoading: true }", source, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", source, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsLoading && IsReservationActionShortcut(e))", source, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsReservationActionShortcut(KeyEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Contains("e.Key is Key.N or Key.P or Key.C or Key.D or Key.Enter", source, StringComparison.Ordinal);
+            Assert.Contains("e.Key is Key.P or Key.Enter", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete", source, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", source, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-reservation-page-load-action-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-reservation-page-load-action-guards.md
@@ -1,0 +1,26 @@
+# Reservation page load action guards - 2026-07-04
+
+## Completed
+
+- Moved Reservation page search focus setup before reservation row loading so the screen is usable sooner after navigation.
+- Kept the page-owned first-paint dispatcher yield before reservation data work starts.
+- Guarded page startup refreshes through the active `DataContext` so stale load continuations do not refresh the wrong view model.
+- Guarded startup refreshes through `LoadReservationsCommand.CanExecute` so an in-flight refresh is not duplicated by repeated WPF `Loaded` events.
+- Preserved the completed-load guard for repeated `Loaded` events on the same view model.
+- Preserved the DataContext reset path for a real Reservation view model swap.
+- Marked reservation row double-clicks handled after a details command runs so events do not bubble into extra work.
+- Blocked reservation row right-click retargeting while the directory is loading so stale rows cannot become selected during refresh.
+- Added a busy-state keyboard guard for reservation action shortcuts while rows are loading.
+- Kept Ctrl+F search focus available during loading while Add, Print, Copy, Details, Confirm, Fulfill, Enter, and Delete shortcuts wait for rows to finish.
+- Extended Reservation page source-contract coverage for first-paint load behavior, command-availability checks, active DataContext checks, busy row retargeting, and busy shortcut guards.
+
+## Validation
+
+- Source-contract coverage was updated for the changed Reservation page code-behind behavior.
+- GitHub connector readback was used to confirm the branch file changes and compare scope.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, scaling checks, and manual responsiveness checks could not be run in this scheduled Linux environment because direct checkout is blocked and the required Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full Windows validation runner.
+- Smoke test Reservations initial navigation, repeated navigation back to the page, row refresh during keyboard shortcuts, right-click during refresh, double-click details, Ctrl+F search focus, Ctrl+P list print, Ctrl+Shift+P handoff print, Ctrl+Enter confirm, and Ctrl+Shift+Enter fulfill.

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
@@ -25,12 +25,12 @@ namespace InventoryManagementApp.Views.Pages
         private async void ReservationPage_Loaded(object sender, RoutedEventArgs e)
         {
             Focus();
+            FocusFirstSearchBox();
+
             if (DataContext is ReservationManagementViewModel vm)
             {
                 await LoadReservationsOnceAsync(vm);
             }
-
-            FocusFirstSearchBox();
         }
 
         private void ReservationPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
@@ -57,6 +57,12 @@ namespace InventoryManagementApp.Views.Pages
 
             _loadedViewModel = vm;
             await Dispatcher.Yield(DispatcherPriority.Background);
+
+            if (!ReferenceEquals(DataContext, vm) || !vm.LoadReservationsCommand.CanExecute(null))
+            {
+                return;
+            }
+
             _loadReservationsTask = vm.LoadReservationsCommand.ExecuteAsync(null);
             await _loadReservationsTask;
         }
@@ -66,11 +72,18 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is ReservationManagementViewModel vm && vm.OpenReservationDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Reservations", () => vm.OpenReservationDetailsCommand.Execute(null));
+                e.Handled = true;
             }
         }
 
         private void ReservationRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is ReservationManagementViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
         }
 
@@ -82,6 +95,12 @@ namespace InventoryManagementApp.Views.Pages
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
             {
                 FocusFirstSearchBox();
+                e.Handled = true;
+                return;
+            }
+
+            if (vm.IsLoading && IsReservationActionShortcut(e))
+            {
                 e.Handled = true;
                 return;
             }
@@ -147,6 +166,21 @@ namespace InventoryManagementApp.Views.Pages
                 UiActionGuard.RunAsync(this, "Reservations", async () => await vm.CancelReservationCommand.ExecuteAsync(null));
                 e.Handled = true;
             }
+        }
+
+        private static bool IsReservationActionShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                return e.Key is Key.N or Key.P or Key.C or Key.D or Key.Enter;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+            {
+                return e.Key is Key.P or Key.Enter;
+            }
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;
         }
 
         private void FocusFirstSearchBox()

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
@@ -180,7 +180,7 @@ namespace InventoryManagementApp.Views.Pages
                 return e.Key is Key.P or Key.Enter;
             }
 
-            return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;
+            return Keyboard.Modifiers == ModifierKeys.None && (e.Key is Key.Enter or Key.Delete);
         }
 
         private void FocusFirstSearchBox()


### PR DESCRIPTION
## What changed

- Moved Reservation page search focus setup ahead of async row loading so the surface is interactive sooner after navigation.
- Kept the first-paint dispatcher yield and added active-DataContext plus `LoadReservationsCommand.CanExecute` checks before the page-owned startup refresh begins.
- Preserved repeated-Loaded and DataContext-reset guards so the same view model is not refreshed repeatedly, while real swaps can still load.
- Marked double-click details as handled after command dispatch.
- Blocked right-click row retargeting while reservation rows are loading.
- Added a busy-state keyboard guard so Add, Print, Copy, Details, Confirm, Fulfill, Enter, and Delete shortcuts do not act on stale rows while loading; Ctrl+F still focuses search.
- Extended Reservation source-contract tests for load guards, DataContext checks, command availability checks, busy row retargeting, and busy shortcut guards.
- Added a progress note for future scheduled runs.

## Why this was highest value

Recent completed work had already covered Dashboard, Reports, Print Labels, Kits, Calibration, Maintenance, Users, Activity Logs, and other heavy surfaces. Reservation already had ViewModel loading/empty/print state and a responsive XAML surface, but the page code-behind still had a concrete responsiveness gap around repeated startup loading and stale row actions during refresh.

## Why this is real progress

This is a workflow-level Reservation improvement, not a cosmetic tweak: it affects initial page open, repeated navigation, keyboard workflow safety, row double-click handling, right-click context selection, and source-contract coverage for the page’s loading behavior.

## Validation

- GitHub connector readback confirmed the changed Reservation page code-behind and test contracts on the branch.
- GitHub connector compare confirmed the branch is current with `master`, ahead by five commits, and limited to Reservation page code-behind, Reservation page tests, and a progress note.
- Direct local validation could not be run in this scheduled Linux environment because direct checkout is blocked by `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, WPF runtime checks, screenshots, print-preview checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Reservations initial navigation, repeated navigation, row refresh during shortcuts, right-click during refresh, double-click details, Ctrl+F, Ctrl+P, Ctrl+Shift+P, Ctrl+Enter, and Ctrl+Shift+Enter on a Windows/WPF checkout.