### PR TITLE
Improve Kit Management action responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
@@ -60,7 +60,7 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml");
 
-            Assert.Contains("<TextBox Width=\"240\" MinWidth=\"190\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBox x:Name=\"SearchTextBox\" Width=\"240\" MinWidth=\"190\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<ComboBox Width=\"140\" MinWidth=\"120\"", xaml, StringComparison.Ordinal);
             Assert.Equal(2, CountOccurrences(xaml, "MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\""));
             Assert.Contains("Visibility=\"{Binding IsKitDirectoryEmptyVisible, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
@@ -155,9 +155,35 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("private Task? _loadKitsTask;", source, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += KitManagementPage_DataContextChanged;", source, StringComparison.Ordinal);
             Assert.Contains("LoadKitsOnceForViewModelAsync", source, StringComparison.Ordinal);
+            Assert.Contains("SearchTextBox.Focus();", source, StringComparison.Ordinal);
             Assert.Contains("await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);", source, StringComparison.Ordinal);
             Assert.Contains("vm.LoadKitsCommand.CanExecute(null)", source, StringComparison.Ordinal);
             Assert.Contains("ReferenceEquals(currentVm, vm)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitManagementPage_CodeBehindGuardsBusyActionsAndRetargetsInvokedRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs");
+
+            Assert.Contains("if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)", source, StringComparison.Ordinal);
+            Assert.Contains("SearchTextBox.SelectAll();", source, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsKitItemInteractionBusy && IsManagedKitShortcut(e))", source, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsManagedKitShortcut(KeyEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers;", source, StringComparison.Ordinal);
+            Assert.Contains("vm.AddKitCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("vm.EditKitCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("vm.AddKitItemCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("vm.EditKitItemCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("vm.CopySelectedKitCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("vm.DeleteKitCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsKitItemInteractionBusy)", source, StringComparison.Ordinal);
+            Assert.Contains("sender is FrameworkElement { DataContext: Kit kit }", source, StringComparison.Ordinal);
+            Assert.Contains("vm.SelectedKit = kit;", source, StringComparison.Ordinal);
+            Assert.Contains("sender is FrameworkElement { DataContext: KitItem kitItem }", source, StringComparison.Ordinal);
+            Assert.Contains("vm.SelectedKitItem = kitItem;", source, StringComparison.Ordinal);
+            Assert.Contains("DataContext is KitManagementViewModel { IsKitItemInteractionBusy: true }", source, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", source, StringComparison.Ordinal);
         }
 
         private static int CountOccurrences(string text, string value)

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-kit-management-action-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-kit-management-action-responsiveness.md
@@ -1,0 +1,21 @@
+# Kit Management action responsiveness
+
+Date: 2026-07-05
+
+## Completed
+
+- Moved Kit Management search focus ahead of page-owned startup loading so operators can start searching as soon as the page paints.
+- Added Ctrl+F search focus/select-all handling that remains available while kit rows or membership rows are loading.
+- Added busy-state suppression for Kit Management keyboard shortcuts while kit or membership rows are loading so stale Add/Edit/Delete/Print/Details actions do not dispatch during refresh.
+- Expanded guarded keyboard shortcuts for Add Kit, Edit Kit, Add Item, Edit Item, Copy, Delete, Details, Refresh, Print Kit, and Print Directory.
+- Retargeted kit row double-click details to the invoked row before opening details.
+- Retargeted kit item row double-click editing to the invoked membership row before opening edit.
+- Blocked kit and membership row double-click actions while rows are loading.
+- Blocked right-click row retargeting while kit or membership rows are loading so context menus cannot point at stale data.
+- Kept existing first-paint dispatcher yielding and active DataContext startup-load checks intact.
+- Extended Kit Management source-contract coverage for focus, shortcut gating, row retargeting, busy gesture guards, and right-click loading protection.
+
+## Validation
+
+- GitHub connector readback was used for the changed files because this scheduled Linux environment cannot clone the repository directly and does not provide Windows/.NET/WPF validation tooling.
+- Full validation still needs a Windows/.NET-capable checkout: `pwsh -File scripts/run-full-validation.ps1`.

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
@@ -90,7 +90,7 @@
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
                     <TextBlock Text="Find and filter" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <TextBox Width="240" MinWidth="190" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,4" ToolTip="Search kit number, name, category, or description"/>
+                        <TextBox x:Name="SearchTextBox" Width="240" MinWidth="190" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,4" ToolTip="Search kit number, name, category, or description"/>
                         <ComboBox Width="140" MinWidth="120" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}" Margin="0,0,6,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearSearchCommand}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,4,4"/>

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
+using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -22,6 +23,8 @@ namespace InventoryManagementApp.Views.Pages
 
         private async void KitManagementPage_Loaded(object sender, RoutedEventArgs e)
         {
+            SearchTextBox.Focus();
+
             if (DataContext is KitManagementViewModel vm)
             {
                 await LoadKitsOnceForViewModelAsync(vm);
@@ -60,12 +63,56 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
-        private void KitManagementPage_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        private void KitManagementPage_PreviewKeyDown(object sender, KeyEventArgs e)
         {
             if (DataContext is not KitManagementViewModel vm)
                 return;
 
-            if (e.Key == Key.Enter && vm.OpenKitDetailsCommand.CanExecute(null))
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
+            {
+                SearchTextBox.Focus();
+                SearchTextBox.SelectAll();
+                e.Handled = true;
+                return;
+            }
+
+            if (vm.IsKitItemInteractionBusy && IsManagedKitShortcut(e))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N && vm.AddKitCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Kit Management", async () => await vm.AddKitCommand.ExecuteAsync(null));
+                e.Handled = true;
+            }
+            else if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.E && vm.EditKitCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Kit Management", async () => await vm.EditKitCommand.ExecuteAsync(null));
+                e.Handled = true;
+            }
+            else if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.I && vm.AddKitItemCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Kit Management", async () => await vm.AddKitItemCommand.ExecuteAsync(null));
+                e.Handled = true;
+            }
+            else if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.E && vm.EditKitItemCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Kit Management", async () => await vm.EditKitItemCommand.ExecuteAsync(null));
+                e.Handled = true;
+            }
+            else if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.C && vm.CopySelectedKitCommand.CanExecute(null))
+            {
+                UiActionGuard.Run(this, "Kit Management", () => vm.CopySelectedKitCommand.Execute(null));
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Delete && vm.DeleteKitCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Kit Management", async () => await vm.DeleteKitCommand.ExecuteAsync(null));
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Enter && vm.OpenKitDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Kit Management", () => vm.OpenKitDetailsCommand.Execute(null));
                 e.Handled = true;
@@ -87,9 +134,32 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
+        private static bool IsManagedKitShortcut(KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter || e.Key == Key.F5 || e.Key == Key.Delete)
+                return true;
+
+            return Keyboard.Modifiers is ModifierKeys.Control or (ModifierKeys.Control | ModifierKeys.Shift)
+                && e.Key is Key.N or Key.E or Key.I or Key.C or Key.P or Key.D;
+        }
+
         private void KitRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is KitManagementViewModel vm && vm.OpenKitDetailsCommand.CanExecute(null))
