### PR TITLE
Improve Categories startup and action responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs
@@ -81,11 +81,26 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void CategoriesPage_DisablesSelectedCategoryActionsWhileRowsAreBusyOrUnselected()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
+
+            Assert.Contains("Content=\"Open\" Click=\"OpenCategoryDetail_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Copy Handoff\" Click=\"CopyCategory_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Print Sheet\" Click=\"PrintSelectedCategory_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Open Category Detail\" Click=\"OpenCategoryDetail_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Copy Setup Handoff\" Click=\"CopyCategory_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Print Selected Sheet\" Click=\"PrintSelectedCategory_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void CategoryViewModel_GuardsLoadingCommandsAndProfessionalDirectoryState()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
 
             Assert.Contains("public bool IsCategoryInteractionBusy => IsBusy;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsCategoryActionAvailable => !IsCategoryInteractionBusy;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsSelectedCategoryActionAvailable => !IsCategoryInteractionBusy && SelectedCategory != null;", source, StringComparison.Ordinal);
             Assert.Contains("public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FilteredCategories.Count > 0;", source, StringComparison.Ordinal);
             Assert.Contains("public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FilteredCategories.Count == 0;", source, StringComparison.Ordinal);
             Assert.Contains("CategoryPrintSummary", source, StringComparison.Ordinal);
@@ -95,7 +110,21 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Category refresh is already running.", source, StringComparison.Ordinal);
             Assert.Contains("_refreshCommand = new AsyncCommand(LoadAsync, () => !IsCategoryInteractionBusy && SelectedInventoryId > 0);", source, StringComparison.Ordinal);
             Assert.Contains("_clearSearchCommand = new AsyncCommand(ClearSearchAsync, () => !IsCategoryInteractionBusy && !string.IsNullOrWhiteSpace(SearchText));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsCategoryActionAvailable));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsSelectedCategoryActionAvailable));", source, StringComparison.Ordinal);
             Assert.Contains("RaiseCommandStates();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoryViewModel_PreservesVisibleRowsWhenDirectoryRefreshFails()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+            var loadBlock = ExtractSourceBlock(source, "private async Task LoadCategoryDirectoryAsync", "private void ShowCategoryLoadFailureDialogOnce");
+
+            Assert.Contains("Category refresh failed. Existing category rows were kept so current work can continue.", loadBlock, StringComparison.Ordinal);
+            Assert.Contains("Existing category rows were kept when available", source, StringComparison.Ordinal);
+            Assert.Contains("RaiseDirectoryProperties();", loadBlock, StringComparison.Ordinal);
+            Assert.DoesNotContain("ClearCategoryStateAfterLoadFailure();", loadBlock, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -116,6 +145,55 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("new GridLength(90)", source, StringComparison.Ordinal);
             Assert.DoesNotContain("new GridLength(220)", source, StringComparison.Ordinal);
             Assert.DoesNotContain("new GridLength(280)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_GuardsStartupLoadingThroughActiveViewModelAndFirstPaintYield()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+
+            Assert.Contains("private Task? _initializeCategoriesTask;", source, StringComparison.Ordinal);
+            Assert.Contains("private CategoryManagementViewModel? _initializedViewModel;", source, StringComparison.Ordinal);
+            Assert.Contains("Loaded += CategoriesPage_Loaded;", source, StringComparison.Ordinal);
+            Assert.Contains("DataContextChanged += CategoriesPage_DataContextChanged;", source, StringComparison.Ordinal);
+            Assert.Contains("FindBox.Focus();", source, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("!ReferenceEquals(DataContext, vm) || vm.IsCategoryInteractionBusy", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeCategoriesTask = vm.InitializeAsync();", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("private bool _hasInitialized;", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Loaded += async (_, __) =>", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_GuardsRowGesturesAndKeyboardActionsWhileRowsLoad()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+            var doubleClick = ExtractSourceBlock(source, "private void CategoryRow_MouseDoubleClick", "private void CategoryRow_PreviewMouseRightButtonDown");
+            var rightClick = ExtractSourceBlock(source, "private void CategoryRow_PreviewMouseRightButtonDown", "private void OpenCategoryDetail_Click");
+            var keyHandler = ExtractSourceBlock(source, "private void Page_PreviewKeyDown", "private static bool IsCategoryActionShortcut");
+            var busyShortcut = ExtractSourceBlock(source, "private static bool IsCategoryActionShortcut", "private static bool IsTextInputFocused");
+
+            Assert.Contains("ViewModel is { IsCategoryInteractionBusy: true }", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e) == null", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("ViewModel is { IsCategoryInteractionBusy: true }", rightClick, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", rightClick, StringComparison.Ordinal);
+            Assert.Contains("ViewModel.IsCategoryInteractionBusy && IsCategoryActionShortcut(e)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("e.Key is Key.R or Key.S or Key.P or Key.C", busyShortcut, StringComparison.Ordinal);
+            Assert.Contains("return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;", busyShortcut, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_CodeBehindActionsCheckBusyStateBeforeOpeningSelectionWorkflows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+
+            Assert.Contains("private bool AreCategoryRowsReady(string title)", source, StringComparison.Ordinal);
+            Assert.Contains("Category rows are still loading. Wait for the refresh to finish before using category actions.", source, StringComparison.Ordinal);
+            Assert.Contains("!AreCategoryRowsReady(\"Category Detail\") || !TryGetSelectedCategory(out var category)", source, StringComparison.Ordinal);
+            Assert.Contains("!AreCategoryRowsReady(\"Category Sheet\") || !TryGetSelectedCategory(out var category)", source, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -154,6 +232,17 @@ namespace InventoryManagementApp.Tests
             }
 
             throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
+
+            return source[start..end];
         }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-categories-startup-action-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-categories-startup-action-responsiveness.md
@@ -1,0 +1,24 @@
+# Categories Startup And Action Responsiveness
+
+Date: 2026-07-05 NZST
+
+## Completed
+
+- Replaced the Categories page one-time boolean loaded guard with a view-model-aware startup initialization guard.
+- Focused the category search box before page-owned initialization work begins so the screen paints and accepts input sooner after navigation.
+- Deferred Categories initialization until background dispatcher priority, then rechecked the active DataContext and busy state before database-backed loading begins.
+- Reset page-owned startup tracking on real DataContext changes so new view models still initialize cleanly.
+- Blocked category row double-click details while category rows are loading.
+- Retargeted the selected category row before double-click details so mouse actions use the invoked row.
+- Blocked category right-click row retargeting while category rows are loading.
+- Added a Categories refresh keyboard shortcut and routed Save, Print, Copy, Delete, and Enter actions through busy-state guards.
+- Preserved Ctrl+F and Ctrl+N focus shortcuts while rows load, and kept Ctrl+C from overriding text input copy behavior.
+- Added code-behind guards so Open, Copy Handoff, and Print Sheet do not run while category rows refresh.
+- Added ViewModel-backed selected-category action readiness for buttons and context-menu items.
+- Preserved existing category rows after directory refresh failures so operators do not lose the current directory view during a transient load problem.
+- Extended Categories source-contract coverage for first-paint loading, DataContext reset behavior, busy row gestures, keyboard guards, selected action bindings, code-behind busy checks, and refresh-failure row preservation.
+
+## Validation Notes
+
+- Source-contract coverage was updated in `InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs`.
+- Full Windows validation, WPF runtime checks, screenshots, scaling checks, and live keyboard/print-preview smoke testing still need to run in a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
@@ -107,12 +107,18 @@ namespace InventoryManagementApp.ViewModels
                 _isBusy = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(IsCategoryInteractionBusy));
+                OnPropertyChanged(nameof(IsCategoryActionAvailable));
+                OnPropertyChanged(nameof(IsSelectedCategoryActionAvailable));
                 RaiseDirectoryProperties();
                 RaiseCommandStates();
             }
         }
 
         public bool IsCategoryInteractionBusy => IsBusy;
+
+        public bool IsCategoryActionAvailable => !IsCategoryInteractionBusy;
+
+        public bool IsSelectedCategoryActionAvailable => !IsCategoryInteractionBusy && SelectedCategory != null;
 
         public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FilteredCategories.Count > 0;
 
@@ -311,8 +317,10 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load categories for inventory {InventoryId}", SelectedInventoryId);
-                ClearCategoryStateAfterLoadFailure();
-                StatusMessage = "Categories could not be loaded. Category rows were cleared until reload succeeds.";
+                StatusMessage = Categories.Count == 0
+                    ? "Categories could not be loaded. Retry refresh before creating or printing category rows."
+                    : "Category refresh failed. Existing category rows were kept so current work can continue.";
+                RaiseDirectoryProperties();
                 ShowCategoryLoadFailureDialogOnce();
             }
             finally { IsBusy = false; }
@@ -322,7 +330,7 @@ namespace InventoryManagementApp.ViewModels
         {
             if (_loadFailureDialogShown) return;
             _loadFailureDialogShown = true;
-            WpfMessageBox.Show("Categories could not be loaded. Category rows were cleared until reload succeeds. Please retry or check the application log.", "Category Management", MessageBoxButton.OK, MessageBoxImage.Error);
+            WpfMessageBox.Show("Categories could not be refreshed. Existing category rows were kept when available; retry refresh or check the application log.", "Category Management", MessageBoxButton.OK, MessageBoxImage.Error);
         }
 
         private void ClearCategoryStateAfterLoadFailure()
@@ -520,6 +528,8 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CategoryPrintSummary));
             OnPropertyChanged(nameof(IsDirectoryPrintAvailable));
             OnPropertyChanged(nameof(IsCategoryEmptyStateVisible));
