### PR TITLE
Improve Rental History responsiveness and action safety

### DIFF
--- a/InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs
@@ -30,7 +30,8 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel Grid.Column=\"1\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<pages:SearchBar Width=\"300\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<pages:SearchBar x:Name=\"HistorySearchBar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Width=\"300\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
             Assert.Contains("SearchCommand=\"{Binding SearchCommand}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ClearCommand=\"{Binding ClearSearchCommand}\"", xaml, StringComparison.Ordinal);
@@ -57,27 +58,37 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RentalHistoryWindow_BoundsEmptyStateFilteringStateAndPaneText()
+        public void RentalHistoryWindow_BoundsEmptyFilteringAndOmittedRowStates()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
 
             Assert.Contains("Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Grid MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<RowDefinition Height=\"Auto\"/>\n                    <RowDefinition Height=\"*\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("MaxWidth=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" Margin=\"8,0,8,8\" MaxWidth=\"780\" HorizontalAlignment=\"Left\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Binding=\"{Binding HasOmittedHistoryRows}\" Value=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border MaxWidth=\"340\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Binding=\"{Binding HasNoResults}\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Binding=\"{Binding IsEmptyStateVisible}\" Value=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding EmptyStateTitle}\" Style=\"{StaticResource SectionHeader}\" TextAlignment=\"Center\" TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding EmptyStateMessage}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border MaxWidth=\"300\" Margin=\"12\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Top\">", xaml, StringComparison.Ordinal);
             Assert.Contains("Binding=\"{Binding IsFiltering}\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Binding=\"{Binding HasNoResults}\" Value=\"True\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Width=\"360\" HorizontalAlignment=\"Center\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
-        public void RentalHistoryWindow_PreservesHistoryCommandsAndRowHandlers()
+        public void RentalHistoryWindow_PreservesHistoryCommandsShortcutsAndRowHandlers()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml.cs");
 
+            Assert.Contains("Key=\"D\" Modifiers=\"Control\" Command=\"{Binding OpenDetailsCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Key=\"E\" Modifiers=\"Control\" Command=\"{Binding ExportCsvCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Key=\"Escape\" Command=\"{Binding CloseCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("InputGestureText=\"Ctrl+D\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("InputGestureText=\"Ctrl+E\"", xaml, StringComparison.Ordinal);
             Assert.Contains("OpenDetailsCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("CloseCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("SearchCommand", xaml, StringComparison.Ordinal);
@@ -87,6 +98,66 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("HistoryRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
             Assert.Contains("Open Details", xaml, StringComparison.Ordinal);
             Assert.Contains("Export Current View", xaml, StringComparison.Ordinal);
+
+            Assert.Contains("PreviewKeyDown += RentalHistoryWindow_PreviewKeyDown;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("HistorySearchBar.Focus();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.E", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Escape", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryWindow_BlocksStaleRowActionsWhileFiltering()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml.cs");
+
+            Assert.Contains("IsEnabled=\"{Binding IsHistoryActionReady}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsFiltering && IsRentalHistoryActionShortcut(e))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsRentalHistoryActionShortcut(KeyEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return e.Key is Key.D or Key.E;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsFiltering)\n            {\n                e.Handled = true;\n                return;\n            }", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContext is RentalHistoryViewModel { IsFiltering: true }", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryViewModel_CapsVisibleRowsAndReportsOmittedHistory()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
+
+            Assert.Contains("internal const int MaxVisibleHistoryRows = 500;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private int _matchedHistoryCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_matchedHistoryCount = _allHistory.Count;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("History = new ObservableCollection<RentalModel>(_allHistory.Take(MaxVisibleHistoryRows).Select(r => r.Rental));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public int OmittedHistoryCount => Math.Max(0, _matchedHistoryCount - History.Count);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool HasOmittedHistoryRows => OmittedHistoryCount > 0;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Showing first {History.Count} matches", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Export {History.Count} visible record(s); {OmittedHistoryCount} row(s) are omitted", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (visibleRows.Count < MaxVisibleHistoryRows)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("return new FilteredHistoryResult(visibleRows, matchedCount);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private sealed record FilteredHistoryResult(IReadOnlyList<RentalModel> VisibleRows, int MatchedCount);", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryViewModel_DisablesActionsAndEmptyStateDuringFiltering()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
+
+            Assert.Contains("public bool IsEmptyStateVisible => HasNoResults && !IsFiltering;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanOpenDetails => SelectedEntry != null && !IsFiltering;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanExportHistory => History.Count > 0 && !IsFiltering;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanClearSearch => !IsFiltering && (HasActiveSearch || !string.IsNullOrWhiteSpace(SearchText));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool IsHistoryActionReady => !IsFiltering;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ClearSearchCommand = new RelayCommand(ClearSearch, () => CanClearSearch);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OpenDetailsCommand = new RelayCommand(OpenDetails, () => CanOpenDetails);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ExportCsvCommand = new RelayCommand(ExportCsv, () => CanExportHistory);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OpenDetailsCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ClearSearchCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsHistoryActionReady));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (!CanOpenDetails || SelectedEntry == null)", viewModel, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-rental-history-action-cap-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-rental-history-action-cap-responsiveness.md
@@ -1,0 +1,20 @@
+# Rental History action and row-cap responsiveness
+
+## Completed
+
+- Capped Rental History visible rows to the first 500 matching records so very large item histories do not force the dialog grid to materialize every row at once.
+- Added matched, visible, omitted, and total row accounting to the Rental History view model.
+- Updated search and export status text so operators know when rows are intentionally omitted from the current grid for responsiveness.
+- Kept CSV export scoped to visible rows and made the omitted-row caveat visible before export.
+- Disabled Details, Export, Clear Search, context-menu, double-click, right-click retargeting, and action shortcuts while filtering is in progress.
+- Added Ctrl+F, Ctrl+D, Ctrl+E, and Esc keyboard handling for search focus, details, export, and close.
+- Named the Rental History search control so keyboard focus can jump straight to search without extra navigation.
+- Changed the empty state to use an explicit non-filtering visibility property so it does not compete with the active filtering overlay.
+- Added an omitted-row banner above the virtualized history grid.
+- Preserved row virtualization, full-row selection, responsive scrolling, bounded header/search/footer layout, and existing search/export/detail commands.
+- Extended Rental History source-contract coverage for row caps, omitted-row reporting, action readiness, keyboard shortcuts, stale row guards, and non-overlapping empty/filtering states.
+
+## Validation
+
+- GitHub connector readback and compare should be used for this scheduled pass because direct local checkout is blocked in the Linux runner.
+- Local Windows WPF runtime checks, screenshots, scaling checks, live keyboard testing, CSV export smoke testing, and `pwsh -File scripts/run-full-validation.ps1` still need to be run from a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -20,34 +20,71 @@ namespace InventoryManagementApp.ViewModels.Rental
 {
     public class RentalHistoryViewModel : ObservableObject, IDisposable
     {
+        internal const int MaxVisibleHistoryRows = 500;
+
         private readonly List<RentalHistorySearchRow> _allHistory;
         private readonly ILogger<RentalHistoryViewModel> _logger;
         private readonly IDialogService _dialogService;
         private CancellationTokenSource? _searchCts;
         private bool _disposed;
+        private int _matchedHistoryCount;
 
         public ObservableCollection<RentalModel> History { get; }
         public string ItemDisplayName { get; }
         public string WindowSummary => _allHistory.Count == 1
             ? "1 rental record loaded"
             : $"{_allHistory.Count} rental records loaded";
-        public string ResultsSummary => History.Count == _allHistory.Count
-            ? WindowSummary
-            : $"{History.Count} of {_allHistory.Count} records shown";
-        public string SearchStatus => IsFiltering
-            ? "Searching rental history..."
-            : HasActiveSearch
-                ? $"{ResultsSummary} for \"{AppliedSearchText}\""
-                : WindowSummary;
+        public string ResultsSummary
+        {
+            get
+            {
+                if (HasOmittedHistoryRows)
+                    return HasActiveSearch
+                        ? $"{History.Count} of {_matchedHistoryCount} matching records shown"
+                        : $"{History.Count} of {_matchedHistoryCount} loaded records shown";
+
+                if (HasActiveSearch)
+                    return $"{History.Count} of {_allHistory.Count} records shown";
+
+                return WindowSummary;
+            }
+        }
+        public string SearchStatus
+        {
+            get
+            {
+                if (IsFiltering)
+                    return "Searching rental history...";
+
+                if (HasOmittedHistoryRows)
+                    return HasActiveSearch
+                        ? $"Showing first {History.Count} matches for \"{AppliedSearchText}\"; refine search to review {OmittedHistoryCount} omitted row(s)."
+                        : $"Showing first {History.Count} rental records; search to narrow {OmittedHistoryCount} omitted row(s).";
+
+                return HasActiveSearch
+                    ? $"{ResultsSummary} for \"{AppliedSearchText}\""
+                    : WindowSummary;
+            }
+        }
+        public int VisibleHistoryCount => History.Count;
+        public int TotalHistoryCount => _allHistory.Count;
+        public int OmittedHistoryCount => Math.Max(0, _matchedHistoryCount - History.Count);
+        public bool HasOmittedHistoryRows => OmittedHistoryCount > 0;
         public bool HasActiveSearch => !string.IsNullOrWhiteSpace(AppliedSearchText);
         public bool HasNoResults => History.Count == 0;
+        public bool IsEmptyStateVisible => HasNoResults && !IsFiltering;
+        public bool CanOpenDetails => SelectedEntry != null && !IsFiltering;
         public bool CanExportHistory => History.Count > 0 && !IsFiltering;
+        public bool CanClearSearch => !IsFiltering && (HasActiveSearch || !string.IsNullOrWhiteSpace(SearchText));
+        public bool IsHistoryActionReady => !IsFiltering;
         public string EmptyStateTitle => HasActiveSearch ? "No matching rental records" : "No rental history records";
         public string EmptyStateMessage => HasActiveSearch
             ? "Clear the search or try a rental number, item number, customer, location, status, or date."
             : "Previous rental activity for this item will appear here once records exist.";
         public string ExportSummary => CanExportHistory
-            ? $"Export {History.Count} visible record(s) to CSV."
+            ? HasOmittedHistoryRows
+                ? $"Export {History.Count} visible record(s); {OmittedHistoryCount} row(s) are omitted from the current grid for responsiveness."
+                : $"Export {History.Count} visible record(s) to CSV."
             : IsFiltering
                 ? "Wait for search to finish before exporting."
                 : "No visible rental records to export.";
@@ -62,7 +99,11 @@ namespace InventoryManagementApp.ViewModels.Rental
             set
             {
                 if (SetProperty(ref _searchText, value))
+                {
                     OnPropertyChanged(nameof(SearchPrompt));
+                    OnPropertyChanged(nameof(CanClearSearch));
+                    ClearSearchCommand.NotifyCanExecuteChanged();
+                }
             }
         }
 
@@ -78,6 +119,8 @@ namespace InventoryManagementApp.ViewModels.Rental
                     OnPropertyChanged(nameof(SearchStatus));
                     OnPropertyChanged(nameof(EmptyStateTitle));
                     OnPropertyChanged(nameof(EmptyStateMessage));
+                    OnPropertyChanged(nameof(CanClearSearch));
+                    ClearSearchCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -91,9 +134,15 @@ namespace InventoryManagementApp.ViewModels.Rental
                 if (SetProperty(ref _isFiltering, value))
                 {
                     SearchCommand.NotifyCanExecuteChanged();
+                    ClearSearchCommand.NotifyCanExecuteChanged();
+                    OpenDetailsCommand.NotifyCanExecuteChanged();
                     ExportCsvCommand.NotifyCanExecuteChanged();
                     OnPropertyChanged(nameof(SearchStatus));
+                    OnPropertyChanged(nameof(IsEmptyStateVisible));
+                    OnPropertyChanged(nameof(CanOpenDetails));
                     OnPropertyChanged(nameof(CanExportHistory));
+                    OnPropertyChanged(nameof(CanClearSearch));
+                    OnPropertyChanged(nameof(IsHistoryActionReady));
                     OnPropertyChanged(nameof(ExportSummary));
                 }
             }
@@ -108,6 +157,7 @@ namespace InventoryManagementApp.ViewModels.Rental
                 if (SetProperty(ref _selectedEntry, value))
                 {
                     OnPropertyChanged(nameof(SelectedEntrySummary));
+                    OnPropertyChanged(nameof(CanOpenDetails));
                     OpenDetailsCommand.NotifyCanExecuteChanged();
                 }
             }
@@ -134,13 +184,14 @@ namespace InventoryManagementApp.ViewModels.Rental
                 .ThenByDescending(r => r.RentalID)
                 .Select(r => new RentalHistorySearchRow(r))
                 .ToList();
-            History = new ObservableCollection<RentalModel>(_allHistory.Select(r => r.Rental));
+            _matchedHistoryCount = _allHistory.Count;
+            History = new ObservableCollection<RentalModel>(_allHistory.Take(MaxVisibleHistoryRows).Select(r => r.Rental));
             _logger = logger ?? NullLogger<RentalHistoryViewModel>.Instance;
             _dialogService = dialogService;
 
             SearchCommand = new AsyncRelayCommand(ExecuteSearchAsync, () => !IsFiltering);
-            ClearSearchCommand = new RelayCommand(ClearSearch);
-            OpenDetailsCommand = new RelayCommand(OpenDetails, () => SelectedEntry != null);
+            ClearSearchCommand = new RelayCommand(ClearSearch, () => CanClearSearch);
+            OpenDetailsCommand = new RelayCommand(OpenDetails, () => CanOpenDetails);
             ExportCsvCommand = new RelayCommand(ExportCsv, () => CanExportHistory);
             CloseCommand = new RelayCommand(CloseWindow);
         }
@@ -162,7 +213,8 @@ namespace InventoryManagementApp.ViewModels.Rental
                     return;
 
                 var previousSelectionId = SelectedEntry?.RentalID;
-                History.ReplaceRange(results);
+                History.ReplaceRange(results.VisibleRows);
+                _matchedHistoryCount = results.MatchedCount;
                 AppliedSearchText = term;
                 RestoreSelection(previousSelectionId);
                 NotifyHistoryViewChanged();
@@ -192,27 +244,35 @@ namespace InventoryManagementApp.ViewModels.Rental
             ThrowIfDisposed();
 
             _searchCts?.Cancel();
+            if (IsFiltering)
+                return;
+
             SearchText = string.Empty;
             AppliedSearchText = string.Empty;
             var previousSelectionId = SelectedEntry?.RentalID;
-            History.ReplaceRange(_allHistory.Select(r => r.Rental));
+            _matchedHistoryCount = _allHistory.Count;
+            History.ReplaceRange(_allHistory.Take(MaxVisibleHistoryRows).Select(r => r.Rental));
             RestoreSelection(previousSelectionId);
             NotifyHistoryViewChanged();
         }
 
-        List<RentalModel> BuildFilteredHistory(string term, CancellationToken cancellationToken)
+        FilteredHistoryResult BuildFilteredHistory(string term, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(term))
-                return _allHistory.Select(r => r.Rental).ToList();
+            var visibleRows = new List<RentalModel>(MaxVisibleHistoryRows);
+            var matchedCount = 0;
 
-            return _allHistory
-                .Where(r =>
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    return r.Matches(term);
-                })
-                .Select(r => r.Rental)
-                .ToList();
+            foreach (var row in _allHistory)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!string.IsNullOrWhiteSpace(term) && !row.Matches(term))
+                    continue;
+
+                matchedCount++;
+                if (visibleRows.Count < MaxVisibleHistoryRows)
+                    visibleRows.Add(row.Rental);
+            }
+
+            return new FilteredHistoryResult(visibleRows, matchedCount);
         }
 
         void RestoreSelection(int? previousSelectionId)
@@ -226,17 +286,27 @@ namespace InventoryManagementApp.ViewModels.Rental
         {
             OnPropertyChanged(nameof(ResultsSummary));
             OnPropertyChanged(nameof(SearchStatus));
+            OnPropertyChanged(nameof(VisibleHistoryCount));
+            OnPropertyChanged(nameof(TotalHistoryCount));
+            OnPropertyChanged(nameof(OmittedHistoryCount));
+            OnPropertyChanged(nameof(HasOmittedHistoryRows));
             OnPropertyChanged(nameof(HasNoResults));
+            OnPropertyChanged(nameof(IsEmptyStateVisible));
+            OnPropertyChanged(nameof(CanOpenDetails));
             OnPropertyChanged(nameof(CanExportHistory));
+            OnPropertyChanged(nameof(CanClearSearch));
+            OnPropertyChanged(nameof(IsHistoryActionReady));
             OnPropertyChanged(nameof(EmptyStateTitle));
             OnPropertyChanged(nameof(EmptyStateMessage));
             OnPropertyChanged(nameof(ExportSummary));
+            ClearSearchCommand.NotifyCanExecuteChanged();
+            OpenDetailsCommand.NotifyCanExecuteChanged();
             ExportCsvCommand.NotifyCanExecuteChanged();
         }
 
         void OpenDetails()
         {
-            if (SelectedEntry == null)
+            if (!CanOpenDetails || SelectedEntry == null)
                 return;
 
             var returned = SelectedEntry.ReturnDate?.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) ?? "Not returned";
@@ -353,8 +423,11 @@ namespace InventoryManagementApp.ViewModels.Rental
 
             _searchCts?.Cancel();
             _searchCts?.Dispose();
+            _searchCts = null;
             _disposed = true;
         }
