### PR TITLE
[codex] Harden dashboard load state responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -107,11 +107,48 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("DataContextChanged += DashboardPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("ReferenceEquals(_loadedDashboardViewModel, vm) && _hasLoadedDashboardForViewModel", codeBehind, StringComparison.Ordinal);
             Assert.Contains("_loadedDashboardViewModel = vm;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("_hasLoadedDashboardForViewModel = true;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("private void DashboardPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("_loadedDashboardViewModel = e.NewValue as DashboardViewModel;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("_hasLoadedDashboardForViewModel = false;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DashboardLoadRetryButton_Click", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("_hasLoadedDashboardForViewModel = true;\n            await LoadDashboardAsync(\"Loading dashboard data...\");", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_MarksStartupLoadCompleteOnlyAfterActiveViewModelFinishes()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("if (token.IsCancellationRequested || !ReferenceEquals(DataContext, vm))\n                    return;", codeBehind, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(codeBehind, "!ReferenceEquals(DataContext, vm)"));
+            Assert.Contains("await vm.LoadAsync(token);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadedDashboardViewModel = vm;\n                _hasLoadedDashboardForViewModel = true;\n                SetDashboardLoadStatus(null, showRetry: false);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_hasLoadedDashboardForViewModel = false;\n                if (ReferenceEquals(_loadCts, loadCts))", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_KeepsStaleCancelledLoadsFromReenablingActions()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("var loadCts = new CancellationTokenSource();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadCts = loadCts;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (IsLoaded && !_isUnloadingDashboard && ReferenceEquals(_loadCts, loadCts))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (ReferenceEquals(_loadCts, loadCts))\n                {\n                    Cursor = previousCursor;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SetDashboardInteractiveActionsEnabled(true);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadCts?.Dispose();\n                    _loadCts = null;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("loadCts.Dispose();", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_UnloadSuppressesCancelledRetryNoise()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("private bool _isUnloadingDashboard;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_isUnloadingDashboard = false;\n            Focus();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_isUnloadingDashboard = true;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("!_isUnloadingDashboard", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadCts?.Cancel();\n            _loadCts?.Dispose();\n            _loadCts = null;", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -119,7 +119,7 @@ namespace InventoryManagementApp.Tests
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
 
             Assert.Contains("if (token.IsCancellationRequested || !ReferenceEquals(DataContext, vm))\n                    return;", codeBehind, StringComparison.Ordinal);
-            Assert.Equal(2, CountOccurrences(codeBehind, "!ReferenceEquals(DataContext, vm)"));
+            Assert.True(CountOccurrences(codeBehind, "!ReferenceEquals(DataContext, vm)") >= 2);
             Assert.Contains("await vm.LoadAsync(token);", codeBehind, StringComparison.Ordinal);
             Assert.Contains("_loadedDashboardViewModel = vm;\n                _hasLoadedDashboardForViewModel = true;\n                SetDashboardLoadStatus(null, showRetry: false);", codeBehind, StringComparison.Ordinal);
             Assert.Contains("_hasLoadedDashboardForViewModel = false;\n                if (ReferenceEquals(_loadCts, loadCts))", codeBehind, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-dashboard-load-state-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-dashboard-load-state-responsiveness.md
@@ -1,0 +1,21 @@
+# Dashboard Load State Responsiveness
+
+Date: 2026-07-05
+
+## Completed
+
+- Kept the Dashboard first-paint load path view-model-aware while moving the completed-load marker to the successful end of the refresh instead of before data work begins.
+- Rechecked cancellation and the active `DataContext` after the dispatcher yield and again after `DashboardViewModel.LoadAsync` returns so stale loads cannot claim success after navigation or context swaps.
+- Scoped each refresh to its own `CancellationTokenSource` so stale/cancelled loads cannot re-enable dashboard actions or hide the current load status after a newer refresh starts.
+- Preserved retry messaging for real load failures while keeping unload-triggered cancellation from showing a noisy cancelled-load retry banner.
+- Reset Dashboard startup completion after failed loads so returning to the page or pressing Retry can attempt a fresh load instead of treating the failed pass as complete.
+- Refreshed the retry click path to align the tracked view model with the current `DataContext` before starting a manual reload.
+- Kept Dashboard toolbar, row, context-menu, print, and keyboard actions disabled while the active refresh is still in progress.
+- Extended Dashboard source-contract coverage for success-only load completion, active `DataContext` checks, stale-load action protection, scoped cancellation cleanup, unload cancellation suppression, and retry state handling.
+
+## Validation
+
+- Source inspection confirmed the Dashboard code-behind now marks `_hasLoadedDashboardForViewModel` true only after the active view model completes `LoadAsync` without cancellation or context replacement.
+- Source inspection confirmed stale `CancellationTokenSource` instances cannot run the final action re-enable/status cleanup for newer loads.
+- Source-contract tests were updated in `DashboardPageResponsiveContractTests` to preserve the new load-state guarantees.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime smoke testing, screenshots, scaling checks, and live Dashboard responsiveness checks could not run in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
@@ -19,6 +19,7 @@ namespace InventoryManagementApp.Views.Pages
         private bool _isLoadingDashboard;
         private DashboardViewModel? _loadedDashboardViewModel;
         private bool _hasLoadedDashboardForViewModel;
+        private bool _isUnloadingDashboard;
 
         public DashboardPage()
         {
@@ -31,6 +32,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private async void DashboardPage_Loaded(object sender, RoutedEventArgs e)
         {
+            _isUnloadingDashboard = false;
             Focus();
 
             if (DataContext is not DashboardViewModel vm)
@@ -40,7 +42,6 @@ namespace InventoryManagementApp.Views.Pages
                 return;
 
             _loadedDashboardViewModel = vm;
-            _hasLoadedDashboardForViewModel = true;
             await LoadDashboardAsync("Loading dashboard data...");
         }
 
@@ -55,6 +56,9 @@ namespace InventoryManagementApp.Views.Pages
 
         private async void DashboardLoadRetryButton_Click(object sender, RoutedEventArgs e)
         {
+            if (DataContext is DashboardViewModel vm)
+                _loadedDashboardViewModel = vm;
+
             _hasLoadedDashboardForViewModel = false;
             await LoadDashboardAsync("Refreshing dashboard data...");
         }
@@ -68,8 +72,9 @@ namespace InventoryManagementApp.Views.Pages
             SetDashboardInteractiveActionsEnabled(false);
             _loadCts?.Cancel();
             _loadCts?.Dispose();
-            _loadCts = new CancellationTokenSource();
-            var token = _loadCts.Token;
+            var loadCts = new CancellationTokenSource();
+            _loadCts = loadCts;
+            var token = loadCts.Token;
             var previousCursor = Cursor;
 
             SetDashboardLoadStatus(loadingMessage, showRetry: false);
@@ -78,24 +83,45 @@ namespace InventoryManagementApp.Views.Pages
             try
             {
                 await Dispatcher.Yield(DispatcherPriority.Background);
+
+                if (token.IsCancellationRequested || !ReferenceEquals(DataContext, vm))
+                    return;
+
                 await vm.LoadAsync(token);
+
+                if (token.IsCancellationRequested || !ReferenceEquals(DataContext, vm))
+                    return;
+
+                _loadedDashboardViewModel = vm;
+                _hasLoadedDashboardForViewModel = true;
                 SetDashboardLoadStatus(null, showRetry: false);
             }
             catch (OperationCanceledException)
             {
-                if (IsLoaded)
+                if (IsLoaded && !_isUnloadingDashboard && ReferenceEquals(_loadCts, loadCts))
                     SetDashboardLoadStatus("Dashboard refresh was cancelled before it finished.", showRetry: true);
             }
             catch (Exception)
             {
-                SetDashboardLoadStatus("Dashboard data could not be loaded. Check the database connection, then retry.", showRetry: true);
+                _hasLoadedDashboardForViewModel = false;
+                if (ReferenceEquals(_loadCts, loadCts))
+                    SetDashboardLoadStatus("Dashboard data could not be loaded. Check the database connection, then retry.", showRetry: true);
             }
             finally
             {
-                Cursor = previousCursor;
-                _isLoadingDashboard = false;
-                SetDashboardInteractiveActionsEnabled(true);
-                DashboardLoadRetryButton.IsEnabled = DashboardLoadRetryButton.Visibility == Visibility.Visible;
+                if (ReferenceEquals(_loadCts, loadCts))
+                {
+                    Cursor = previousCursor;
+                    _isLoadingDashboard = false;
+                    SetDashboardInteractiveActionsEnabled(true);
+                    DashboardLoadRetryButton.IsEnabled = DashboardLoadRetryButton.Visibility == Visibility.Visible;
+                    _loadCts?.Dispose();
+                    _loadCts = null;
+                }
+                else
+                {
+                    loadCts.Dispose();
+                }
             }
         }
 
@@ -142,6 +168,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void DashboardPage_Unloaded(object sender, RoutedEventArgs e)
         {
+            _isUnloadingDashboard = true;
             _loadCts?.Cancel();
             _loadCts?.Dispose();
             _loadCts = null;


### PR DESCRIPTION
## What changed

- Kept Dashboard startup loading view-model-aware while moving the completed-load marker to the successful end of the refresh.
- Rechecked cancellation and the active `DataContext` after first-paint dispatcher yield and after `DashboardViewModel.LoadAsync` returns.
- Scoped each refresh to its own `CancellationTokenSource` so stale/cancelled loads cannot re-enable Dashboard actions or hide current load status after a newer refresh starts.
- Preserved retry messaging for real failures while suppressing noisy retry banners for unload-triggered cancellation.
- Reset Dashboard startup completion after failed loads so reload/navigation can try again instead of treating the failed pass as complete.
- Aligned the retry click path with the current `DataContext` before manual reload.
- Kept toolbar, row, context-menu, print, and keyboard actions disabled while the active refresh is still in progress.
- Extended Dashboard source-contract coverage around success-only completion, active-context checks, stale-load cleanup, unload cancellation suppression, and retry state.
- Added a progress note for the completed Dashboard load-state responsiveness slice.

## Why this was highest value

Dashboard is a high-traffic screen with multiple grids and fast action entry points. Recent evidence showed it already had responsive layout contracts, but its load-state lifecycle could mark a failed first load as complete or let stale cancelled work restore interactivity after navigation/context changes. That directly affects perceived speed, action safety, and professional data display when opening the app or switching back to Dashboard.

## Scope and progress

This is a focused workflow-level reliability slice: it improves Dashboard first paint, retry behavior, stale-load safety, action gating, keyboard/print safety during loading, and source-contract coverage without adding unrelated screens or broad architecture changes.

## Validation

- GitHub connector compare/readback confirmed the PR is current with `master` and limited to Dashboard code-behind, Dashboard source-contract tests, and the Dashboard progress note.
- Source inspection confirmed `_hasLoadedDashboardForViewModel` is set only after the active view model completes `LoadAsync` without cancellation or context replacement.
- Source inspection confirmed stale `CancellationTokenSource` instances cannot run the final action re-enable/status cleanup for newer loads.
- Source-contract tests were updated to preserve the new load-state guarantees.

## Not run / limitations

- `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime smoke testing, screenshots, scaling checks, and live Dashboard responsiveness checks could not run in this scheduled Linux environment because direct checkout/raw GitHub access is blocked by HTTP 403 and Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run the full Windows validation runner and a WPF Dashboard smoke test in a Windows/.NET-capable checkout when available.
- Continue looking for screens where load-state completion or stale cancellation can make the UI feel sluggish or unsafe.