### PR TITLE
Harden Settings initialization against stale loads

### DIFF
--- a/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
@@ -100,11 +100,13 @@ namespace InventoryManagementApp.Tests
             var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml.cs");
 
             Assert.Contains("private bool _sensitiveFieldSyncQueued;", source, StringComparison.Ordinal);
-            Assert.Contains("private void QueueSensitiveFieldSync()", source, StringComparison.Ordinal);
-            Assert.Contains("if (_settingsViewModel == null || _sensitiveFieldSyncQueued)", source, StringComparison.Ordinal);
+            Assert.Contains("private void QueueSensitiveFieldSync(SettingsViewModel? sourceViewModel)", source, StringComparison.Ordinal);
+            Assert.Contains("sourceViewModel == null || _sensitiveFieldSyncQueued || !ReferenceEquals(_settingsViewModel, sourceViewModel)", source, StringComparison.Ordinal);
             Assert.Contains("_sensitiveFieldSyncQueued = true;", source, StringComparison.Ordinal);
-            Assert.Contains("Dispatcher.BeginInvoke(SyncSensitiveFieldsFromViewModel, DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("Dispatcher.BeginInvoke(() => SyncSensitiveFieldsFromViewModel(sourceViewModel), DispatcherPriority.Background);", source, StringComparison.Ordinal);
             Assert.Contains("_sensitiveFieldSyncQueued = false;", source, StringComparison.Ordinal);
+            Assert.Contains("private void SyncSensitiveFieldsFromViewModel(SettingsViewModel sourceViewModel)", source, StringComparison.Ordinal);
+            Assert.Contains("if (!ReferenceEquals(_settingsViewModel, sourceViewModel))", source, StringComparison.Ordinal);
             Assert.DoesNotContain("Dispatcher.Invoke(SyncSensitiveFieldsFromViewModel)", source, StringComparison.Ordinal);
         }
 
@@ -117,23 +119,43 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("StartSettingsInitialization();", source, StringComparison.Ordinal);
             Assert.Contains("private void StartSettingsInitialization()", source, StringComparison.Ordinal);
             Assert.Contains("if (_settingsViewModel == null || _initializeSettingsTask != null)", source, StringComparison.Ordinal);
-            Assert.Contains("_initializeSettingsTask = InitializeSettingsAsync(_settingsViewModel);", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeSettingsCts = new CancellationTokenSource();", source, StringComparison.Ordinal);
+            Assert.Contains("var version = ++_initializeSettingsVersion;", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeSettingsTask = InitializeSettingsAsync(_settingsViewModel, _initializeSettingsCts.Token, version);", source, StringComparison.Ordinal);
             Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
             Assert.Contains("await viewModel.InitializeAsync().ConfigureAwait(true);", source, StringComparison.Ordinal);
-            Assert.Contains("QueueSensitiveFieldSync();", source, StringComparison.Ordinal);
+            Assert.Contains("QueueSensitiveFieldSync(viewModel);", source, StringComparison.Ordinal);
         }
 
         [Fact]
-        public void SettingsPage_CodeBehindDetachesAndAvoidsStaleInitializationErrors()
+        public void SettingsPage_CodeBehindCancelsStaleInitializationOnUnloadAndDataContextSwap()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml.cs");
 
+            Assert.Contains("using System.Threading;", source, StringComparison.Ordinal);
+            Assert.Contains("private CancellationTokenSource? _initializeSettingsCts;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _initializeSettingsVersion;", source, StringComparison.Ordinal);
+            Assert.Contains("CancelSettingsInitialization();", source, StringComparison.Ordinal);
+            Assert.Contains("private void CancelSettingsInitialization()", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeSettingsVersion++;", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeSettingsCts?.Cancel();", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeSettingsCts?.Dispose();", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeSettingsCts = null;", source, StringComparison.Ordinal);
             Assert.Contains("_initializeSettingsTask = null;", source, StringComparison.Ordinal);
-            Assert.Contains("if (!ReferenceEquals(_settingsViewModel, viewModel))", source, StringComparison.Ordinal);
+            Assert.Contains("catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SettingsPage_CodeBehindAvoidsStaleInitializationSuccessAndErrors()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml.cs");
+
+            Assert.True(CountOccurrences(source, "version != _initializeSettingsVersion") >= 3);
+            Assert.True(CountOccurrences(source, "!ReferenceEquals(_settingsViewModel, viewModel)") >= 3);
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", source, StringComparison.Ordinal);
             Assert.Contains("MessageBox.Show(", source, StringComparison.Ordinal);
             Assert.Contains("$\"Failed to load settings: {ex.Message}\"", source, StringComparison.Ordinal);
             Assert.Contains("MessageBoxImage.Error", source, StringComparison.Ordinal);
-            Assert.Contains("QueueSensitiveFieldSync();", source, StringComparison.Ordinal);
             Assert.Contains("_settingsViewModel.PropertyChanged -= SettingsViewModel_PropertyChanged;", source, StringComparison.Ordinal);
             Assert.Contains("_settingsViewModel.PropertyChanged += SettingsViewModel_PropertyChanged;", source, StringComparison.Ordinal);
         }