+
+        private sealed record FilteredHistoryResult(IReadOnlyList<RentalModel> VisibleRows, int MatchedCount);
 
         private sealed class RentalHistorySearchRow
         {

--- a/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
@@ -115,7 +115,7 @@
                     </WrapPanel>
                 </Border>
 
-                <Border Grid.Row="2" Style="{StaticResource AdminHandoffCard}" Margin="8,0,8,8" MaxWidth="780" HorizontalAlignment="Left">
+                <Border Grid.Row="2" Margin="8,0,8,8" MaxWidth="780" HorizontalAlignment="Left">
                     <Border.Style>
                         <Style TargetType="Border" BasedOn="{StaticResource AdminHandoffCard}">
                             <Setter Property="Visibility" Value="Collapsed"/>

--- a/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
@@ -7,6 +7,11 @@
         Width="1040" Height="660" MinWidth="760" MinHeight="520"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
+    <Window.InputBindings>
+        <KeyBinding Key="D" Modifiers="Control" Command="{Binding OpenDetailsCommand}"/>
+        <KeyBinding Key="E" Modifiers="Control" Command="{Binding ExportCsvCommand}"/>
+        <KeyBinding Key="Escape" Command="{Binding CloseCommand}"/>
+    </Window.InputBindings>
     <Window.Resources>
         <Style x:Key="RentalHistoryMetricCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
             <Setter Property="MinWidth" Value="190"/>
@@ -39,8 +44,8 @@
                     <TextBlock Text="{Binding ItemDisplayName}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,12,0"/>
                 </StackPanel>
                 <WrapPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="14,0,0,0">
-                    <Button Style="{StaticResource PrimaryButton}" MinWidth="86" Content="Details" Command="{Binding OpenDetailsCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" MinWidth="86" Content="Close" Command="{Binding CloseCommand}" Margin="0,0,0,6"/>
+                    <Button Style="{StaticResource PrimaryButton}" MinWidth="86" Content="Details" Command="{Binding OpenDetailsCommand}" ToolTip="Open selected rental details (Ctrl+D)" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" MinWidth="86" Content="Close" Command="{Binding CloseCommand}" ToolTip="Close rental history (Esc)" Margin="0,0,0,6"/>
                 </WrapPanel>
             </Grid>
         </Border>
@@ -74,6 +79,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
@@ -96,7 +102,8 @@
                 <Border Grid.Row="1" Style="{StaticResource DesktopSectionActionStrip}" Padding="8">
                     <WrapPanel VerticalAlignment="Center">
                         <TextBlock Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                        <pages:SearchBar Width="300"
+                        <pages:SearchBar x:Name="HistorySearchBar"
+                                         Width="300"
                                          MinWidth="220"
                                          Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                                          SearchCommand="{Binding SearchCommand}"
@@ -104,11 +111,25 @@
                                          SearchLabel=""
                                          Margin="0,0,10,6"/>
                         <TextBlock Text="{Binding SearchStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="360" Margin="0,0,10,6"/>
-                        <Button Style="{StaticResource PrimaryButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" Margin="0,0,0,6"/>
+                        <Button Style="{StaticResource PrimaryButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" ToolTip="Export the visible history rows (Ctrl+E)" Margin="0,0,0,6"/>
                     </WrapPanel>
                 </Border>
 
-                <Grid Grid.Row="2" MinWidth="0">
+                <Border Grid.Row="2" Style="{StaticResource AdminHandoffCard}" Margin="8,0,8,8" MaxWidth="780" HorizontalAlignment="Left">
+                    <Border.Style>
+                        <Style TargetType="Border" BasedOn="{StaticResource AdminHandoffCard}">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasOmittedHistoryRows}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
+                    <TextBlock Text="{Binding ExportSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                </Border>
+
+                <Grid Grid.Row="3" MinWidth="0">
                     <DataGrid x:Name="RentalHistoryDataGrid"
                               ItemsSource="{Binding History}"
                               SelectedItem="{Binding SelectedEntry}"