+            OnPropertyChanged(nameof(IsCategoryActionAvailable));
+            OnPropertyChanged(nameof(IsSelectedCategoryActionAvailable));
             OnPropertyChanged(nameof(CategoryEmptyStateTitle));
             OnPropertyChanged(nameof(CategoryEmptyStateMessage));
             OnPropertyChanged(nameof(CategoryNameStatus));
@@ -534,6 +544,7 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(SelectedCategorySummary));
             OnPropertyChanged(nameof(SelectedCategoryChecklist));
             OnPropertyChanged(nameof(SelectedCategoryHandoff));
+            OnPropertyChanged(nameof(IsSelectedCategoryActionAvailable));
         }
 
         private void RaiseCommandStates()

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
@@ -92,9 +92,9 @@
                     <WrapPanel>
                         <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding AddCommand}" Margin="0,0,4,4" ToolTip="Create and link a new category"/>
                         <Button Style="{StaticResource PrimaryButton}" Content="Save" Command="{Binding SaveCommand}" Margin="0,0,4,4" ToolTip="Save the selected category name"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Open" Click="OpenCategoryDetail_Click" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopyCategory_Click" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Open" Click="OpenCategoryDetail_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopyCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintCategories_Click" IsEnabled="{Binding IsDirectoryPrintAvailable}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