--- a/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
@@ -103,7 +103,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("private void QueueSensitiveFieldSync(SettingsViewModel? sourceViewModel)", source, StringComparison.Ordinal);
             Assert.Contains("sourceViewModel == null || _sensitiveFieldSyncQueued || !ReferenceEquals(_settingsViewModel, sourceViewModel)", source, StringComparison.Ordinal);
             Assert.Contains("_sensitiveFieldSyncQueued = true;", source, StringComparison.Ordinal);
-            Assert.Contains("Dispatcher.BeginInvoke(() => SyncSensitiveFieldsFromViewModel(sourceViewModel), DispatcherPriority.Background);", source, StringComparison.Ordinal);
+            Assert.Contains("Dispatcher.BeginInvoke(new Action(() => SyncSensitiveFieldsFromViewModel(sourceViewModel)), DispatcherPriority.Background);", source, StringComparison.Ordinal);
             Assert.Contains("_sensitiveFieldSyncQueued = false;", source, StringComparison.Ordinal);
             Assert.Contains("private void SyncSensitiveFieldsFromViewModel(SettingsViewModel sourceViewModel)", source, StringComparison.Ordinal);
             Assert.Contains("if (!ReferenceEquals(_settingsViewModel, sourceViewModel))", source, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-settings-initialization-stale-load-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-settings-initialization-stale-load-guards.md
@@ -1,0 +1,20 @@
+# Settings Initialization Stale-Load Guards
+
+Date: 2026-07-05
+
+## Completed
+
+- Kept Settings first-paint initialization asynchronous while adding cancellation for page unloads and DataContext swaps.
+- Added an initialization version token so stale Settings loads cannot queue success follow-up work or display failure dialogs after a newer view model is active.
+- Reset queued sensitive-field synchronization when the active Settings view model changes.
+- Scoped SMTP password and SMS API key password-box synchronization to the source view model that raised the change.
+- Rechecked active view model identity before sensitive fields are copied into password boxes.
+- Swallowed expected cancellation from Settings navigation instead of surfacing it as a failed-load dialog.
+- Disposed the previous initialization cancellation source when Settings is detached or restarted.
+- Preserved the existing deferred theme-designer tab insertion, first-paint dispatcher yield, and duplicate initialization guard.
+- Extended Settings responsive/source-contract coverage for cancellation source ownership, initialization versioning, stale success guards, stale error guards, and active-view-model sensitive-field sync.
+
+## Validation
+
+- Source-contract coverage was updated in `SettingsPageResponsiveContractTests` for the new Settings page initialization and sensitive-field synchronization behavior.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, and live responsiveness checks could not be run in the scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -17,6 +18,8 @@ namespace InventoryManagementApp.Views.Pages
         private bool _themeDesignerTabRetryQueued;
         private bool _sensitiveFieldSyncQueued;
         private Task? _initializeSettingsTask;
+        private CancellationTokenSource? _initializeSettingsCts;
+        private int _initializeSettingsVersion;
 
         public SettingsPage()
         {
@@ -30,19 +33,20 @@ namespace InventoryManagementApp.Views.Pages
         {
             AddThemeDesignerTab();
             AttachViewModel(DataContext as SettingsViewModel);
-            QueueSensitiveFieldSync();
+            QueueSensitiveFieldSync(_settingsViewModel);
             StartSettingsInitialization();
         }
 
         private void SettingsPage_Unloaded(object sender, RoutedEventArgs e)
         {
+            CancelSettingsInitialization();
             AttachViewModel(null);
         }
 
         private void SettingsPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             AttachViewModel(e.NewValue as SettingsViewModel);
-            QueueSensitiveFieldSync();
+            QueueSensitiveFieldSync(_settingsViewModel);
             StartSettingsInitialization();
         }
 
@@ -123,50 +127,61 @@ namespace InventoryManagementApp.Views.Pages
                 _settingsViewModel.PropertyChanged -= SettingsViewModel_PropertyChanged;
             }
 