@@ -139,10 +160,10 @@
                             <StaticResource ResourceKey="RentalStatusColumn"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
-                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                <MenuItem Header="Open Details" Command="{Binding OpenDetailsCommand}"/>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}" IsEnabled="{Binding IsHistoryActionReady}">
+                                <MenuItem Header="Open Details" Command="{Binding OpenDetailsCommand}" InputGestureText="Ctrl+D"/>
                                 <Separator/>
-                                <MenuItem Header="Export Current View" Command="{Binding ExportCsvCommand}"/>
+                                <MenuItem Header="Export Current View" Command="{Binding ExportCsvCommand}" InputGestureText="Ctrl+E"/>
                                 <MenuItem Header="Clear Search" Command="{Binding ClearSearchCommand}"/>
                             </ContextMenu>
                         </DataGrid.ContextMenu>
@@ -152,7 +173,7 @@
                             <Style TargetType="Border" BasedOn="{StaticResource AdminHandoffCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding HasNoResults}" Value="True">
+                                    <DataTrigger Binding="{Binding IsEmptyStateVisible}" Value="True">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -190,11 +211,11 @@
                     <ColumnDefinition Width="*" MinWidth="0"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="{Binding SelectedEntrySummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,12,4"/>
+                <TextBlock Grid.Column="0" Text="{Binding SearchStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,12,4"/>
                 <WrapPanel Grid.Column="1" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource PrimaryButton}" MinWidth="86" Content="Details" Command="{Binding OpenDetailsCommand}" Margin="0,0,6,4"/>
