### PR TITLE
[codex] Improve customer directory responsiveness guards

### DIFF
--- a/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
@@ -92,6 +92,70 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("CustomerRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void CustomersPage_LoadsOnceAfterFirstPaintAndResetsForNewViewModels()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml.cs");
+
+            Assert.Contains("private Task? _loadCustomersTask;", source, StringComparison.Ordinal);
+            Assert.Contains("private CustomerManagementViewModel? _loadedViewModel;", source, StringComparison.Ordinal);
+            Assert.Contains("DataContextChanged += CustomersPage_DataContextChanged;", source, StringComparison.Ordinal);
+            Assert.Contains("FocusFirstSearchBox();\n\n            if (DataContext is CustomerManagementViewModel vm)", source, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("if (!ReferenceEquals(DataContext, vm) || vm.IsCustomerDirectoryBusy)", source, StringComparison.Ordinal);
+            Assert.Contains("_loadCustomersTask = vm.LoadCustomersAsync();", source, StringComparison.Ordinal);
+            Assert.Contains("IsCompletedSuccessfully", source, StringComparison.Ordinal);
+            Assert.Contains("_loadCustomersTask = null;", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomersPage_BlocksStaleRowAndShortcutActionsWhileRowsLoad()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml.cs");
+
+            Assert.Contains("CustomerManagementViewModel { IsCustomerDirectoryBusy: true }", source, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", source, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsCustomerDirectoryBusy && IsCustomerActionShortcut(e))", source, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsCustomerActionShortcut(KeyEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Contains("e.Key is Key.N or Key.P or Key.C or Key.D", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && (e.Key is Key.Enter or Key.Delete)", source, StringComparison.Ordinal);
+            Assert.Contains("Key == Key.N && vm.AddCustomerCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("Key == Key.P && vm.PrintCustomerDirectoryCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("Key == Key.Delete && vm.DeleteCustomerCommand.CanExecute(null)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerViewModel_GuardsBusyStateAndSelectedCommandAvailability()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CustomerManagementViewModel.cs");
+
+            Assert.Contains("AddCustomerCommand = new AsyncRelayCommand(AddCustomerAsync, CanRefreshCustomerDirectory);", source, StringComparison.Ordinal);
+            Assert.Contains("UpdateCustomerCommand = new AsyncRelayCommand(UpdateCustomerAsync, CanInteractWithSelectedCustomer);", source, StringComparison.Ordinal);
+            Assert.Contains("EditCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(EditCustomerAsync, CanInteractWithCustomer);", source, StringComparison.Ordinal);
+            Assert.Contains("DeleteCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(c => DeleteCustomerAsync(c), CanInteractWithCustomer);", source, StringComparison.Ordinal);
+            Assert.Contains("OpenCustomerDetailsCommand = new RelayCommand(OpenCustomerDetails, CanInteractWithSelectedCustomer);", source, StringComparison.Ordinal);
+            Assert.Contains("PrintSelectedCustomerCommand = new RelayCommand(PrintSelectedCustomer, CanInteractWithSelectedCustomer);", source, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedCustomerCommand = new RelayCommand(CopySelectedCustomer, CanInteractWithSelectedCustomer);", source, StringComparison.Ordinal);
+            Assert.Contains("private bool CanInteractWithSelectedCustomer() => !IsCustomerDirectoryBusy && SelectedCustomer != null;", source, StringComparison.Ordinal);
+            Assert.Contains("private bool CanInteractWithCustomer(CustomerModel? customer) => !IsCustomerDirectoryBusy && customer != null;", source, StringComparison.Ordinal);
+            Assert.Contains("NotifySelectedCustomerActionStateChanged();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerViewModel_ExposesBusyPrintAndActionStatus()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CustomerManagementViewModel.cs");
+
+            Assert.Contains("Print paused while customer rows load", source, StringComparison.Ordinal);
+            Assert.Contains("Customer actions are paused while the directory refreshes", source, StringComparison.Ordinal);
+            Assert.Contains("ShowCustomerDirectoryBusyMessage", source, StringComparison.Ordinal);
+            Assert.Contains("Customer rows are still updating. Try again after the directory finishes loading.", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsCustomerDirectoryBusy || SelectedCustomer == null", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsCustomerDirectoryBusy || customer == null", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CustomerPrintSummary));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CustomerOperationsSummary));", source, StringComparison.Ordinal);
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-customer-directory-responsiveness-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-customer-directory-responsiveness-guards.md
@@ -1,0 +1,20 @@
+# Customer directory responsiveness guards - 2026-07-04
+
+Completed a customer-directory workflow slice focused on faster first interaction, safer busy states, and professional row actions.
+
+- Moved customer search focus ahead of directory loading so operators can begin typing as soon as the page opens.
+- Added first-paint customer loading that runs once per view model, reuses any in-flight load, and resets only when a real DataContext swap occurs.
+- Deferred the initial load until background dispatcher priority to avoid blocking first paint.
+- Blocked stale right-click row retargeting while the customer directory is refreshing.
+- Marked customer row double-click details handled after dispatch to avoid duplicate routed actions.
+- Added customer keyboard shortcuts for find, add, directory print, selected sheet print, copy handoff, details, row open, and delete.
+- Guarded those keyboard shortcuts while customer rows are loading, while still allowing Ctrl+F search focus.
+- Disabled selected-customer actions, row edit/delete actions, add, search, clear, and print commands while the directory is busy.
+- Added user-facing busy messaging for direct details, copy, and selected-sheet print attempts during refreshes.
+- Updated customer print/action summaries so loading states clearly explain that prints and row actions are paused.
+- Extended source-contract coverage for once-per-view-model loading, first-paint behavior, busy row guards, keyboard shortcuts, command availability, and busy action summaries.
+
+Validation notes:
+
+- GitHub connector readback was used for the live `master` files and branch updates because direct checkout was blocked by the scheduled environment.
+- Full local Windows/.NET/WPF validation was not available in this environment; source-contract tests were updated for the changed workflow contracts.

--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -54,6 +54,9 @@ namespace InventoryManagementApp.ViewModels
         {
             get
             {
+                if (IsCustomerDirectoryBusy)
+                    return "Print paused while customer rows load";
+
                 if (Customers.Count == 0)
                     return "No printable customer rows yet";
 
@@ -84,10 +87,14 @@ namespace InventoryManagementApp.ViewModels
                 if (SetProperty(ref _isCustomerDirectoryBusy, value))
                 {
                     OnPropertyChanged(nameof(CustomerFilterStatus));
+                    OnPropertyChanged(nameof(CustomerPrintSummary));
                     OnPropertyChanged(nameof(CustomerEmptyStateMessage));
+                    OnPropertyChanged(nameof(CustomerOperationsSummary));
+                    AddCustomerCommand.NotifyCanExecuteChanged();
                     SearchCustomersCommand.NotifyCanExecuteChanged();
                     ClearCustomerSearchCommand.NotifyCanExecuteChanged();
                     PrintCustomerDirectoryCommand.NotifyCanExecuteChanged();
+                    NotifySelectedCustomerActionStateChanged();
                 }
             }
         }
@@ -105,9 +112,18 @@ namespace InventoryManagementApp.ViewModels
             ? "No address is selected yet."
             : ValueOrNotRecorded(SelectedCustomer.Address);
 
-        public string CustomerOperationsSummary => SelectedCustomer == null
-            ? "Choose a customer before starting a rental, reservation, delivery promise, or printed handoff."
-            : "Verify this contact, then use Rentals or Requests to review open activity before promising availability or collection times.";
+        public string CustomerOperationsSummary
+        {
+            get
+            {
+                if (IsCustomerDirectoryBusy)
+                    return "Customer actions are paused while the directory refreshes, so row handoffs stay tied to current data.";
+
+                return SelectedCustomer == null
+                    ? "Choose a customer before starting a rental, reservation, delivery promise, or printed handoff."
+                    : "Verify this contact, then use Rentals or Requests to review open activity before promising availability or collection times.";
+            }
+        }
 
         private CustomerModel? _selectedCustomer;
         public CustomerModel? SelectedCustomer
@@ -117,12 +133,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _selectedCustomer, value))
                 {
-                    ((AsyncRelayCommand)UpdateCustomerCommand).NotifyCanExecuteChanged();
-                    ((AsyncRelayCommand)DeleteCustomerCommand).NotifyCanExecuteChanged();
-                    ((AsyncRelayCommand)EditCustomerCommand).NotifyCanExecuteChanged();
-                    OpenCustomerDetailsCommand.NotifyCanExecuteChanged();
-                    PrintSelectedCustomerCommand.NotifyCanExecuteChanged();
-                    CopySelectedCustomerCommand.NotifyCanExecuteChanged();
+                    NotifySelectedCustomerActionStateChanged();
                     OnPropertyChanged(nameof(SelectedCustomerSummary));
                     OnPropertyChanged(nameof(CustomerContactSummary));
                     OnPropertyChanged(nameof(CustomerAddressSummary));
@@ -190,18 +201,18 @@ namespace InventoryManagementApp.ViewModels
         {
             _customerService = customerService;
             _dialogService = dialogService;
-            AddCustomerCommand = new AsyncRelayCommand(AddCustomerAsync);
-            UpdateCustomerCommand = new AsyncRelayCommand(UpdateCustomerAsync, () => SelectedCustomer != null);
+            AddCustomerCommand = new AsyncRelayCommand(AddCustomerAsync, CanRefreshCustomerDirectory);
+            UpdateCustomerCommand = new AsyncRelayCommand(UpdateCustomerAsync, CanInteractWithSelectedCustomer);
             SearchCustomersCommand = new AsyncRelayCommand(SearchCustomersAsync, CanRefreshCustomerDirectory);
-            DeleteCustomerCommand = new AsyncRelayCommand(() => DeleteCustomerAsync(), () => SelectedCustomer != null);
-            EditCustomerCommand = new AsyncRelayCommand(() => EditCustomerAsync(SelectedCustomer), () => SelectedCustomer != null);
-            EditCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(EditCustomerAsync);
-            DeleteCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(c => DeleteCustomerAsync(c));
+            DeleteCustomerCommand = new AsyncRelayCommand(() => DeleteCustomerAsync(), CanInteractWithSelectedCustomer);
+            EditCustomerCommand = new AsyncRelayCommand(() => EditCustomerAsync(SelectedCustomer), CanInteractWithSelectedCustomer);
+            EditCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(EditCustomerAsync, CanInteractWithCustomer);
+            DeleteCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(c => DeleteCustomerAsync(c), CanInteractWithCustomer);
             ClearCustomerSearchCommand = new AsyncRelayCommand(ClearCustomerSearchAsync, CanRefreshCustomerDirectory);
-            OpenCustomerDetailsCommand = new RelayCommand(OpenCustomerDetails, () => SelectedCustomer != null);
+            OpenCustomerDetailsCommand = new RelayCommand(OpenCustomerDetails, CanInteractWithSelectedCustomer);
             PrintCustomerDirectoryCommand = new RelayCommand(PrintCustomerDirectory, CanPrintCustomerDirectory);
-            PrintSelectedCustomerCommand = new RelayCommand(PrintSelectedCustomer, () => SelectedCustomer != null);
-            CopySelectedCustomerCommand = new RelayCommand(CopySelectedCustomer, () => SelectedCustomer != null);
+            PrintSelectedCustomerCommand = new RelayCommand(PrintSelectedCustomer, CanInteractWithSelectedCustomer);
+            CopySelectedCustomerCommand = new RelayCommand(CopySelectedCustomer, CanInteractWithSelectedCustomer);
         }
 
         public async Task LoadCustomersAsync()
@@ -231,6 +242,8 @@ namespace InventoryManagementApp.ViewModels
 
         async Task AddCustomerAsync()
         {
+            if (IsCustomerDirectoryBusy) return;
+
             var customer = _dialogService?.ShowAddCustomerDialog();
             if (customer == null || _customerService == null || _dialogService == null) return;
 
@@ -257,7 +270,7 @@ namespace InventoryManagementApp.ViewModels
 
         async Task UpdateCustomerAsync()
         {
-            if (SelectedCustomer == null || _customerService == null || _dialogService == null) return;
+            if (IsCustomerDirectoryBusy || SelectedCustomer == null || _customerService == null || _dialogService == null) return;
             var selectedId = SelectedCustomer.CustomerID;
             var updated = new CustomerModel
             {
@@ -365,10 +378,28 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CustomerFilterStatus));
             OnPropertyChanged(nameof(CustomerPrintSummary));
             OnPropertyChanged(nameof(CustomerEmptyStateMessage));
+            OnPropertyChanged(nameof(CustomerOperationsSummary));
             PrintCustomerDirectoryCommand.NotifyCanExecuteChanged();
+            NotifySelectedCustomerActionStateChanged();
+        }
+
+        private void NotifySelectedCustomerActionStateChanged()
+        {
+            ((AsyncRelayCommand)UpdateCustomerCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)DeleteCustomerCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)EditCustomerCommand).NotifyCanExecuteChanged();
+            EditCustomerFromRowCommand.NotifyCanExecuteChanged();
+            DeleteCustomerFromRowCommand.NotifyCanExecuteChanged();
+            OpenCustomerDetailsCommand.NotifyCanExecuteChanged();
+            PrintSelectedCustomerCommand.NotifyCanExecuteChanged();
+            CopySelectedCustomerCommand.NotifyCanExecuteChanged();
         }
 
         private bool CanRefreshCustomerDirectory() => !IsCustomerDirectoryBusy;
+
+        private bool CanInteractWithSelectedCustomer() => !IsCustomerDirectoryBusy && SelectedCustomer != null;
+
+        private bool CanInteractWithCustomer(CustomerModel? customer) => !IsCustomerDirectoryBusy && customer != null;
 
         private bool CanPrintCustomerDirectory() => Customers.Count > 0 && !IsCustomerDirectoryBusy;
 
@@ -393,7 +424,7 @@ namespace InventoryManagementApp.ViewModels
         async Task DeleteCustomerAsync(CustomerModel? customer = null)
         {
             customer ??= SelectedCustomer;
-            if (customer == null || _customerService == null || _dialogService == null)
+            if (IsCustomerDirectoryBusy || customer == null || _customerService == null || _dialogService == null)
                 return;
 
             var confirmed = await _dialogService.ShowConfirmAsync("Delete Customer", $"Delete {ValueOrNotRecorded(customer.Company)} from the customer list?");
@@ -423,7 +454,7 @@ namespace InventoryManagementApp.ViewModels
 
         public async Task EditCustomerAsync(CustomerModel? customer)
         {
-            if (customer == null || _dialogService == null || _customerService == null) return;
+            if (IsCustomerDirectoryBusy || customer == null || _dialogService == null || _customerService == null) return;
             var edited = _dialogService.ShowEditCustomerDialog(customer);
             if (edited == null) return;
             try
@@ -449,7 +480,16 @@ namespace InventoryManagementApp.ViewModels
 
         void OpenCustomerDetails()
         {
-            if (SelectedCustomer == null || _dialogService == null)
+            if (_dialogService == null)
+                return;
+
+            if (IsCustomerDirectoryBusy)
+            {
+                ShowCustomerDirectoryBusyMessage("Customer Details");
+                return;
+            }
+
+            if (SelectedCustomer == null)
                 return;
 
             var customer = SelectedCustomer;
@@ -460,7 +500,16 @@ namespace InventoryManagementApp.ViewModels
 
         void CopySelectedCustomer()
         {
-            if (SelectedCustomer == null || _dialogService == null)
+            if (_dialogService == null)
+                return;
+
+            if (IsCustomerDirectoryBusy)
+            {
+                ShowCustomerDirectoryBusyMessage("Customer Handoff");
+                return;
+            }
+
+            if (SelectedCustomer == null)
                 return;
 
             try
@@ -563,7 +612,16 @@ namespace InventoryManagementApp.ViewModels
 
         void PrintSelectedCustomer()
         {
-            if (SelectedCustomer == null || _dialogService == null)
+            if (_dialogService == null)
+                return;
+
+            if (IsCustomerDirectoryBusy)
+            {
+                ShowCustomerDirectoryBusyMessage("Customer Sheet");
+                return;
+            }
+
+            if (SelectedCustomer == null)
                 return;
 
             try
@@ -591,6 +649,11 @@ namespace InventoryManagementApp.ViewModels
             {
                 _dialogService.ShowInfo($"Failed to print customer sheet: {ex.Message}", "Print Failed");
             }
+        }
+
+        private void ShowCustomerDirectoryBusyMessage(string title)
+        {
+            _dialogService?.ShowInfo("Customer rows are still updating. Try again after the directory finishes loading.", title);
         }
 
         void SelectBestCustomerAfterRefresh(int? preferredCustomerId = null, bool clearSelectionWhenPreferredMissing = false)

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
@@ -1,24 +1,70 @@
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
 {
     public partial class CustomersPage : Page
     {
+        private Task? _loadCustomersTask;
+        private CustomerManagementViewModel? _loadedViewModel;
+
         public CustomersPage()
         {
             InitializeComponent();
             Loaded += CustomersPage_Loaded;
+            DataContextChanged += CustomersPage_DataContextChanged;
+            PreviewKeyDown += CustomersPage_PreviewKeyDown;
         }
 
         private async void CustomersPage_Loaded(object sender, RoutedEventArgs e)
         {
+            Focus();
+            FocusFirstSearchBox();
+
             if (DataContext is CustomerManagementViewModel vm)
             {
-                await vm.LoadCustomersAsync();
+                await LoadCustomersOnceAsync(vm);
             }
+        }
+
+        private void CustomersPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(_loadedViewModel, e.NewValue))
+            {
+                _loadedViewModel = null;
+                _loadCustomersTask = null;
+            }
+        }
+
+        private async Task LoadCustomersOnceAsync(CustomerManagementViewModel vm)
+        {
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadCustomersTask is { IsCompleted: false })
+            {
+                await _loadCustomersTask;
+                return;
+            }
+
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadCustomersTask is { IsCompletedSuccessfully: true })
+            {
+                return;
+            }
+
+            _loadedViewModel = vm;
+            await Dispatcher.Yield(DispatcherPriority.Background);
+
+            if (!ReferenceEquals(DataContext, vm) || vm.IsCustomerDirectoryBusy)
+            {
+                return;
+            }
+
+            _loadCustomersTask = vm.LoadCustomersAsync();
+            await _loadCustomersTask;
         }
 
         private void CustomerRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -26,12 +72,132 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is CustomerManagementViewModel vm && vm.OpenCustomerDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Customers", () => vm.OpenCustomerDetailsCommand.Execute(null));
+                e.Handled = true;
             }
         }
 
         private void CustomerRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is CustomerManagementViewModel { IsCustomerDirectoryBusy: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
+        }
+
+        private void CustomersPage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (DataContext is not CustomerManagementViewModel vm)
+                return;
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
+            {
+                FocusFirstSearchBox();
+                e.Handled = true;
+                return;
+            }
+
+            if (vm.IsCustomerDirectoryBusy && IsCustomerActionShortcut(e))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N && vm.AddCustomerCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Customers", async () => await vm.AddCustomerCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && vm.PrintCustomerDirectoryCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Customers", () => vm.PrintCustomerDirectoryCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P && vm.PrintSelectedCustomerCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Customers", () => vm.PrintSelectedCustomerCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopySelectedCustomerCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Customers", () => vm.CopySelectedCustomerCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D && vm.OpenCustomerDetailsCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Customers", () => vm.OpenCustomerDetailsCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter && vm.OpenCustomerDetailsCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Customers", () => vm.OpenCustomerDetailsCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete && vm.DeleteCustomerCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Customers", async () => await vm.DeleteCustomerCommand.ExecuteAsync(null));
+                e.Handled = true;
+            }
+        }
+
+        private static bool IsCustomerActionShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                return e.Key is Key.N or Key.P or Key.C or Key.D;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+            {
+                return e.Key == Key.P;
+            }
+
+            return Keyboard.Modifiers == ModifierKeys.None && (e.Key is Key.Enter or Key.Delete);
+        }
+
+        private void FocusFirstSearchBox()
+        {
+            var searchBox = FindDescendant<TextBox>(this);
+            if (searchBox == null)
+                return;
+
+            searchBox.Focus();
+            searchBox.SelectAll();
+        }
+
+        private static bool IsTextInputFocused()
+        {
+            return Keyboard.FocusedElement is TextBoxBase or PasswordBox;
+        }
+
+        private static T? FindDescendant<T>(DependencyObject current) where T : DependencyObject
+        {
+            for (var index = 0; index < VisualTreeHelper.GetChildrenCount(current); index++)
+            {
+                var child = VisualTreeHelper.GetChild(current, index);
+                if (child is T match)
+                    return match;
+
+                var nested = FindDescendant<T>(child);
+                if (nested != null)
+                    return nested;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## What changed

- Moved customer search focus ahead of directory loading so the page is interactive sooner after navigation.
- Added first-paint customer loading that runs once per view model, reuses any in-flight load, and resets on real DataContext swaps.
- Deferred the initial customer directory load to background dispatcher priority to reduce first-paint blocking.
- Blocked stale row double-click/right-click actions while customer rows are refreshing.
- Added keyboard shortcuts for find, add, directory print, selected customer print, copy handoff, details/open, and delete.
- Guarded customer action shortcuts while loading while still allowing Ctrl+F search focus.
- Disabled add/search/clear/print and selected customer commands while the directory is busy.
- Disabled row edit/delete commands while the directory is busy.
- Added clear busy-state messaging for details, copy handoff, selected sheet print, and print summaries.
- Extended source-contract tests for the loading, action, shortcut, command availability, and busy messaging contracts.
- Recorded a progress note for this workflow slice.

## Why this was highest value

Recent scheduled work already covered Reports, Print Labels, Label Output, and Reservations. The Customer Directory has similar operator-heavy table behavior and already had virtualization/loading overlays, but its page load and row/action surface still allowed repeat navigation loads and stale actions during refreshes. Tightening this workflow directly improves screen opening, tab switching, searching, printing, and customer handoff responsiveness.

## Why this is real progress

This is a vertical customer-directory slice across page lifecycle, keyboard workflow, row selection safety, view-model command availability, user-facing busy states, tests, and progress notes. It avoids speculative new features and keeps the changes inside the active WPF/MVVM app.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, four focused commits ahead, and limited to customer page code-behind, customer view model, customer responsive contract tests, and one progress note.
- Connector readback confirmed the updated page lifecycle, busy row guards, keyboard shortcuts, command availability guards, and test contracts are present.

Could not run `pwsh -File scripts/run-full-validation.ps1`, WPF runtime checks, screenshots, or print-preview checks because direct checkout is blocked in this scheduled environment and Windows/.NET/WPF runtime validation is unavailable here.

## Follow-up

Run the repository validation script in a Windows/.NET-capable checkout and consider applying the same once-per-view-model load/shortcut guard pattern to the next operator-heavy workflow that still reloads on every WPF `Loaded` event.