### PR TITLE
Improve Import Export run log action responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
@@ -93,7 +93,7 @@ namespace InventoryManagementApp.Tests
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
 
             Assert.True(CountOccurrences(xaml, "IsEnabled=\"{Binding CanReviewSelectedLog}\"") >= 6);
-            Assert.True(CountOccurrences(xaml, "IsEnabled=\"{Binding CanPrintImportExportLogs}\"") >= 6);
+            Assert.True(CountOccurrences(xaml, "IsEnabled=\"{Binding CanPrintImportExportLogs}\"") >= 5);
             Assert.Contains("<ContextMenu DataContext=\"{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<MenuItem Header=\"Open Log Detail\" Click=\"OpenSelectedLog_Click\" IsEnabled=\"{Binding CanReviewSelectedLog}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<MenuItem Header=\"Copy Selected Log\" Click=\"CopySelectedLog_Click\" IsEnabled=\"{Binding CanReviewSelectedLog}\"/>", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
@@ -88,6 +88,31 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ImportExportPage_DisablesRunLogActionsThroughSharedReadinessBindings()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
+
+            Assert.True(CountOccurrences(xaml, "IsEnabled=\"{Binding CanReviewSelectedLog}\"") >= 6);
+            Assert.True(CountOccurrences(xaml, "IsEnabled=\"{Binding CanPrintImportExportLogs}\"") >= 6);
+            Assert.Contains("<ContextMenu DataContext=\"{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<MenuItem Header=\"Open Log Detail\" Click=\"OpenSelectedLog_Click\" IsEnabled=\"{Binding CanReviewSelectedLog}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<MenuItem Header=\"Copy Selected Log\" Click=\"CopySelectedLog_Click\" IsEnabled=\"{Binding CanReviewSelectedLog}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<MenuItem Header=\"Print Current Log\" Click=\"PrintLogs_Click\" IsEnabled=\"{Binding CanPrintImportExportLogs}\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportPage_ShowsBusyOverlayWithoutCompetingWithEmptyState()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
+
+            Assert.Contains("<DataTrigger Binding=\"{Binding IsDataOperationBusy}\" Value=\"True\">\n                                                    <Setter Property=\"Visibility\" Value=\"Collapsed\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"380\" MinHeight=\"116\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"Data operation in progress\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"{Binding DataOperationSummary}\" Style=\"{StaticResource CaptionTextBlock}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ProgressBar IsIndeterminate=\"True\" Height=\"6\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ImportExportViewModel_GatesAllDataOperationsThroughSharedBusyState()
         {
             var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
@@ -144,6 +169,24 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ImportExportPage_CodeBehindGuardsBusyRowGesturesAndKeyboardShortcuts()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
+
+            Assert.Contains("PreviewKeyDown += ImportExportPage_PreviewKeyDown;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void ImportExportPage_PreviewKeyDown", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (IsDataOperationBusy())\n            {\n                e.Handled = true;\n                return;\n            }", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("RetargetLogSelectionFromEvent(e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsRunLogShortcut(KeyEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return e.Key is Key.C or Key.D or Key.P;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsTextEditingElement(object? source) =>", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("source is TextBoxBase or PasswordBox;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static T? FindAncestor<T>(DependencyObject? current)", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ImportExportPage_PreservesDataCommandsAndLogRowHandlers()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
@@ -161,6 +204,21 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("OpenSelectedLog_Click", xaml, StringComparison.Ordinal);
             Assert.Contains("ImportExportLogGrid_MouseDoubleClick", xaml, StringComparison.Ordinal);
             Assert.Contains("ImportExportLogRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            var count = 0;
+            var startIndex = 0;
+            while (true)
+            {
+                var index = text.IndexOf(value, startIndex, StringComparison.Ordinal);
+                if (index < 0)
+                    return count;
+
+                count++;
+                startIndex = index + value.Length;
+            }
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-import-export-run-log-action-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-import-export-run-log-action-responsiveness.md
@@ -1,0 +1,25 @@
+# Import / Export Run Log Action Responsiveness - 2026-07-05
+
+## Completed
+
+- Bound Import / Export run-log copy, open-detail, and print actions to shared ViewModel readiness so visible buttons and context-menu actions pause while data operations run.
+- Added a bounded busy overlay for the Run Log grid and kept the empty state hidden while import, export, backup, restore, or image operations are active.
+- Gave the Run Log context menu the page ViewModel as its data context so menu item readiness matches toolbar and handoff actions.
+- Guarded run-log double-click detail opening while data operations are busy.
+- Retargeted run-log double-clicks to the invoked row before opening details so stale selection does not drive the action.
+- Blocked right-click row retargeting during active data operations.
+- Added keyboard-safe Run Log shortcuts for open detail, copy selected result, print log, and clear log.
+- Swallowed Run Log keyboard shortcuts while data operations are active so stale copy/print/open/clear actions cannot dispatch during long-running file work.
+- Preserved text-editing copy behavior before handling page-level shortcuts.
+- Kept print-preview output capped to the existing 250-row packet with omitted-row accounting.
+- Extended source-contract coverage for run-log action readiness bindings, busy/empty state separation, context-menu readiness, keyboard guards, row gesture guards, and print caps.
+
+## Validation
+
+- GitHub connector readback confirmed the Import / Export page XAML, code-behind, source-contract tests, and this progress note were updated on the feature branch.
+- Local Windows/.NET/WPF validation could not be run in this scheduled environment because direct checkout is blocked and the environment does not provide the required Windows desktop toolchain.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test Import / Export with a long-running import/export/backup, selected and unselected log rows, right-click while busy, Ctrl+D, Ctrl+C, Ctrl+P, Delete, print preview, and empty-log/busy-log transitions.

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
@@ -110,8 +110,8 @@
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
                     <TextBlock Text="Result actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <Button Style="{StaticResource DataActionButton}" Content="Copy Selected" Click="CopySelectedLog_Click"/>
-                        <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click"/>
+                        <Button Style="{StaticResource DataActionButton}" Content="Copy Selected" Click="CopySelectedLog_Click" IsEnabled="{Binding CanReviewSelectedLog}"/>
+                        <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintImportExportLogs}"/>
                         <Button Style="{StaticResource DataActionButton}" Content="Clear Log" Command="{Binding ClearImportExportLogsCommand}"/>
                         <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" VerticalAlignment="Center" Margin="6,1,0,4" MaxWidth="520"/>
                     </WrapPanel>
@@ -213,8 +213,8 @@
                                         </Border>
                                         <Border Style="{StaticResource DesktopInsetCard}" Padding="10">
                                             <WrapPanel>
-                                                <Button Style="{StaticResource PrimaryButton}" Content="Copy Result" Click="CopySelectedLog_Click" Margin="0,0,4,4"/>
-                                                <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click"/>
+                                                <Button Style="{StaticResource PrimaryButton}" Content="Copy Result" Click="CopySelectedLog_Click" IsEnabled="{Binding CanReviewSelectedLog}" Margin="0,0,4,4"/>
+                                                <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintImportExportLogs}"/>
                                                 <Button Style="{StaticResource DataActionButton}" Content="Clear Log" Command="{Binding ClearImportExportLogsCommand}"/>
                                             </WrapPanel>
                                         </Border>
@@ -448,8 +448,8 @@
                                 </Border>
                                 <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
                                     <WrapPanel>
-                                        <Button Style="{StaticResource DataActionButton}" Content="Copy Selected" Click="CopySelectedLog_Click"/>
-                                        <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click"/>
+                                        <Button Style="{StaticResource DataActionButton}" Content="Copy Selected" Click="CopySelectedLog_Click" IsEnabled="{Binding CanReviewSelectedLog}"/>
+                                        <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintImportExportLogs}"/>
                                         <Button Style="{StaticResource DataActionButton}" Content="Clear" Command="{Binding ClearImportExportLogsCommand}"/>
                                     </WrapPanel>
                                 </Border>
@@ -474,11 +474,11 @@
                                         </Style>
                                     </DataGrid.RowStyle>
                                     <DataGrid.ContextMenu>
-                                        <ContextMenu>
-                                            <MenuItem Header="Open Log Detail" Click="OpenSelectedLog_Click"/>
-                                            <MenuItem Header="Copy Selected Log" Click="CopySelectedLog_Click"/>
+                                        <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                            <MenuItem Header="Open Log Detail" Click="OpenSelectedLog_Click" IsEnabled="{Binding CanReviewSelectedLog}"/>
+                                            <MenuItem Header="Copy Selected Log" Click="CopySelectedLog_Click" IsEnabled="{Binding CanReviewSelectedLog}"/>
                                             <Separator/>
-                                            <MenuItem Header="Print Current Log" Click="PrintLogs_Click"/>
+                                            <MenuItem Header="Print Current Log" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintImportExportLogs}"/>
                                         </ContextMenu>
                                     </DataGrid.ContextMenu>
                                     <DataGrid.Columns>
@@ -504,12 +504,32 @@
                                                 <DataTrigger Binding="{Binding HasLogEntries}" Value="False">
                                                     <Setter Property="Visibility" Value="Visible"/>
                                                 </DataTrigger>
+                                                <DataTrigger Binding="{Binding IsDataOperationBusy}" Value="True">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
                                     </Border.Style>
                                     <StackPanel>
                                         <TextBlock Text="No operation log rows yet" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
                                         <TextBlock Text="Run an import, export, image import, or backup action. The exact result appears here for review, copy, and print handoff." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
+                                <Border Grid.Row="2" MaxWidth="380" MinHeight="116" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <Border.Style>
+                                        <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsDataOperationBusy}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <StackPanel>
+                                        <ProgressBar IsIndeterminate="True" Height="6" Margin="0,0,0,10"/>
+                                        <TextBlock Text="Data operation in progress" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                                        <TextBlock Text="{Binding DataOperationSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                                     </StackPanel>
                                 </Border>
                                 <Border Grid.Row="3" Style="{StaticResource DesktopPaneSubheader}" BorderThickness="0,1,0,0">
@@ -551,8 +571,8 @@
                                 </ScrollViewer>
                                 <Border Grid.Row="2" Style="{StaticResource DesktopInsetCard}" Padding="10">
                                     <WrapPanel>
-                                        <Button Style="{StaticResource DataActionButton}" Content="Copy" Click="CopySelectedLog_Click"/>
-                                        <Button Style="{StaticResource DataActionButton}" Content="Print" Click="PrintLogs_Click"/>
+                                        <Button Style="{StaticResource DataActionButton}" Content="Copy" Click="CopySelectedLog_Click" IsEnabled="{Binding CanReviewSelectedLog}"/>
+                                        <Button Style="{StaticResource DataActionButton}" Content="Print" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintImportExportLogs}"/>
                                     </WrapPanel>
                                 </Border>
                             </Grid>

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -19,16 +20,73 @@ namespace InventoryManagementApp.Views.Pages
         public ImportExportPage()
         {
             InitializeComponent();
+            PreviewKeyDown += ImportExportPage_PreviewKeyDown;
         }
 
         private void ImportExportLogGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (IsDataOperationBusy())
+            {
+                e.Handled = true;
+                return;
+            }
+
+            RetargetLogSelectionFromEvent(e);
             OpenSelectedLog_Click(sender, e);
+            e.Handled = true;
         }
 
         private void ImportExportLogRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (IsDataOperationBusy())
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
+        }
+
+        private void ImportExportPage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (IsTextEditingElement(e.OriginalSource))
+                return;
+
+            if (IsDataOperationBusy())
+            {
+                if (IsRunLogShortcut(e))
+                    e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D && CanReviewSelectedLog())
+            {
+                OpenSelectedLog_Click(sender, e);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && CanReviewSelectedLog())
+            {
+                CopySelectedLog_Click(sender, e);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && CanPrintImportExportLogs())
+            {
+                PrintLogs_Click(sender, e);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete && CanClearImportExportLogs())
+            {
+                if (DataContext is ImportExportViewModel vm)
+                    vm.ClearImportExportLogsCommand.Execute(null);
+
+                e.Handled = true;
+            }
         }
 
         private void OpenSelectedLog_Click(object sender, RoutedEventArgs e)
