### PR TITLE
[codex] Improve customer directory responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
@@ -57,10 +57,11 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("<pages:SearchBar Width=\"300\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Center\" Visibility=\"{Binding IsCustomerEmptyStateVisible, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("CustomerEmptyStateMessage", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"310\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<DataTrigger Binding=\"{Binding Customers.Count}\" Value=\"0\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
         }
 
@@ -74,6 +75,37 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<ProgressBar IsIndeterminate=\"True\" Height=\"6\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Updating customer directory", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding CustomerFilterStatus}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomersPage_BindsVisibleActionsToReadyState()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
+
+            Assert.Contains("Content=\"Add\" Command=\"{Binding AddCustomerCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Details\" Command=\"{Binding OpenCustomerDetailsCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Edit\" Command=\"{Binding EditCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Copy Contact\" Command=\"{Binding CopySelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Print Sheet\" Command=\"{Binding PrintSelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Directory\" Command=\"{Binding PrintCustomerDirectoryCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Delete\" Command=\"{Binding DeleteCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding IsCustomerDirectoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding IsCustomerDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomersPage_ContextMenuAndHandoffActionsRespectReadyState()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
+
+            Assert.Contains("Header=\"Open Customer Details\" Command=\"{Binding OpenCustomerDetailsCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Edit Customer\" Command=\"{Binding EditCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Copy Contact Handoff\" Command=\"{Binding CopySelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Print Customer Sheet\" Command=\"{Binding PrintSelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Print Customer Directory\" Command=\"{Binding PrintCustomerDirectoryCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Delete Customer\" Command=\"{Binding DeleteCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Copy Contact\" Command=\"{Binding CopySelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Clear Search\" Command=\"{Binding ClearCustomerSearchCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryActionAvailable}\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -112,7 +144,10 @@ namespace InventoryManagementApp.Tests
         public void CustomersPage_BlocksStaleRowAndShortcutActionsWhileRowsLoad()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml.cs");
+            var doubleClick = ExtractSourceBlock(source, "private void CustomerRow_MouseDoubleClick", "private void CustomerRow_PreviewMouseRightButtonDown");
 
+            Assert.Contains("if (vm.IsCustomerDirectoryBusy)", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e) == null", doubleClick, StringComparison.Ordinal);
             Assert.Contains("CustomerManagementViewModel { IsCustomerDirectoryBusy: true }", source, StringComparison.Ordinal);
             Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", source, StringComparison.Ordinal);
             Assert.Contains("if (vm.IsCustomerDirectoryBusy && IsCustomerActionShortcut(e))", source, StringComparison.Ordinal);
@@ -136,7 +171,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("OpenCustomerDetailsCommand = new RelayCommand(OpenCustomerDetails, CanInteractWithSelectedCustomer);", source, StringComparison.Ordinal);
             Assert.Contains("PrintSelectedCustomerCommand = new RelayCommand(PrintSelectedCustomer, CanInteractWithSelectedCustomer);", source, StringComparison.Ordinal);
             Assert.Contains("CopySelectedCustomerCommand = new RelayCommand(CopySelectedCustomer, CanInteractWithSelectedCustomer);", source, StringComparison.Ordinal);
-            Assert.Contains("private bool CanInteractWithSelectedCustomer() => !IsCustomerDirectoryBusy && SelectedCustomer != null;", source, StringComparison.Ordinal);
+            Assert.Contains("private bool CanInteractWithSelectedCustomer() => IsSelectedCustomerActionAvailable;", source, StringComparison.Ordinal);
             Assert.Contains("private bool CanInteractWithCustomer(CustomerModel? customer) => !IsCustomerDirectoryBusy && customer != null;", source, StringComparison.Ordinal);
             Assert.Contains("NotifySelectedCustomerActionStateChanged();", source, StringComparison.Ordinal);
         }
@@ -146,6 +181,10 @@ namespace InventoryManagementApp.Tests
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CustomerManagementViewModel.cs");
 
+            Assert.Contains("public bool IsCustomerDirectoryActionAvailable => !IsCustomerDirectoryBusy;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsSelectedCustomerActionAvailable => !IsCustomerDirectoryBusy && SelectedCustomer != null;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsCustomerDirectoryPrintAvailable => !IsCustomerDirectoryBusy && Customers.Count > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsCustomerEmptyStateVisible => !IsCustomerDirectoryBusy && Customers.Count == 0;", source, StringComparison.Ordinal);
             Assert.Contains("Print paused while customer rows load", source, StringComparison.Ordinal);
             Assert.Contains("Customer actions are paused while the directory refreshes", source, StringComparison.Ordinal);
             Assert.Contains("ShowCustomerDirectoryBusyMessage", source, StringComparison.Ordinal);
@@ -154,6 +193,22 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("if (IsCustomerDirectoryBusy || customer == null", source, StringComparison.Ordinal);
             Assert.Contains("OnPropertyChanged(nameof(CustomerPrintSummary));", source, StringComparison.Ordinal);
             Assert.Contains("OnPropertyChanged(nameof(CustomerOperationsSummary));", source, StringComparison.Ordinal);
+            Assert.Contains("NotifyCustomerAvailabilityStateChanged();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerViewModel_PreservesVisibleRowsWhenLoadOrSearchFails()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CustomerManagementViewModel.cs");
+            var loadBlock = ExtractSourceBlock(source, "public async Task LoadCustomersAsync", "async Task AddCustomerAsync");
+            var searchBlock = ExtractSourceBlock(source, "async Task SearchCustomersAsync", "private async Task RefreshCustomerDirectoryAfterMutationFailureAsync");
+
+            Assert.Contains("Existing customer rows were kept when available", loadBlock, StringComparison.Ordinal);
+            Assert.Contains("Existing customer rows were kept when available", searchBlock, StringComparison.Ordinal);
+            Assert.Contains("NotifyCustomerDirectoryStateChanged();", loadBlock, StringComparison.Ordinal);
+            Assert.Contains("NotifyCustomerDirectoryStateChanged();", searchBlock, StringComparison.Ordinal);
+            Assert.DoesNotContain("ClearCustomerDirectoryAfterLoadFailure();", loadBlock, StringComparison.Ordinal);
+            Assert.DoesNotContain("ClearCustomerDirectoryAfterLoadFailure();", searchBlock, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)
@@ -174,6 +229,17 @@ namespace InventoryManagementApp.Tests
             }
 
             throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
