### PR TITLE
Improve Users workbench loading and action responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
@@ -45,6 +45,93 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task LoadUsersAsync_ExposesBusyStateAndDisablesDirectoryActionsWhileRowsLoad()
+        {
+            var existingUser = new UserModel { UserID = 2, UserName = "bravo", Role = "Technician" };
+            var newUser = new UserModel { UserID = 1, UserName = "alpha", Role = "Admin", IsAdmin = true };
+            var service = new StubUserService();
+            service.Users.Add(existingUser);
+            var dialog = new StubDialogService();
+            var vm = new UserManagementViewModel(service, new StubFileDialogService(), dialog);
+
+            await vm.LoadUsersAsync();
+            vm.SelectedUser = existingUser;
+            service.Users.Insert(0, newUser);
+            service.HoldNextGetAllUsers();
+
+            var reloadTask = vm.LoadUsersAsync();
+            await service.WaitForGetAllUsersAsync();
+
+            Assert.True(vm.IsLoadingUsers);
+            Assert.False(vm.LoadUsersCommand.CanExecute(null));
+            Assert.False(vm.AddUserCommand.CanExecute(null));
+            Assert.False(vm.SearchUsersCommand.CanExecute(null));
+            Assert.False(vm.ClearUserSearchCommand.CanExecute(null));
+            Assert.False(vm.EditUserCommand.CanExecute(null));
+            Assert.False(vm.UploadUserPhotoCommand.CanExecute(null));
+            Assert.False(vm.ResetPasswordFromRowCommand.CanExecute(existingUser));
+            Assert.False(vm.DeleteUserFromRowCommand.CanExecute(existingUser));
+            Assert.False(vm.CanPrintUsers);
+            Assert.Contains("Refreshing account directory", vm.UserDirectoryStatusText);
+            Assert.Contains("Search pauses", vm.UserFilterStatusText);
+
+            await vm.LoadUsersAsync();
+            Assert.Equal(2, service.GetAllUsersCallCount);
+
+            service.ReleaseHeldGetAllUsers();
+            await reloadTask;
+
+            Assert.False(vm.IsLoadingUsers);
+            Assert.True(vm.LoadUsersCommand.CanExecute(null));
+            Assert.True(vm.AddUserCommand.CanExecute(null));
+            Assert.True(vm.SearchUsersCommand.CanExecute(null));
+            Assert.True(vm.ClearUserSearchCommand.CanExecute(null));
+            Assert.True(vm.CanPrintUsers);
+            Assert.Equal(2, vm.VisibleUserCount);
+            Assert.Equal(2, vm.TotalUserCount);
+            Assert.Equal(new[] { "alpha", "bravo" }, vm.Users.Select(user => user.UserName).ToArray());
+        }
+
+        [Fact]
+        public async Task SearchUsers_FiltersByUserIdLockoutAndAccessSummary()
+        {
+            var service = new StubUserService();
+            service.Users.Add(new UserModel
+            {
+                UserID = 101,
+                UserName = "scheduler",
+                Role = "Planner",
+                Permissions = UserModel.BuildPermissions(new[] { UserModel.PermissionReservations })
+            });
+            service.Users.Add(new UserModel
+            {
+                UserID = 202,
+                UserName = "locked",
+                Role = "Auditor",
+                FailedLoginAttempts = 3,
+                Permissions = UserModel.BuildPermissions(Array.Empty<string>())
+            });
+
+            var vm = new UserManagementViewModel(service, new StubFileDialogService(), new StubDialogService());
+            await vm.LoadUsersAsync();
+
+            vm.UserSearchText = "101";
+            vm.SearchUsersCommand.Execute(null);
+            var userById = Assert.Single(vm.Users);
+            Assert.Equal("scheduler", userById.UserName);
+
+            vm.UserSearchText = "failed login";
+            vm.SearchUsersCommand.Execute(null);
+            var userByLockout = Assert.Single(vm.Users);
+            Assert.Equal("locked", userByLockout.UserName);
+
+            vm.UserSearchText = "Reservations";
+            vm.SearchUsersCommand.Execute(null);
+            var userByAccess = Assert.Single(vm.Users);
+            Assert.Equal("scheduler", userByAccess.UserName);
+        }
+
+        [Fact]
         public async Task AddUserAsync_WhenAddFailsAfterPersistence_RefreshesRowsAndSelectsSavedUser()
         {
             var service = new StubUserService { ThrowAfterAdd = true };
@@ -151,20 +238,44 @@ namespace InventoryManagementApp.Tests
 
         private sealed class StubUserService : IUserService
         {
+            private TaskCompletionSource? _getAllUsersStarted;
+            private TaskCompletionSource? _releaseGetAllUsers;
+
             public List<UserModel> Users { get; } = new();
             public bool ChangePasswordResult { get; set; } = true;
             public bool ThrowOnGetAllUsers { get; set; }
             public bool ThrowOnGetAllUsersAfterMutation { get; set; }
             public bool ThrowAfterAdd { get; set; }
             public bool ThrowAfterDelete { get; set; }
+            public int GetAllUsersCallCount { get; private set; }
             public int UpdateCallCount { get; private set; }
 
-            public Task<List<UserModel>> GetAllUsersAsync(CancellationToken cancellationToken = default)
+            public void HoldNextGetAllUsers()
             {
+                _getAllUsersStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _releaseGetAllUsers = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            public Task WaitForGetAllUsersAsync() => _getAllUsersStarted?.Task ?? Task.CompletedTask;
+
+            public void ReleaseHeldGetAllUsers() => _releaseGetAllUsers?.TrySetResult();
+
+            public async Task<List<UserModel>> GetAllUsersAsync(CancellationToken cancellationToken = default)
+            {
+                GetAllUsersCallCount++;
+
+                if (_getAllUsersStarted != null && _releaseGetAllUsers != null)
+                {
+                    _getAllUsersStarted.TrySetResult();
+                    await _releaseGetAllUsers.Task;
+                    _getAllUsersStarted = null;
+                    _releaseGetAllUsers = null;
+                }
+
                 if (ThrowOnGetAllUsers || ThrowOnGetAllUsersAfterMutation)
                     throw new InvalidOperationException("Users are offline");
 
-                return Task.FromResult(Users.ToList());
+                return Users.ToList();
             }
 
             public Task<int> CountUsersAsync(CancellationToken cancellationToken = default)

--- a/InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs
@@ -48,16 +48,68 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void UsersPage_BoundsSearchEmptyStateAndHandoffScrolling()
+        public void UsersPage_BoundsSearchEmptyStateLoadingStateAndHandoffScrolling()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
 
             Assert.Contains("<pages:SearchBar Width=\"300\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding CanUseUserActions}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<MultiDataTrigger>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Condition Binding=\"{Binding IsLoadingUsers}\" Value=\"False\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"360\" MinHeight=\"118\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<DataTrigger Binding=\"{Binding IsLoadingUsers}\" Value=\"True\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"330\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersPage_UsesViewModelBackedStatusAndActionReadiness()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
+
+            Assert.Contains("UserDirectoryStatusText", xaml, StringComparison.Ordinal);
+            Assert.Contains("UserFilterStatusText", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectedAccessStatusText", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectedSecurityStatusText", xaml, StringComparison.Ordinal);
+            Assert.Contains("UserEmptyStateTitle", xaml, StringComparison.Ordinal);
+            Assert.Contains("UserEmptyStateMessage", xaml, StringComparison.Ordinal);
+            Assert.Contains("VisibleUserCount", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanUseUserActions", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanUseSelectedUserActions", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanPrintUsers", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersPage_DisablesToolbarContextAndFooterActionsDuringBusyState()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
+
+            Assert.Contains("Content=\"Add User\" Command=\"{Binding AddUserCommand}\" IsEnabled=\"{Binding CanUseUserActions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Edit Access\" Command=\"{Binding EditUserCommand}\" IsEnabled=\"{Binding CanUseSelectedUserActions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Reset Password\" Click=\"ResetSelectedUser_Click\" IsEnabled=\"{Binding CanUseSelectedUserActions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Copy Handoff\" Click=\"CopySelectedUser_Click\" IsEnabled=\"{Binding CanUseSelectedUserActions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Print Directory\" Click=\"PrintUsers_Click\" IsEnabled=\"{Binding CanPrintUsers}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Open User Detail\" Click=\"OpenSelectedUser_Click\" IsEnabled=\"{Binding CanUseSelectedUserActions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Print Current Directory\" Click=\"PrintUsers_Click\" IsEnabled=\"{Binding CanPrintUsers}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersPage_CodeBehindGuardsBusyRowActionsAndPrint()
+        {
+            var code = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs");
+
+            Assert.Contains("private bool IsUserDirectoryBusy => ViewModel?.IsLoadingUsers == true;", code, StringComparison.Ordinal);
+            Assert.Contains("TryRequireUserDirectoryReady", code, StringComparison.Ordinal);
+            Assert.Contains("User rows are still loading", code, StringComparison.Ordinal);
+            Assert.Contains("UserRow_MouseDoubleClick", code, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", code, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", code, StringComparison.Ordinal);
+            Assert.Contains("ViewModel?.CanUseSelectedUserActions != true", code, StringComparison.Ordinal);
+            Assert.Contains("!ViewModel.CanPrintUsers", code, StringComparison.Ordinal);
+            Assert.Contains("active state, contact handoff details", code, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-users-workbench-loading-actions.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-users-workbench-loading-actions.md
@@ -1,0 +1,26 @@
+# Users Workbench Loading And Action Responsiveness - 2026-07-04
+
+## Completed
+
+- Added ViewModel-backed user-directory loading state so refresh work exposes `IsLoadingUsers` and keeps all command availability in sync.
+- Disabled add, search, clear-filter, edit, upload-photo, reset-password, delete, selected-user, and print actions while account rows are refreshing.
+- Added visible/total count, filter status, selected access, selected security, empty-state, print-readiness, and directory status properties for source-backed UI copy.
+- Sorted refreshed users deterministically by active state, user name, and user ID so the account directory displays consistently after reloads and mutation recovery.
+- Expanded account search to include user ID and lockout/security status in addition to user, role, contact, and access summary text.
+- Preserved existing rows while a refresh is in progress, then clearly shows loading copy and pauses unsafe actions until refresh completes.
+- Added a bounded loading overlay in the virtualized Users directory region and prevented the empty state from competing with active loads.
+- Wired toolbar, subheader, context-menu, handoff-panel, search, print, and footer controls to shared user action/readiness state.
+- Guarded row double-click, right-click retargeting, open-detail, copy-handoff, reset-password, and print handlers in code-behind while rows are loading.
+- Improved User Directory print-preview description and footer copy to emphasize active state, contact handoff, access coverage, lockout state, and omitted rows.
+- Added behavior coverage for loading state, command disabling, duplicate reload suppression, deterministic display order, and expanded search coverage.
+- Extended Users page source-contract tests for loading overlays, status bindings, disabled actions, context-menu readiness, and code-behind busy guards.
+
+## Validation
+
+- Source-contract and behavior tests were updated for the new Users workbench loading/action contracts.
+- Direct local validation could not be run in this scheduled Linux environment because direct GitHub checkout is blocked by HTTP 403 `CONNECT tunnel failed`, and Windows/.NET/WPF tooling is unavailable here.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` in a Windows/.NET-capable checkout.
+- Smoke test Users initial load, reload during existing rows, search by user ID/access/lockout, double-click during load, right-click during load, reset password during load, copy handoff during load, and 250+ row directory printing.

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -35,11 +35,29 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<UserModel> Users { get; } = new();
 
+        private bool _isLoadingUsers;
+        public bool IsLoadingUsers
+        {
+            get => _isLoadingUsers;
+            private set
+            {
+                if (SetProperty(ref _isLoadingUsers, value))
+                {
+                    NotifyUserDirectoryStateChanged();
+                    NotifyUserCommandStatesChanged();
+                }
+            }
+        }
+
         private string _userSearchText = string.Empty;
         public string UserSearchText
         {
             get => _userSearchText;
-            set => SetProperty(ref _userSearchText, value);
+            set
+            {
+                if (SetProperty(ref _userSearchText, value))
+                    NotifyUserDirectoryStateChanged();
+            }
         }
 
         private UserModel? _selectedUser;
@@ -50,11 +68,71 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _selectedUser, value))
                 {
-                    ((AsyncRelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
-                    ((AsyncRelayCommand)EditUserCommand).NotifyCanExecuteChanged();
+                    NotifySelectedUserStateChanged();
+                    NotifyUserCommandStatesChanged();
                 }
             }
         }
+
+        public int TotalUserCount => _allUsers.Count;
+        public int VisibleUserCount => Users.Count;
+        public bool HasUserFilter => !string.IsNullOrWhiteSpace(UserSearchText);
+        public bool CanUseUserActions => !IsLoadingUsers;
+        public bool CanUseSelectedUserActions => !IsLoadingUsers && SelectedUser != null;
+        public bool CanPrintUsers => !IsLoadingUsers && Users.Count > 0;
+
+        public string UserDirectoryStatusText
+        {
+            get
+            {
+                if (IsLoadingUsers)
+                    return Users.Count > 0
+                        ? $"Refreshing account directory - keeping {Users.Count} current rows visible"
+                        : "Loading account directory";
+
+                if (Users.Count == 0)
+                    return HasUserFilter
+                        ? $"No users match \"{UserSearchText.Trim()}\""
+                        : "No user accounts are available";
+
+                return $"Admin desk ready - {Users.Count} visible of {_allUsers.Count} accounts";
+            }
+        }
+
+        public string UserFilterStatusText
+        {
+            get
+            {
+                if (IsLoadingUsers)
+                    return "Search pauses until account rows finish loading";
+
+                return HasUserFilter
+                    ? $"Filter: {UserSearchText.Trim()}"
+                    : "All accounts";
+            }
+        }
+
+        public string SelectedAccessStatusText =>
+            IsLoadingUsers
+                ? "Account rows are refreshing"
+                : SelectedUser?.AccessSummary ?? "No account selected";
+
+        public string SelectedSecurityStatusText =>
+            IsLoadingUsers
+                ? "Security state loading"
+                : SelectedUser?.LockoutStatus ?? "Select a user";
+
+        public string UserEmptyStateTitle =>
+            IsLoadingUsers
+                ? "Loading users"
+                : HasUserFilter ? "No users match this filter" : "No users are available";
+
+        public string UserEmptyStateMessage =>
+            IsLoadingUsers
+                ? "Account rows are being prepared. Existing rows stay visible when available."
+                : HasUserFilter
+                    ? "Clear the filter or search another user, role, contact detail, access area, status, or user ID."
+                    : "Add a new account before assigning app access, resetting passwords, or printing directory evidence.";
 
         public IAsyncRelayCommand LoadUsersCommand { get; }
         public IAsyncRelayCommand UploadUserPhotoCommand { get; }
@@ -86,27 +164,30 @@ namespace InventoryManagementApp.ViewModels
             _logger = logger ?? NullLogger<UserManagementViewModel>.Instance;
             _serviceProvider = serviceProvider;
 
-            LoadUsersCommand = new AsyncRelayCommand(LoadUsersAsync);
-            UploadUserPhotoCommand = new AsyncRelayCommand(UploadUserPhotoAsync);
-            UpdateUserCommand = new AsyncRelayCommand(UpdateUserAsync, () => SelectedUser != null);
-            AddUserCommand = new AsyncRelayCommand(AddUserAsync);
+            LoadUsersCommand = new AsyncRelayCommand(LoadUsersAsync, () => !IsLoadingUsers);
+            UploadUserPhotoCommand = new AsyncRelayCommand(UploadUserPhotoAsync, () => CanUseSelectedUserActions);
+            UpdateUserCommand = new AsyncRelayCommand(UpdateUserAsync, () => CanUseSelectedUserActions);
+            AddUserCommand = new AsyncRelayCommand(AddUserAsync, () => CanUseUserActions);
 
-            SearchUsersCommand = new RelayCommand(SearchUsers);
-            ClearUserSearchCommand = new RelayCommand(ClearUserSearch);
+            SearchUsersCommand = new RelayCommand(SearchUsers, () => CanUseUserActions);
+            ClearUserSearchCommand = new RelayCommand(ClearUserSearch, () => CanUseUserActions);
 
-            EditUserCommand = new AsyncRelayCommand(() => EditUserAsync(SelectedUser), () => SelectedUser != null);
-            EditUserFromRowCommand = new AsyncRelayCommand<UserModel>(EditUserAsync);
-            ResetPasswordFromRowCommand = new AsyncRelayCommand<UserModel>(ResetPasswordFor);
-            DeleteUserFromRowCommand = new AsyncRelayCommand<UserModel>(DeleteUserAsync);
+            EditUserCommand = new AsyncRelayCommand(() => EditUserAsync(SelectedUser), () => CanUseSelectedUserActions);
+            EditUserFromRowCommand = new AsyncRelayCommand<UserModel>(EditUserAsync, user => CanUseUserActions && user != null);
+            ResetPasswordFromRowCommand = new AsyncRelayCommand<UserModel>(ResetPasswordFor, user => CanUseUserActions && user != null);
+            DeleteUserFromRowCommand = new AsyncRelayCommand<UserModel>(DeleteUserAsync, user => CanUseUserActions && user != null);
         }
 
         public async Task LoadUsersAsync()
         {
+            if (IsLoadingUsers)
+                return;
+
+            IsLoadingUsers = true;
+
             try
             {
-                _allUsers = await _userService.GetAllUsersAsync(CancellationToken.None);
-                AssignInitialsBrushes(_allUsers);
-                Users.ReplaceRange(FilterUsers(_allUsers));
+                ApplyUserRows(await _userService.GetAllUsersAsync(CancellationToken.None));
             }
             catch (Exception ex)
             {
@@ -114,6 +195,23 @@ namespace InventoryManagementApp.ViewModels
                 ClearUsersAfterLoadFailure();
                 await _dialogService.ShowInfoAsync($"Failed to load users: {ex.Message}. User rows were cleared until refresh succeeds.", "Error");
             }
+            finally
+            {
+                IsLoadingUsers = false;
+            }
+        }
+
+        private void ApplyUserRows(IEnumerable<UserModel> users)
+        {
+            _allUsers = users
+                .OrderByDescending(user => user.IsActive)
+                .ThenBy(user => user.UserName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(user => user.UserID)
+                .ToList();
+
+            AssignInitialsBrushes(_allUsers);
+            Users.ReplaceRange(FilterUsers(_allUsers));
+            NotifyUserDirectoryStateChanged();
         }
 
         private void ClearUsersAfterLoadFailure()
@@ -121,17 +219,15 @@ namespace InventoryManagementApp.ViewModels
             _allUsers.Clear();
             Users.Clear();
             SelectedUser = null;
-            ((AsyncRelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
-            ((AsyncRelayCommand)EditUserCommand).NotifyCanExecuteChanged();
+            NotifyUserDirectoryStateChanged();
+            NotifyUserCommandStatesChanged();
         }
 
         private async Task<bool> RefreshUsersAfterMutationFailureAsync(int? preferredUserId, bool clearSelectionWhenMissing)
         {
             try
             {
-                _allUsers = await _userService.GetAllUsersAsync(CancellationToken.None);
-                AssignInitialsBrushes(_allUsers);
-                Users.ReplaceRange(FilterUsers(_allUsers));
+                ApplyUserRows(await _userService.GetAllUsersAsync(CancellationToken.None));
 
                 var refreshedSelection = preferredUserId.HasValue
                     ? Users.FirstOrDefault(user => user.UserID == preferredUserId.Value)
@@ -202,7 +298,7 @@ namespace InventoryManagementApp.ViewModels
 
         public async Task UploadUserPhotoAsync()
         {
-            if (SelectedUser == null) return;
+            if (!CanUseSelectedUserActions || SelectedUser == null) return;
 
             var path = _fileDialogService.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
             if (string.IsNullOrWhiteSpace(path))
@@ -249,6 +345,7 @@ namespace InventoryManagementApp.ViewModels
                 if (idx >= 0) Users[idx] = SelectedUser;
                 if (_userContext?.CurrentUser?.UserID == SelectedUser.UserID)
                     _userContext.CurrentUser = SelectedUser;
+                NotifyUserDirectoryStateChanged();
             }
             catch (UnauthorizedAccessException)
             {
@@ -264,7 +361,7 @@ namespace InventoryManagementApp.ViewModels
 
         public async Task UpdateUserAsync()
         {
-            if (SelectedUser == null) return;
+            if (!CanUseSelectedUserActions || SelectedUser == null) return;
             try
             {
                 await _userService.UpdateUserAsync(SelectedUser);
@@ -274,6 +371,7 @@ namespace InventoryManagementApp.ViewModels
                 if (idx >= 0) Users[idx] = SelectedUser;
                 if (_userContext?.CurrentUser?.UserID == SelectedUser.UserID)
                     _userContext.CurrentUser = SelectedUser;
+                NotifyUserDirectoryStateChanged();
             }
             catch (UnauthorizedAccessException)
             {
@@ -289,11 +387,13 @@ namespace InventoryManagementApp.ViewModels
 
         public async Task AddUserAsync()
         {
+            if (!CanUseUserActions) return;
+
             HashSet<string> existingNames;
             try
             {
                 existingNames = new HashSet<string>(
-                    (await _userService.GetAllUsersAsync(CancellationToken.None)).Select(u => u.UserName),
+                    _allUsers.Select(u => u.UserName),
                     StringComparer.OrdinalIgnoreCase);
             }
             catch (Exception ex)
@@ -332,8 +432,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _userService.AddUserAsync(newUser);
                 _allUsers.Add(newUser);
-                Users.Add(newUser);
-                SelectedUser = newUser;
+                ApplyUserRows(_allUsers);
+                SelectedUser = Users.FirstOrDefault(user => ReferenceEquals(user, newUser))
+                    ?? Users.FirstOrDefault(user => user.UserID == newUser.UserID)
+                    ?? newUser;
             }
             catch (UnauthorizedAccessException)
             {
@@ -384,7 +486,9 @@ namespace InventoryManagementApp.ViewModels
 
         void SearchUsers()
         {
+            if (!CanUseUserActions) return;
             Users.ReplaceRange(FilterUsers(_allUsers));
+            NotifyUserDirectoryStateChanged();
         }
 
         private IEnumerable<UserModel> FilterUsers(IEnumerable<UserModel> users)
@@ -396,24 +500,28 @@ namespace InventoryManagementApp.ViewModels
 
             var term = UserSearchText.Trim();
             return users.Where(u =>
+                u.UserID.ToString().Contains(term, StringComparison.OrdinalIgnoreCase) ||
                 (u.UserName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                 (u.Role?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                 (u.Email?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                 (u.Phone?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                 (u.Mobile?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                 (u.Address?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (u.LockoutStatus?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                 (u.AccessSummary?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false));
         }
 
         void ClearUserSearch()
         {
+            if (!CanUseUserActions) return;
             UserSearchText = string.Empty;
             Users.ReplaceRange(_allUsers);
+            NotifyUserDirectoryStateChanged();
         }
 
         public async Task EditUserAsync(UserModel? user)
         {
-            if (user == null) return;
+            if (!CanUseUserActions || user == null) return;
 
             UserModel source = user;
             try
@@ -464,6 +572,7 @@ namespace InventoryManagementApp.ViewModels
                         var idxAll = _allUsers.IndexOf(user);
                         if (idxAll >= 0) _allUsers[idxAll] = clone;
                         AssignInitialsBrushes(_allUsers);
+                        NotifyUserDirectoryStateChanged();
                         if (ReferenceEquals(SelectedUser, user)) SelectedUser = clone;
                         if (_userContext?.CurrentUser?.UserID == clone.UserID)
                             _userContext.CurrentUser = clone;
@@ -494,7 +603,7 @@ namespace InventoryManagementApp.ViewModels
 
         async Task ResetPasswordFor(UserModel? user)
         {
-            if (user == null) return;
+            if (!CanUseUserActions || user == null) return;
             var newPassword = PasswordDefaults.TemporaryPassword;
             try
             {
@@ -516,6 +625,8 @@ namespace InventoryManagementApp.ViewModels
                     user.FailedLoginAttempts = refreshed.FailedLoginAttempts;
                     user.LockoutEndUtc = refreshed.LockoutEndUtc;
                     user.Permissions = refreshed.Permissions;
+                    NotifySelectedUserStateChanged();
+                    NotifyUserDirectoryStateChanged();
                 }
                 await _dialogService.ShowInfoAsync(
                     $"Password has been reset to \"{newPassword}\". The user must change it at next login.",
@@ -540,7 +651,7 @@ namespace InventoryManagementApp.ViewModels
 
         async Task DeleteUserAsync(UserModel? user)
         {
-            if (user == null) return;
+            if (!CanUseUserActions || user == null) return;
             try
             {
                 var deleted = await _userService.TryDeleteUserAsync(user.UserID);
@@ -549,6 +660,8 @@ namespace InventoryManagementApp.ViewModels
                     _allUsers.Remove(user);
                     Users.Remove(user);
                     if (ReferenceEquals(SelectedUser, user)) SelectedUser = null;
+                    NotifyUserDirectoryStateChanged();
+                    NotifyUserCommandStatesChanged();
                 }
                 else
                 {
@@ -566,6 +679,43 @@ namespace InventoryManagementApp.ViewModels
                 _logger.LogError(ex, "Failed to delete user {UserID}", user.UserID);
                 await _dialogService.ShowInfoAsync(BuildMutationFailureMessage("Failed to delete user", ex, refreshed), "Error");
             }
+        }
+
+        private void NotifyUserDirectoryStateChanged()
+        {
+            OnPropertyChanged(nameof(TotalUserCount));
+            OnPropertyChanged(nameof(VisibleUserCount));
+            OnPropertyChanged(nameof(HasUserFilter));
+            OnPropertyChanged(nameof(CanUseUserActions));
+            OnPropertyChanged(nameof(CanUseSelectedUserActions));
+            OnPropertyChanged(nameof(CanPrintUsers));
+            OnPropertyChanged(nameof(UserDirectoryStatusText));
+            OnPropertyChanged(nameof(UserFilterStatusText));
+            OnPropertyChanged(nameof(UserEmptyStateTitle));
+            OnPropertyChanged(nameof(UserEmptyStateMessage));
+            OnPropertyChanged(nameof(SelectedAccessStatusText));
+            OnPropertyChanged(nameof(SelectedSecurityStatusText));
+        }
+
+        private void NotifySelectedUserStateChanged()
+        {
+            OnPropertyChanged(nameof(CanUseSelectedUserActions));
+            OnPropertyChanged(nameof(SelectedAccessStatusText));
+            OnPropertyChanged(nameof(SelectedSecurityStatusText));
+        }
+
+        private void NotifyUserCommandStatesChanged()
+        {
+            LoadUsersCommand.NotifyCanExecuteChanged();
+            UploadUserPhotoCommand.NotifyCanExecuteChanged();
+            UpdateUserCommand.NotifyCanExecuteChanged();
+            AddUserCommand.NotifyCanExecuteChanged();
+            SearchUsersCommand.NotifyCanExecuteChanged();
+            ClearUserSearchCommand.NotifyCanExecuteChanged();
+            EditUserCommand.NotifyCanExecuteChanged();
+            EditUserFromRowCommand.NotifyCanExecuteChanged();
+            ResetPasswordFromRowCommand.NotifyCanExecuteChanged();
+            DeleteUserFromRowCommand.NotifyCanExecuteChanged();
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -32,6 +32,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly IServiceProvider? _serviceProvider;
 
         private List<UserModel> _allUsers = new();
+        private bool _hasLoadedUsers;
 
         public ObservableCollection<UserModel> Users { get; } = new();
 
@@ -208,6 +209,7 @@ namespace InventoryManagementApp.ViewModels
                 .ThenBy(user => user.UserName, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(user => user.UserID)
                 .ToList();
+            _hasLoadedUsers = true;
 
             AssignInitialsBrushes(_allUsers);
             Users.ReplaceRange(FilterUsers(_allUsers));
@@ -217,6 +219,7 @@ namespace InventoryManagementApp.ViewModels
         private void ClearUsersAfterLoadFailure()
         {
             _allUsers.Clear();
+            _hasLoadedUsers = false;
             Users.Clear();
             SelectedUser = null;
             NotifyUserDirectoryStateChanged();
@@ -392,8 +395,12 @@ namespace InventoryManagementApp.ViewModels
             HashSet<string> existingNames;
             try
             {
+                var existingUsers = _hasLoadedUsers
+                    ? _allUsers
+                    : await _userService.GetAllUsersAsync(CancellationToken.None);
+
                 existingNames = new HashSet<string>(
-                    _allUsers.Select(u => u.UserName),
+                    existingUsers.Select(u => u.UserName),
                     StringComparer.OrdinalIgnoreCase);
             }
             catch (Exception ex)
@@ -432,6 +439,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _userService.AddUserAsync(newUser);
                 _allUsers.Add(newUser);
+                UserSearchText = string.Empty;
                 ApplyUserRows(_allUsers);
                 SelectedUser = Users.FirstOrDefault(user => ReferenceEquals(user, newUser))
                     ?? Users.FirstOrDefault(user => user.UserID == newUser.UserID)

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -40,14 +40,19 @@
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
+                    <TextBlock Text="{Binding UserDirectoryStatusText}"
+                               Style="{StaticResource CaptionTextBlock}"
+                               FontWeight="SemiBold"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0"/>
                 </StackPanel>
                 <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add User" Command="{Binding AddUserCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit Access" Command="{Binding EditUserCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Reset Password" Click="ResetSelectedUser_Click" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Upload Photo" Command="{Binding UploadUserPhotoCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedUser_Click" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintUsers_Click" Margin="0,0,0,6"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add User" Command="{Binding AddUserCommand}" IsEnabled="{Binding CanUseUserActions}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Edit Access" Command="{Binding EditUserCommand}" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Reset Password" Click="ResetSelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Upload Photo" Command="{Binding UploadUserPhotoCommand}" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintUsers_Click" IsEnabled="{Binding CanPrintUsers}" Margin="0,0,0,6"/>
                 </WrapPanel>
             </DockPanel>
         </Border>
@@ -56,28 +61,28 @@
             <Border Style="{StaticResource UserStatCard}">
                 <StackPanel>
                     <TextBlock Text="Visible Users" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding Users.Count}" Style="{StaticResource UserStatValueText}"/>
-                    <TextBlock Text="Rows matching the current account search" Style="{StaticResource UserDetailText}"/>
+                    <TextBlock Text="{Binding VisibleUserCount}" Style="{StaticResource UserStatValueText}"/>
+                    <TextBlock Text="{Binding UserDirectoryStatusText}" Style="{StaticResource UserDetailText}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource UserStatCard}">
                 <StackPanel>
                     <TextBlock Text="Directory Filter" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding UserSearchText, TargetNullValue=All accounts}" Style="{StaticResource UserStatValueText}"/>
-                    <TextBlock Text="Search by user, role, contact, or access summary before printing" Style="{StaticResource UserDetailText}"/>
+                    <TextBlock Text="{Binding UserFilterStatusText}" Style="{StaticResource UserStatValueText}"/>
+                    <TextBlock Text="Search by ID, user, role, contact, lockout, or access summary before printing" Style="{StaticResource UserDetailText}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource UserStatCard}">
                 <StackPanel>
                     <TextBlock Text="Selected Access" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding SelectedUser.AccessSummary, TargetNullValue=No account selected}" Style="{StaticResource UserStatValueText}"/>
+                    <TextBlock Text="{Binding SelectedAccessStatusText}" Style="{StaticResource UserStatValueText}"/>
                     <TextBlock Text="Review allowed app areas before editing permissions" Style="{StaticResource UserDetailText}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource UserStatCard}" Margin="0,0,0,8">
                 <StackPanel>
                     <TextBlock Text="Security State" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding SelectedUser.LockoutStatus, TargetNullValue=Select a user}" Style="{StaticResource UserStatValueText}"/>
+                    <TextBlock Text="{Binding SelectedSecurityStatusText}" Style="{StaticResource UserStatValueText}"/>
                     <TextBlock Text="Password reset, lockout, and active-status context" Style="{StaticResource UserDetailText}"/>
                 </StackPanel>
             </Border>
@@ -107,7 +112,7 @@
                                            TextWrapping="Wrap"/>
                             </StackPanel>
                             <TextBlock DockPanel.Dock="Right"
-                                       Text="{Binding Users.Count, StringFormat='Visible: {0}'}"
+                                       Text="{Binding UserDirectoryStatusText}"
                                        Style="{StaticResource CaptionTextBlock}"
                                        VerticalAlignment="Center"
                                        TextWrapping="Wrap"
@@ -125,12 +130,13 @@
                                                  Text="{Binding UserSearchText, UpdateSourceTrigger=PropertyChanged}"
                                                  SearchCommand="{Binding SearchUsersCommand}"
                                                  ClearCommand="{Binding ClearUserSearchCommand}"
+                                                 IsEnabled="{Binding CanUseUserActions}"
                                                  Margin="0,0,8,6"/>
                             </WrapPanel>
                             <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="12,0,0,0">
-                                <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddUserCommand}" Margin="0,0,4,6"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Clear Filter" Command="{Binding ClearUserSearchCommand}" Margin="0,0,4,6"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintUsers_Click" Margin="0,0,0,6"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddUserCommand}" IsEnabled="{Binding CanUseUserActions}" Margin="0,0,4,6"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Clear Filter" Command="{Binding ClearUserSearchCommand}" IsEnabled="{Binding CanUseUserActions}" Margin="0,0,4,6"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintUsers_Click" IsEnabled="{Binding CanPrintUsers}" Margin="0,0,0,6"/>
                             </WrapPanel>
                         </DockPanel>
                     </Border>
@@ -211,15 +217,15 @@
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                <MenuItem Header="Open User Detail" Click="OpenSelectedUser_Click"/>
-                                <MenuItem Header="Edit User Access" Command="{Binding EditUserCommand}"/>
-                                <MenuItem Header="Reset Password" Click="ResetSelectedUser_Click"/>
-                                <MenuItem Header="Upload Photo" Command="{Binding UploadUserPhotoCommand}"/>
+                                <MenuItem Header="Open User Detail" Click="OpenSelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}"/>
+                                <MenuItem Header="Edit User Access" Command="{Binding EditUserCommand}" IsEnabled="{Binding CanUseSelectedUserActions}"/>
+                                <MenuItem Header="Reset Password" Click="ResetSelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}"/>
+                                <MenuItem Header="Upload Photo" Command="{Binding UploadUserPhotoCommand}" IsEnabled="{Binding CanUseSelectedUserActions}"/>
                                 <Separator/>
-                                <MenuItem Header="Copy User Handoff" Click="CopySelectedUser_Click"/>
-                                <MenuItem Header="Print Current Directory" Click="PrintUsers_Click"/>
+                                <MenuItem Header="Copy User Handoff" Click="CopySelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}"/>
+                                <MenuItem Header="Print Current Directory" Click="PrintUsers_Click" IsEnabled="{Binding CanPrintUsers}"/>
                                 <Separator/>
-                                <MenuItem Header="Delete User" Command="{Binding DeleteUserFromRowCommand}" CommandParameter="{Binding SelectedUser}"/>
+                                <MenuItem Header="Delete User" Command="{Binding DeleteUserFromRowCommand}" CommandParameter="{Binding SelectedUser}" IsEnabled="{Binding CanUseSelectedUserActions}"/>
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>
@@ -229,15 +235,36 @@
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Users.Count}" Value="0">
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding Users.Count}" Value="0"/>
+                                            <Condition Binding="{Binding IsLoadingUsers}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="{Binding UserEmptyStateTitle}" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="{Binding UserEmptyStateMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Grid.Row="2" MaxWidth="360" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsLoadingUsers}" Value="True">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
-                            <TextBlock Text="No users match this filter" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
-                            <TextBlock Text="Clear the filter or add a new account before assigning app access." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Loading account directory" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="Existing rows remain visible when available. Account actions pause until the refresh finishes." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
                 </Grid>
@@ -327,10 +354,10 @@
 
                     <Border Grid.Row="2" Style="{StaticResource DesktopSectionActionStrip}">
                         <WrapPanel HorizontalAlignment="Right">
-                            <Button Style="{StaticResource GhostButton}" Content="Open Detail" Click="OpenSelectedUser_Click" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedUser_Click" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Reset Password" Click="ResetSelectedUser_Click" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintUsers_Click" Margin="0,0,0,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Open Detail" Click="OpenSelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Reset Password" Click="ResetSelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintUsers_Click" IsEnabled="{Binding CanPrintUsers}" Margin="0,0,0,4"/>
                         </WrapPanel>
                     </Border>
                 </Grid>
@@ -344,7 +371,7 @@
                 Padding="8,4">
             <DockPanel>
                 <TextBlock DockPanel.Dock="Left"
-                           Text="{Binding Users.Count, StringFormat='Admin desk ready - {0} visible accounts'}"
+                           Text="{Binding UserDirectoryStatusText}"
                            FontSize="11"
                            VerticalAlignment="Center"/>
                 <TextBlock DockPanel.Dock="Right"

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
@@ -29,13 +29,41 @@ namespace InventoryManagementApp.Views.Pages
         public UserManagementViewModel? ViewModel =>
             DataContext as UserManagementViewModel;
 
+        private bool IsUserDirectoryBusy => ViewModel?.IsLoadingUsers == true;
+
+        private bool TryRequireUserDirectoryReady(string actionDescription)
+        {
+            if (!IsUserDirectoryBusy)
+                return true;
+
+            WpfMessageBox.Show(
+                $"User rows are still loading. Wait for the account directory to finish before {actionDescription}.",
+                "User Directory",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+            return false;
+        }
+
         private void UserRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (!TryRequireUserDirectoryReady("opening account details"))
+            {
+                e.Handled = true;
+                return;
+            }
+
             OpenSelectedUser_Click(sender, e);
+            e.Handled = true;
         }
 
         private void UserRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (IsUserDirectoryBusy)
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
         }
 
@@ -43,7 +71,10 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "User Directory", () =>
             {
-                if (UsersDataGrid.SelectedItem is not UserModel user)
+                if (!TryRequireUserDirectoryReady("opening account details"))
+                    return;
+
+                if (ViewModel?.CanUseSelectedUserActions != true || UsersDataGrid.SelectedItem is not UserModel user)
                 {
                     WpfMessageBox.Show("Select a user row first.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -64,7 +95,10 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "User Directory", () =>
             {
-                if (UsersDataGrid.SelectedItem is not UserModel user)
+                if (!TryRequireUserDirectoryReady("copying account handoff details"))
+                    return;
+
+                if (ViewModel?.CanUseSelectedUserActions != true || UsersDataGrid.SelectedItem is not UserModel user)
                 {
                     WpfMessageBox.Show("Select a user row first.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -78,7 +112,10 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.RunAsync(this, "User Directory", async () =>
             {
-                if (ViewModel == null || UsersDataGrid.SelectedItem is not UserModel user)
+                if (!TryRequireUserDirectoryReady("resetting a password"))
+                    return;
+
+                if (ViewModel == null || ViewModel.CanUseSelectedUserActions != true || UsersDataGrid.SelectedItem is not UserModel user)
                 {
                     WpfMessageBox.Show("Select a user row first.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -92,7 +129,10 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "User Directory", () =>
             {
-                if (ViewModel == null || ViewModel.Users.Count == 0)
+                if (!TryRequireUserDirectoryReady("printing the account directory"))
+                    return;
+
+                if (ViewModel == null || !ViewModel.CanPrintUsers)
                 {
                     WpfMessageBox.Show("There are no users to print.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -102,7 +142,7 @@ namespace InventoryManagementApp.Views.Pages
                 var printRows = ViewModel.Users.Take(MaxUsersPrintRows).ToList();
                 var summary = $"Visible users: {totalVisibleCount}; printed rows: {printRows.Count}; omitted rows: {Math.Max(0, totalVisibleCount - printRows.Count)}";
                 var document = BuildPrintDocument(printRows, totalVisibleCount, summary);
-                ShowPrintPreview(document, "User Directory", "Review the current account directory, access coverage, lockout state, and any omitted rows before filing an admin handoff.");
+                ShowPrintPreview(document, "User Directory", "Review the current account directory, access coverage, lockout state, active state, contact handoff details, and any omitted rows before filing an admin packet.");
             });
         }
 
@@ -195,7 +235,7 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             document.Blocks.Add(table);
-            document.Blocks.Add(new Paragraph(new Run("Review access coverage, lockout state, disabled accounts, and any omitted rows before changing permissions or filing this directory packet."))
+            document.Blocks.Add(new Paragraph(new Run("Review access coverage, lockout state, disabled accounts, contact handoff details, and any omitted rows before changing permissions or filing this directory packet."))
             {
                 FontSize = 10,
                 FontStyle = FontStyles.Italic,


### PR DESCRIPTION
## What changed

- Added ViewModel-backed Users workbench loading state with `IsLoadingUsers`, shared action readiness, selected-user readiness, print readiness, visible/total counts, dynamic filter status, selected access/security status, and loading/empty messages.
- Disabled add, search, clear-filter, edit, upload-photo, reset-password, delete, selected-user, context-menu, handoff-panel, and print actions while account rows are refreshing.
- Preserved existing rows during refresh and added a bounded loading overlay so operators see why actions are paused without losing the current directory view.
- Sorted refreshed user rows deterministically by active state, user name, and user ID for steadier professional display after reloads and recovery refreshes.
- Expanded account search to include user ID and lockout/security status in addition to user, role, contact, and access summary text.
- Guarded row double-click, right-click row retargeting, open-detail, copy-handoff, reset-password, and print handlers in code-behind while the directory is busy.
- Kept Add User duplicate-name setup safe by using the loaded row snapshot after a successful directory load and falling back to the user service if Add is invoked before the directory has loaded.
- Cleared the filter after adding a new user so the newly created account remains visible and selected.
- Improved User Directory print-preview description and footer copy to emphasize active state, contact handoff, access coverage, lockout state, and omitted rows.
- Added ViewModel behavior coverage for loading state, command disabling, duplicate reload suppression, deterministic display order, and expanded search coverage.
- Extended Users page source-contract coverage for loading overlays, status bindings, disabled actions, context-menu readiness, and code-behind busy guards.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-users-workbench-loading-actions.md`.

## Why this was highest value

Recent scheduled runs already covered Dashboard, Manage Items, Item Search, Customer Directory, Reservations, Reports, Print Labels, Label Output, and several operational workbenches. Repository evidence showed the Users workbench had responsive layout and print caps, but the load/search/action surface still did not have a shared busy-state contract. Users is an admin/security workflow where stale row actions, duplicate reloads, and unclear loading state are high-friction and high-risk.

## Why this is real progress

This is a vertical Users workbench slice across ViewModel state, deterministic data display, search behavior, XAML status/action binding, code-behind gesture/action safety, print copy, tests, and progress notes. It improves more than ten practical workflow paths without adding unrelated screens or speculative architecture.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, seven focused commits ahead, and limited to:
  - `InventoryManagementApp/ViewModels/UserManagementViewModel.cs`
  - `InventoryManagementApp/Views/Pages/UsersPage.xaml`
  - `InventoryManagementApp/Views/Pages/UsersPage.xaml.cs`
  - `InventoryManagementApp.Tests/UserManagementViewModelTests.cs`
  - `InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-users-workbench-loading-actions.md`
- Connector readback confirmed the Users ViewModel loading/action state, XAML bindings, code-behind guards, behavior/source-contract tests, and progress note are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `cd380414fa79690bc4c0407a8f16d47c4e07d3d6` before PR creation.

Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime checks, screenshots, scaling checks, or print-preview rendering because direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and Windows/.NET/WPF tooling is unavailable here.

## Follow-up

- Run full Windows validation.
- Smoke test Users initial load, reload during existing rows, search by user ID/access/lockout, double-click/right-click during load, reset password during load, copy handoff during load, Add User before and after initial load, and 250+ row directory printing.