+            if (DataContext is not KitManagementViewModel vm)
+                return;
+
+            if (vm.IsKitItemInteractionBusy)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (sender is FrameworkElement { DataContext: Kit kit })
+            {
+                vm.SelectedKit = kit;
+            }
+
+            if (vm.OpenKitDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Kit Management", () => vm.OpenKitDetailsCommand.Execute(null));
                 e.Handled = true;
@@ -98,7 +168,21 @@ namespace InventoryManagementApp.Views.Pages
 
         private void KitItemRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is KitManagementViewModel vm && vm.EditKitItemCommand.CanExecute(null))
+            if (DataContext is not KitManagementViewModel vm)
+                return;
+
+            if (vm.IsKitItemInteractionBusy)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (sender is FrameworkElement { DataContext: KitItem kitItem })
+            {
+                vm.SelectedKitItem = kitItem;
+            }
+
+            if (vm.EditKitItemCommand.CanExecute(null))
             {
                 UiActionGuard.RunAsync(this, "Kit Management", async () => await vm.EditKitItemCommand.ExecuteAsync(null));
                 e.Handled = true;
@@ -107,6 +191,12 @@ namespace InventoryManagementApp.Views.Pages
 
         private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (DataContext is KitManagementViewModel { IsKitItemInteractionBusy: true })
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
         }
     }

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
@@ -139,8 +139,16 @@ namespace InventoryManagementApp.Views.Pages
             if (e.Key == Key.Enter || e.Key == Key.F5 || e.Key == Key.Delete)
                 return true;
 
-            return Keyboard.Modifiers is ModifierKeys.Control or (ModifierKeys.Control | ModifierKeys.Shift)
-                && e.Key is Key.N or Key.E or Key.I or Key.C or Key.P or Key.D;
+            var modifiers = Keyboard.Modifiers;
+            if (modifiers != ModifierKeys.Control && modifiers != (ModifierKeys.Control | ModifierKeys.Shift))
+                return false;
+
+            return e.Key == Key.N
+                || e.Key == Key.E
+                || e.Key == Key.I
+                || e.Key == Key.C
+                || e.Key == Key.P
+                || e.Key == Key.D;
         }
 
         private void KitRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## Summary

- Focus the Kit Management search box before page-owned startup loading so the page is usable immediately after first paint.
- Add busy-state keyboard suppression while kit or membership rows are loading, while preserving Ctrl+F search focus.
- Expand guarded keyboard routing for Add/Edit/Delete/Copy/Details/Refresh/Print and kit-item actions through command availability and `UiActionGuard`.
- Retarget kit and kit-item double-click actions to the invoked row, and block double-click/right-click row retargeting while rows are loading.
- Extend Kit Management responsive/source-contract coverage and record the completed workflow slice.

## Why this was highest value

Recent work had already improved Kit Management layout and loading states, but the code-behind still allowed keyboard and row gestures to reach stale selections while membership rows were refreshing. That is a direct UI responsiveness/data-display safety gap in an existing workflow.

## Scope as real progress

This completes a vertical interaction slice for Kit Management: first-paint search readiness, keyboard behavior, row gesture safety, context-menu retargeting safety, source-contract coverage, and progress notes.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master` and focused to Kit Management XAML/code-behind, the Kit Management responsive contract test, and one progress note.
- Connector status readback found no attached commit statuses for the branch head before PR creation.

## Could not check

- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, scaling checks, and manual responsiveness checks could not be run because the scheduled Linux environment cannot directly clone the repo and does not provide Windows/.NET/WPF tooling.

## Follow-up

- Run the full Windows validation runner and smoke-test Kit Management search, keyboard shortcuts, double-clicks, right-click context menus, loading overlays, and print actions while kit/member rows are loading and after they complete.