+            CancelSettingsInitialization();
             _settingsViewModel = viewModel;
-            _initializeSettingsTask = null;
+            _sensitiveFieldSyncQueued = false;
             if (_settingsViewModel != null)
             {
                 _settingsViewModel.PropertyChanged += SettingsViewModel_PropertyChanged;
             }
         }
 
+        private void CancelSettingsInitialization()
+        {
+            _initializeSettingsVersion++;
+            _initializeSettingsCts?.Cancel();
+            _initializeSettingsCts?.Dispose();
+            _initializeSettingsCts = null;
+            _initializeSettingsTask = null;
+        }
+
         private void SettingsViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName is nameof(SettingsViewModel.SmtpPassword) or nameof(SettingsViewModel.SmsApiKey))
+            if (e.PropertyName is nameof(SettingsViewModel.SmtpPassword) or nameof(SettingsViewModel.SmsApiKey)
+                && sender is SettingsViewModel sourceViewModel)
             {
-                QueueSensitiveFieldSync();
+                QueueSensitiveFieldSync(sourceViewModel);
             }
         }
 
-        private void QueueSensitiveFieldSync()
+        private void QueueSensitiveFieldSync(SettingsViewModel? sourceViewModel)
         {
-            if (_settingsViewModel == null || _sensitiveFieldSyncQueued)
+            if (sourceViewModel == null || _sensitiveFieldSyncQueued || !ReferenceEquals(_settingsViewModel, sourceViewModel))
             {
                 return;
             }
 
             _sensitiveFieldSyncQueued = true;
-            Dispatcher.BeginInvoke(SyncSensitiveFieldsFromViewModel, DispatcherPriority.Background);
+            Dispatcher.BeginInvoke(() => SyncSensitiveFieldsFromViewModel(sourceViewModel), DispatcherPriority.Background);
         }
 
-        private void SyncSensitiveFieldsFromViewModel()
+        private void SyncSensitiveFieldsFromViewModel(SettingsViewModel sourceViewModel)
         {
             _sensitiveFieldSyncQueued = false;
 
-            if (_settingsViewModel == null)
+            if (!ReferenceEquals(_settingsViewModel, sourceViewModel))
             {
                 return;
             }
 
-            if (SmtpPasswordBox.Password != _settingsViewModel.SmtpPassword)
+            if (SmtpPasswordBox.Password != sourceViewModel.SmtpPassword)
             {
-                SmtpPasswordBox.Password = _settingsViewModel.SmtpPassword;
+                SmtpPasswordBox.Password = sourceViewModel.SmtpPassword;
             }
 
-            if (SmsApiKeyBox.Password != _settingsViewModel.SmsApiKey)
+            if (SmsApiKeyBox.Password != sourceViewModel.SmsApiKey)
             {
-                SmsApiKeyBox.Password = _settingsViewModel.SmsApiKey;
+                SmsApiKeyBox.Password = sourceViewModel.SmsApiKey;
             }
         }
 