@@ -176,9 +176,9 @@
                         </DataGrid.RowStyle>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                <MenuItem Header="Open Category Detail" Click="OpenCategoryDetail_Click"/>
-                                <MenuItem Header="Copy Setup Handoff" Click="CopyCategory_Click"/>
-                                <MenuItem Header="Print Selected Sheet" Click="PrintSelectedCategory_Click"/>
+                                <MenuItem Header="Open Category Detail" Click="OpenCategoryDetail_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}"/>
+                                <MenuItem Header="Copy Setup Handoff" Click="CopyCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}"/>
+                                <MenuItem Header="Print Selected Sheet" Click="PrintSelectedCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}"/>
                                 <Separator/>
                                 <MenuItem Header="New Category" Command="{Binding AddCommand}"/>
                                 <MenuItem Header="Save Rename" Command="{Binding SaveCommand}"/>
@@ -299,9 +299,9 @@
 
                             <Border Style="{StaticResource DesktopInsetCard}" Padding="10" Margin="0,0,0,8">
                                 <WrapPanel>
-                                    <Button Style="{StaticResource PrimaryButton}" Content="Open" Click="OpenCategoryDetail_Click" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Copy" Click="CopyCategory_Click" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Open" Click="OpenCategoryDetail_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Copy" Click="CopyCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
                                     <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,4,4"/>
                                 </WrapPanel>
                             </Border>
