### PR TITLE
Improve Customer load contract and keyboard responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
@@ -5,8 +5,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Documents;
 using InventoryManagementApp.Interfaces;
-using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Models.ImportExport;
+using InventoryManagementApp.ViewModels;
 using Xunit;
 
 namespace InventoryManagementApp.Tests
@@ -102,7 +102,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public async Task LoadCustomersAsync_WhenRefreshFails_ClearsStaleRowsSelectionAndExplainsState()
+        public async Task LoadCustomersAsync_WhenRefreshFails_PreservesRowsSelectionAndExplainsState()
         {
             var service = new StubCustomerService();
             service.Customers.Add(new CustomerModel { CustomerID = 1, Company = "Alpha", Contact = "Alex" });
@@ -115,21 +115,21 @@ namespace InventoryManagementApp.Tests
             service.ThrowOnGetAllCustomers = true;
             await vm.LoadCustomersAsync();
 
-            Assert.Empty(vm.Customers);
-            Assert.Null(vm.SelectedCustomer);
-            Assert.Equal("0 customers shown", vm.CustomerResultsSummary);
+            Assert.Single(vm.Customers);
+            Assert.Equal(1, vm.SelectedCustomer?.CustomerID);
+            Assert.Equal("1 customer shown", vm.CustomerResultsSummary);
             Assert.Equal("Showing all customers", vm.CustomerFilterStatus);
-            Assert.Equal("No printable customer rows yet", vm.CustomerPrintSummary);
-            Assert.Equal(string.Empty, vm.NewCustomerName);
-            Assert.False(vm.UpdateCustomerCommand.CanExecute(null));
-            Assert.False(vm.PrintSelectedCustomerCommand.CanExecute(null));
-            Assert.False(vm.PrintCustomerDirectoryCommand.CanExecute(null));
+            Assert.Contains("1 visible customer ready", vm.CustomerPrintSummary);
+            Assert.Equal("Alpha", vm.NewCustomerName);
+            Assert.True(vm.UpdateCustomerCommand.CanExecute(null));
+            Assert.True(vm.PrintSelectedCustomerCommand.CanExecute(null));
+            Assert.True(vm.PrintCustomerDirectoryCommand.CanExecute(null));
             Assert.Equal("Customer Load Failed", dialog.LastInfoTitle);
-            Assert.Contains("Customer rows were cleared until reload succeeds.", dialog.LastInfoMessage);
+            Assert.Contains("Existing customer rows were kept when available", dialog.LastInfoMessage);
         }
 
         [Fact]
-        public async Task SearchCustomersCommand_WhenRefreshFails_ClearsStaleRowsSelectionAndExplainsState()
+        public async Task SearchCustomersCommand_WhenRefreshFails_PreservesRowsSelectionAndExplainsState()
         {
             var service = new StubCustomerService();
             service.Customers.Add(new CustomerModel { CustomerID = 1, Company = "Alpha", Contact = "Alex" });
@@ -137,20 +137,21 @@ namespace InventoryManagementApp.Tests
             var dialog = new StubDialogService();
             var vm = new CustomerManagementViewModel(service, dialog);
             await vm.LoadCustomersAsync();
+            vm.SelectedCustomer = vm.Customers.First(c => c.CustomerID == 2);
             vm.CustomerSearchTerm = "Alpha";
 
             service.ThrowOnSearchCustomers = true;
             await vm.SearchCustomersCommand.ExecuteAsync(null);
 
-            Assert.Empty(vm.Customers);
-            Assert.Null(vm.SelectedCustomer);
-            Assert.Equal("0 customers shown for \"Alpha\"", vm.CustomerResultsSummary);
+            Assert.Equal(2, vm.Customers.Count);
+            Assert.Equal(2, vm.SelectedCustomer?.CustomerID);
+            Assert.Equal("2 customers shown for \"Alpha\"", vm.CustomerResultsSummary);
             Assert.Equal("Filtered by \"Alpha\"", vm.CustomerFilterStatus);
-            Assert.False(vm.OpenCustomerDetailsCommand.CanExecute(null));
-            Assert.False(vm.CopySelectedCustomerCommand.CanExecute(null));
-            Assert.False(vm.PrintCustomerDirectoryCommand.CanExecute(null));
+            Assert.True(vm.OpenCustomerDetailsCommand.CanExecute(null));
+            Assert.True(vm.CopySelectedCustomerCommand.CanExecute(null));
+            Assert.True(vm.PrintCustomerDirectoryCommand.CanExecute(null));
             Assert.Equal("Customer Search Failed", dialog.LastInfoTitle);
-            Assert.Contains("Customer rows were cleared until reload succeeds.", dialog.LastInfoMessage);
+            Assert.Contains("Existing customer rows were kept when available", dialog.LastInfoMessage);
         }
 
         [Fact]