-                    <Button Style="{StaticResource GhostButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" Margin="0,0,6,4"/>
-                    <Button Style="{StaticResource GhostButton}" MinWidth="86" Content="Close" Command="{Binding CloseCommand}" Margin="0,0,0,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" MinWidth="86" Content="Details" Command="{Binding OpenDetailsCommand}" ToolTip="Open selected rental details (Ctrl+D)" Margin="0,0,6,4"/>
+                    <Button Style="{StaticResource GhostButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" ToolTip="Export the visible history rows (Ctrl+E)" Margin="0,0,6,4"/>
+                    <Button Style="{StaticResource GhostButton}" MinWidth="86" Content="Close" Command="{Binding CloseCommand}" ToolTip="Close rental history (Esc)" Margin="0,0,0,4"/>
                 </WrapPanel>
             </Grid>
         </Border>

--- a/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml.cs
@@ -11,6 +11,7 @@ namespace InventoryManagementApp.Views.Windows
         public RentalHistoryWindow()
         {
             InitializeComponent();
+            PreviewKeyDown += RentalHistoryWindow_PreviewKeyDown;
             this.DisposeDataContextOnUnload();
         }
 
@@ -19,16 +20,82 @@ namespace InventoryManagementApp.Views.Windows
             DataContext = viewModel;
         }
 