+
+            return source[start..end];
         }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-customer-directory-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-customer-directory-responsiveness.md
@@ -1,0 +1,20 @@
+# Customer Directory Responsiveness
+
+Date: 2026-07-05
+
+## Completed
+
+- Kept customer startup loading page-owned and first-paint friendly while improving row gesture safety.
+- Retargeted customer row double-clicks to the invoked row before opening details so stale selection does not open the wrong contact.
+- Blocked customer row double-clicks while the directory is refreshing, matching the existing right-click and keyboard busy guards.
+- Added ViewModel-backed customer directory action, selected-row action, print, and empty-state availability properties.
+- Bound top toolbar, search strip, context menu, handoff panel, action strip, and footer actions to the new ready-state properties so paused workflows look disabled immediately.
+- Changed the empty-state overlay to use `IsCustomerEmptyStateVisible` so it cannot overlap the loading overlay while the directory is busy.
+- Preserved existing customer rows when load/search refreshes fail, keeping the current directory usable instead of clearing it after transient service errors.
+- Kept existing mutation-failure recovery behavior where a failed recovery reload can still clear rows rather than showing stale post-mutation state as current.
+- Extended customer responsive source-contract coverage for the ready-state bindings, non-overlapping empty/loading state, double-click retargeting, busy guards, and row-preserving failure handling.
+
+## Validation
+
+- Source readback via the GitHub connector confirmed the changed customer XAML, code-behind, view model, tests, and this progress note are present on the branch.
+- Local `dotnet`, WPF runtime, screenshots, and `pwsh -File scripts/run-full-validation.ps1` could not be run in this scheduled Linux environment because direct checkout is blocked and Windows/.NET tooling is unavailable.

