### PR TITLE
Improve rental item picker responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/RentalItemPickerWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalItemPickerWindowResponsiveContractTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalItemPickerWindowResponsiveContractTests
+    {
+        [Fact]
+        public void RentalItemPickerWindow_UsesCompactResponsiveBoundsAndHeaderSummary()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalItemPickerWindow.xaml");
+
+            Assert.Contains("Width=\"760\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Height=\"540\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"560\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"420\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"RentalItemPickerRoot\" Margin=\"10\" MinWidth=\"0\" ClipToBounds=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"ResultSummaryBadge\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"ResultSummaryText\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel MinWidth=\"0\" MaxWidth=\"500\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"720\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"620\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalItemPickerWindow_WrapsSearchAndFooterActionsForScaledWidths()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalItemPickerWindow.xaml");
+
+            Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"FindButton\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"84\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"360\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"420\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\" HorizontalAlignment=\"Right\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"UseItemButton\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel DockPanel.Dock=\"Right\" Orientation=\"Horizontal\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"260\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalItemPickerWindow_EnablesVirtualizedScrollableGridWithBoundedColumns()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalItemPickerWindow.xaml");
+
+            Assert.Contains("x:Name=\"ItemsGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionChanged=\"ItemsGrid_SelectionChanged\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Width=\"104\" MinWidth=\"82\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Width=\"2*\" MinWidth=\"150\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Width=\"1.1*\" MinWidth=\"112\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"110\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"120\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalItemPickerWindow_ShowsSeparateLoadingAndEmptyStates()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalItemPickerWindow.xaml");
+
+            Assert.Contains("x:Name=\"EmptyStatePanel\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"340\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"112\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"LoadingOverlay\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsHitTestVisible=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Loading available rental items", xaml, StringComparison.Ordinal);
+            Assert.Contains("Keeping the picker responsive", xaml, StringComparison.Ordinal);
+            Assert.Contains("Visibility=\"Collapsed\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalItemPickerWindow_VersionsLoadsAndSuppressesStaleResults()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalItemPickerWindow.xaml.cs");
+
+            Assert.Contains("int _loadVersion;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("bool _isLoading;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Interlocked.Increment(ref _loadVersion)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (version != _loadVersion)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_searchTimer.Stop();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadVersion++;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Unloaded += RentalItemPickerWindow_Unloaded;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.ContextIdle);", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalItemPickerWindow_DisablesActionsAndGridWhileLoading()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalItemPickerWindow.xaml.cs");
+
+            Assert.Contains("UpdatePickerState(isLoading: true", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("LoadingOverlay.Visibility = isLoading ? Visibility.Visible : Visibility.Collapsed;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("EmptyStatePanel.Visibility = !isLoading && showEmptyState ? Visibility.Visible : Visibility.Collapsed;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("FindButton.IsEnabled = !isLoading;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("UseItemButton.IsEnabled = !isLoading && ItemsGrid.SelectedItem is ItemModel;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ItemsGrid.IsEnabled = !isLoading;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void ItemsGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Wait for available rental items to finish loading.", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalItemPickerWindow_AddsKeyboardAndRowSelectionSafety()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalItemPickerWindow.xaml.cs");
+
+            Assert.Contains("PreviewKeyDown += RentalItemPickerWindow_PreviewKeyDown;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SearchBox.Focus();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SearchBox.SelectAll();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Escape", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (_isLoading && IsPickerActionShortcut(e))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ItemsGrid.SelectedItem = item;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-rental-item-picker-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-rental-item-picker-responsiveness.md
@@ -1,0 +1,23 @@
+# Rental Item Picker Responsiveness
+
+Completed a focused responsiveness pass for the rental item picker dialog.
+
+- Added compact responsive window bounds and a bounded root layout for scaled desktop use.
+- Added a header result summary so operators can see available-row status without scanning the grid.
+- Wrapped the search and footer action surfaces for narrow/scaled windows.
+- Enabled explicit row and column virtualization plus scrollbars on the picker grid.
+- Tuned grid column widths to reduce horizontal pressure while preserving useful item, location, quantity, and brand data.
+- Added a loading overlay that blocks stale row selection while available rental items are loading.
+- Added a separate empty state so no-result messaging does not compete with the loading overlay.
+- Added load versioning so stale debounced searches cannot replace newer picker results.
+- Stopped pending search work and invalidated in-flight loads when the picker unloads.
+- Preserved first-paint search focus before deferred item loading begins.
+- Disabled Find, Use Item, and grid interaction while loading.
+- Retargeted double-click selection to the invoked row before accepting the item.
+- Added Ctrl+F search focus, Enter accept, and Escape cancel keyboard handling with busy-state guards.
+- Added source-contract coverage for layout bounds, virtualization, loading/empty states, stale-load guards, action disabling, row retargeting, and keyboard behavior.
+
+Validation notes:
+
+- Source inspection and source-contract tests were updated for the picker workflow.
+- Full Windows validation, WPF runtime smoke testing, screenshots, and live responsiveness checks still need to run from a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Views/Windows/RentalItemPickerWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentalItemPickerWindow.xaml
@@ -2,13 +2,13 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Select Rental Item"
-        Width="720"
-        Height="560"
-        MinWidth="620"
-        MinHeight="460"
+        Width="760"
+        Height="540"
+        MinWidth="560"
+        MinHeight="420"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="12">
+    <Grid x:Name="RentalItemPickerRoot" Margin="10" MinWidth="0" ClipToBounds="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -16,47 +16,157 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,10">
-            <StackPanel>
-                <TextBlock x:Name="TitleText" Text="Select Rental Item" Style="{StaticResource PageTitleTextBlock}"/>
-                <TextBlock Text="Search available rental inventory, select a row, then confirm the item for this job." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-            </StackPanel>
+        <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
+            <DockPanel LastChildFill="True">
+                <Border x:Name="ResultSummaryBadge"
+                        DockPanel.Dock="Right"
+                        Style="{StaticResource DesktopSummaryCard}"
+                        Padding="8,6"
+                        MinWidth="132"
+                        MaxWidth="220"
+                        Margin="12,0,0,0">
+                    <StackPanel>
+                        <TextBlock Text="Available" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock x:Name="ResultSummaryText"
+                                   Text="Ready"
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,2,0,0"/>
+                    </StackPanel>
+                </Border>
+                <StackPanel MinWidth="0" MaxWidth="500">
+                    <TextBlock x:Name="TitleText"
+                               Text="Select Rental Item"
+                               Style="{StaticResource PageTitleTextBlock}"
+                               TextWrapping="Wrap"/>
+                    <TextBlock Text="Search available rental inventory, select a row, then confirm the item for this job."
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+            </DockPanel>
         </Border>
 
         <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}" Margin="0,0,0,8">
             <DockPanel LastChildFill="True">
-                <Button DockPanel.Dock="Right" Style="{StaticResource PrimaryButton}" Content="Find" Click="Find_Click" Margin="8,0,0,0"/>
+                <WrapPanel DockPanel.Dock="Right"
+                           HorizontalAlignment="Right"
+                           VerticalAlignment="Center"
+                           Margin="8,0,0,0">
+                    <Button x:Name="FindButton"
+                            Style="{StaticResource PrimaryButton}"
+                            Content="Find"
+                            Click="Find_Click"
+                            MinWidth="84"
+                            Margin="0,0,0,4"/>
+                </WrapPanel>
                 <TextBox x:Name="SearchBox"
-                         MinWidth="260"
+                         MinWidth="220"
+                         MaxWidth="360"
                          VerticalContentAlignment="Center"
                          TextChanged="SearchBox_TextChanged"
                          KeyDown="SearchBox_KeyDown"/>
             </DockPanel>
         </Border>
 
-        <DataGrid Grid.Row="2"
-                  x:Name="ItemsGrid"
-                  AutoGenerateColumns="False"
-                  IsReadOnly="True"
-                  SelectionMode="Single"
-                  MouseDoubleClick="ItemsGrid_MouseDoubleClick"
-                  Style="{StaticResource VirtualizedDataGridStyle}">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="110"/>
-                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
-                <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="120"/>
-                <DataGridTextColumn Header="Available" Binding="{Binding QuantityOnHand}" Width="90"/>
-                <DataGridTextColumn Header="Brand" Binding="{Binding Brand}" Width="120"/>
-            </DataGrid.Columns>
-        </DataGrid>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinWidth="0" MinHeight="140">
+            <Grid MinWidth="0">
+                <DataGrid x:Name="ItemsGrid"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          SelectionMode="Single"
+                          SelectionUnit="FullRow"
+                          SelectionChanged="ItemsGrid_SelectionChanged"
+                          MouseDoubleClick="ItemsGrid_MouseDoubleClick"
+                          Style="{StaticResource VirtualizedDataGridStyle}"
+                          EnableRowVirtualization="True"
+                          EnableColumnVirtualization="True"
+                          ScrollViewer.CanContentScroll="True"
+                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                          ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="104" MinWidth="82"/>
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*" MinWidth="150"/>
+                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="1.1*" MinWidth="112"/>
+                        <DataGridTextColumn Header="Available" Binding="{Binding QuantityOnHand}" Width="96" MinWidth="82"/>
+                        <DataGridTextColumn Header="Brand" Binding="{Binding Brand}" Width="1*" MinWidth="108"/>
+                    </DataGrid.Columns>
+                </DataGrid>
 
-        <Border Grid.Row="3" Style="{StaticResource DesktopSectionActionStrip}" Margin="0,10,0,0">
-            <DockPanel LastChildFill="False">
-                <TextBlock x:Name="StatusText" DockPanel.Dock="Left" Text="Enter a search term, or press Find to show available rental items." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="12,0,0,0">
-                    <Button Style="{StaticResource GhostButton}" Content="Cancel" Click="Cancel_Click" Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Use Item" Click="UseItem_Click"/>
-                </StackPanel>
+                <Border x:Name="EmptyStatePanel"
+                        Style="{StaticResource Card}"
+                        Padding="14"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        MaxWidth="340"
+                        MinHeight="112"
+                        Margin="12"
+                        Visibility="Collapsed"
+                        IsHitTestVisible="False">
+                    <StackPanel>
+                        <TextBlock x:Name="EmptyStateTitle"
+                                   Text="No available items"
+                                   Style="{StaticResource SectionHeader}"
+                                   TextAlignment="Center"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock x:Name="EmptyStateMessage"
+                                   Text="Try a different search term or clear the search to browse available rental inventory."
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   TextWrapping="Wrap"
+                                   TextAlignment="Center"
+                                   Margin="0,6,0,0"/>
+                    </StackPanel>
+                </Border>
+
+                <Border x:Name="LoadingOverlay"
+                        Background="{DynamicResource SurfaceBrush}"
+                        BorderBrush="{DynamicResource BorderBrushBase}"
+                        BorderThickness="1"
+                        CornerRadius="6"
+                        Padding="16"
+                        MaxWidth="360"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Visibility="Collapsed"
+                        IsHitTestVisible="True">
+                    <StackPanel>
+                        <TextBlock Text="Loading available rental items"
+                                   Style="{StaticResource SectionHeader}"
+                                   TextAlignment="Center"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock x:Name="LoadingStatusText"
+                                   Text="Keeping the picker responsive while matching inventory is loaded."
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   TextWrapping="Wrap"
+                                   TextAlignment="Center"
+                                   Margin="0,6,0,0"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="3" Style="{StaticResource DesktopSectionActionStrip}" Margin="0,8,0,0">
+            <DockPanel LastChildFill="True">
+                <TextBlock x:Name="StatusText"
+                           DockPanel.Dock="Left"
+                           Text="Enter a search term, or press Find to show available rental items."
+                           Style="{StaticResource CaptionTextBlock}"
+                           TextWrapping="Wrap"
+                           MaxWidth="420"
+                           VerticalAlignment="Center"/>
+                <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right" Margin="12,0,0,0">
+                    <Button Style="{StaticResource GhostButton}"
+                            Content="Cancel"
+                            Click="Cancel_Click"
+                            MinWidth="84"
+                            Margin="0,0,6,4"/>
+                    <Button x:Name="UseItemButton"
+                            Style="{StaticResource PrimaryButton}"
+                            Content="Use Item"
+                            Click="UseItem_Click"
+                            MinWidth="96"
+                            Margin="0,0,0,4"/>
+                </WrapPanel>
             </DockPanel>
         </Border>
     </Grid>

--- a/InventoryManagementApp/Views/Windows/RentalItemPickerWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/RentalItemPickerWindow.xaml.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Threading;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Interfaces;
@@ -16,7 +19,9 @@ namespace InventoryManagementApp.Views.Windows
         readonly IItemService _itemService;
         readonly int _excludedItemId;
         readonly DispatcherTimer _searchTimer;
+        int _loadVersion;
         bool _isLoaded;
+        bool _isLoading;
 
         public RentalItemPickerWindow(IItemService itemService, string title, int excludedItemId = 0)
         {
@@ -31,22 +36,41 @@ namespace InventoryManagementApp.Views.Windows
             };
             Title = title;
             TitleText.Text = title;
-            Loaded += async (_, _) =>
-            {
-                _isLoaded = true;
-                SearchBox.Focus();
-                await LoadItemsAsync();
-            };
+            Loaded += RentalItemPickerWindow_Loaded;
+            Unloaded += RentalItemPickerWindow_Unloaded;
+            PreviewKeyDown += RentalItemPickerWindow_PreviewKeyDown;
+            UpdatePickerState(isLoading: false, visibleItemCount: 0, showEmptyState: false);
         }
 
         public ItemModel? SelectedItem { get; private set; }
 
+        async void RentalItemPickerWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (_isLoaded)
+                return;
+
+            _isLoaded = true;
+            SearchBox.Focus();
+            await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.ContextIdle);
+            await LoadItemsAsync();
+        }
+
+        void RentalItemPickerWindow_Unloaded(object sender, RoutedEventArgs e)
+        {
+            _searchTimer.Stop();
+            _loadVersion++;
+            _isLoading = false;
+            UpdatePickerState(isLoading: false, visibleItemCount: ItemsGrid.Items.Count, showEmptyState: false);
+        }
+
         async Task LoadItemsAsync()
         {
+            var version = Interlocked.Increment(ref _loadVersion);
+            var term = SearchBox.Text?.Trim();
+            UpdatePickerState(isLoading: true, visibleItemCount: ItemsGrid.Items.Count, showEmptyState: false);
+
             try
             {
-                StatusText.Text = "Loading available rental items...";
-                var term = SearchBox.Text?.Trim();
                 var items = new List<ItemModel>();
                 var page = new ItemPage(1, 100);
                 var source = string.IsNullOrWhiteSpace(term)
@@ -55,32 +79,79 @@ namespace InventoryManagementApp.Views.Windows
 
                 await foreach (var item in source)
                 {
+                    if (version != _loadVersion)
+                        return;
+
                     if (IsAvailableForRentalPick(item))
                         items.Add(item);
                 }
 
+                if (version != _loadVersion)
+                    return;
+
                 ItemsGrid.ItemsSource = items;
-                StatusText.Text = items.Count == 1 ? "1 available item shown." : $"{items.Count} available items shown.";
+                ItemsGrid.SelectedItem = null;
+                var showEmptyState = items.Count == 0;
+                UpdatePickerState(isLoading: false, visibleItemCount: items.Count, showEmptyState: showEmptyState);
             }
             catch (Exception ex)
             {
+                if (version != _loadVersion)
+                    return;
+
                 ItemsGrid.ItemsSource = Array.Empty<ItemModel>();
+                ItemsGrid.SelectedItem = null;
+                UpdatePickerState(isLoading: false, visibleItemCount: 0, showEmptyState: true);
                 StatusText.Text = $"Unable to load items: {ex.Message}";
+                EmptyStateTitle.Text = "Unable to load items";
+                EmptyStateMessage.Text = "Check the inventory data source, then try Find again.";
             }
+        }
+
+        void UpdatePickerState(bool isLoading, int visibleItemCount, bool showEmptyState)
+        {
+            _isLoading = isLoading;
+            LoadingOverlay.Visibility = isLoading ? Visibility.Visible : Visibility.Collapsed;
+            EmptyStatePanel.Visibility = !isLoading && showEmptyState ? Visibility.Visible : Visibility.Collapsed;
+            FindButton.IsEnabled = !isLoading;
+            UseItemButton.IsEnabled = !isLoading && ItemsGrid.SelectedItem is ItemModel;
+            ItemsGrid.IsEnabled = !isLoading;
+
+            if (isLoading)
+            {
+                StatusText.Text = "Loading available rental items...";
+                ResultSummaryText.Text = "Loading";
+                return;
+            }
+
+            ResultSummaryText.Text = visibleItemCount == 1 ? "1 item" : $"{visibleItemCount} items";
+            if (showEmptyState)
+                StatusText.Text = "No available rental items match the current search.";
+            else
+                StatusText.Text = visibleItemCount == 1 ? "1 available item shown." : $"{visibleItemCount} available items shown.";
+
+            EmptyStateTitle.Text = "No available items";
+            EmptyStateMessage.Text = "Try a different search term or clear the search to browse available rental inventory.";
         }
 
         private async void Find_Click(object sender, RoutedEventArgs e)
         {
+            if (_isLoading)
+                return;
+
             _searchTimer.Stop();
             await LoadItemsAsync();
         }
 
