### PR TITLE
Improve Activity Logs input responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
@@ -77,6 +77,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("IsEnabled=\"{Binding CanUseSelectedLogActions}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("IsEnabled=\"{Binding CanPrintActivityRows}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("IsEnabled=\"{Binding CanChangeActivityFilters}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding CanRefreshActivityRows}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<TextBlock Text=\"{Binding PrintStatusText}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("DataContext=\"{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}\"", xaml, StringComparison.Ordinal);
         }
@@ -102,9 +103,47 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += ActivityLogsPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("ReferenceEquals(_loadedViewModel, vm)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ActivitySearchBox.Focus();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("!vm.RefreshCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DataContext is ActivityLogsViewModel { IsBusy: true }", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (vm.IsBusy)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("vm.PrintStatusText", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsPage_CodeBehindRetargetsRowsAndSuppressesBusyGestures()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("private bool IsActivityDirectoryBusy() =>", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (IsActivityDirectoryBusy())\n            {\n                e.Handled = true;\n                return;\n            }", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("RetargetActivitySelectionFromEvent(e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ActivityGrid.SelectedItem = log;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ActivityGrid.ScrollIntoView(log);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.SelectedLog = log;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static T? FindAncestor<T>(DependencyObject? current)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("System.Windows.Media.VisualTreeHelper.GetParent(current) ?? LogicalTreeHelper.GetParent(current)", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsPage_CodeBehindAddsKeyboardShortcutsWithoutBreakingTextEditing()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("PreviewKeyDown += ActivityLogsPage_PreviewKeyDown;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void ActivityLogsPage_PreviewKeyDown", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ActivitySearchBox.SelectAll();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("RefreshLogs_Click(sender, e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("OpenRelatedPage_Click(sender, e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("CopySelectedLog_Click(sender, e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("PrintLogs_Click(sender, e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("OpenSelectedLog_Click(sender, e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsActivityLogShortcut(KeyEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return e.Key is Key.R or Key.O or Key.D or Key.C or Key.P;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsTextEditingElement(object? source)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return source is TextBox or ComboBox;", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -127,8 +166,13 @@ namespace InventoryManagementApp.Tests
             var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
 
             Assert.Contains("public bool IsBusy => IsLoading || IsFiltering;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanRefreshActivityRows => !IsBusy;", viewModel, StringComparison.Ordinal);
             Assert.Contains("public bool CanPrintActivityRows => !IsBusy && FilteredLogs.Count > 0;", viewModel, StringComparison.Ordinal);
             Assert.Contains("public bool CanUseSelectedLogActions => !IsBusy && SelectedLog != null;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("RefreshCommand = new AsyncRelayCommand(LoadLogsAsync, () => CanRefreshActivityRows);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (IsBusy)\n                return false;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("RefreshCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CanRefreshActivityRows));", viewModel, StringComparison.Ordinal);
             Assert.Contains("public string ActivityEmptyStateTitle", viewModel, StringComparison.Ordinal);
             Assert.Contains("public string ActivityEmptyStateMessage", viewModel, StringComparison.Ordinal);
             Assert.Contains("public string PrintStatusText", viewModel, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-activity-logs-input-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-activity-logs-input-responsiveness.md
@@ -1,0 +1,21 @@
+# Activity Logs Input Responsiveness
+
+Date: 2026-07-05
+
+## Completed
+
+- Focused the Activity Logs search box before page-owned startup loading so operators can begin filtering immediately after navigation.
+- Routed startup loading through `RefreshCommand.CanExecute` before and after the first-paint dispatcher yield to avoid overlapping loads while rows are loading or filters are applying.
+- Added `CanRefreshActivityRows` so toolbar/context refresh availability reflects both loading and filtering state.
+- Kept manual refresh from marking the page as loaded unless the refresh succeeds.
+- Blocked activity row double-click and right-click retargeting while the directory is busy.
+- Retargeted double-click detail actions to the invoked row before opening the detail dialog.
+- Added keyboard routes for search focus, refresh, related-page open, detail open, handoff copy, print preview, and Enter-to-detail.
+- Preserved text-editing copy/filter input behavior while still allowing Ctrl+F to return focus to search.
+- Added guarded visual/logical ancestor lookup for row retargeting from templated grid content.
+- Extended Activity Logs source-contract coverage for refresh readiness, fast search focus, row retargeting, busy gesture suppression, keyboard shortcuts, and text-edit preservation.
+
+## Validation
+
+- Source-contract coverage was updated in `ActivityLogsPageResponsiveContractTests`.
+- Direct local checkout, `pwsh -File scripts/run-full-validation.ps1`, .NET build/test execution, WPF runtime smoke tests, screenshots, live keyboard testing, and print-preview rendering could not be run in this scheduled Linux environment because GitHub HTTP checkout is blocked and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -124,7 +124,10 @@ namespace InventoryManagementApp.ViewModels
             private set
             {
                 if (SetProperty(ref _isFiltering, value))
+                {
+                    RefreshCommand.NotifyCanExecuteChanged();
                     NotifyActivityStateChanged();
+                }
             }
         }
 
@@ -134,6 +137,7 @@ namespace InventoryManagementApp.ViewModels
         public bool IsBusy => IsLoading || IsFiltering;
         public bool HasActiveFilters => HasActiveFilter();
         public bool CanChangeActivityFilters => !IsLoading;
+        public bool CanRefreshActivityRows => !IsBusy;
         public bool CanUseSelectedLogActions => !IsBusy && SelectedLog != null;
         public bool CanPrintActivityRows => !IsBusy && FilteredLogs.Count > 0;
         public bool CanShowActivityEmptyState => !IsBusy && FilteredLogs.Count == 0;
@@ -240,7 +244,7 @@ namespace InventoryManagementApp.ViewModels
         {
             _service = service;
             _logger = logger ?? NullLogger<ActivityLogsViewModel>.Instance;
-            RefreshCommand = new AsyncRelayCommand(LoadLogsAsync, () => !IsLoading);
+            RefreshCommand = new AsyncRelayCommand(LoadLogsAsync, () => CanRefreshActivityRows);
             ClearFiltersCommand = new RelayCommand(ClearFilters, () => !IsLoading && HasActiveFilter());
             UserFilters.Add(AllUsersFilter);
             ActionFilters.Add(AllActionsFilter);
@@ -248,7 +252,7 @@ namespace InventoryManagementApp.ViewModels
 
         public async Task<bool> LoadLogsAsync()
         {
-            if (IsLoading)
+            if (IsBusy)
                 return false;
 
             try
@@ -428,6 +432,7 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(IsBusy));
             OnPropertyChanged(nameof(HasActiveFilters));
             OnPropertyChanged(nameof(CanChangeActivityFilters));
+            OnPropertyChanged(nameof(CanRefreshActivityRows));
             OnPropertyChanged(nameof(CanUseSelectedLogActions));
             OnPropertyChanged(nameof(CanPrintActivityRows));
             OnPropertyChanged(nameof(CanShowActivityEmptyState));

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
@@ -97,7 +97,8 @@
                 <DockPanel LastChildFill="True">
                     <TextBlock Text="Audit filters" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <TextBox MinWidth="180"
+                        <TextBox x:Name="ActivitySearchBox"
+                                 MinWidth="180"
                                  Width="250"
                                  Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                                  IsEnabled="{Binding CanChangeActivityFilters}"
@@ -194,7 +195,7 @@
                                 <MenuItem Header="Copy Handoff" Click="CopySelectedLog_Click" IsEnabled="{Binding CanUseSelectedLogActions}"/>
                                 <Separator/>
                                 <MenuItem Header="Print Current Results" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintActivityRows}"/>
-                                <MenuItem Header="Refresh" Click="RefreshLogs_Click" IsEnabled="{Binding CanChangeActivityFilters}"/>
+                                <MenuItem Header="Refresh" Click="RefreshLogs_Click" IsEnabled="{Binding CanRefreshActivityRows}"/>
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                         <DataGrid.Columns>

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -24,6 +24,7 @@ namespace InventoryManagementApp.Views.Pages
             InitializeComponent();
             Loaded += ActivityLogsPage_Loaded;
             DataContextChanged += ActivityLogsPage_DataContextChanged;
+            PreviewKeyDown += ActivityLogsPage_PreviewKeyDown;
         }
 
         private async void ActivityLogsPage_Loaded(object sender, RoutedEventArgs e)
@@ -31,11 +32,16 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is not ActivityLogsViewModel vm)
                 return;
 
+            ActivitySearchBox.Focus();
+
             if (_hasLoadedLogs && ReferenceEquals(_loadedViewModel, vm))
                 return;
 
+            if (!vm.RefreshCommand.CanExecute(null))
+                return;
+
             await Dispatcher.Yield(DispatcherPriority.Background);
-            if (!ReferenceEquals(DataContext, vm))
+            if (!ReferenceEquals(DataContext, vm) || !vm.RefreshCommand.CanExecute(null))
                 return;
 
             _loadedViewModel = vm;
@@ -53,22 +59,88 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ActivityGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (IsActivityDirectoryBusy())
+            {
+                e.Handled = true;
+                return;
+            }
+
+            RetargetActivitySelectionFromEvent(e);
             OpenSelectedLog_Click(sender, e);
+            e.Handled = true;
         }
 
         private void ActivityGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (IsActivityDirectoryBusy())
+            {
+                e.Handled = true;
+                return;
+            }
+
             GridContextMenuSelection.SelectRow(sender, e);
         }
 
         private async void RefreshLogs_Click(object sender, RoutedEventArgs e)
         {
-            if (DataContext is ActivityLogsViewModel vm)
+            if (DataContext is ActivityLogsViewModel vm && vm.RefreshCommand.CanExecute(null))
             {
-                await vm.LoadLogsAsync();
-                _hasLoadedLogs = true;
+                _hasLoadedLogs = false;
+                var loaded = await vm.LoadLogsAsync();
+                _hasLoadedLogs = loaded;
                 _loadedViewModel = vm;
             }
+        }
+
+        private void ActivityLogsPage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
+            {
+                ActivitySearchBox.Focus();
+                ActivitySearchBox.SelectAll();
+                e.Handled = true;
+                return;
+            }
+
+            if (IsTextEditingElement(e.OriginalSource) || !IsActivityLogShortcut(e))
+                return;
+
+            if (IsActivityDirectoryBusy())
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R)
+            {
+                RefreshLogs_Click(sender, e);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.O)
+            {
+                OpenRelatedPage_Click(sender, e);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C)
+            {
+                CopySelectedLog_Click(sender, e);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)
+            {
+                PrintLogs_Click(sender, e);
+                e.Handled = true;
+                return;
+            }
+
+            OpenSelectedLog_Click(sender, e);
+            e.Handled = true;
         }
 
         private void OpenSelectedLog_Click(object sender, RoutedEventArgs e)
@@ -205,6 +277,20 @@ namespace InventoryManagementApp.Views.Pages
             });
         }
 