--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -79,6 +79,14 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        public bool IsCustomerDirectoryActionAvailable => !IsCustomerDirectoryBusy;
+
+        public bool IsSelectedCustomerActionAvailable => !IsCustomerDirectoryBusy && SelectedCustomer != null;
+
+        public bool IsCustomerDirectoryPrintAvailable => !IsCustomerDirectoryBusy && Customers.Count > 0;
+
+        public bool IsCustomerEmptyStateVisible => !IsCustomerDirectoryBusy && Customers.Count == 0;
+
         public bool IsCustomerDirectoryBusy
         {
             get => _isCustomerDirectoryBusy;
@@ -90,6 +98,7 @@ namespace InventoryManagementApp.ViewModels
                     OnPropertyChanged(nameof(CustomerPrintSummary));
                     OnPropertyChanged(nameof(CustomerEmptyStateMessage));
                     OnPropertyChanged(nameof(CustomerOperationsSummary));
+                    NotifyCustomerAvailabilityStateChanged();
                     AddCustomerCommand.NotifyCanExecuteChanged();
                     SearchCustomersCommand.NotifyCanExecuteChanged();
                     ClearCustomerSearchCommand.NotifyCanExecuteChanged();
@@ -138,6 +147,7 @@ namespace InventoryManagementApp.ViewModels
                     OnPropertyChanged(nameof(CustomerContactSummary));
                     OnPropertyChanged(nameof(CustomerAddressSummary));
                     OnPropertyChanged(nameof(CustomerOperationsSummary));
+                    OnPropertyChanged(nameof(IsSelectedCustomerActionAvailable));
 
                     if (value != null)
                     {
@@ -230,9 +240,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                ClearCustomerDirectoryAfterLoadFailure();
+                NotifyCustomerDirectoryStateChanged();
                 if (_dialogService != null)
-                    await _dialogService.ShowInfoAsync($"Failed to load customers: {ex.Message} Customer rows were cleared until reload succeeds.", "Customer Load Failed");
+                    await _dialogService.ShowInfoAsync($"Failed to load customers: {ex.Message} Existing customer rows were kept when available so current work can continue.", "Customer Load Failed");
             }
             finally
             {
@@ -319,9 +329,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                ClearCustomerDirectoryAfterLoadFailure();
+                NotifyCustomerDirectoryStateChanged();
                 if (_dialogService != null)
-                    await _dialogService.ShowInfoAsync($"Failed to search customers: {ex.Message} Customer rows were cleared until reload succeeds.", "Customer Search Failed");
+                    await _dialogService.ShowInfoAsync($"Failed to search customers: {ex.Message} Existing customer rows were kept when available so current work can continue.", "Customer Search Failed");
             }
             finally
             {
@@ -379,8 +389,17 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CustomerPrintSummary));
             OnPropertyChanged(nameof(CustomerEmptyStateMessage));
             OnPropertyChanged(nameof(CustomerOperationsSummary));
+            NotifyCustomerAvailabilityStateChanged();
             PrintCustomerDirectoryCommand.NotifyCanExecuteChanged();
             NotifySelectedCustomerActionStateChanged();
+        }
+
+        private void NotifyCustomerAvailabilityStateChanged()
+        {
+            OnPropertyChanged(nameof(IsCustomerDirectoryActionAvailable));
+            OnPropertyChanged(nameof(IsSelectedCustomerActionAvailable));
+            OnPropertyChanged(nameof(IsCustomerDirectoryPrintAvailable));
+            OnPropertyChanged(nameof(IsCustomerEmptyStateVisible));
         }
 
         private void NotifySelectedCustomerActionStateChanged()
@@ -397,11 +416,11 @@ namespace InventoryManagementApp.ViewModels
 
         private bool CanRefreshCustomerDirectory() => !IsCustomerDirectoryBusy;
 
-        private bool CanInteractWithSelectedCustomer() => !IsCustomerDirectoryBusy && SelectedCustomer != null;
+        private bool CanInteractWithSelectedCustomer() => IsSelectedCustomerActionAvailable;
 
         private bool CanInteractWithCustomer(CustomerModel? customer) => !IsCustomerDirectoryBusy && customer != null;
 