@@ -93,6 +151,15 @@ namespace InventoryManagementApp.Views.Pages
         private bool IsDataOperationBusy() =>
             DataContext is ImportExportViewModel vm && vm.IsDataOperationBusy;
 
+        private bool CanReviewSelectedLog() =>
+            DataContext is ImportExportViewModel { CanReviewSelectedLog: true };
+
+        private bool CanPrintImportExportLogs() =>
+            DataContext is ImportExportViewModel { CanPrintImportExportLogs: true };
+
+        private bool CanClearImportExportLogs() =>
+            DataContext is ImportExportViewModel vm && vm.ClearImportExportLogsCommand.CanExecute(null);
+
         private void PrintLogs_Click(object sender, RoutedEventArgs e)
         {
             UiActionGuard.Run(this, "Import / Export", () =>
@@ -123,6 +190,43 @@ namespace InventoryManagementApp.Views.Pages
                 var document = BuildPrintDocument(vm.ImportExportLogs.ToList(), vm.LogSummary);
                 new PrintPreviewWindow().ShowPreview(document, "Import / Export Log", "Review the current session's import, export, image, backup, and restore results before staff handoff.");
             });
+        }
+
+        private string RetargetLogSelectionFromEvent(MouseButtonEventArgs e)
+        {
+            var row = FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row?.Item is string log && !string.IsNullOrWhiteSpace(log))
+            {
+                ImportExportLogGrid.SelectedItem = log;
+                return log;
+            }
+
+            return GetSelectedLogForAction();
+        }
+
+        private static bool IsRunLogShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+                return e.Key is Key.C or Key.D or Key.P;
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete;
+        }
+
+        private static bool IsTextEditingElement(object? source) =>
+            source is TextBoxBase or PasswordBox;
+
+        private static T? FindAncestor<T>(DependencyObject? current)
+            where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T match)
+                    return match;
+
+                current = VisualTreeHelper.GetParent(current);
+            }
+
+            return null;
         }
 
         private static FlowDocument BuildPrintDocument(


### PR DESCRIPTION
## What changed

- Bound Import / Export run-log copy, open-detail, and print buttons to shared ViewModel readiness so visible actions pause while import, export, backup, restore, or image operations are active.
- Gave the Run Log context menu the page ViewModel as its data context and bound menu items to the same selected-log/print readiness state.
- Added a bounded busy overlay for the Run Log grid and hid the empty state while data operations are active.
- Guarded run-log double-click detail opening while operations are busy.
- Retargeted double-click detail opening to the invoked run-log row so stale selection does not drive the action.
- Blocked right-click row retargeting during active data operations.
- Added keyboard-safe run-log shortcuts for open detail, copy selected result, print log, and clear log.
- Swallowed run-log shortcuts while data operations are busy, while preserving text-editing copy behavior.
- Kept the existing 250-row print-preview cap and omitted-row accounting intact.
- Extended source-contract coverage for action readiness bindings, context-menu readiness, busy/empty state separation, row gesture guards, keyboard shortcuts, and print caps.
- Recorded the completed workflow slice in progress notes.

## Why this was highest value

Recent scheduled work has already tightened the primary page grids and several dialogs. Import / Export still had a concrete responsiveness gap: the ViewModel exposed a shared busy/readiness state, but visible run-log buttons, context-menu actions, row gestures, and keyboard paths did not consistently reflect it. This workflow performs expensive file and backup operations, so stale copy/print/open/clear actions during long-running work are a direct UI responsiveness and professional data-display risk.

## Why this is real progress

This is a vertical Import / Export run-log workflow slice across XAML action state, context-menu binding, busy/empty display, code-behind gesture safety, keyboard workflow, print-entry preservation, source-contract coverage, and progress notes. It stays inside the existing WPF/MVVM architecture and avoids unrelated features.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, five commits ahead, and limited to:
  - `InventoryManagementApp/Views/Pages/ImportExportPage.xaml`
  - `InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs`
  - `InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-05-import-export-run-log-action-responsiveness.md`
- Connector readback confirmed the XAML readiness bindings, context-menu DataContext binding, busy overlay, empty-state busy collapse, code-behind busy guards, row retargeting, keyboard shortcuts, source-contract assertions, and progress note are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `979700b963de7e96e844a1587d7bd51c466d9ae6` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Import / Export import/export/backup, keyboard, context-menu, and print-preview behavior

These require a Windows/.NET/WPF-capable checkout; direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and `gh`, `pwsh`, and Windows desktop tooling are unavailable.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Import / Export with a long-running import/export/backup, selected and unselected log rows, right-click while busy, Ctrl+D, Ctrl+C, Ctrl+P, Delete, print preview, and empty-log/busy-log transitions.