+        private bool IsActivityDirectoryBusy() => DataContext is ActivityLogsViewModel { IsBusy: true };
+
+        private void RetargetActivitySelectionFromEvent(RoutedEventArgs e)
+        {
+            var row = FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row?.Item is not ActivityLog log)
+                return;
+
+            ActivityGrid.SelectedItem = log;
+            ActivityGrid.ScrollIntoView(log);
+            if (DataContext is ActivityLogsViewModel vm)
+                vm.SelectedLog = log;
+        }
+
         private ActivityLog? GetSelectedActivityLogForAction()
         {
             if (ActivityGrid.SelectedItem is ActivityLog gridLog)
@@ -213,6 +299,48 @@ namespace InventoryManagementApp.Views.Pages
             return DataContext is ActivityLogsViewModel vm
                 ? vm.SelectedLog
                 : null;
+        }
+
+        private static bool IsActivityLogShortcut(KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+                return e.Key is Key.R or Key.O or Key.D or Key.C or Key.P;
+
+            return Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter;
+        }
+
+        private static bool IsTextEditingElement(object? source)
+        {
+            return source is TextBox or ComboBox;
+        }
+
+        private static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T match)
+                    return match;
+
+                current = TryGetParent(current);
+            }
+
+            return null;
+        }
+
+        private static DependencyObject? TryGetParent(DependencyObject current)
+        {
+            try
+            {
+                return System.Windows.Media.VisualTreeHelper.GetParent(current) ?? LogicalTreeHelper.GetParent(current);
+            }
+            catch (InvalidOperationException)
+            {
+                return LogicalTreeHelper.GetParent(current);
+            }
+            catch (ArgumentException)
+            {
+                return LogicalTreeHelper.GetParent(current);
+            }
         }
 
         private static string FormatLogDetail(ActivityLog log)