-        private bool CanPrintCustomerDirectory() => Customers.Count > 0 && !IsCustomerDirectoryBusy;
+        private bool CanPrintCustomerDirectory() => IsCustomerDirectoryPrintAvailable;
 
         private void ClearNewCustomerFields()
         {

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml
@@ -38,13 +38,13 @@
                     <TextBlock Text="Find customer records, verify contact details, and prepare advisor handoffs before rentals or service follow-up." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                 </StackPanel>
                 <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCustomerCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Command="{Binding PrintSelectedCustomerCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Directory" Command="{Binding PrintCustomerDirectoryCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCustomerCommand}" Margin="0,0,0,6"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCustomerCommand}" IsEnabled="{Binding IsCustomerDirectoryActionAvailable}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Command="{Binding PrintSelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Directory" Command="{Binding PrintCustomerDirectoryCommand}" IsEnabled="{Binding IsCustomerDirectoryPrintAvailable}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,0,6"/>
                 </WrapPanel>
             </DockPanel>
         </Border>
@@ -109,6 +109,7 @@
                                 <TextBlock Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,6"/>
                                 <pages:SearchBar Width="300"
                                                  MinWidth="220"
+                                                 IsEnabled="{Binding IsCustomerDirectoryActionAvailable}"
                                                  Text="{Binding CustomerSearchTerm, UpdateSourceTrigger=PropertyChanged}"
                                                  SearchCommand="{Binding SearchCustomersCommand}"
                                                  ClearCommand="{Binding ClearCustomerSearchCommand}"
@@ -117,9 +118,9 @@
                             </WrapPanel>
                             <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="12,0,0,0">
                                 <TextBlock Text="{Binding CustomerFilterStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,8,6"/>
-                                <Button Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}" Margin="0,0,4,6"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearCustomerSearchCommand}" Margin="0,0,4,6"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintCustomerDirectoryCommand}" Margin="0,0,0,6"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}" IsEnabled="{Binding IsCustomerDirectoryActionAvailable}" Margin="0,0,4,6"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearCustomerSearchCommand}" IsEnabled="{Binding IsCustomerDirectoryActionAvailable}" Margin="0,0,4,6"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintCustomerDirectoryCommand}" IsEnabled="{Binding IsCustomerDirectoryPrintAvailable}" Margin="0,0,0,6"/>
                             </WrapPanel>
                         </DockPanel>
                     </Border>
@@ -179,27 +180,17 @@
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                <MenuItem Header="Open Customer Details" Command="{Binding OpenCustomerDetailsCommand}"/>
-                                <MenuItem Header="Edit Customer" Command="{Binding EditCustomerCommand}"/>
-                                <MenuItem Header="Copy Contact Handoff" Command="{Binding CopySelectedCustomerCommand}"/>
-                                <MenuItem Header="Print Customer Sheet" Command="{Binding PrintSelectedCustomerCommand}"/>
+                                <MenuItem Header="Open Customer Details" Command="{Binding OpenCustomerDetailsCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}"/>
+                                <MenuItem Header="Edit Customer" Command="{Binding EditCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}"/>
+                                <MenuItem Header="Copy Contact Handoff" Command="{Binding CopySelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}"/>
+                                <MenuItem Header="Print Customer Sheet" Command="{Binding PrintSelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}"/>
                                 <Separator/>
-                                <MenuItem Header="Print Customer Directory" Command="{Binding PrintCustomerDirectoryCommand}"/>
-                                <MenuItem Header="Delete Customer" Command="{Binding DeleteCustomerCommand}"/>
+                                <MenuItem Header="Print Customer Directory" Command="{Binding PrintCustomerDirectoryCommand}" IsEnabled="{Binding IsCustomerDirectoryPrintAvailable}"/>
+                                <MenuItem Header="Delete Customer" Command="{Binding DeleteCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}"/>
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>
-                    <Border Grid.Row="2" MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
-                        <Border.Style>
-                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Customers.Count}" Value="0">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Border.Style>
+                    <Border Grid.Row="2" MaxWidth="330" MinHeight="120" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding IsCustomerEmptyStateVisible, Converter={StaticResource BoolToVis}}" Style="{StaticResource DesktopNoteCard}">
                         <StackPanel>
                             <TextBlock Text="No customers found" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
                             <TextBlock Text="{Binding CustomerEmptyStateMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
@@ -273,10 +264,10 @@
                             </Border>
 
                             <WrapPanel Margin="0,0,0,8">