-        private void SearchBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
         {
             if (!_isLoaded)
                 return;
 
             _searchTimer.Stop();
+            if (_isLoading)
+                _loadVersion++;
+
             _searchTimer.Start();
         }
 
@@ -90,8 +161,46 @@ namespace InventoryManagementApp.Views.Windows
                 return;
 
             e.Handled = true;
+            if (_isLoading)
+                return;
+
             _searchTimer.Stop();
             await LoadItemsAsync();
+        }
+
+        private void RentalItemPickerWindow_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
+            {
+                e.Handled = true;
+                SearchBox.Focus();
+                SearchBox.SelectAll();
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Escape)
+            {
+                e.Handled = true;
+                DialogResult = false;
+                return;
+            }
+
+            if (_isLoading && IsPickerActionShortcut(e))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter)
+            {
+                e.Handled = true;
+                SelectCurrentItem();
+            }
+        }
+
+        static bool IsPickerActionShortcut(KeyEventArgs e)
+        {
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter;
         }
 
         private void UseItem_Click(object sender, RoutedEventArgs e)
@@ -99,13 +208,34 @@ namespace InventoryManagementApp.Views.Windows
             SelectCurrentItem();
         }
 
+        private void ItemsGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UseItemButton.IsEnabled = !_isLoading && ItemsGrid.SelectedItem is ItemModel;
+        }
+
         private void ItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (_isLoading)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject) is { DataContext: ItemModel item })