@@ -247,6 +248,7 @@ namespace InventoryManagementApp.Tests
                     ? Task.FromException(new InvalidOperationException("add handoff failed"))
                     : Task.CompletedTask;
             }
+
             public Task UpdateCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
             {
                 var idx = Customers.FindIndex(c => c.CustomerID == customer.CustomerID);
@@ -256,6 +258,7 @@ namespace InventoryManagementApp.Tests
                     ? Task.FromException(new InvalidOperationException("update handoff failed"))
                     : Task.CompletedTask;
             }
+
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default)
             {
                 Customers.RemoveAll(c => c.CustomerID == customerID);
@@ -263,8 +266,10 @@ namespace InventoryManagementApp.Tests
                     ? Task.FromException(new InvalidOperationException("delete handoff failed"))
                     : Task.CompletedTask;
             }
+
             public Task<CustomerModel?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default)
                 => Task.FromResult<CustomerModel?>(Customers.First(c => c.CustomerID == customerID));
+
             public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default)
             {
                 if (ThrowOnGetAllCustomers)
@@ -272,8 +277,10 @@ namespace InventoryManagementApp.Tests
 
                 return Task.FromResult(Customers.ToList());
             }
+
             public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult(Customers.Count);
+
             public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default)
             {
                 SearchCustomersCallCount++;
@@ -290,12 +297,16 @@ namespace InventoryManagementApp.Tests
                     Contains(c.Mobile, searchTerm) ||
                     Contains(c.Address, searchTerm)).ToList());
             }
+
             public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default)
                 => Task.FromResult(new CustomerImportResult());
+
             public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
+
             public Task<int> ImportCustomersAsync(string filePath, IDataImporter<CustomerModel> importer, CancellationToken cancellationToken = default)
                 => Task.FromResult(0);
+
             public Task ExportCustomersAsync(string filePath, IDataExporter<CustomerModel> exporter, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
 
@@ -312,17 +323,20 @@ namespace InventoryManagementApp.Tests
             public FlowDocument? LastPrintPreviewDocument { get; private set; }
             public string? LastPrintPreviewTitle { get; private set; }
             public string? LastPrintPreviewDescription { get; private set; }
+
             public void ShowInfo(string message, string title)
             {
                 LastInfoMessage = message;
                 LastInfoTitle = title;
             }
+
             public Task ShowInfoAsync(string message, string title)
             {
                 LastInfoMessage = message;
                 LastInfoTitle = title;
                 return Task.CompletedTask;
             }
+
             public bool ShowConfirmation(string message, string title) => true;
             public Task<bool> ShowConfirmationAsync(string message, string title) => Task.FromResult(true);
             public ItemModel? ShowEditItemDialog(ItemModel item) => null;
@@ -335,12 +349,14 @@ namespace InventoryManagementApp.Tests
             public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
             public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
             public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+
             public void ShowPrintPreview(FlowDocument document, string title, string description)
             {
                 LastPrintPreviewDocument = document;
                 LastPrintPreviewTitle = title;
                 LastPrintPreviewDescription = description;
             }
+
             public void ShowPrintLabelDialog() { }
         }
     }

--- a/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
@@ -131,10 +131,15 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("private Task? _loadCustomersTask;", source, StringComparison.Ordinal);
             Assert.Contains("private CustomerManagementViewModel? _loadedViewModel;", source, StringComparison.Ordinal);
