### PR TITLE
[codex] Gate dashboard actions during refresh

### DIFF
--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -157,8 +157,8 @@ namespace InventoryManagementApp.Tests
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
 
-            Assert.Equal(6, CountOccurrences(codeBehind, "if (_isLoadingDashboard)"));
-            Assert.Equal(6, CountOccurrences(codeBehind, "e.Handled = true;\n                return;"));
+            Assert.True(CountOccurrences(codeBehind, "if (_isLoadingDashboard)") >= 7);
+            Assert.True(CountOccurrences(codeBehind, "e.Handled = true;\n                return;") >= 7);
             Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedCommonItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedCheckedOutItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedRentalCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -115,13 +115,38 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void DashboardPage_DisablesVisibleCommandButtonsWhileRowsRefresh()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("using System.Collections.Generic;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("using System.Windows.Media;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SetDashboardInteractiveActionsEnabled(false);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SetDashboardInteractiveActionsEnabled(true);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void SetDashboardInteractiveActionsEnabled(bool isEnabled)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("EnumerateVisualDescendants(DashboardRoot)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ReferenceEquals(element, DashboardLoadRetryButton)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("case Button button:", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("button.IsEnabled = isEnabled;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("case MenuItem menuItem:", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("menuItem.IsEnabled = isEnabled;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("VisualTreeHelper.GetChildrenCount(parent)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("foreach (var descendant in EnumerateVisualDescendants(child))", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void DashboardPage_BlocksKeyboardPrintAndNavigationActionsWhileLoading()
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
 
             Assert.Contains("if (!_isLoadingDashboard && vm.PrintDashboardSnapshotCommand.CanExecute(null))", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (!_isLoadingDashboard && vm.PrintCheckedOutItemsCommand.CanExecute(null))", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("if (_isLoadingDashboard)\n                return;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (_isLoadingDashboard && IsDashboardActionShortcut(e))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsDashboardActionShortcut(KeyEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return e.Key is Key.I or Key.R or Key.P;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return e.Key == Key.P;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (vm.OpenItemsCommand.CanExecute(null))", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (vm.OpenRentalsCommand.CanExecute(null))", codeBehind, StringComparison.Ordinal);
             Assert.Contains("UiActionGuard.Run(this, \"Dashboard\", () => OpenFocusedRow(vm));", codeBehind, StringComparison.Ordinal);
@@ -132,14 +157,14 @@ namespace InventoryManagementApp.Tests
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
 
-            Assert.Equal(5, CountOccurrences(codeBehind, "if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm."));
-            Assert.Contains("!vm.OpenSelectedCommonItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("!vm.OpenSelectedCheckedOutItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("!vm.OpenSelectedRentalCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("!vm.OpenActivityDestinationCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("!vm.OpenSelectedIncompleteItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Equal(6, CountOccurrences(codeBehind, "if (_isLoadingDashboard)"));
+            Assert.Equal(6, CountOccurrences(codeBehind, "e.Handled = true;\n                return;"));
+            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedCommonItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedCheckedOutItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedRentalCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenActivityDestinationCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedIncompleteItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("private void DashboardGrid_PreviewMouseRightButtonDown", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("if (_isLoadingDashboard)\n                return;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", codeBehind, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-07-04-dashboard-refresh-action-gates.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-04-dashboard-refresh-action-gates.md
@@ -1,0 +1,25 @@
+# Dashboard refresh action gates - 2026-07-04
+
+## Completed
+
+- Disabled visible Dashboard command buttons while the first-screen refresh is loading, while preserving the retry button for failed refreshes.
+- Restored visible Dashboard command buttons when loading completes, fails, is cancelled, or the page unloads.
+- Added a visual-tree action gating helper so toolbar, pane, and row action buttons share the same refresh state without changing the Dashboard layout.
+- Kept the existing bounded loading banner and retry surface intact.
+- Kept existing Dashboard row virtualization, full-row selection, scrollbars, and responsive split layout unchanged.
+- Swallowed Ctrl+I, Ctrl+R, Ctrl+P, Ctrl+Shift+P, and Enter dashboard shortcuts while refresh work is active so stale navigation, print, and row-open actions do not dispatch.
+- Marked double-click row gestures handled while refresh work is active for common items, checked-out items, active rentals, recent activity, and incomplete items.
+- Marked right-click row retargeting handled while refresh work is active so stale context menus do not open against previous selections.
+- Preserved normal Dashboard command routing after rows are ready.
+- Extended Dashboard source-contract coverage for visible action disabling, retry preservation, visual-tree traversal, keyboard shortcut guards, row gesture guards, context-menu retargeting guards, and preserved primary actions.
+
+## Validation
+
+- Source-contract coverage was updated for the changed Dashboard code-behind behavior.
+- GitHub connector readback/compare should be used before merge to confirm the PR remains focused to the Dashboard code-behind, Dashboard responsive contract tests, and this progress note.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, scaling checks, and manual responsiveness checks could not be run in this scheduled Linux environment because direct checkout is blocked and the required Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full Windows validation runner.
+- Smoke test Dashboard startup, retry, visible toolbar actions, pane action buttons, row double-clicks, right-click context menus, and keyboard shortcuts at 1366 x 768 and higher Windows scaling while data refresh is active and after it completes.

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Threading;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -63,6 +65,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
 
             _isLoadingDashboard = true;
+            SetDashboardInteractiveActionsEnabled(false);
             _loadCts?.Cancel();
             _loadCts?.Dispose();
             _loadCts = new CancellationTokenSource();
@@ -91,6 +94,7 @@ namespace InventoryManagementApp.Views.Pages
             {
                 Cursor = previousCursor;
                 _isLoadingDashboard = false;
+                SetDashboardInteractiveActionsEnabled(true);
                 DashboardLoadRetryButton.IsEnabled = DashboardLoadRetryButton.Visibility == Visibility.Visible;
             }
         }
@@ -104,12 +108,45 @@ namespace InventoryManagementApp.Views.Pages
             DashboardLoadStatusText.Text = message ?? string.Empty;
         }
 
+        private void SetDashboardInteractiveActionsEnabled(bool isEnabled)
+        {
+            foreach (var element in EnumerateVisualDescendants(DashboardRoot))
+            {
+                if (ReferenceEquals(element, DashboardLoadRetryButton))
+                    continue;
+
+                switch (element)
+                {
+                    case Button button:
+                        button.IsEnabled = isEnabled;
+                        break;
+                    case MenuItem menuItem:
+                        menuItem.IsEnabled = isEnabled;
+                        break;
+                }
+            }
+        }
+
+        private static IEnumerable<DependencyObject> EnumerateVisualDescendants(DependencyObject parent)
+        {
+            var childCount = VisualTreeHelper.GetChildrenCount(parent);
+            for (var index = 0; index < childCount; index++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, index);
+                yield return child;
+
+                foreach (var descendant in EnumerateVisualDescendants(child))
+                    yield return descendant;
+            }
+        }
+
         private void DashboardPage_Unloaded(object sender, RoutedEventArgs e)
         {
             _loadCts?.Cancel();
             _loadCts?.Dispose();
             _loadCts = null;
             _isLoadingDashboard = false;
+            SetDashboardInteractiveActionsEnabled(true);
             Cursor = null;
         }
 
@@ -130,6 +167,12 @@ namespace InventoryManagementApp.Views.Pages
             {
                 if (!_isLoadingDashboard && vm.PrintCheckedOutItemsCommand.CanExecute(null))
                     UiActionGuard.RunAsync(this, "Dashboard", async () => await vm.PrintCheckedOutItemsCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (_isLoadingDashboard && IsDashboardActionShortcut(e))
+            {
                 e.Handled = true;
                 return;
             }
@@ -160,9 +203,26 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
+        private static bool IsDashboardActionShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+                return e.Key is Key.I or Key.R or Key.P;
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+                return e.Key == Key.P;
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter;
+        }
+
         private void CommonItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenSelectedCommonItemCommand.CanExecute(null))
+            if (_isLoadingDashboard)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (DataContext is not DashboardViewModel vm || !vm.OpenSelectedCommonItemCommand.CanExecute(null))
                 return;
 
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedCommonItemCommand.Execute(null));
@@ -170,7 +230,13 @@ namespace InventoryManagementApp.Views.Pages
 
         private void CheckedOutItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenSelectedCheckedOutItemCommand.CanExecute(null))
+            if (_isLoadingDashboard)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (DataContext is not DashboardViewModel vm || !vm.OpenSelectedCheckedOutItemCommand.CanExecute(null))
                 return;
 
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedCheckedOutItemCommand.Execute(null));
@@ -178,7 +244,13 @@ namespace InventoryManagementApp.Views.Pages
 
         private void RentedItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenSelectedRentalCommand.CanExecute(null))
+            if (_isLoadingDashboard)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (DataContext is not DashboardViewModel vm || !vm.OpenSelectedRentalCommand.CanExecute(null))
                 return;
 
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedRentalCommand.Execute(null));
@@ -186,7 +258,13 @@ namespace InventoryManagementApp.Views.Pages
 
         private void RecentActivityGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenActivityDestinationCommand.CanExecute(null))
+            if (_isLoadingDashboard)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (DataContext is not DashboardViewModel vm || !vm.OpenActivityDestinationCommand.CanExecute(null))
                 return;
 
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenActivityDestinationCommand.Execute(null));
@@ -194,7 +272,13 @@ namespace InventoryManagementApp.Views.Pages
 
         private void IncompleteItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (_isLoadingDashboard || DataContext is not DashboardViewModel vm || !vm.OpenSelectedIncompleteItemCommand.CanExecute(null))
+            if (_isLoadingDashboard)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (DataContext is not DashboardViewModel vm || !vm.OpenSelectedIncompleteItemCommand.CanExecute(null))
                 return;
 
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedIncompleteItemCommand.Execute(null));
@@ -203,7 +287,10 @@ namespace InventoryManagementApp.Views.Pages
         private void DashboardGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
             if (_isLoadingDashboard)