+                ItemsGrid.SelectedItem = item;
+
+            e.Handled = true;
             SelectCurrentItem();
         }
 
         void SelectCurrentItem()
         {
+            if (_isLoading)
+            {
+                StatusText.Text = "Wait for available rental items to finish loading.";
+                return;
+            }
+
             if (ItemsGrid.SelectedItem is not ItemModel item)
             {
                 StatusText.Text = "Select an available item first.";
@@ -119,6 +249,19 @@ namespace InventoryManagementApp.Views.Windows
         private void Cancel_Click(object sender, RoutedEventArgs e)
         {
             DialogResult = false;
+        }
+
+        static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T match)
+                    return match;
+
+                current = VisualTreeHelper.GetParent(current);
+            }
+
+            return null;
         }
 
         bool IsAvailableForRentalPick(ItemModel item)


### PR DESCRIPTION
## What changed

- Added compact responsive bounds and a clipped root layout to the Rental Item Picker dialog.
- Added a header result summary so available-row count is visible without scanning the grid.
- Wrapped the search strip and footer actions for narrow/scaled Windows layouts.
- Enabled explicit row/column virtualization and scrollbars on the picker grid.
- Reduced column pressure while preserving item number, name, location, availability, and brand data.
- Added a loading overlay that blocks stale grid interaction while available rental items load.
- Added a separate empty/error state so no-result messaging does not compete with loading feedback.
- Added load versioning so stale debounced searches cannot replace newer picker results.
- Invalidated pending search work when the picker unloads.
- Preserved first-paint search focus before deferred item loading begins.
- Disabled Find, Use Item, and grid interaction while loading.
- Retargeted double-click acceptance to the invoked row before selecting the rental item.
- Added Ctrl+F search focus, Enter accept, and Escape cancel keyboard behavior with busy-state guards.
- Added source-contract tests for layout bounds, virtualization, loading/empty states, stale-load guards, action disabling, row retargeting, and keyboard behavior.
- Recorded the completed workflow slice in progress notes.

