### PR TITLE
Improve Rentals startup and input responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
@@ -105,16 +105,19 @@ namespace InventoryManagementApp.Tests
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
 
+            Assert.Contains("Task? _loadRentalsTask;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("ManageRentalsViewModel? _loadedViewModel;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += ManageRentalsPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("SearchTextBox.Focus();", codeBehind, StringComparison.Ordinal);
             Assert.Contains("UpdateCompactHeightMode();", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("if (DataContext is ManageRentalsViewModel vm && !ReferenceEquals(_loadedViewModel, vm))", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("_loadedViewModel = vm;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("await vm.LoadRentalsAsync();", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("if (!ReferenceEquals(e.NewValue, _loadedViewModel))", codeBehind, StringComparison.Ordinal);
-            Assert.DoesNotContain("if (DataContext is ManageRentalsViewModel vm)\n            {\n                await vm.LoadRentalsAsync();\n            }", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
+            Assert.Contains("await LoadRentalsOnceAsync(vm);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (ReferenceEquals(_loadedViewModel, vm) && _loadRentalsTask is { IsCompleted: false })", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (ReferenceEquals(_loadedViewModel, vm) && _loadRentalsTask is { IsCompletedSuccessfully: true })", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!ReferenceEquals(DataContext, vm) || vm.IsLoading)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadRentalsTask = vm.LoadRentalsAsync();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadRentalsTask = null;", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (DataContext is ManageRentalsViewModel vm && !ReferenceEquals(_loadedViewModel, vm))", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -134,14 +137,35 @@ namespace InventoryManagementApp.Tests
         public void ManageRentalsPage_LoadingStateBlocksCodeBehindActionBypasses()
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
+            var normalized = NormalizeNewlines(codeBehind);
 
-            Assert.Contains("!vm.IsLoading && vm.OpenRentalDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("!vm.IsLoading && vm.OpenRequestDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("if (vm.IsLoading)\n                return;", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
-            Assert.Contains("if (DataContext is ManageRentalsViewModel { IsLoading: true })", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("e.Handled = true;\n                return;", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
-            Assert.DoesNotContain("DataContext is ManageRentalsViewModel vm && vm.OpenRentalDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.DoesNotContain("DataContext is ManageRentalsViewModel vm && vm.OpenRequestDetailsCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (DataContext is ManageRentalsViewModel { IsLoading: true })\n            {\n                e.Handled = true;\n                return;\n            }", normalized, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsLoading && IsRentalActionShortcut(e))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsRentalActionShortcut(KeyEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return e.Key is Key.P or Key.D or Key.H or Key.I or Key.E or Key.R;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return e.Key is Key.P or Key.R;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsLoading)\n                return;", normalized, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (vm.IsLoading)\n                return;\n\n            if (Keyboard.Modifiers == ModifierKeys.Control", normalized, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageRentalsPage_RowGesturesSelectInvokedRowsAndStopDuringLoading()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
+            var rentalDoubleClick = ExtractSourceBlock(codeBehind, "private void RentalRow_MouseDoubleClick", "private void RentalRow_PreviewMouseRightButtonDown");
+            var requestDoubleClick = ExtractSourceBlock(codeBehind, "private void RequestRow_MouseDoubleClick", "private void RequestRow_PreviewMouseRightButtonDown");
+            var selectionBlock = ExtractSourceBlock(codeBehind, "private DataGridRow? SelectRowForContextMenu", "    }\n}");
+
+            Assert.Contains("if (SelectRowForContextMenu(sender, e) == null)", rentalDoubleClick, StringComparison.Ordinal);
+            Assert.Contains("if (SelectRowForContextMenu(sender, e) == null)", requestDoubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", rentalDoubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", requestDoubleClick, StringComparison.Ordinal);
+            Assert.Contains("private DataGridRow? SelectRowForContextMenu", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (DataContext is ManageRentalsViewModel { IsLoading: true })", selectionBlock, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", selectionBlock, StringComparison.Ordinal);
+            Assert.Contains("return row;", selectionBlock, StringComparison.Ordinal);
+            Assert.DoesNotContain("private void SelectRowForContextMenu", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -177,6 +201,17 @@ namespace InventoryManagementApp.Tests
         }
 
         private static string NormalizeNewlines(string value) => value.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
+
+            return source[start..end];
+        }
 
         private static string ReadRepoFile(params string[] parts)
         {

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-rentals-startup-input-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-rentals-startup-input-responsiveness.md
@@ -1,0 +1,25 @@
+# Rentals Startup And Input Responsiveness
+
+Date: 2026-07-05 NZST
+
+## Completed
+
+- Replaced the Rentals page simple one-view-model loaded flag with a tracked load task so repeated WPF `Loaded` events reuse an in-flight load instead of starting duplicate refresh work.
+- Kept the first-paint dispatcher yield before page-owned rental loading begins.
+- Rechecked the active DataContext before starting the rental desk load so stale page instances do not refresh the wrong view model.
+- Skipped page-owned startup loading when the rental view model is already busy.
+- Reset page-owned load tracking when a real DataContext swap occurs.
+- Preserved immediate search-box focus and compact-height layout setup before data refresh work starts.
+- Blocked rental row double-click details while rows are loading.
+- Retargeted rental row selection before double-click details so the invoked row drives the details command.
+- Blocked request row double-click details while the request queue is loading.
+- Retargeted request row selection before double-click details so the invoked request drives the details command.
+- Blocked right-click row retargeting during loading and marked the gesture handled so stale context menus do not jump selection.
+- Swallowed rental action keyboard shortcuts during loading while preserving Ctrl+F search focus.
+- Kept print, check-in, extend, request, history, details, enter, and delete keyboard paths routed through command availability after loading completes.
+- Extended Rentals source-contract coverage for first-paint load reuse, DataContext reset behavior, active-view-model checks, busy shortcut handling, row gesture retargeting, and busy row blocking.
+
+## Validation Notes
+
+- Source-contract coverage was updated in `InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs`.
+- Full Windows validation, WPF runtime checks, screenshots, scaling checks, live keyboard testing, and print-preview smoke testing still need to run in a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -1,6 +1,8 @@
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 namespace InventoryManagementApp.Views.Pages
@@ -12,6 +14,7 @@ namespace InventoryManagementApp.Views.Pages
     {
         const double CompactHeightThreshold = 650;
         bool _isCompactHeight;
+        Task? _loadRentalsTask;
         ManageRentalsViewModel? _loadedViewModel;
 
         public ManageRentalsPage()
@@ -30,18 +33,44 @@ namespace InventoryManagementApp.Views.Pages
             SearchTextBox.SelectAll();
             UpdateCompactHeightMode();
 
-            if (DataContext is ManageRentalsViewModel vm && !ReferenceEquals(_loadedViewModel, vm))
+            if (DataContext is ManageRentalsViewModel vm)
             {
-                _loadedViewModel = vm;
-                await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
-                await vm.LoadRentalsAsync();
+                await LoadRentalsOnceAsync(vm);
             }
         }
 
         private void ManageRentalsPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (!ReferenceEquals(e.NewValue, _loadedViewModel))
+            {
                 _loadedViewModel = null;
+                _loadRentalsTask = null;
+            }
+        }
+
+        private async Task LoadRentalsOnceAsync(ManageRentalsViewModel vm)
+        {
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadRentalsTask is { IsCompleted: false })
+            {
+                await _loadRentalsTask;
+                return;
+            }
+
+            if (ReferenceEquals(_loadedViewModel, vm) && _loadRentalsTask is { IsCompletedSuccessfully: true })
+            {
+                return;
+            }
+
+            _loadedViewModel = vm;
+            await Dispatcher.Yield(DispatcherPriority.Background);
+
+            if (!ReferenceEquals(DataContext, vm) || vm.IsLoading)
+            {
+                return;
+            }
+
+            _loadRentalsTask = vm.LoadRentalsAsync();
+            await _loadRentalsTask;
         }
 
         private void ManageRentalsPage_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -71,9 +100,19 @@ namespace InventoryManagementApp.Views.Pages
 
         private void RentalRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is ManageRentalsViewModel vm && !vm.IsLoading && vm.OpenRentalDetailsCommand.CanExecute(null))
+            if (DataContext is ManageRentalsViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (SelectRowForContextMenu(sender, e) == null)
+                return;
+
+            if (DataContext is ManageRentalsViewModel vm && vm.OpenRentalDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Rentals", () => vm.OpenRentalDetailsCommand.Execute(null));
+                e.Handled = true;
             }
         }
 
@@ -84,9 +123,19 @@ namespace InventoryManagementApp.Views.Pages
 
         private void RequestRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is ManageRentalsViewModel vm && !vm.IsLoading && vm.OpenRequestDetailsCommand.CanExecute(null))
+            if (DataContext is ManageRentalsViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (SelectRowForContextMenu(sender, e) == null)
+                return;
+
+            if (DataContext is ManageRentalsViewModel vm && vm.OpenRequestDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Rentals", () => vm.OpenRequestDetailsCommand.Execute(null));
+                e.Handled = true;
             }
         }
 
@@ -108,8 +157,11 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (vm.IsLoading)
+            if (vm.IsLoading && IsRentalActionShortcut(e))
+            {
+                e.Handled = true;
                 return;
+            }
 
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && vm.PrintSearchResultsCommand.CanExecute(null))
             {
@@ -181,6 +233,21 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
+        private static bool IsRentalActionShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                return e.Key is Key.P or Key.D or Key.H or Key.I or Key.E or Key.R;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+            {
+                return e.Key is Key.P or Key.R;
+            }
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;
+        }
+
         private void OpenFocusedDetails(ManageRentalsViewModel vm)
         {
             if (vm.IsLoading)
@@ -204,16 +271,17 @@ namespace InventoryManagementApp.Views.Pages
             });
         }
 
-        private void SelectRowForContextMenu(object sender, MouseButtonEventArgs e)
+        private DataGridRow? SelectRowForContextMenu(object sender, MouseButtonEventArgs e)
         {
             if (DataContext is ManageRentalsViewModel { IsLoading: true })
             {
-                return;
+                e.Handled = true;
+                return null;
             }
 
             var row = GridContextMenuSelection.SelectRow(sender, e);
             if (row == null)
-                return;
+                return null;
 
             if (DataContext is ManageRentalsViewModel vm)
             {
@@ -222,6 +290,8 @@ namespace InventoryManagementApp.Views.Pages
                 else if (row.Item is Reservation request)
                     vm.SelectedRequest = request;
             }
+
+            return row;
         }
     }
 }


### PR DESCRIPTION
## What changed

- Replaced the Rentals page simple loaded-view-model check with an in-flight load task guard so repeated `Loaded` events reuse the same startup load.
- Kept first-paint focus and compact-height layout setup before rental loading starts.
- Rechecked the active DataContext and existing busy state before starting page-owned data refresh work.
- Reset startup load tracking on real DataContext changes.
- Blocked rental and request row double-click details while data is loading.
- Retargeted rental/request row selection before double-click details so the invoked row drives the command.
- Blocked and handled right-click row retargeting while loading to avoid stale context-menu selection changes.
- Swallowed rental action keyboard shortcuts while loading while preserving Ctrl+F search focus.
- Kept print, details, history, check-in, extend, request, enter, and delete keyboard paths routed through command availability after loading completes.
- Added source-contract coverage for the new startup loading, busy shortcut, and row gesture behavior.
- Added a progress note for future scheduled runs.

## Why this was highest value

Recent completed work already covered Reports, Print Labels, Reservations, Users, Manage Items, Categories, Maintenance, Calibration, and related responsive layouts. Rentals is another high-traffic workflow with data grids, request queues, print actions, and keyboard shortcuts; repo evidence showed it had a loading flag but weaker protection against duplicate startup loads and stale input actions during refresh.

## Scope and progress

This is a focused workflow-level improvement for Rentals startup and input responsiveness. It avoids new dependencies or unrelated features and keeps the existing WPF layout and MVVM surface intact.

## Validation

- Connector compare confirmed the branch is current with `master` and only changes Rentals code-behind, Rentals responsive contract tests, and one progress note.
- Connector readback confirmed the updated code-behind contains the in-flight load guard, active DataContext check, busy shortcut guard, handled busy row gestures, and invoked-row selection before double-click actions.
- Connector readback confirmed the responsive contract tests cover the new loading and row gesture behavior.
- No GitHub commit statuses or workflow runs were attached to the branch head.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET build/test
- WPF runtime smoke test
- Screenshots/scaling checks
- Live keyboard, grid, context-menu, and print-preview behavior

These require a Windows/.NET/WPF-capable checkout; direct checkout and raw GitHub access are blocked in this scheduled Linux environment.

## Follow-up

- Run full Windows validation when available.
- Consider ViewModel-level `CanExecute` busy-state tightening for Rentals commands if future runtime evidence shows toolbar/context-menu actions can still be invoked while a service operation is active.