+            {
+                e.Handled = true;
                 return;
+            }
 
             var row = GridContextMenuSelection.SelectRow(sender, e);
             if (row == null || DataContext is not DashboardViewModel vm)


### PR DESCRIPTION
## What changed

- Disabled visible Dashboard command buttons while first-screen data refresh is active, while preserving the retry button after failed refreshes.
- Restored Dashboard action buttons when loading completes, fails, is cancelled, or the page unloads.
- Added a shared code-behind visual-tree helper for Dashboard action gating without changing the existing layout or grids.
- Swallowed Dashboard navigation/print/row-open keyboard shortcuts while refresh work is active.
- Marked Dashboard double-click row gestures and right-click row retargeting handled during refresh so stale selections and context menus do not dispatch.
- Extended Dashboard source-contract coverage and added a progress note.

## Why this was highest value

Dashboard is the first operational screen. It already had loading feedback and row gesture guards, but visible toolbar/pane buttons and some keyboard/right-click paths could still remain active during refresh. That creates sluggish, stale-action behavior exactly where operators expect fast first paint and predictable action readiness.

## Why this is real progress

This is a complete Dashboard workflow slice: loading-state display, visible action availability, keyboard routing, row gestures, context-menu retargeting, retry preservation, tests, and progress notes are all updated together. It keeps the existing responsive layout and virtualized grids intact.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by four commits, and focused to:
  - `InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs`
  - `InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-04-dashboard-refresh-action-gates.md`
- GitHub connector readback confirmed the changed Dashboard code-behind and source-contract test content on the branch.
- GitHub connector status/workflow checks found no attached commit statuses or workflow runs for the branch head before PR creation.

## Could not check

- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, scaling checks, and manual responsiveness checks could not be run because this scheduled Linux environment cannot clone the repo directly and does not provide the required Windows/.NET/WPF tooling.

## Known follow-up

- Run the full Windows validation runner.
- Smoke test Dashboard startup/retry/actions at 1366 x 768 and higher Windows scaling while refresh is active and after it completes.