### PR TITLE
Improve Manage Items startup and keyboard responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
@@ -112,15 +112,43 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void ManageItemsPage_CodeBehindGuardsRowActionsWhileLoading()
+        public void ManageItemsPage_CodeBehindGuardsStartupAndRowActionsWhileLoading()
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml.cs");
 
+            Assert.Contains("private ItemsViewModel? _loadedViewModel;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += ManageItemsPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("PreviewKeyDown += ManageItemsPage_PreviewKeyDown;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (ReferenceEquals(_loadedViewModel, vm))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (vm.Items.IsLoading || vm.Items.Count > 0)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!vm.Items.IsLoading && vm.Items.Count == 0 && vm.Items.HasMoreItems)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (IsItemDirectoryBusy())", codeBehind, StringComparison.Ordinal);
             Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("return DataContext is ItemsViewModel { Items.IsLoading: true };", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("private bool _isLoadedForCurrentLifetime;", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (_isLoadedForCurrentLifetime)", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageItemsPage_ProvidesKeyboardShortcutsThroughCommandAvailability()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml.cs");
+
+            Assert.Contains("private void ManageItemsPage_PreviewKeyDown(object sender, KeyEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("IsManagedDirectoryShortcut(e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N && vm.NewItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.M && vm.OpenMobileCaptureCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.E && vm.EditItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D && vm.ViewDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.H && vm.OpenRentalHistoryCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.S && vm.CommitChangesCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete && vm.DeleteItemsCommand.CanExecute(ItemDirectoryGrid.SelectedItems)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter && vm.ViewDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("UiActionGuard.RunAsync(this, \"Manage Items\", async () => await vm.NewItemCommand.ExecuteAsync(null));", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("UiActionGuard.Run(this, \"Manage Items\", () => vm.ViewDetailsCommand.Execute(null));", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return e.Key is Key.N or Key.M or Key.E or Key.D or Key.H or Key.S;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Delete or Key.Enter;", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-manage-items-startup-keyboard-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-manage-items-startup-keyboard-responsiveness.md
@@ -1,0 +1,32 @@
+# Manage Items Startup And Keyboard Responsiveness - 2026-07-04
+
+## Completed
+
+- Replaced the page-level boolean startup guard with a view-model-aware load guard so repeated WPF `Loaded` events for the same `ItemsViewModel` do not repeat directory work.
+- Skipped page-owned startup loading when the Manage Items open command already loaded rows before the page was displayed.
+- Skipped page-owned startup loading when the incremental collection is already loading, avoiding overlapping first-page requests.
+- Preserved the dispatcher yield before page-owned startup work so the page can paint before any fallback load begins.
+- Guarded fallback page loading so `LoadMoreAsync` only runs when no rows are loaded, no load is active, and more rows are available.
+- Reset the startup guard on real DataContext swaps and canceled startup work on unload.
+- Kept row double-click and right-click retargeting paused while item rows are loading.
+- Added keyboard workflow support for New, Mobile Capture, Edit, Details, Rental History, Save, Delete, and Enter-to-details.
+- Routed keyboard actions through command `CanExecute` checks and `UiActionGuard` so shortcuts match the same availability rules as visible buttons.
+- Swallowed managed directory shortcuts while rows are busy so keyboard input cannot dispatch stale row actions during refresh.
+- Extended Manage Items source-contract coverage for startup load reuse, loaded-row skip behavior, busy guards, and keyboard command routing.
+
+## Why It Matters
+
+Manage Items is a high-traffic directory with incremental loading, inline edits, item photos, availability context, and selected-row handoff details. The main shell already preloads the first page before showing the workflow, but the page `Loaded` handler could still issue another initialization/load cycle after display. This pass reduces redundant startup work, keeps first paint responsive, and gives operators fast keyboard paths without bypassing loading and command availability checks.
+
+## Validation
+
+- Connector readback should confirm the page now tracks `_loadedViewModel`, skips fallback loading when rows already exist or a load is active, keeps the dispatcher yield, and routes keyboard shortcuts through command availability checks.
+- Source-contract tests were updated to guard the startup, busy-state, and keyboard workflow contracts.
+
+## Not Run Here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- .NET restore/build/test
+- WPF runtime smoke tests, screenshots, scaling checks, or live keyboard testing
+
+Those remain unavailable in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is not present.

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -12,7 +12,7 @@ namespace InventoryManagementApp.Views.Pages
     public partial class ManageItemsPage : Page
     {
         private CancellationTokenSource _loadCts = new();
-        private bool _isLoadedForCurrentLifetime;
+        private ItemsViewModel? _loadedViewModel;
 
         public ManageItemsPage()
         {
@@ -21,12 +21,13 @@ namespace InventoryManagementApp.Views.Pages
             Loaded += ManageItemsPage_Loaded;
             Unloaded += ManageItemsPage_Unloaded;
             DataContextChanged += ManageItemsPage_DataContextChanged;
+            PreviewKeyDown += ManageItemsPage_PreviewKeyDown;
         }
 
         private void ManageItemsPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            if (!ReferenceEquals(e.OldValue, e.NewValue))
-                _isLoadedForCurrentLifetime = false;
+            if (!ReferenceEquals(e.NewValue, _loadedViewModel))
+                _loadedViewModel = null;
         }
 
         private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
@@ -59,32 +60,39 @@ namespace InventoryManagementApp.Views.Pages
 
         private async void ManageItemsPage_Loaded(object sender, RoutedEventArgs e)
         {
-            if (_isLoadedForCurrentLifetime)
-                return;
-
-            _isLoadedForCurrentLifetime = true;
-
             if (DataContext is not ItemsViewModel vm)
             {
                 vm = ((App)Application.Current).Host.Services.GetRequiredService<ItemsViewModel>();
                 DataContext = vm;
             }
 
+            if (ReferenceEquals(_loadedViewModel, vm))
+                return;
+
+            _loadedViewModel = vm;
+
+            if (vm.Items.IsLoading || vm.Items.Count > 0)
+                return;
+
             try
             {
-                await vm.InitializeAsync(_loadCts.Token);
                 await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
-                await vm.LoadMoreAsync(_loadCts.Token);
+                await vm.InitializeAsync(_loadCts.Token);
+
+                if (!vm.Items.IsLoading && vm.Items.Count == 0 && vm.Items.HasMoreItems)
+                    await vm.LoadMoreAsync(_loadCts.Token);
             }
             catch (OperationCanceledException)
             {
+                if (ReferenceEquals(_loadedViewModel, vm))
+                    _loadedViewModel = null;
             }
         }
 
         private void ManageItemsPage_Unloaded(object sender, RoutedEventArgs e)
         {
             _loadCts.Cancel();
-            _isLoadedForCurrentLifetime = false;
+            _loadedViewModel = null;
             if (DataContext is ItemsViewModel vm)
             {
                 vm.Dispose();
@@ -92,6 +100,84 @@ namespace InventoryManagementApp.Views.Pages
             }
             _loadCts.Dispose();
             _loadCts = new CancellationTokenSource();
+        }
+
+        private void ManageItemsPage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (DataContext is not ItemsViewModel vm)
+                return;
+
+            if (IsItemDirectoryBusy())
+            {
+                if (IsManagedDirectoryShortcut(e))
+                    e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N && vm.NewItemCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Manage Items", async () => await vm.NewItemCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.M && vm.OpenMobileCaptureCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Manage Items", async () => await vm.OpenMobileCaptureCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.E && vm.EditItemCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Manage Items", async () => await vm.EditItemCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D && vm.ViewDetailsCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Manage Items", () => vm.ViewDetailsCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.H && vm.OpenRentalHistoryCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Manage Items", async () => await vm.OpenRentalHistoryCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.S && vm.CommitChangesCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Manage Items", async () => await vm.CommitChangesCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete && vm.DeleteItemsCommand.CanExecute(ItemDirectoryGrid.SelectedItems))
+            {
+                UiActionGuard.RunAsync(this, "Manage Items", async () => await vm.DeleteItemsCommand.ExecuteAsync(ItemDirectoryGrid.SelectedItems));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter && vm.ViewDetailsCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Manage Items", () => vm.ViewDetailsCommand.Execute(null));
+                e.Handled = true;
+            }
+        }
+
+        private static bool IsManagedDirectoryShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                return e.Key is Key.N or Key.M or Key.E or Key.D or Key.H or Key.S;
+            }
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Delete or Key.Enter;
         }
 
         private bool IsItemDirectoryBusy()


### PR DESCRIPTION
## What changed

- Replaced the Manage Items page boolean startup guard with a view-model-aware loaded guard.
- Skipped fallback page-owned loading when the shell open command has already loaded item rows before display.
- Skipped overlapping fallback loading when the incremental item collection is already loading.
- Preserved the dispatcher yield before fallback startup work so the page can paint before page-owned data work begins.
- Guarded fallback `LoadMoreAsync` so it runs only when no rows are loaded, no load is active, and more rows are available.
- Reset startup tracking on real DataContext changes and canceled page-owned startup work on unload.
- Kept row double-click and right-click retargeting paused while item rows load.
- Added keyboard-safe Manage Items shortcuts for New, Mobile Capture, Edit, Details, Rental History, Save, Delete, and Enter-to-details.
- Routed keyboard paths through command `CanExecute` checks and `UiActionGuard` to match visible button availability.
- Swallowed managed directory shortcuts during loading so keyboard input cannot dispatch stale row actions.
- Extended Manage Items source-contract coverage for startup load reuse, loaded-row skip behavior, busy guards, and keyboard command routing.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-04-manage-items-startup-keyboard-responsiveness.md`.

## Why this was highest value

Recent runs covered Dashboard, Reports, Item Search, Customers, Reservations, Print Labels, Activity Logs, and Users. Repository evidence showed Manage Items still had a concrete responsiveness issue: `MainViewModel.OpenManageItemsCommand` preloads the first page before displaying the page, while `ManageItemsPage.Loaded` could initialize and load again after display. Manage Items is a high-traffic incremental directory, so reducing duplicate startup work and adding guarded keyboard workflow paths directly supports loading speed, UI responsiveness, and professional data display.

## Why this is real progress

This is a vertical Manage Items workflow pass across startup loading behavior, duplicate load suppression, busy row-action safety, keyboard operator workflow, source-contract tests, and progress notes. It improves more than ten practical paths without adding unrelated screens or revisiting recently completed workflows.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, three focused commits ahead, and limited to:
  - `InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs`
  - `InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-manage-items-startup-keyboard-responsiveness.md`
- Connector readback confirmed the loaded-view-model guard, loaded-row/active-load skip, dispatcher yield, guarded fallback load, busy keyboard shortcut swallowing, command `CanExecute` checks, and source-contract assertions are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `f58f6d1a641a49efa87d0240a588448b6148b9bb` before PR creation.

Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime checks, screenshots, scaling checks, or live keyboard testing because direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and Windows/.NET/WPF tooling is unavailable here.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Manage Items initial open, repeated open after shell preload, rapid navigation away during fallback load, row double-click/right-click while loading, Ctrl+N, Ctrl+M, Ctrl+E, Ctrl+D, Ctrl+H, Ctrl+S, Delete, and Enter with zero/one/multiple selected rows.