@@ -314,9 +314,9 @@
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,6,0,0">
             <DockPanel LastChildFill="True">
                 <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Open" Click="OpenCategoryDetail_Click" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Open" Click="OpenCategoryDetail_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintCategories_Click" IsEnabled="{Binding IsDirectoryPrintAvailable}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Clear Filter" Command="{Binding ClearSearchCommand}" Margin="0,0,0,4"/>
                 </WrapPanel>
                 <StackPanel MinWidth="0">

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
@@ -2,11 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Views.Windows;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,24 +19,69 @@ namespace InventoryManagementApp.Views.Pages
     public partial class CategoriesPage : Page
     {
         private const int MaxDirectoryPrintRows = 250;
-        private bool _hasInitialized;
+        private readonly int _inventoryId;
+        private Task? _initializeCategoriesTask;
+        private CategoryManagementViewModel? _initializedViewModel;
 
         public CategoriesPage(int inventoryId)
         {
             InitializeComponent();
+            _inventoryId = inventoryId;
             var sp = ((App)System.Windows.Application.Current).Host.Services;
             var vm = sp.GetRequiredService<CategoryManagementViewModel>();
             DataContext = vm;
-            Loaded += async (_, __) =>
-            {
-                if (_hasInitialized) return;
-                _hasInitialized = true;
-                vm.SelectedInventoryId = inventoryId;
-                await vm.InitializeAsync().ConfigureAwait(false);
-            };
+            Loaded += CategoriesPage_Loaded;
+            DataContextChanged += CategoriesPage_DataContextChanged;
         }
 
         private CategoryManagementViewModel? ViewModel => DataContext as CategoryManagementViewModel;
+
+        private async void CategoriesPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            Focus();
+            FindBox.Focus();
+            FindBox.SelectAll();
+
+            if (DataContext is CategoryManagementViewModel vm)
+            {
+                await InitializeCategoriesOnceAsync(vm);
+            }
+        }
+
+        private void CategoriesPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!ReferenceEquals(_initializedViewModel, e.NewValue))
+            {
+                _initializedViewModel = null;
+                _initializeCategoriesTask = null;
+            }
+        }
+
+        private async Task InitializeCategoriesOnceAsync(CategoryManagementViewModel vm)
+        {
+            if (ReferenceEquals(_initializedViewModel, vm) && _initializeCategoriesTask is { IsCompleted: false })
+            {
+                await _initializeCategoriesTask;
+                return;
+            }
+
+            if (ReferenceEquals(_initializedViewModel, vm) && _initializeCategoriesTask is { IsCompletedSuccessfully: true })
+            {
+                return;
+            }
+
+            _initializedViewModel = vm;
+            vm.SelectedInventoryId = _inventoryId;
+            await Dispatcher.Yield(DispatcherPriority.Background);
+
+            if (!ReferenceEquals(DataContext, vm) || vm.IsCategoryInteractionBusy)
+            {
+                return;
+            }
+
+            _initializeCategoriesTask = vm.InitializeAsync();
+            await _initializeCategoriesTask;
+        }
 
         private void Page_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
