### PR TITLE
Harden Maintenance and Calibration startup lifecycle

### DIFF
--- a/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
@@ -151,10 +151,20 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("private Task? _loadCalibrationTask;", source, StringComparison.Ordinal);
             Assert.Contains("private CalibrationManagementViewModel? _loadedViewModel;", source, StringComparison.Ordinal);
+            Assert.Contains("private CancellationTokenSource? _startupLoadCancellation;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _startupLoadVersion;", source, StringComparison.Ordinal);
+            Assert.Contains("Unloaded += CalibrationPage_Unloaded;", source, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += CalibrationPage_DataContextChanged;", source, StringComparison.Ordinal);
             Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
             Assert.Contains("LoadCalibrationOnceAsync", source, StringComparison.Ordinal);
             Assert.Contains("IsCompletedSuccessfully", source, StringComparison.Ordinal);
+            Assert.Contains("CancelStartupLoad();", source, StringComparison.Ordinal);
+            Assert.Contains("token.ThrowIfCancellationRequested();", source, StringComparison.Ordinal);
+            Assert.Contains("loadVersion != _startupLoadVersion", source, StringComparison.Ordinal);
+            Assert.Contains("!ReferenceEquals(DataContext, vm)", source, StringComparison.Ordinal);
+            Assert.Contains("catch (OperationCanceledException) when (token.IsCancellationRequested || !IsLoaded || !ReferenceEquals(DataContext, vm))", source, StringComparison.Ordinal);
+            Assert.Contains("_startupLoadCancellation?.Cancel();", source, StringComparison.Ordinal);
+            Assert.Contains("_startupLoadCancellation?.Dispose();", source, StringComparison.Ordinal);
             Assert.Contains("_loadCalibrationTask = null;", source, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
@@ -146,10 +146,20 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("private Task? _loadMaintenanceTask;", source, StringComparison.Ordinal);
             Assert.Contains("private MaintenanceManagementViewModel? _loadedViewModel;", source, StringComparison.Ordinal);
+            Assert.Contains("private CancellationTokenSource? _startupLoadCancellation;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _startupLoadVersion;", source, StringComparison.Ordinal);
+            Assert.Contains("Unloaded += MaintenancePage_Unloaded;", source, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += MaintenancePage_DataContextChanged;", source, StringComparison.Ordinal);
             Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", source, StringComparison.Ordinal);
             Assert.Contains("LoadMaintenanceOnceAsync", source, StringComparison.Ordinal);
             Assert.Contains("IsCompletedSuccessfully", source, StringComparison.Ordinal);
+            Assert.Contains("CancelStartupLoad();", source, StringComparison.Ordinal);
+            Assert.Contains("token.ThrowIfCancellationRequested();", source, StringComparison.Ordinal);
+            Assert.Contains("loadVersion != _startupLoadVersion", source, StringComparison.Ordinal);
+            Assert.Contains("!ReferenceEquals(DataContext, vm)", source, StringComparison.Ordinal);
+            Assert.Contains("catch (OperationCanceledException) when (token.IsCancellationRequested || !IsLoaded || !ReferenceEquals(DataContext, vm))", source, StringComparison.Ordinal);
+            Assert.Contains("_startupLoadCancellation?.Cancel();", source, StringComparison.Ordinal);
+            Assert.Contains("_startupLoadCancellation?.Dispose();", source, StringComparison.Ordinal);
             Assert.Contains("_loadMaintenanceTask = null;", source, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-maintenance-calibration-startup-lifecycle.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-maintenance-calibration-startup-lifecycle.md
@@ -1,0 +1,25 @@
+# Maintenance and Calibration Startup Lifecycle Responsiveness
+
+Date: 2026-07-05
+
+## Completed
+
+- Added page-owned startup cancellation state to the Maintenance and Calibration workbenches.
+- Cancelled deferred startup loading when either page unloads before its first background-priority load begins.
+- Cancelled stale startup paths when the page receives a different view model.
+- Added startup-load version checks before dispatching Maintenance or Calibration load commands.
+- Rechecked active `DataContext` after first paint and again after startup load completion.
+- Swallowed expected navigation/DataContext cancellation so routine page switches do not surface noisy startup failures.
+- Disposed stale startup cancellation sources after unload, DataContext swaps, or completed startup attempts.
+- Preserved same-view-model duplicate-load suppression and first-paint search focus.
+- Kept existing row double-click, right-click, keyboard, print, and command availability guards intact.
+- Extended Maintenance and Calibration responsive source-contract coverage for unload cancellation, version checks, cancellation cleanup, and stale DataContext guards.
+
+## Why It Matters
+
+Maintenance and Calibration are operational register screens with expensive data-backed startup work, row actions, print entry points, and technician/certificate handoff panels. Their layouts and action guards were already strong, but their page-owned startup loaders could keep a stale deferred path alive after navigation or a view-model swap. The new lifecycle guards keep first paint responsive while preventing stale startup work from dispatching over the active page state.
+
+## Validation Notes
+
+- Source-contract coverage was updated for both pages.
+- Local Windows/.NET validation and WPF runtime smoke testing still need to run in a Windows-capable checkout because this scheduled Linux environment cannot clone the repository directly and does not provide WPF tooling.

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -13,11 +15,14 @@ namespace InventoryManagementApp.Views.Pages
     {
         private Task? _loadCalibrationTask;
         private CalibrationManagementViewModel? _loadedViewModel;
+        private CancellationTokenSource? _startupLoadCancellation;
+        private int _startupLoadVersion;
 
         public CalibrationPage()
         {
             InitializeComponent();
             Loaded += CalibrationPage_Loaded;
+            Unloaded += CalibrationPage_Unloaded;
             DataContextChanged += CalibrationPage_DataContextChanged;
             PreviewKeyDown += CalibrationPage_PreviewKeyDown;
         }
@@ -33,10 +38,18 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
+        private void CalibrationPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            CancelStartupLoad();
+            _loadedViewModel = null;
+            _loadCalibrationTask = null;
+        }
+
         private void CalibrationPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (!ReferenceEquals(_loadedViewModel, e.NewValue))
             {
+                CancelStartupLoad();
                 _loadedViewModel = null;
                 _loadCalibrationTask = null;
             }
@@ -55,16 +68,51 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
+            CancelStartupLoad();
+            var cancellation = new CancellationTokenSource();
+            _startupLoadCancellation = cancellation;
+            var token = cancellation.Token;
+            var loadVersion = _startupLoadVersion;
             _loadedViewModel = vm;
-            await Dispatcher.Yield(DispatcherPriority.Background);
 
-            if (!ReferenceEquals(DataContext, vm) || !vm.LoadCalibrationCommand.CanExecute(null))
+            try
             {
-                return;
-            }
+                await Dispatcher.Yield(DispatcherPriority.Background);
+                token.ThrowIfCancellationRequested();
 
-            _loadCalibrationTask = vm.LoadCalibrationCommand.ExecuteAsync(null);
-            await _loadCalibrationTask;
+                if (loadVersion != _startupLoadVersion || !ReferenceEquals(DataContext, vm) || !vm.LoadCalibrationCommand.CanExecute(null))
+                {
+                    return;
+                }
+
+                _loadCalibrationTask = vm.LoadCalibrationCommand.ExecuteAsync(null);
+                await _loadCalibrationTask;
+                token.ThrowIfCancellationRequested();
+
+                if (loadVersion != _startupLoadVersion || !ReferenceEquals(DataContext, vm))
+                {
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested || !IsLoaded || !ReferenceEquals(DataContext, vm))
+            {
+            }
+            finally
+            {
+                if (ReferenceEquals(_startupLoadCancellation, cancellation))
+                {
+                    _startupLoadCancellation.Dispose();
+                    _startupLoadCancellation = null;
+                }
+            }
+        }
+
+        private void CancelStartupLoad()
+        {
+            _startupLoadVersion++;
+            _startupLoadCancellation?.Cancel();
+            _startupLoadCancellation?.Dispose();
+            _startupLoadCancellation = null;
         }
 
         private void CalibrationRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -13,11 +15,14 @@ namespace InventoryManagementApp.Views.Pages
     {
         private Task? _loadMaintenanceTask;
         private MaintenanceManagementViewModel? _loadedViewModel;
+        private CancellationTokenSource? _startupLoadCancellation;
+        private int _startupLoadVersion;
 
         public MaintenancePage()
         {
             InitializeComponent();
             Loaded += MaintenancePage_Loaded;
+            Unloaded += MaintenancePage_Unloaded;
             DataContextChanged += MaintenancePage_DataContextChanged;
             PreviewKeyDown += MaintenancePage_PreviewKeyDown;
         }
@@ -33,10 +38,18 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
+        private void MaintenancePage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            CancelStartupLoad();
+            _loadedViewModel = null;
+            _loadMaintenanceTask = null;
+        }
+
         private void MaintenancePage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (!ReferenceEquals(_loadedViewModel, e.NewValue))
             {
+                CancelStartupLoad();
                 _loadedViewModel = null;
                 _loadMaintenanceTask = null;
             }
@@ -55,16 +68,51 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
+            CancelStartupLoad();
+            var cancellation = new CancellationTokenSource();
+            _startupLoadCancellation = cancellation;
+            var token = cancellation.Token;
+            var loadVersion = _startupLoadVersion;
             _loadedViewModel = vm;
-            await Dispatcher.Yield(DispatcherPriority.Background);
 
-            if (!ReferenceEquals(DataContext, vm) || !vm.LoadMaintenanceCommand.CanExecute(null))
+            try
             {
-                return;
-            }
+                await Dispatcher.Yield(DispatcherPriority.Background);
+                token.ThrowIfCancellationRequested();
 
-            _loadMaintenanceTask = vm.LoadMaintenanceCommand.ExecuteAsync(null);
-            await _loadMaintenanceTask;
+                if (loadVersion != _startupLoadVersion || !ReferenceEquals(DataContext, vm) || !vm.LoadMaintenanceCommand.CanExecute(null))
+                {
+                    return;
+                }
+
+                _loadMaintenanceTask = vm.LoadMaintenanceCommand.ExecuteAsync(null);
+                await _loadMaintenanceTask;
+                token.ThrowIfCancellationRequested();
+
+                if (loadVersion != _startupLoadVersion || !ReferenceEquals(DataContext, vm))
+                {
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested || !IsLoaded || !ReferenceEquals(DataContext, vm))
+            {
+            }
+            finally
+            {
+                if (ReferenceEquals(_startupLoadCancellation, cancellation))
+                {
+                    _startupLoadCancellation.Dispose();
+                    _startupLoadCancellation = null;
+                }
+            }
+        }
+
+        private void CancelStartupLoad()
+        {
+            _startupLoadVersion++;
+            _startupLoadCancellation?.Cancel();
+            _startupLoadCancellation?.Dispose();
+            _startupLoadCancellation = null;
         }
 
         private void MaintenanceRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## What changed

- Added page-owned startup cancellation state to Maintenance and Calibration pages.
- Cancelled deferred startup loading on page unload before first background-priority load dispatch.
- Cancelled stale startup paths when either page receives a different view model.
- Added startup-load version checks before dispatching Maintenance or Calibration load commands.
- Rechecked the active `DataContext` after first paint and again after startup load completion.
- Swallowed expected navigation/DataContext cancellation instead of letting routine page switches look like startup failures.
- Disposed stale startup cancellation sources after unload, DataContext swaps, and completed startup attempts.
- Preserved same-view-model duplicate-load suppression and first-paint search focus.
- Preserved existing row double-click, right-click, keyboard, print, and command availability guards.
- Extended Maintenance and Calibration responsive source-contract tests for unload cancellation, version checks, cancellation cleanup, and stale DataContext guards.
- Recorded the completed workflow slice in progress notes.

## Why this was highest value

Current repo notes show Maintenance and Calibration already had strong responsive layout, loading overlays, virtualized grids, bounded print output, and action guards. Their remaining shared gap was the page-owned startup lifecycle: deferred first-paint loading could remain alive across unload or DataContext replacement. These are operational register screens with expensive data-backed startup work, so stale startup dispatch directly affects navigation responsiveness and action safety.

## Why this is real progress

This is a focused paired workflow slice across two related operational screens: startup orchestration, unload/DataContext cleanup, stale-load protection, cancellation handling, source-contract coverage, and progress notes. It avoids repeating recent layout work and keeps the existing MVVM command surface intact.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, five commits ahead, and limited to:
  - `InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs`
  - `InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs`
  - `InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs`
  - `InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-05-maintenance-calibration-startup-lifecycle.md`
- Connector readback confirmed unload handlers, cancellation source fields, startup version checks, active `DataContext` rechecks, expected cancellation handling, cleanup/disposal, and source-contract assertions are present.
- Connector status readback found no attached commit statuses on branch head `4387b515fe6ad8941482e973c266697cc483d238` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Maintenance/Calibration navigation, startup, DataContext-swap, keyboard, context-menu, and print behavior

These require a Windows/.NET/WPF-capable checkout. Direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and the required Windows desktop tooling is unavailable here.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Maintenance and Calibration initial open, navigation away/back during slow loads, DataContext swaps, Ctrl+F/Ctrl+N/Ctrl+R/Ctrl+P/Ctrl+Shift+P/Ctrl+C/Ctrl+D/Ctrl+E, Enter/Delete, row double-click, right-click while loading, and print preview entry points.