### PR TITLE
Improve operational record page action responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/OperationalRecordPageActionGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/OperationalRecordPageActionGuardContractTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class OperationalRecordPageActionGuardContractTests
+    {
+        [Fact]
+        public void MaintenancePage_GuardsStartupLoadingThroughActiveViewModelAndCommandAvailability()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml.cs");
+
+            Assert.Contains("FocusFirstSearchBox();", source, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("!ReferenceEquals(DataContext, vm) || !vm.LoadMaintenanceCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("_loadMaintenanceTask = vm.LoadMaintenanceCommand.ExecuteAsync(null);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenancePage_GuardsRowGesturesWhileMaintenanceRowsLoad()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml.cs");
+            var doubleClick = ExtractSourceBlock(source, "private void MaintenanceRow_MouseDoubleClick", "private void MaintenanceRow_PreviewMouseRightButtonDown");
+            var rightClick = ExtractSourceBlock(source, "private void MaintenanceRow_PreviewMouseRightButtonDown", "private void MaintenancePage_PreviewKeyDown");
+
+            Assert.Contains("MaintenanceManagementViewModel { IsLoading: true }", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e) == null", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("OpenMaintenanceDetailsCommand.CanExecute(null)", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("MaintenanceManagementViewModel { IsLoading: true }", rightClick, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", rightClick, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenancePage_GuardsKeyboardWorkflowThroughBusyStateAndCanExecute()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml.cs");
+            var keyHandler = ExtractSourceBlock(source, "private void MaintenancePage_PreviewKeyDown", "private static bool IsMaintenanceActionShortcut");
+            var busyShortcut = ExtractSourceBlock(source, "private static bool IsMaintenanceActionShortcut", "private void FocusFirstSearchBox");
+
+            Assert.Contains("PreviewKeyDown += MaintenancePage_PreviewKeyDown;", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("vm.IsLoading && IsMaintenanceActionShortcut(e)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("AddMaintenanceCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("RefreshCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("PrintMaintenanceListCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("PrintSelectedMaintenanceCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedMaintenanceCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("OpenMaintenanceDetailsCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("EditMaintenanceCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("CompleteMaintenanceCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("DeleteMaintenanceCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("e.Key is Key.N or Key.R or Key.P or Key.C or Key.D or Key.E or Key.Enter", busyShortcut, StringComparison.Ordinal);
+            Assert.Contains("return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;", busyShortcut, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPage_GuardsStartupLoadingThroughActiveViewModelAndCommandAvailability()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml.cs");
+
+            Assert.Contains("FocusFirstSearchBox();", source, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("!ReferenceEquals(DataContext, vm) || !vm.LoadCalibrationCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("_loadCalibrationTask = vm.LoadCalibrationCommand.ExecuteAsync(null);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPage_GuardsRowGesturesWhileCalibrationRowsLoad()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml.cs");
+            var doubleClick = ExtractSourceBlock(source, "private void CalibrationRow_MouseDoubleClick", "private void CalibrationRow_PreviewMouseRightButtonDown");
+            var rightClick = ExtractSourceBlock(source, "private void CalibrationRow_PreviewMouseRightButtonDown", "private void CalibrationPage_PreviewKeyDown");
+
+            Assert.Contains("CalibrationManagementViewModel { IsLoading: true }", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e) == null", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("OpenCalibrationDetailsCommand.CanExecute(null)", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("CalibrationManagementViewModel { IsLoading: true }", rightClick, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", rightClick, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPage_GuardsKeyboardWorkflowThroughBusyStateAndCanExecute()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml.cs");
+            var keyHandler = ExtractSourceBlock(source, "private void CalibrationPage_PreviewKeyDown", "private static bool IsCalibrationActionShortcut");
+            var busyShortcut = ExtractSourceBlock(source, "private static bool IsCalibrationActionShortcut", "private void FocusFirstSearchBox");
+
+            Assert.Contains("PreviewKeyDown += CalibrationPage_PreviewKeyDown;", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("vm.IsLoading && IsCalibrationActionShortcut(e)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("AddCalibrationCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("RefreshCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("PrintCalibrationListCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("PrintSelectedCalibrationCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedCalibrationCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("OpenCalibrationDetailsCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("EditCalibrationCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("DeleteCalibrationCommand.CanExecute(null)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("e.Key is Key.N or Key.R or Key.P or Key.C or Key.D or Key.E", busyShortcut, StringComparison.Ordinal);
+            Assert.Contains("return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;", busyShortcut, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
+
+            return source[start..end];
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-operational-record-keyboard-busy-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-operational-record-keyboard-busy-guards.md
@@ -1,0 +1,35 @@
+# Operational Record Page Keyboard And Busy Guards - 2026-07-05
+
+## Completed
+
+- Added first-paint search focus to the Maintenance page before page-owned loading starts.
+- Added an active DataContext and `LoadMaintenanceCommand.CanExecute` guard before Maintenance page-owned startup loading begins.
+- Blocked Maintenance row double-click details while maintenance rows are loading.
+- Retargeted the Maintenance selected row before double-click details so keyboard/mouse actions use the row the operator invoked.
+- Blocked Maintenance right-click row retargeting while maintenance rows are loading.
+- Added Maintenance keyboard workflow shortcuts for find, add, refresh, print schedule, print selected record, copy handoff, details, edit, complete, delete, and Enter-to-details.
+- Routed Maintenance keyboard shortcuts through command `CanExecute` and `UiActionGuard` so disabled commands stay disabled from the keyboard.
+- Swallowed Maintenance action shortcuts during row loading while preserving Ctrl+F search focus.
+- Added first-paint search focus to the Calibration page before page-owned loading starts.
+- Added an active DataContext and `LoadCalibrationCommand.CanExecute` guard before Calibration page-owned startup loading begins.
+- Blocked Calibration row double-click details while calibration rows are loading.
+- Retargeted the Calibration selected row before double-click details so keyboard/mouse actions use the row the operator invoked.
+- Blocked Calibration right-click row retargeting while calibration rows are loading.
+- Added Calibration keyboard workflow shortcuts for find, add, refresh, print due report, print selected certificate, copy handoff, details, edit, delete, and Enter-to-details.
+- Routed Calibration keyboard shortcuts through command `CanExecute` and `UiActionGuard` so disabled commands stay disabled from the keyboard.
+- Swallowed Calibration action shortcuts during row loading while preserving Ctrl+F search focus.
+- Added source-contract coverage for Maintenance and Calibration startup guards, busy row gestures, keyboard shortcuts, command availability, and busy shortcut suppression.
+
+## Why It Matters
+
+Maintenance and Calibration already had responsive layouts, loading overlays, and ViewModel-level busy-aware commands. Their page code-behind still allowed stale row gestures and lacked keyboard workflow parity. This pass makes both operational-record workbenches feel faster and safer during screen open, refresh, row selection, printing, and technician/certificate handoff actions.
+
+## Validation
+
+- GitHub connector readback should confirm the two page code-behind updates, the new source-contract test file, and this progress note.
+- Full Windows validation, WPF runtime testing, screenshots, and live keyboard checks remain blocked in this scheduled Linux environment because direct checkout is unavailable and Windows/.NET/WPF tooling is not present.
+
+## Follow-Up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test Maintenance and Calibration initial open, repeated navigation, row double-click/right-click during loading, Ctrl+F, Ctrl+N, Ctrl+R, Ctrl+P, Ctrl+Shift+P, Ctrl+C, Ctrl+D, Ctrl+E, Enter, Delete, and Maintenance Ctrl+Enter while rows are loading and after rows are ready.

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
@@ -1,7 +1,9 @@
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 
@@ -17,10 +19,14 @@ namespace InventoryManagementApp.Views.Pages
             InitializeComponent();
             Loaded += CalibrationPage_Loaded;
             DataContextChanged += CalibrationPage_DataContextChanged;
+            PreviewKeyDown += CalibrationPage_PreviewKeyDown;
         }
 
         private async void CalibrationPage_Loaded(object sender, RoutedEventArgs e)
         {
+            Focus();
+            FocusFirstSearchBox();
+
             if (DataContext is CalibrationManagementViewModel vm)
             {
                 await LoadCalibrationOnceAsync(vm);
@@ -51,21 +57,170 @@ namespace InventoryManagementApp.Views.Pages
 
             _loadedViewModel = vm;
             await Dispatcher.Yield(DispatcherPriority.Background);
+
+            if (!ReferenceEquals(DataContext, vm) || !vm.LoadCalibrationCommand.CanExecute(null))
+            {
+                return;
+            }
+
             _loadCalibrationTask = vm.LoadCalibrationCommand.ExecuteAsync(null);
             await _loadCalibrationTask;
         }
 
         private void CalibrationRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is CalibrationManagementViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (GridContextMenuSelection.SelectRow(sender, e) == null)
+                return;
+
             if (DataContext is CalibrationManagementViewModel vm && vm.OpenCalibrationDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Calibration", () => vm.OpenCalibrationDetailsCommand.Execute(null));
+                e.Handled = true;
             }
         }
 
         private void CalibrationRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is CalibrationManagementViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
+        }
+
+        private void CalibrationPage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (DataContext is not CalibrationManagementViewModel vm)
+                return;
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
+            {
+                FocusFirstSearchBox();
+                e.Handled = true;
+                return;
+            }
+
+            if (vm.IsLoading && IsCalibrationActionShortcut(e))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N && vm.AddCalibrationCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Calibration", async () => await vm.AddCalibrationCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R && vm.RefreshCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Calibration", async () => await vm.RefreshCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && vm.PrintCalibrationListCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Calibration", () => vm.PrintCalibrationListCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P && vm.PrintSelectedCalibrationCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Calibration", () => vm.PrintSelectedCalibrationCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopySelectedCalibrationCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Calibration", () => vm.CopySelectedCalibrationCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D && vm.OpenCalibrationDetailsCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Calibration", () => vm.OpenCalibrationDetailsCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.E && vm.EditCalibrationCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Calibration", async () => await vm.EditCalibrationCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter && vm.OpenCalibrationDetailsCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Calibration", () => vm.OpenCalibrationDetailsCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete && vm.DeleteCalibrationCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Calibration", async () => await vm.DeleteCalibrationCommand.ExecuteAsync(null));
+                e.Handled = true;
+            }
+        }
+
+        private static bool IsCalibrationActionShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                return e.Key is Key.N or Key.R or Key.P or Key.C or Key.D or Key.E;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+            {
+                return e.Key == Key.P;
+            }
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;
+        }
+
+        private void FocusFirstSearchBox()
+        {
+            var searchBox = FindDescendant<TextBox>(this);
+            if (searchBox == null)
+                return;
+
+            searchBox.Focus();
+            searchBox.SelectAll();
+        }
+
+        private static bool IsTextInputFocused()
+        {
+            return Keyboard.FocusedElement is TextBoxBase or PasswordBox;
+        }
+
+        private static T? FindDescendant<T>(DependencyObject current) where T : DependencyObject
+        {
+            for (var index = 0; index < VisualTreeHelper.GetChildrenCount(current); index++)
+            {
+                var child = VisualTreeHelper.GetChild(current, index);
+                if (child is T match)
+                    return match;
+
+                var nested = FindDescendant<T>(child);
+                if (nested != null)
+                    return nested;
+            }
+
+            return null;
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
@@ -1,7 +1,9 @@
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 
@@ -17,10 +19,14 @@ namespace InventoryManagementApp.Views.Pages
             InitializeComponent();
             Loaded += MaintenancePage_Loaded;
             DataContextChanged += MaintenancePage_DataContextChanged;
+            PreviewKeyDown += MaintenancePage_PreviewKeyDown;
         }
 
         private async void MaintenancePage_Loaded(object sender, RoutedEventArgs e)
         {
+            Focus();
+            FocusFirstSearchBox();
+
             if (DataContext is MaintenanceManagementViewModel vm)
             {
                 await LoadMaintenanceOnceAsync(vm);
@@ -51,21 +57,177 @@ namespace InventoryManagementApp.Views.Pages
 
             _loadedViewModel = vm;
             await Dispatcher.Yield(DispatcherPriority.Background);
+
+            if (!ReferenceEquals(DataContext, vm) || !vm.LoadMaintenanceCommand.CanExecute(null))
+            {
+                return;
+            }
+
             _loadMaintenanceTask = vm.LoadMaintenanceCommand.ExecuteAsync(null);
             await _loadMaintenanceTask;
         }
 
         private void MaintenanceRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is MaintenanceManagementViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (GridContextMenuSelection.SelectRow(sender, e) == null)
+                return;
+
             if (DataContext is MaintenanceManagementViewModel vm && vm.OpenMaintenanceDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Maintenance", () => vm.OpenMaintenanceDetailsCommand.Execute(null));
+                e.Handled = true;
             }
         }
 
         private void MaintenanceRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is MaintenanceManagementViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
+        }
+
+        private void MaintenancePage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (DataContext is not MaintenanceManagementViewModel vm)
+                return;
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
+            {
+                FocusFirstSearchBox();
+                e.Handled = true;
+                return;
+            }
+
+            if (vm.IsLoading && IsMaintenanceActionShortcut(e))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N && vm.AddMaintenanceCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Maintenance", async () => await vm.AddMaintenanceCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R && vm.RefreshCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Maintenance", async () => await vm.RefreshCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && vm.PrintMaintenanceListCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Maintenance", () => vm.PrintMaintenanceListCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P && vm.PrintSelectedMaintenanceCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Maintenance", () => vm.PrintSelectedMaintenanceCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopySelectedMaintenanceCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Maintenance", () => vm.CopySelectedMaintenanceCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D && vm.OpenMaintenanceDetailsCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Maintenance", () => vm.OpenMaintenanceDetailsCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.E && vm.EditMaintenanceCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Maintenance", async () => await vm.EditMaintenanceCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.Enter && vm.CompleteMaintenanceCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Maintenance", async () => await vm.CompleteMaintenanceCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter && vm.OpenMaintenanceDetailsCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Maintenance", () => vm.OpenMaintenanceDetailsCommand.Execute(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete && vm.DeleteMaintenanceCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Maintenance", async () => await vm.DeleteMaintenanceCommand.ExecuteAsync(null));
+                e.Handled = true;
+            }
+        }
+
+        private static bool IsMaintenanceActionShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                return e.Key is Key.N or Key.R or Key.P or Key.C or Key.D or Key.E or Key.Enter;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+            {
+                return e.Key == Key.P;
+            }
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;
+        }
+
+        private void FocusFirstSearchBox()
+        {
+            var searchBox = FindDescendant<TextBox>(this);
+            if (searchBox == null)
+                return;
+
+            searchBox.Focus();
+            searchBox.SelectAll();
+        }
+
+        private static bool IsTextInputFocused()
+        {
+            return Keyboard.FocusedElement is TextBoxBase or PasswordBox;
+        }
+
+        private static T? FindDescendant<T>(DependencyObject current) where T : DependencyObject
+        {
+            for (var index = 0; index < VisualTreeHelper.GetChildrenCount(current); index++)
+            {
+                var child = VisualTreeHelper.GetChild(current, index);
+                if (child is T match)
+                    return match;
+
+                var nested = FindDescendant<T>(child);
+                if (nested != null)
+                    return nested;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## What changed

- Added first-paint search focus to Maintenance and Calibration before page-owned startup loading begins.
- Guarded Maintenance startup loading through the active DataContext and `LoadMaintenanceCommand.CanExecute` after the dispatcher yield.
- Guarded Calibration startup loading through the active DataContext and `LoadCalibrationCommand.CanExecute` after the dispatcher yield.
- Blocked Maintenance row double-click details while maintenance rows are loading.
- Blocked Calibration row double-click details while calibration rows are loading.
- Retargeted the selected row before Maintenance and Calibration double-click details so mouse actions use the row the operator invoked.
- Blocked Maintenance and Calibration right-click row retargeting while rows are loading.
- Added Maintenance keyboard shortcuts for find, add, refresh, print schedule, print selected record, copy handoff, details, edit, complete, delete, and Enter-to-details.
- Added Calibration keyboard shortcuts for find, add, refresh, print due report, print selected certificate, copy handoff, details, edit, delete, and Enter-to-details.
- Routed both pages' keyboard shortcuts through command `CanExecute` checks and `UiActionGuard`.
- Swallowed action shortcuts while each page is loading so stale row actions cannot dispatch during refresh, while preserving Ctrl+F search focus.
- Added source-contract coverage for the operational-record startup guards, busy row gestures, keyboard command routing, command availability checks, and busy shortcut suppression.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-05-operational-record-keyboard-busy-guards.md`.

## Why this was highest value

Recent scheduled work already covered Dashboard, Reports, Print Labels, Reservations, Users, Manage Items, Activity Logs, Categories, and several print-preview paths. Repository evidence showed Maintenance and Calibration already had responsive layouts, loading overlays, bounded print output, and ViewModel-level busy-aware commands, but their page code-behind still allowed stale row gestures and lacked keyboard workflow parity. These are high-traffic operational-record screens, so tightening action dispatch directly supports loading speed, UI responsiveness, and professional data handling without inventing unrelated features.

## Why this is real progress

This is a vertical operational-record workflow slice across two sibling WPF pages: startup loading, first-paint usability, row double-clicks, right-click context targeting, keyboard workflow, print/action command routing, busy-state suppression, source-contract coverage, and progress notes. It covers more than ten operator-facing paths while staying inside the existing MVVM/WPF architecture.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, four focused commits ahead, and limited to:
  - `InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs`
  - `InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs`
  - `InventoryManagementApp.Tests/OperationalRecordPageActionGuardContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-05-operational-record-keyboard-busy-guards.md`
- Connector readback confirmed the Maintenance and Calibration active-DataContext startup guards, command availability checks, first-paint search focus, busy row gesture guards, row retargeting, keyboard shortcuts, busy shortcut suppression, and source-contract assertions are present.
- Connector status readback found no attached commit statuses on branch head `58171dc24acb4c2cca4d2053269c9b86778871b1` before PR creation.

Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime checks, screenshots, scaling checks, or live keyboard testing because direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and Windows/.NET/WPF tooling is unavailable here.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Maintenance and Calibration initial open, repeated navigation, row double-click/right-click during loading, Ctrl+F, Ctrl+N, Ctrl+R, Ctrl+P, Ctrl+Shift+P, Ctrl+C, Ctrl+D, Ctrl+E, Enter, Delete, and Maintenance Ctrl+Enter while rows are loading and after rows are ready.