@@ -56,6 +103,19 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
+            if (ViewModel.IsCategoryInteractionBusy && IsCategoryActionShortcut(e))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R && ViewModel.RefreshCommand.CanExecute(null))
+            {
+                ViewModel.RefreshCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.S && ViewModel.SaveCommand.CanExecute(null))
             {
                 ViewModel.SaveCommand.Execute(null);
@@ -70,7 +130,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C)
+            if (!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C)
             {
                 CopyCategory_Click(sender, e);
                 e.Handled = true;
@@ -91,18 +151,44 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
+        private static bool IsCategoryActionShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                return e.Key is Key.R or Key.S or Key.P or Key.C;
+            }
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;
+        }
+
         private static bool IsTextInputFocused()
         {
-            return Keyboard.FocusedElement is System.Windows.Controls.Primitives.TextBoxBase or PasswordBox or System.Windows.Controls.ComboBox;
+            return Keyboard.FocusedElement is TextBoxBase or PasswordBox or ComboBox;
         }
 
         private void CategoryRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (ViewModel is { IsCategoryInteractionBusy: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (GridContextMenuSelection.SelectRow(sender, e) == null)
+                return;
+
             OpenCategoryDetail_Click(sender, e);
+            e.Handled = true;
         }
 
         private void CategoryRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (ViewModel is { IsCategoryInteractionBusy: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
         }
 
@@ -110,7 +196,7 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Category Detail", () =>
             {
-                if (!TryGetSelectedCategory(out var category))
+                if (!AreCategoryRowsReady("Category Detail") || !TryGetSelectedCategory(out var category))
                     return;
 
                 DetailDialogWindow.ShowDialogFor(
@@ -128,7 +214,7 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Category Detail", () =>
             {
-                if (!TryGetSelectedCategory(out var category))
+                if (!AreCategoryRowsReady("Category Detail") || !TryGetSelectedCategory(out var category))
                     return;
 
                 System.Windows.Clipboard.SetText(FormatCategoryDetail(category));
@@ -162,12 +248,21 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Category Sheet", () =>
             {
-                if (!TryGetSelectedCategory(out var category))
+                if (!AreCategoryRowsReady("Category Sheet") || !TryGetSelectedCategory(out var category))
                     return;
 
                 var document = BuildSelectedCategoryPrintDocument(category);
                 ShowPrintPreview(document, $"Category Sheet - {category.Name}");
             });
+        }
+
+        private bool AreCategoryRowsReady(string title)
+        {
+            if (ViewModel is not { IsCategoryInteractionBusy: true })
+                return true;
+
+            WpfMessageBox.Show("Category rows are still loading. Wait for the refresh to finish before using category actions.", title, MessageBoxButton.OK, MessageBoxImage.Information);
+            return false;
         }
 
         private bool TryGetSelectedCategory(out CategoryManagementViewModel.CategoryItem category)


### PR DESCRIPTION
## What changed

- Replaced the Categories page one-time boolean loaded guard with a view-model-aware startup initialization guard.
- Focused the category search box before page-owned initialization work starts so the screen paints and accepts input sooner after navigation.
- Deferred Categories initialization until background dispatcher priority, then rechecked the active DataContext and busy state before database-backed loading begins.
- Reset page-owned startup tracking on real DataContext changes so new view models still initialize cleanly.
- Blocked category row double-click details while category rows are loading.
- Retargeted the selected category row before double-click details so mouse actions use the invoked row.
- Blocked category right-click row retargeting while category rows are loading.
- Added a Categories refresh keyboard shortcut and routed Save, Print, Copy, Delete, and Enter actions through busy-state guards.
- Preserved Ctrl+F and Ctrl+N focus shortcuts while rows load, and kept Ctrl+C from overriding text input copy behavior.
- Added code-behind guards so Open, Copy Handoff, and Print Sheet do not run while category rows refresh.
- Added ViewModel-backed selected-category action readiness for toolbar, handoff, footer, and context-menu actions.
- Preserved existing category rows after directory refresh failures so operators do not lose the current directory view during a transient load problem.
- Extended Categories source-contract coverage for first-paint loading, DataContext reset behavior, busy row gestures, keyboard guards, selected action bindings, code-behind busy checks, and refresh-failure row preservation.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-05-categories-startup-action-responsiveness.md`.

## Why this was highest value

Recent scheduled runs covered Dashboard, Reports, Print Labels, Reservations, Users, Manage Items, Maintenance, and Calibration. Repository evidence showed Categories already had responsive layout, virtualization, loading overlays, and bounded print output, but its page lifecycle and gesture/action layer still used a one-time boolean startup guard and allowed stale row actions while category rows refreshed. Categories is a core setup workflow, so tightening startup and action dispatch directly supports loading speed, UI responsiveness, and professional data display without inventing unrelated features.

## Why this is real progress

This is a vertical Categories workflow slice across startup loading behavior, first-paint focus, DataContext reset handling, row double-click/right-click safety, keyboard workflow, visible action readiness, refresh-failure data preservation, tests, and progress notes. It covers more than ten operator-facing paths while staying within the existing MVVM/WPF architecture.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, five focused commits ahead, and limited to:
  - `InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs`
  - `InventoryManagementApp/Views/Pages/CategoriesPage.xaml`
  - `InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs`
  - `InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-05-categories-startup-action-responsiveness.md`
- Connector readback confirmed the startup guard, dispatcher yield, DataContext reset, busy keyboard/row guards, selected action readiness bindings, refresh-failure row preservation, source-contract assertions, and progress note are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `6a0f513ced5fc148649f3f76fde65dabdb6bf451` before PR creation.

Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime checks, screenshots, scaling checks, live keyboard testing, or print-preview rendering because direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and Windows/.NET/WPF tooling is unavailable here.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Categories initial open, repeated navigation, DataContext swaps, refresh failure recovery, double-click/right-click while rows load, Ctrl+F, Ctrl+N, Ctrl+R, Ctrl+S, Ctrl+P, Ctrl+C in and outside text input, Delete, Enter, Open, Copy Handoff, Print Sheet, and Print Directory.