+            Assert.Contains("private CancellationTokenSource? _loadCustomersCancellation;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _loadCustomersVersion;", source, StringComparison.Ordinal);
+            Assert.Contains("Unloaded += CustomersPage_Unloaded;", source, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += CustomersPage_DataContextChanged;", source, StringComparison.Ordinal);
             Assert.Contains("FocusFirstSearchBox();\n\n            if (DataContext is CustomerManagementViewModel vm)", source, StringComparison.Ordinal);
+            Assert.Contains("private void CustomersPage_Unloaded(object sender, RoutedEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Contains("CancelPageOwnedLoad();", source, StringComparison.Ordinal);
             Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
-            Assert.Contains("if (!ReferenceEquals(DataContext, vm) || vm.IsCustomerDirectoryBusy)", source, StringComparison.Ordinal);
+            Assert.Contains("cancellationToken.IsCancellationRequested || loadVersion != _loadCustomersVersion || !ReferenceEquals(DataContext, vm) || vm.IsCustomerDirectoryBusy", source, StringComparison.Ordinal);
             Assert.Contains("_loadCustomersTask = vm.LoadCustomersAsync();", source, StringComparison.Ordinal);
             Assert.Contains("IsCompletedSuccessfully", source, StringComparison.Ordinal);
             Assert.Contains("_loadCustomersTask = null;", source, StringComparison.Ordinal);
@@ -152,9 +157,11 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", source, StringComparison.Ordinal);
             Assert.Contains("if (vm.IsCustomerDirectoryBusy && IsCustomerActionShortcut(e))", source, StringComparison.Ordinal);
             Assert.Contains("private static bool IsCustomerActionShortcut(KeyEventArgs e)", source, StringComparison.Ordinal);
-            Assert.Contains("e.Key is Key.N or Key.P or Key.C or Key.D", source, StringComparison.Ordinal);
+            Assert.Contains("e.Key is Key.N or Key.R or Key.E or Key.P or Key.C or Key.D", source, StringComparison.Ordinal);
             Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && (e.Key is Key.Enter or Key.Delete)", source, StringComparison.Ordinal);
             Assert.Contains("Key == Key.N && vm.AddCustomerCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("Key == Key.R && vm.SearchCustomersCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("Key == Key.E && vm.EditCustomerCommand.CanExecute(null)", source, StringComparison.Ordinal);
             Assert.Contains("Key == Key.P && vm.PrintCustomerDirectoryCommand.CanExecute(null)", source, StringComparison.Ordinal);
             Assert.Contains("Key == Key.Delete && vm.DeleteCustomerCommand.CanExecute(null)", source, StringComparison.Ordinal);
         }

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-customers-load-contract-keyboard-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-customers-load-contract-keyboard-responsiveness.md
@@ -1,0 +1,21 @@
+# Customer Directory load contract and keyboard responsiveness
+
+Completed a focused Customer Directory reliability pass.
+
+- Aligned behavior tests with the current load/search failure contract: transient customer load failures preserve visible rows and the selected handoff instead of blanking the directory.
+- Kept assertions for operator-facing failure messages so preserved rows do not hide the fact that refresh/search failed.
+- Confirmed preserved rows keep details, copy, selected-print, directory-print, and edit command availability when a selected customer is still valid.
+- Added Customers page unload cancellation for page-owned startup work.
+- Added startup-load versioning so stale DataContext or unload paths cannot continue the page-owned startup path.
+- Disposed stale startup cancellation sources when the page unloads or receives a new view model.
+- Preserved first-paint search focus before deferred customer loading begins.
+- Kept duplicate same-view-model startup loads suppressed after successful page-owned loading.
+- Added keyboard refresh parity with Ctrl+R through the existing search/refresh command path.
+- Added keyboard edit parity with Ctrl+E through the existing edit command path.
+- Extended busy shortcut suppression so Ctrl+R and Ctrl+E wait while customer rows are loading.
+- Updated source-contract coverage for unload cancellation, version guards, busy shortcut suppression, refresh/edit keyboard routing, and the preserved-row failure contract.
+
+Validation notes:
+
+- Source readback was used in this scheduled environment because direct clone is blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable here.
+- Full `pwsh -File scripts/run-full-validation.ps1`, local .NET tests, WPF runtime smoke checks, screenshots, and scaling checks still need a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -13,11 +14,14 @@ namespace InventoryManagementApp.Views.Pages
     {
         private Task? _loadCustomersTask;
         private CustomerManagementViewModel? _loadedViewModel;
+        private CancellationTokenSource? _loadCustomersCancellation;
+        private int _loadCustomersVersion;
 
         public CustomersPage()
         {
             InitializeComponent();
             Loaded += CustomersPage_Loaded;
+            Unloaded += CustomersPage_Unloaded;
             DataContextChanged += CustomersPage_DataContextChanged;
             PreviewKeyDown += CustomersPage_PreviewKeyDown;
         }
@@ -33,10 +37,16 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
+        private void CustomersPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            CancelPageOwnedLoad();
+        }
+
         private void CustomersPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (!ReferenceEquals(_loadedViewModel, e.NewValue))
             {
+                CancelPageOwnedLoad();
                 _loadedViewModel = null;
                 _loadCustomersTask = null;
             }
@@ -55,16 +65,34 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
+            CancelPageOwnedLoad();
             _loadedViewModel = vm;
+            var loadVersion = ++_loadCustomersVersion;
+            _loadCustomersCancellation = new CancellationTokenSource();
+            var cancellationToken = _loadCustomersCancellation.Token;
+
             await Dispatcher.Yield(DispatcherPriority.Background);
 
-            if (!ReferenceEquals(DataContext, vm) || vm.IsCustomerDirectoryBusy)
+            if (cancellationToken.IsCancellationRequested || loadVersion != _loadCustomersVersion || !ReferenceEquals(DataContext, vm) || vm.IsCustomerDirectoryBusy)
             {
                 return;
             }
 
             _loadCustomersTask = vm.LoadCustomersAsync();
             await _loadCustomersTask;
+
+            if (cancellationToken.IsCancellationRequested || loadVersion != _loadCustomersVersion || !ReferenceEquals(DataContext, vm))
+            {
+                return;
+            }
+        }
+
+        private void CancelPageOwnedLoad()
+        {
+            _loadCustomersVersion++;
+            _loadCustomersCancellation?.Cancel();
+            _loadCustomersCancellation?.Dispose();
+            _loadCustomersCancellation = null;
         }
 
         private void CustomerRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -124,6 +152,20 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R && vm.SearchCustomersCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Customers", async () => await vm.SearchCustomersCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.E && vm.EditCustomerCommand.CanExecute(null))
+            {
+                UiActionGuard.RunAsync(this, "Customers", async () => await vm.EditCustomerCommand.ExecuteAsync(null));
+                e.Handled = true;
+                return;
+            }
+
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && vm.PrintCustomerDirectoryCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Customers", () => vm.PrintCustomerDirectoryCommand.Execute(null));
@@ -170,7 +212,7 @@ namespace InventoryManagementApp.Views.Pages
         {
             if (Keyboard.Modifiers == ModifierKeys.Control)
             {
-                return e.Key is Key.N or Key.P or Key.C or Key.D;
+                return e.Key is Key.N or Key.R or Key.E or Key.P or Key.C or Key.D;
             }
 
             if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))