## Why this was highest value

Recent merged work already covered the primary pages and several heavy dialogs. The Rental Item Picker remained a rental workflow dialog with direct search/grid interaction, debounced loading, and item acceptance, but it lacked stale-search suppression, busy action gates, professional empty/loading states, and explicit grid responsiveness contracts. That made it a good next workflow-level improvement without repeating already-completed page work.

## Why this is real progress

This is a vertical dialog workflow slice across XAML layout, grid/data display, code-behind loading lifecycle, keyboard/row interaction, source-contract coverage, and progress notes. It keeps the existing service and MVVM-adjacent structure intact and avoids unrelated features.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, four commits ahead, and limited to:
  - `InventoryManagementApp/Views/Windows/RentalItemPickerWindow.xaml`
  - `InventoryManagementApp/Views/Windows/RentalItemPickerWindow.xaml.cs`
  - `InventoryManagementApp.Tests/RentalItemPickerWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-05-rental-item-picker-responsiveness.md`
- Connector readback confirmed the responsive XAML, loading/empty overlays, virtualization attributes, load versioning, unload invalidation, busy action guards, keyboard handlers, double-click row retargeting, source-contract assertions, and progress note are present.
- Local XML parsing confirmed the revised `RentalItemPickerWindow.xaml` is well-formed.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Rental Item Picker search, loading, row selection, keyboard, and dialog acceptance behavior

These require a Windows/.NET/WPF-capable checkout. Direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and the required Windows desktop tooling is unavailable here.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Rental Item Picker with empty results, slow search results, rapid typing, double-click selection, Enter accept, Escape cancel, and Ctrl+F at 1366x768 and higher Windows scaling.