### PR TITLE
Improve Print Preview responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/PrintPreviewWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/PrintPreviewWindowResponsiveContractTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class PrintPreviewWindowResponsiveContractTests
+    {
+        [Fact]
+        public void PrintPreviewWindow_UsesCompactResponsiveBoundsAndStatusSurfaces()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("Width=\"1040\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Height=\"720\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"720\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"PreviewRoot\" Style=\"{StaticResource ThemedWindowRoot}\" MinWidth=\"0\" ClipToBounds=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"PreviewStatus\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding PreviewStatus}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"PreviewFooterStatus\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding FooterStatus}\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"1120\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"760\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewWindow_ReducesSplitPressureAndKeepsDocumentCanvasScrollable()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"5\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"0.32*\" MinWidth=\"220\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\"\n                          Width=\"5\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource ThemedDocumentCanvasFrame}\" MinWidth=\"0\" ClipToBounds=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Focusable=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"6\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"0.36*\" MinWidth=\"240\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewWindow_WrapsActionsAndDocumentsKeyboardReviewShortcuts()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("<WrapPanel Grid.Column=\"1\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\" MaxWidth=\"300\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Command=\"{Binding PageSetupCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Command=\"{Binding PrintCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Command=\"{Binding CloseCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Ctrl+P prints, Ctrl+Shift+P reapplies page setup, and Esc closes the preview when no print job is active.", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"78\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MaxWidth=\"330\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewViewModel_GatesPreviewActionsDuringPrint()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "PrintPreviewViewModel.cs");
+
+            Assert.Contains("private bool _hasDocument;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private bool _isPrinting;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanPreviewActions => HasDocument && !IsPrinting;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("PageSetupCommand = new RelayCommand(onPageSetup, () => CanPreviewActions);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("PrintCommand = new RelayCommand(onPrint, () => CanPreviewActions);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("CloseCommand = new RelayCommand(onClose, () => !IsPrinting);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool TryBeginPrint()", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public void EndPrint(bool printed)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("PageSetupCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("PrintCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("CloseCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewWindow_CodeBehindDefersLogoWorkAndAvoidsBlockingInvalidPathDialogs()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml.cs");
+
+            Assert.Contains("private static readonly Uri DefaultLogoUri", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SetPreviewLogo(DefaultLogoUri);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Dispatcher.BeginInvoke(new Action(() => LoadLogoForPreview(_logoPath)), DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static bool TryResolveCustomLogoUri", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return false;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!Equals(logoUri, DefaultLogoUri))\n                    SetPreviewLogo(DefaultLogoUri);", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("MessageBox.Show(\"Logo path is invalid.", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("ResolveLogoUri", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewWindow_CodeBehindUsesSafePageSetupAndPrintBusyGuards()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml.cs");
+
+            Assert.Contains("if (DocViewer.Document == null || DataContext is not PrintPreviewViewModel vm || !vm.CanPreviewActions)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SafePreviewExtent(DocViewer.ActualWidth, DefaultPreviewPageWidth)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SafePreviewExtent(DocViewer.ActualHeight, DefaultPreviewPageHeight)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static double SafePreviewExtent(double actualExtent, double fallbackExtent)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("double.IsFinite(actualExtent) && actualExtent >= MinimumPrintableExtent", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("!vm.TryBeginPrint()", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.EndPrint(printed);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("catch (System.Printing.PrintSystemException ex)", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewWindow_CodeBehindAddsKeyboardShortcutsAndFastCanvasFocus()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml.cs");
+
+            Assert.Contains("PreviewKeyDown += PrintPreviewWindow_PreviewKeyDown;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Dispatcher.BeginInvoke(new Action(() => DocViewer.Focus()), DispatcherPriority.ContextIdle);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Escape && !vm.IsPrinting", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.PrintCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.PageSetupCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.CloseCommand.Execute(null);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/PrintPreviewWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/PrintPreviewWindowResponsiveContractTests.cs
@@ -85,7 +85,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("return false;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (!Equals(logoUri, DefaultLogoUri))\n                    SetPreviewLogo(DefaultLogoUri);", codeBehind, StringComparison.Ordinal);
             Assert.DoesNotContain("MessageBox.Show(\"Logo path is invalid.", codeBehind, StringComparison.Ordinal);
-            Assert.DoesNotContain("ResolveLogoUri", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("private static Uri ResolveLogoUri", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-print-preview-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-print-preview-responsiveness.md
@@ -1,0 +1,28 @@
+# Print Preview Responsiveness
+
+Date: 2026-07-05
+
+## Completed
+
+- Tightened the shared Print Preview window default and minimum bounds for scaled desktop use.
+- Added a clipped, minimum-width-safe root layout so oversized document content stays inside the preview surface.
+- Reduced header, splitter, side-panel, and action-button pressure while preserving the document canvas and checklist panel.
+- Added visible preview and footer status text driven by the preview view model.
+- Added view-model-backed document readiness and print busy state for Page Setup, Print, and Close commands.
+- Disabled Page Setup and Print while a print dialog/job is active to prevent duplicate printer dialogs or page mutations.
+- Deferred custom logo resolution until after preview setup so invalid or slow logo paths do not block first preview paint.
+- Replaced modal invalid-logo warnings with a quiet default-logo fallback.
+- Added safe page setup extents so zero, tiny, or non-finite viewer measurements do not shrink printable documents.
+- Added Ctrl+P, Ctrl+Shift+P, and Esc keyboard paths through command availability.
+- Focused the document viewer after first render for faster keyboard review.
+- Added source-contract coverage for responsive bounds, split pressure, scrollable canvas, command readiness, deferred logo handling, safe page setup, print busy guards, keyboard shortcuts, and status display.
+
+## Validation
+
+- Source-contract coverage was added in `InventoryManagementApp.Tests/PrintPreviewWindowResponsiveContractTests.cs`.
+- GitHub connector readback should be used to confirm the intended source changes because this scheduled Linux environment cannot clone the repository directly or run WPF/.NET validation.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test print preview opening speed, custom-logo fallback, Ctrl+P, Ctrl+Shift+P, Esc, Page Setup, Print cancel, and successful printing at 1366x768 and higher Windows scaling.

--- a/InventoryManagementApp/ViewModels/PrintPreviewViewModel.cs
+++ b/InventoryManagementApp/ViewModels/PrintPreviewViewModel.cs
@@ -6,16 +6,98 @@ namespace InventoryManagementApp.ViewModels
 {
     public class PrintPreviewViewModel : ObservableObject
     {
+        private bool _hasDocument;
+        private bool _isPrinting;
+        private string _previewStatus = "Preparing print preview...";
+        private string _footerStatus = "Preview preparing";
+
         public IRelayCommand PageSetupCommand { get; }
         public IRelayCommand PrintCommand { get; }
         public IRelayCommand CloseCommand { get; }
 
+        public bool HasDocument
+        {
+            get => _hasDocument;
+            private set
+            {
+                if (SetProperty(ref _hasDocument, value))
+                    RefreshCommandState();
+            }
+        }
+
+        public bool IsPrinting
+        {
+            get => _isPrinting;
+            private set
+            {
+                if (SetProperty(ref _isPrinting, value))
+                    RefreshCommandState();
+            }
+        }
+
+        public bool CanPreviewActions => HasDocument && !IsPrinting;
+
+        public string PreviewStatus
+        {
+            get => _previewStatus;
+            private set => SetProperty(ref _previewStatus, value);
+        }
+
+        public string FooterStatus
+        {
+            get => _footerStatus;
+            private set => SetProperty(ref _footerStatus, value);
+        }
+
         public PrintPreviewViewModel(Action onPageSetup, Action onPrint, Action onClose)
         {
-            PageSetupCommand = new RelayCommand(onPageSetup);
-            PrintCommand = new RelayCommand(onPrint);
-            CloseCommand = new RelayCommand(onClose);
+            PageSetupCommand = new RelayCommand(onPageSetup, () => CanPreviewActions);
+            PrintCommand = new RelayCommand(onPrint, () => CanPreviewActions);
+            CloseCommand = new RelayCommand(onClose, () => !IsPrinting);
+        }
+
+        public void SetPreviewReady(string? description)
+        {
+            HasDocument = true;
+            PreviewStatus = string.IsNullOrWhiteSpace(description)
+                ? "Preview ready. Review page setup before printing."
+                : description.Trim();
+            FooterStatus = "Preview ready for final print review";
+            RefreshCommandState();
+        }
+
+        public void SetPageSetupAdjusted()
+        {
+            PreviewStatus = "Page setup applied. Review the document canvas before printing.";
+            FooterStatus = "Page setup refreshed";
+        }
+
+        public bool TryBeginPrint()
+        {
+            if (!CanPreviewActions)
+                return false;
+
+            IsPrinting = true;
+            PreviewStatus = "Print dialog open. Finish or cancel printing before changing the preview.";
+            FooterStatus = "Printing in progress";
+            return true;
+        }
+
+        public void EndPrint(bool printed)
+        {
+            IsPrinting = false;
+            PreviewStatus = printed
+                ? "Print job sent. Review the originating workflow for any follow-up filing."
+                : "Print canceled. Preview remains ready for page setup or printing.";
+            FooterStatus = printed ? "Print job sent" : "Preview ready for final print review";
+        }
+
+        private void RefreshCommandState()
+        {
+            OnPropertyChanged(nameof(CanPreviewActions));
+            PageSetupCommand.NotifyCanExecuteChanged();
+            PrintCommand.NotifyCanExecuteChanged();
+            CloseCommand.NotifyCanExecuteChanged();
         }
     }
 }
-

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
@@ -3,12 +3,12 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Print Preview"
-        Width="1120" Height="760"
-        MinWidth="760" MinHeight="560"
+        Width="1040" Height="720"
+        MinWidth="720" MinHeight="520"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundBrush}"
         FontFamily="{DynamicResource ThemeFontFamily}">
-    <Grid Style="{StaticResource ThemedWindowRoot}">
+    <Grid x:Name="PreviewRoot" Style="{StaticResource ThemedWindowRoot}" MinWidth="0" ClipToBounds="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -18,7 +18,7 @@
         <Border Grid.RowSpan="3" Style="{StaticResource ThemedWindowOverlay}"/>
 
         <Border Grid.Row="0" Style="{StaticResource ThemedWindowHeader}">
-            <Grid>
+            <Grid MinWidth="0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" MinWidth="0"/>
                     <ColumnDefinition Width="Auto"/>
@@ -26,7 +26,7 @@
 
                 <DockPanel Grid.Column="0" LastChildFill="True" MinWidth="0" Margin="0,0,12,0">
                     <Border DockPanel.Dock="Left"
-                            Width="42" Height="42"
+                            Width="38" Height="38"
                             Background="{DynamicResource SurfaceBrush}"
                             BorderBrush="{DynamicResource BorderBrushAlt}"
                             BorderThickness="{DynamicResource ThemeControlBorderThickness}"
@@ -34,51 +34,58 @@
                             Effect="{DynamicResource ThemeControlShadow}"
                             Margin="0,0,10,0">
                         <Image x:Name="PreviewLogo"
-                               Width="30" Height="30"
+                               Width="28" Height="28"
                                Stretch="Uniform"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Center"/>
                     </Border>
-                    <StackPanel VerticalAlignment="Center" MinWidth="0">
+                    <StackPanel VerticalAlignment="Center" MinWidth="0" MaxWidth="620">
                         <TextBlock Text="Preview Workstation" Style="{StaticResource CaptionTextBlock}"/>
                         <TextBlock x:Name="PreviewTitle"
                                    Style="{StaticResource HeadingTextBlock}"
                                    TextWrapping="Wrap"
                                    TextTrimming="CharacterEllipsis"
-                                   MaxWidth="520"/>
+                                   MaxWidth="560"/>
                         <TextBlock x:Name="PreviewDescription"
                                    Style="{StaticResource CaptionTextBlock}"
                                    TextWrapping="Wrap"
-                                   MaxWidth="560"
+                                   MaxWidth="600"
+                                   Margin="0,3,0,0"/>
+                        <TextBlock x:Name="PreviewStatus"
+                                   Text="{Binding PreviewStatus}"
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   TextWrapping="Wrap"
+                                   TextTrimming="CharacterEllipsis"
+                                   MaxWidth="600"
                                    Margin="0,3,0,0"/>
                     </StackPanel>
                 </DockPanel>
 
-                <WrapPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" MaxWidth="330">
+                <WrapPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" MaxWidth="300">
                     <Button Style="{StaticResource GhostButton}"
                             Content="Page Setup"
                             Command="{Binding PageSetupCommand}"
-                            MinWidth="104"
+                            MinWidth="100"
                             Margin="0,0,6,6"/>
                     <Button Style="{StaticResource PrimaryButton}"
                             Content="Print"
                             Command="{Binding PrintCommand}"
-                            MinWidth="84"
+                            MinWidth="78"
                             Margin="0,0,6,6"/>
                     <Button Style="{StaticResource GhostButton}"
                             Content="Close"
                             Command="{Binding CloseCommand}"
-                            MinWidth="84"
+                            MinWidth="78"
                             Margin="0,0,0,6"/>
                 </WrapPanel>
             </Grid>
         </Border>
 
-        <Grid Grid.Row="1" Margin="0,10,0,10">
+        <Grid Grid.Row="1" Margin="0,8,0,8" MinWidth="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" MinWidth="0"/>
-                <ColumnDefinition Width="6"/>
-                <ColumnDefinition Width="0.36*" MinWidth="240"/>
+                <ColumnDefinition Width="5"/>
+                <ColumnDefinition Width="0.32*" MinWidth="220"/>
             </Grid.ColumnDefinitions>
 
             <Border Grid.Column="0" Style="{StaticResource ThemedWindowPane}" MinWidth="0">
@@ -87,33 +94,34 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <DockPanel Grid.Row="0" LastChildFill="True" Margin="0,0,0,10">
-                        <StackPanel DockPanel.Dock="Left" MinWidth="0" Margin="0,0,12,0">
+                    <DockPanel Grid.Row="0" LastChildFill="True" Margin="0,0,0,8" MinWidth="0">
+                        <StackPanel DockPanel.Dock="Left" MinWidth="0" Margin="0,0,12,0" MaxWidth="520">
                             <TextBlock Text="Document Canvas" Style="{StaticResource SubheadingTextBlock}" TextTrimming="CharacterEllipsis"/>
-                            <TextBlock Text="Live preview of the printable content with the current app logo and report title." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Live preview of printable content with current branding, title, and page setup." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                         <TextBlock DockPanel.Dock="Right" Text="Output Review" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap"/>
                     </DockPanel>
 
-                    <Border Grid.Row="1" Style="{StaticResource ThemedDocumentCanvasFrame}" MinWidth="0">
+                    <Border Grid.Row="1" Style="{StaticResource ThemedDocumentCanvasFrame}" MinWidth="0" ClipToBounds="True">
                         <FlowDocumentScrollViewer x:Name="DocViewer"
                                                   Style="{StaticResource ThemedDocumentPreviewViewer}"
                                                   IsToolBarVisible="False"
                                                   VerticalScrollBarVisibility="Auto"
-                                                  HorizontalScrollBarVisibility="Auto"/>
+                                                  HorizontalScrollBarVisibility="Auto"
+                                                  Focusable="True"/>
                     </Border>
                 </Grid>
             </Border>
 
             <GridSplitter Grid.Column="1"
-                          Width="6"
+                          Width="5"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
                           Background="{DynamicResource BorderBrushBase}"/>
 
             <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" MinWidth="0">
                 <StackPanel Margin="8,0,0,0" MinWidth="0">
-                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10" MinWidth="0">
+                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,8" MinWidth="0">
                         <StackPanel>
                             <TextBlock Text="Print checklist" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                             <TextBlock Text="1. Confirm the title and logo match the handoff." TextWrapping="Wrap" Margin="0,6,0,0"/>
@@ -122,10 +130,10 @@
                         </StackPanel>
                     </Border>
 
-                    <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10" MinWidth="0">
+                    <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8" MinWidth="0">
                         <StackPanel>
-                            <TextBlock Text="Branding confidence" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                            <TextBlock Text="This frame gives every directory, sheet, invoice, and handoff preview the same review surface before staff produce customer-facing output." TextWrapping="Wrap"/>
+                            <TextBlock Text="Fast review" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+P prints, Ctrl+Shift+P reapplies page setup, and Esc closes the preview when no print job is active." TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
 
@@ -140,18 +148,20 @@
         </Grid>
 
         <Border Grid.Row="2" Style="{StaticResource ThemedWindowFooter}">
-            <DockPanel LastChildFill="True">
+            <DockPanel LastChildFill="True" MinWidth="0">
                 <TextBlock DockPanel.Dock="Left"
                            Text="Ready for final print review"
                            Style="{StaticResource CaptionTextBlock}"
                            VerticalAlignment="Center"
                            TextWrapping="Wrap"
                            Margin="0,0,12,0"/>
-                <TextBlock Text="Preview footer status"
+                <TextBlock x:Name="PreviewFooterStatus"
+                           Text="{Binding FooterStatus}"
                            Style="{StaticResource CaptionTextBlock}"
                            HorizontalAlignment="Right"
                            VerticalAlignment="Center"
-                           TextWrapping="Wrap"/>
+                           TextWrapping="Wrap"
+                           TextTrimming="CharacterEllipsis"/>
             </DockPanel>
         </Border>
     </Grid>

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
@@ -7,6 +7,8 @@ using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Controls; // WPF PrintDialog
+using System.Windows.Input;
+using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Utilities.Extensions;
 using InventoryManagementApp.Utilities.Printing;
@@ -21,6 +23,7 @@ namespace InventoryManagementApp.Views.Windows
         internal const double DefaultPreviewPageHeight = 1056;
         private const double MinimumPrintableExtent = 320;
         private static readonly Thickness PrintPagePadding = new(36, 36, 36, 36);
+        private static readonly Uri DefaultLogoUri = new("pack://application:,,,/Resources/DefaultLogo.png");
 
         private FlowDocument? _document;
         private string _title = string.Empty;
@@ -31,6 +34,7 @@ namespace InventoryManagementApp.Views.Windows
         {
             InitializeComponent();
             DataContext = new PrintPreviewViewModel(OnPageSetup, OnPrint, Close);
+            PreviewKeyDown += PrintPreviewWindow_PreviewKeyDown;
             this.DisposeDataContextOnUnload();
         }
 
@@ -44,20 +48,19 @@ namespace InventoryManagementApp.Views.Windows
             Title = $"Print Preview - {_title}";
             PreviewTitle.Text = _title;
             PreviewDescription.Text = _description;
-
-            var logoUri = ResolveLogoUri(_logoPath);
-            var bmp = new BitmapImage();
-            bmp.BeginInit();
-            bmp.CacheOption = BitmapCacheOption.OnLoad;
-            bmp.UriSource = logoUri;
-            bmp.EndInit();
-            bmp.Freeze();
-            PreviewLogo.Source = bmp;
+            SetPreviewLogo(DefaultLogoUri);
 
             ApplyDocumentPolish(_document, _title);
             ConfigureDocumentForPage(_document, DefaultPreviewPageWidth, DefaultPreviewPageHeight);
             ApplyTablePolish(_document);
             DocViewer.Document = _document;
+
+            if (DataContext is PrintPreviewViewModel vm)
+                vm.SetPreviewReady(_description);
+
+            Dispatcher.BeginInvoke(new Action(() => LoadLogoForPreview(_logoPath)), DispatcherPriority.Background);
+            Dispatcher.BeginInvoke(new Action(() => DocViewer.Focus()), DispatcherPriority.ContextIdle);
+
             Owner = System.Windows.Application.Current.MainWindow;
             ShowDialog();
         }
@@ -72,23 +75,68 @@ namespace InventoryManagementApp.Views.Windows
             ApplyTablePolish(document);
         }
 
-        private static Uri ResolveLogoUri(string path)
+        private void LoadLogoForPreview(string path)
         {
-            if (!string.IsNullOrWhiteSpace(path))
+            if (!TryResolveCustomLogoUri(path, out var logoUri))
+                return;
+
+            SetPreviewLogo(logoUri);
+        }
+
+        private static bool TryResolveCustomLogoUri(string path, out Uri logoUri)
+        {
+            logoUri = DefaultLogoUri;
+            if (string.IsNullOrWhiteSpace(path))
+                return false;
+
+            try
             {
-                try
+                var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path, true);
+                if (!string.IsNullOrEmpty(full) && File.Exists(full))
                 {
-                    var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path, true);
-                    if (!string.IsNullOrEmpty(full) && File.Exists(full))
-                        return new Uri(full, UriKind.Absolute);
-                    System.Windows.MessageBox.Show("Logo path is invalid.", "Invalid Path");
-                }
-                catch (InvalidOperationException)
-                {
-                    System.Windows.MessageBox.Show("Logo path is invalid.", "Invalid Path");
+                    logoUri = new Uri(full, UriKind.Absolute);
+                    return true;
                 }
             }
-            return new Uri("pack://application:,,,/Resources/DefaultLogo.png");
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+            catch (UriFormatException)
+            {
+                return false;
+            }
+
+            return false;
+        }
+
+        private void SetPreviewLogo(Uri logoUri)
+        {
+            try
+            {
+                var bmp = new BitmapImage();
+                bmp.BeginInit();
+                bmp.CacheOption = BitmapCacheOption.OnLoad;
+                bmp.UriSource = logoUri;
+                bmp.EndInit();
+                bmp.Freeze();
+                PreviewLogo.Source = bmp;
+            }
+            catch (IOException)
+            {
+                if (!Equals(logoUri, DefaultLogoUri))
+                    SetPreviewLogo(DefaultLogoUri);
+            }
+            catch (InvalidOperationException)
+            {
+                if (!Equals(logoUri, DefaultLogoUri))
+                    SetPreviewLogo(DefaultLogoUri);
+            }
+            catch (NotSupportedException)
+            {
+                if (!Equals(logoUri, DefaultLogoUri))
+                    SetPreviewLogo(DefaultLogoUri);
+            }
         }
 
         private static void ApplyDocumentPolish(FlowDocument document, string title)
@@ -260,27 +308,80 @@ namespace InventoryManagementApp.Views.Windows
 
         private void OnPageSetup()
         {
-            if (DocViewer.Document != null)
-            {
-                // FlowDocumentScrollViewer does not have ViewportWidth.
-                // Use a reasonable default or set PageWidth to the window/client width.
-                ConfigureDocumentForPage(DocViewer.Document, DocViewer.ActualWidth, Math.Max(DocViewer.ActualHeight, DefaultPreviewPageHeight));
-                ApplyTablePolish(DocViewer.Document);
-            }
+            if (DocViewer.Document == null || DataContext is not PrintPreviewViewModel vm || !vm.CanPreviewActions)
+                return;
+
+            var pageWidth = SafePreviewExtent(DocViewer.ActualWidth, DefaultPreviewPageWidth);
+            var pageHeight = SafePreviewExtent(DocViewer.ActualHeight, DefaultPreviewPageHeight);
+            ConfigureDocumentForPage(DocViewer.Document, pageWidth, pageHeight);
+            ApplyTablePolish(DocViewer.Document);
+            vm.SetPageSetupAdjusted();
         }
+
+        private static double SafePreviewExtent(double actualExtent, double fallbackExtent)
+            => double.IsFinite(actualExtent) && actualExtent >= MinimumPrintableExtent
+                ? actualExtent
+                : fallbackExtent;
 
         private void OnPrint()
         {
-            if (_document == null) return;
-            var dlg = new System.Windows.Controls.PrintDialog();
-            if (dlg.ShowDialog() == true)
-            {
-                ConfigureDocumentForPage(_document, dlg.PrintableAreaWidth, dlg.PrintableAreaHeight);
-                ApplyTablePolish(_document);
+            if (_document == null || DataContext is not PrintPreviewViewModel vm || !vm.TryBeginPrint())
+                return;
 
-                var paginator = ((IDocumentPaginatorSource)_document).DocumentPaginator;
-                paginator.PageSize = new Size(dlg.PrintableAreaWidth, dlg.PrintableAreaHeight);
-                dlg.PrintDocument(paginator, _title);
+            var printed = false;
+            try
+            {
+                var dlg = new System.Windows.Controls.PrintDialog();
+                if (dlg.ShowDialog() == true)
+                {
+                    ConfigureDocumentForPage(_document, dlg.PrintableAreaWidth, dlg.PrintableAreaHeight);
+                    ApplyTablePolish(_document);
+
+                    var paginator = ((IDocumentPaginatorSource)_document).DocumentPaginator;
+                    paginator.PageSize = new Size(dlg.PrintableAreaWidth, dlg.PrintableAreaHeight);
+                    dlg.PrintDocument(paginator, _title);
+                    printed = true;
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                System.Windows.MessageBox.Show($"Print preview could not send this document to the printer. {ex.Message}", "Print Preview");
+            }
+            catch (System.Printing.PrintSystemException ex)
+            {
+                System.Windows.MessageBox.Show($"Windows could not complete the print request. {ex.Message}", "Print Preview");
+            }
+            finally
+            {
+                vm.EndPrint(printed);
+            }
+        }
+
+        private void PrintPreviewWindow_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (DataContext is not PrintPreviewViewModel vm)
+                return;
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)
+            {
+                if (vm.PrintCommand.CanExecute(null))
+                    vm.PrintCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P)
+            {
+                if (vm.PageSetupCommand.CanExecute(null))
+                    vm.PageSetupCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Escape && !vm.IsPrinting)
+            {
+                vm.CloseCommand.Execute(null);
+                e.Handled = true;
             }
         }
     }


### PR DESCRIPTION
## What changed

- Tightened the shared Print Preview window default and minimum bounds for scaled desktop use.
- Added a clipped, minimum-width-safe root layout so oversized document content stays inside the preview surface.
- Reduced header, splitter, side-panel, and action-button pressure while preserving the document canvas and checklist panel.
- Added visible preview and footer status text driven by the preview view model.
- Added view-model-backed document readiness and print busy state for Page Setup, Print, and Close commands.
- Disabled Page Setup and Print while a print dialog/job is active to prevent duplicate printer dialogs or page mutations.
- Deferred custom logo resolution until after preview setup so invalid or slow logo paths do not block first preview paint.
- Replaced modal invalid-logo warnings with a quiet default-logo fallback.
- Added safe page setup extents so zero, tiny, or non-finite viewer measurements do not shrink printable documents.
- Added Ctrl+P, Ctrl+Shift+P, and Esc keyboard paths through command availability.
- Focused the document viewer after first render for faster keyboard review.
- Added source-contract coverage for responsive bounds, split pressure, scrollable canvas, command readiness, deferred logo handling, safe page setup, print busy guards, keyboard shortcuts, and status display.

## Why this was highest value

Recent runs already improved many page-specific loading/action paths. Print Preview is a shared output workflow used by reports, documents, directories, labels, handoffs, invoices, and operational print paths. Its remaining first-paint and responsiveness risks affected many workflows at once: synchronous custom-logo validation before the dialog opened, fixed layout pressure at scaled desktop sizes, unsafe page setup measurements, and no print busy state around printer dialog entry.

## Why this is real progress

This is a complete shared workflow slice across XAML layout, ViewModel command/readiness state, code-behind startup/printing behavior, keyboard review paths, source-contract coverage, and progress notes. It improves more than ten operator-facing points without adding unrelated screens or dependencies.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, six commits ahead, zero behind, and limited to:
  - `InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml`
  - `InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs`
  - `InventoryManagementApp/ViewModels/PrintPreviewViewModel.cs`
  - `InventoryManagementApp.Tests/PrintPreviewWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-05-print-preview-responsiveness.md`
- Connector readback confirmed the responsive XAML, preview status bindings, command readiness state, deferred logo fallback, safe page setup extents, print busy guard, keyboard shortcuts, source-contract assertions, and progress note are present.
- Connector status readback found no attached commit statuses on branch head `521946441f38ecf14c04c4498ef53fe557f671d7` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live print preview opening speed, custom-logo fallback, page setup, print dialog, keyboard shortcut, and printer behavior

These require a Windows/.NET/WPF-capable checkout. Direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and Windows desktop tooling is unavailable here.

## Follow-up

- Run the full Windows validation runner.
- Smoke test print preview opening speed, custom-logo fallback, Ctrl+P, Ctrl+Shift+P, Esc, Page Setup, Print cancel, and successful printing at 1366x768 and higher Windows scaling.