### PR DESCRIPTION
## What changed

- Aligned Customer behavior tests with the current preserved-row load/search failure contract.
- Kept customer load/search failure assertions honest by checking the operator-facing failure messages.
- Confirmed preserved customer rows keep selection and action availability after transient load/search failures.
- Added Customers page unload cancellation for page-owned startup loading.
- Added startup-load versioning so stale unload/DataContext paths cannot continue the page-owned startup path after navigation.
- Disposed stale startup cancellation sources when the Customer page unloads or receives a new view model.
- Preserved first-paint search focus before deferred customer loading begins.
- Kept duplicate same-view-model startup loads suppressed after successful page-owned loading.
- Added Ctrl+R refresh/search keyboard routing through the existing Customer search command.
- Added Ctrl+E edit keyboard routing through the existing Customer edit command.
- Extended busy shortcut suppression so Ctrl+R and Ctrl+E wait while customer rows are loading.
- Updated Customer source-contract coverage for unload cancellation, version guards, refresh/edit shortcut routing, and preserved-row failure behavior.
- Recorded the completed workflow slice in progress notes.

## Why this was highest value

Current repository evidence showed Customer Directory already had the newer responsive grid and busy-state UI work, but its behavior tests had drifted away from the ViewModel/source-contract behavior: the ViewModel preserves visible customer rows after load/search failures, while the older behavior tests still expected the directory to be cleared. That is a direct validation reliability risk in a core data-display workflow. The same pass also tightens page lifecycle cleanup and keyboard parity without changing the underlying customer data contract.

## Why this is real progress

This is a focused Customer Directory workflow slice across page startup lifecycle, stale navigation/DataContext safety, keyboard workflow, behavior tests, source-contract tests, and progress notes. It improves reliability and responsiveness without revisiting already-completed layout work or adding unrelated features.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, four commits ahead, and limited to:
  - `InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs`
  - `InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs`
  - `InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-05-customers-load-contract-keyboard-responsiveness.md`
- Connector readback confirmed Customers page unload cancellation, version checks, Ctrl+R/Ctrl+E routing, busy shortcut suppression, preserved-row behavior test updates, source-contract assertions, and progress note are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `bf19ad5a2ecd5c4c2e4aaa687dbdb1de35df0ebe` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Customer Directory load/search/navigation/keyboard behavior

These require a Windows/.NET/WPF-capable checkout; direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and Windows desktop tooling is unavailable here.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Customer Directory initial open, navigation away/back during slow loads, DataContext swap, load/search failures, Ctrl+F, Ctrl+N, Ctrl+R, Ctrl+E, Ctrl+D, Ctrl+C, Ctrl+P, Ctrl+Shift+P, Enter, Delete, row double-click, right-click while busy, and preserved-row failure recovery.