@@ -177,22 +192,41 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            _initializeSettingsTask = InitializeSettingsAsync(_settingsViewModel);
+            _initializeSettingsCts?.Dispose();
+            _initializeSettingsCts = new CancellationTokenSource();
+            var version = ++_initializeSettingsVersion;
+            _initializeSettingsTask = InitializeSettingsAsync(_settingsViewModel, _initializeSettingsCts.Token, version);
         }
 
-        private async Task InitializeSettingsAsync(SettingsViewModel viewModel)
+        private async Task InitializeSettingsAsync(SettingsViewModel viewModel, CancellationToken cancellationToken, int version)
         {
             try
             {
                 await Dispatcher.Yield(DispatcherPriority.Background);
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!ReferenceEquals(_settingsViewModel, viewModel) || version != _initializeSettingsVersion)
+                {
+                    return;
+                }
+
                 await viewModel.InitializeAsync().ConfigureAwait(true);
-                QueueSensitiveFieldSync();
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!ReferenceEquals(_settingsViewModel, viewModel) || version != _initializeSettingsVersion)
+                {
+                    return;
+                }
+
+                QueueSensitiveFieldSync(viewModel);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Navigation away from Settings or a DataContext swap owns this cancellation path.
             }
             catch (Exception ex)
             {
                 _initializeSettingsTask = null;
 
-                if (!ReferenceEquals(_settingsViewModel, viewModel))
+                if (!ReferenceEquals(_settingsViewModel, viewModel) || version != _initializeSettingsVersion)
                 {
                     return;
                 }

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
@@ -162,7 +162,7 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             _sensitiveFieldSyncQueued = true;
-            Dispatcher.BeginInvoke(() => SyncSensitiveFieldsFromViewModel(sourceViewModel), DispatcherPriority.Background);
+            Dispatcher.BeginInvoke(new Action(() => SyncSensitiveFieldsFromViewModel(sourceViewModel)), DispatcherPriority.Background);
         }
 
         private void SyncSensitiveFieldsFromViewModel(SettingsViewModel sourceViewModel)


### PR DESCRIPTION
## What changed

- Kept Settings first-paint initialization deferred, but added cancellation for page unloads and DataContext swaps.
- Added an initialization version token so stale Settings loads cannot queue success follow-up work or show failure dialogs after a newer view model is active.
- Scoped SMTP password and SMS API key password-box synchronization to the active Settings view model that raised the change.
- Reset pending sensitive-field sync state when the active Settings view model changes.
- Rechecked active view model identity before copying sensitive fields into password boxes.
- Swallowed expected navigation/DataContext cancellation instead of surfacing it as a settings-load failure.
- Disposed stale initialization cancellation sources and preserved the duplicate initialization guard.
- Preserved deferred theme-designer tab insertion and the first-paint dispatcher yield.
- Extended Settings source-contract coverage for cancellation, versioning, stale success/error guards, and active-view-model sensitive-field sync.
- Added a progress note for this Settings initialization responsiveness slice.

## Why this was highest value

Recent scheduled work already covered the major list/workbench screens. Settings remained a core admin workflow where initialization could continue after navigation or DataContext replacement, then queue password-box sync or error UI against stale state. That is a direct responsiveness and reliability risk for opening Settings, switching pages, and returning during slow configuration reads.

## Why this is real progress

This is a complete vertical slice for Settings startup orchestration: page lifecycle, sensitive field sync, stale-load cancellation, error handling, source contracts, and progress tracking are all updated together without introducing new services or speculative UI.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, touches only the intended Settings code-behind, Settings source-contract test, and progress note, and contains the cancellation/versioning/sensitive-sync contracts.
- I inspected the dispatcher call and corrected it to use an explicit `Action` delegate to avoid a C# overload inference issue.

## Could not check

- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime smoke checks, screenshots, scaling checks, and live Settings responsiveness checks could not be run in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run the full Windows validation runner on a Windows/.NET-capable checkout.
- Smoke test Settings navigation away/back during slow settings or email-account reads, especially the SMTP password and SMS API key fields.