+        private void RentalHistoryWindow_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
+            {
+                HistorySearchBar.Focus();
+                e.Handled = true;
+                return;
+            }
+
+            if (DataContext is not RentalHistoryViewModel vm)
+                return;
+
+            if (vm.IsFiltering && IsRentalHistoryActionShortcut(e))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D)
+            {
+                if (vm.OpenDetailsCommand.CanExecute(null))
+                    vm.OpenDetailsCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.E)
+            {
+                if (vm.ExportCsvCommand.CanExecute(null))
+                    vm.ExportCsvCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Escape)
+            {
+                if (vm.CloseCommand.CanExecute(null))
+                    vm.CloseCommand.Execute(null);
+                e.Handled = true;
+            }
+        }
+
+        private static bool IsRentalHistoryActionShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+                return e.Key is Key.D or Key.E;
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter;
+        }
+
         private void HistoryRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is RentalHistoryViewModel vm && vm.OpenDetailsCommand.CanExecute(null))
+            if (DataContext is not RentalHistoryViewModel vm)
+                return;
+
+            if (vm.IsFiltering)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (vm.OpenDetailsCommand.CanExecute(null))
             {
                 vm.OpenDetailsCommand.Execute(null);
+                e.Handled = true;
             }
         }
 
         private void HistoryRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is RentalHistoryViewModel { IsFiltering: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
             if (sender is DataGridRow row && !row.IsSelected)
             {
                 row.IsSelected = true;


### PR DESCRIPTION
## What changed

- Capped Rental History visible rows to the first 500 matching records so very large item histories do not force the dialog grid to materialize every row at once.
- Added matched, visible, omitted, and total row accounting to the Rental History view model.
- Updated search, results, and export status text so operators know when rows are intentionally omitted from the current grid for responsiveness.
- Kept CSV export scoped to visible rows and surfaced the omitted-row caveat before export.
- Disabled Details, Export, Clear Search, context-menu actions, double-click details, right-click row retargeting, and action shortcuts while filtering is in progress.
- Added Ctrl+F, Ctrl+D, Ctrl+E, and Esc handling for search focus, details, export, and close.
- Named the Rental History search control so keyboard focus can jump straight to search.
- Changed the empty state to use an explicit non-filtering visibility property so it does not overlap the filtering overlay.
- Added an omitted-row banner above the virtualized history grid.
- Preserved row virtualization, full-row selection, responsive scrolling, bounded header/search/footer layout, and existing search/export/detail commands.
- Extended Rental History source-contract coverage for row caps, omitted-row reporting, action readiness, keyboard shortcuts, stale row guards, and non-overlapping empty/filtering states.
- Added a progress note for future scheduled runs.

## Why this was highest value

Recent runs already improved the major page grids and the Dashboard. Rental History is still a data-heavy dialog opened from item workflows, and source inspection showed it had async filtering but weaker stale-action protection, no visible-row cap, and empty/filtering states that could compete. This directly affects screen responsiveness, search/filter behavior, row-action safety, and professional data display without introducing unrelated features.

## Why this is real progress

This is a complete Rental History workflow slice across view-model data shaping, UI status display, keyboard workflow, row gestures, context-menu readiness, export messaging, source-contract coverage, and progress notes. It includes more than ten focused operator-facing improvements while staying within the existing WPF/MVVM architecture.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, six focused commits ahead, and limited to:
  - `InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs`
  - `InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml`
  - `InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml.cs`
  - `InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-05-rental-history-action-cap-responsiveness.md`
- Connector readback confirmed the row cap, omitted-row accounting, action readiness properties, empty/filtering state separation, keyboard guards, row gesture guards, context-menu readiness, XAML status surfaces, tests, and progress note are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `f6d18688ca7d93cff1a5a7407453802e5f359c1f` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live keyboard, grid, context-menu, CSV export, and filtering responsiveness

These require a Windows/.NET/WPF-capable checkout; direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Rental History with 0, small, and 500+ histories; active filtering; Ctrl+F/Ctrl+D/Ctrl+E/Esc; double-click/right-click while filtering; and CSV export with omitted-row messaging.