### PR DESCRIPTION
## What changed

- Focused the Activity Logs search box before page-owned startup loading so operators can start filtering immediately after navigation.
- Routed startup refresh through `RefreshCommand.CanExecute` before and after the first-paint dispatcher yield to avoid overlapping loads while rows load or filters apply.
- Added `CanRefreshActivityRows` so refresh availability reflects both loading and filtering state.
- Kept manual refresh from marking the page loaded unless the refresh actually succeeds.
- Blocked activity row double-click and right-click retargeting while the directory is busy.
- Retargeted double-click detail actions to the invoked row before opening the detail dialog.
- Added keyboard routes for search focus, refresh, related-page open, detail open, handoff copy, print preview, and Enter-to-detail.
- Preserved text-editing behavior while still allowing Ctrl+F to return focus to search.
- Added guarded visual/logical ancestor lookup for row retargeting from templated grid content.
- Extended Activity Logs source-contract coverage for refresh readiness, fast search focus, row retargeting, busy gesture suppression, keyboard shortcuts, and text-edit preservation.

## Why this was highest value

Recent runs have already improved many core workbenches and dialogs. Activity Logs had strong layout and print capping, but its row and keyboard action paths were less hardened than newer screens, leaving room for stale selection, accidental busy actions, and slower audit review.

## Why this is real progress

This is a vertical workflow slice across ViewModel readiness, XAML bindings, code-behind interaction behavior, source-contract tests, and progress notes. It improves opening the page, filtering, refreshing, row selection, detail review, related navigation, copy handoff, and print preview access as one coherent Activity Logs pass.

## Validation

- GitHub compare/readback confirmed the branch is current with `master` and focused to Activity Logs ViewModel, XAML, code-behind, tests, and a progress note.
- Readback confirmed the new search focus, refresh readiness checks, invoked-row retargeting, busy gesture guards, keyboard shortcuts, and test assertions are present.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`, local .NET build/test, WPF runtime smoke tests, screenshots, live keyboard testing, scaling checks, and print-preview rendering could not be run in this scheduled Linux environment because direct checkout remains blocked and `dotnet`, `pwsh`, `gh`, and WPF runtime tooling are unavailable.

## Follow-up

- Run the full Windows validation runner on a capable checkout.
- Smoke test Activity Logs keyboard shortcuts and print preview with large audit datasets on Windows.