-                                <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" Margin="0,0,6,6"/>
-                                <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}" Margin="0,0,6,6"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopySelectedCustomerCommand}" Margin="0,0,6,6"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintSelectedCustomerCommand}" Margin="0,0,0,6"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopySelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintSelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,0,6"/>
                             </WrapPanel>
 
                             <Border Style="{StaticResource DesktopNoteCard}" Margin="0,4,0,0">
@@ -289,8 +280,8 @@
                     </ScrollViewer>
                     <Border Grid.Row="2" Style="{StaticResource DesktopSectionActionStrip}">
                         <WrapPanel HorizontalAlignment="Right">
-                            <Button Style="{StaticResource PrimaryButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" Margin="0,0,6,6"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Command="{Binding PrintSelectedCustomerCommand}" Margin="0,0,0,6"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Command="{Binding PrintSelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,0,6"/>
                         </WrapPanel>
                     </Border>
                 </Grid>
@@ -300,7 +291,7 @@
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,6,0,0">
             <DockPanel LastChildFill="True">
                 <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource GhostButton}" Content="Clear Search" Command="{Binding ClearCustomerSearchCommand}" Margin="0,0,0,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear Search" Command="{Binding ClearCustomerSearchCommand}" IsEnabled="{Binding IsCustomerDirectoryActionAvailable}" Margin="0,0,0,6"/>
                 </WrapPanel>
                 <TextBlock Text="{Binding SelectedCustomerSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
             </DockPanel>

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
@@ -69,7 +69,19 @@ namespace InventoryManagementApp.Views.Pages
 
         private void CustomerRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is CustomerManagementViewModel vm && vm.OpenCustomerDetailsCommand.CanExecute(null))
+            if (DataContext is not CustomerManagementViewModel vm)
+                return;
+
+            if (vm.IsCustomerDirectoryBusy)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (GridContextMenuSelection.SelectRow(sender, e) == null)
+                return;
+
+            if (vm.OpenCustomerDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Customers", () => vm.OpenCustomerDetailsCommand.Execute(null));
                 e.Handled = true;


### PR DESCRIPTION
## What changed

- Added ViewModel-backed customer directory availability state for refresh actions, selected-row actions, directory print, and empty-state visibility.
- Bound the Customers toolbar, search strip, context menu, handoff panel, action strip, and footer actions to those ready-state properties so paused actions show as disabled during refresh.
- Switched the customer empty state to `IsCustomerEmptyStateVisible`, preventing it from overlapping the loading overlay while rows are refreshing.
- Retargeted customer row double-clicks to the invoked row before opening details and blocked double-clicks while rows are loading.
- Preserved existing customer rows when load/search refreshes fail so a transient service failure does not blank the directory.
- Added source-contract coverage for ready-state bindings, non-overlapping empty/loading states, double-click retargeting, busy guards, and row-preserving failure behavior.
- Added a progress note for the completed customer directory responsiveness slice.

## Why this was highest value

Recent work has focused on responsive page startup, busy-state safety, and professional data display. Customers already had broad layout coverage, but source inspection showed a fresh workflow gap: double-click could act on stale selection, the empty state could display during loading, visible action controls did not consistently advertise paused state, and load/search failures cleared useful rows. This directly affects opening the Customers screen, searching, refreshing, and opening customer handoffs.

## Why this is real progress

This is a complete customer-directory workflow slice across UI state, page input handling, ViewModel failure handling, source-contract tests, and progress notes. It improves responsiveness and operator confidence without introducing unrelated features or touching already-completed recent areas.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, five commits ahead, and limited to Customers XAML/code-behind/ViewModel, source-contract tests, and the progress note.
- GitHub connector status readback found no attached commit statuses for the head commit.

## Could not check

- Could not run `pwsh -File scripts/run-full-validation.ps1`, `dotnet restore/build/test`, WPF runtime smoke tests, screenshots, scaling checks, or live responsiveness checks because this scheduled Linux environment cannot clone the repository directly (`CONNECT tunnel failed, response 403`) and does not provide Windows/.NET/WPF tooling.

## Follow-up

- Run the full Windows/.NET validation runner from a capable checkout.
- Visually smoke test Customers at 1366x768 and high Windows scaling to confirm the disabled states and non-overlapping overlays render as expected.