### PR TITLE
Improve checkout history dialog responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/CheckoutHistoryWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CheckoutHistoryWindowResponsiveContractTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CheckoutHistoryWindowResponsiveContractTests
+    {
+        [Fact]
+        public void CheckoutHistoryWindow_UsesScaledDesktopSafeBounds()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CheckoutHistoryWindow.xaml");
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CheckoutHistoryWindow.xaml.cs");
+
+            Assert.Contains("Width=\"820\" Height=\"620\" MinWidth=\"640\" MinHeight=\"460\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ClipToBounds=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("this.UseResponsiveDefaultSize(820, 620);", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("UseResponsiveDefaultSize(920, 820)", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CheckoutHistoryWindow_UsesVirtualizedBoundedGrid()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CheckoutHistoryWindow.xaml");
+
+            Assert.Contains("x:Name=\"CheckoutHistoryGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.IsVirtualizing=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.VirtualizationMode=\"Recycling\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("DataGridTextColumn Header=\"When\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("DataGridTextColumn Header=\"User\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("DataGridTextColumn Header=\"Action\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CheckoutHistoryWindow_CapsRowsAndReportsOmittedHistory()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CheckoutHistoryWindow.xaml.cs");
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CheckoutHistoryWindow.xaml");
+
+            Assert.Contains("const int MaxVisibleHistoryRows = 500;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("OrderByDescending(log => log.Timestamp)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("orderedLogs.Take(MaxVisibleHistoryRows)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("OmittedLogCount = Math.Max(0, TotalLogCount - VisibleLogCount);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("HasOmittedLogs", xaml, StringComparison.Ordinal);
+            Assert.Contains("OmittedLogSummary", xaml, StringComparison.Ordinal);
+            Assert.Contains("FooterStatusText", xaml, StringComparison.Ordinal);
+            Assert.Contains("Showing {VisibleLogCount:N0} of {TotalLogCount:N0}", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CheckoutHistoryWindow_WrapsHeaderMetricsAndFooter()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CheckoutHistoryWindow.xaml");
+
+            Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" MinWidth=\"220\" MaxWidth=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,8,0,8\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("VisibleLogCount", xaml, StringComparison.Ordinal);
+            Assert.Contains("TotalLogCount", xaml, StringComparison.Ordinal);
+            Assert.Contains("OmittedLogCount", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Esc closes this history window.", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CheckoutHistoryWindow_PreservesKeyboardReviewPath()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CheckoutHistoryWindow.xaml");
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CheckoutHistoryWindow.xaml.cs");
+
+            Assert.Contains("KeyDown=\"CheckoutHistoryWindow_OnKeyDown\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Loaded += (_, _) => CheckoutHistoryGrid.Focus();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (e.Key == Key.Escape)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("CloseButton_Click", codeBehind, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/ItemDetailsWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemDetailsWindowResponsiveContractTests.cs
@@ -10,9 +10,12 @@ namespace InventoryManagementApp.Tests
         public void ItemDetailsWindow_UsesScaledDesktopSafeWindowSizing()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ItemDetailsWindow.xaml");
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ItemDetailsWindow.xaml.cs");
 
             Assert.Contains("Width=\"880\" Height=\"760\" MinWidth=\"700\" MinHeight=\"560\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("this.UseResponsiveDefaultSize(880, 760);", codeBehind, StringComparison.Ordinal);
             Assert.DoesNotContain("Width=\"920\" Height=\"820\" MinWidth=\"780\" MinHeight=\"620\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("UseResponsiveDefaultSize(920, 820)", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -91,6 +94,22 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("OpenCheckoutHistoryCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("OpenRentalHistoryCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("CloseCommand", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemDetailsViewModel_RoutesCheckoutHistoryToStructuredDialog()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemDetailsViewModel.cs");
+            var dialogService = ReadRepoFile("InventoryManagementApp", "Services", "DialogService.cs");
+            var dialogInterface = ReadRepoFile("InventoryManagementApp", "Interfaces", "IDialogService.cs");
+
+            Assert.Contains("_dialogService.ShowCheckoutHistory(ItemModel, logs);", viewModel, StringComparison.Ordinal);
+            Assert.DoesNotContain("string.Join(Environment.NewLine, lines)", viewModel, StringComparison.Ordinal);
+            Assert.DoesNotContain("Select(log => $\"{log.Timestamp:yyyy-MM-dd HH:mm} -", viewModel, StringComparison.Ordinal);
+            Assert.Contains("void ShowCheckoutHistory(ItemModel item, IEnumerable<ActivityLog> logs)", dialogInterface, StringComparison.Ordinal);
+            Assert.Contains("public void ShowCheckoutHistory(ItemModel item, IEnumerable<ActivityLog> logs)", dialogService, StringComparison.Ordinal);
+            Assert.Contains("new CheckoutHistoryWindow(item, logs)", dialogService, StringComparison.Ordinal);
+            Assert.Contains("InvokeOnDispatcher(() => ShowCheckoutHistoryCore(item, logs));", dialogService, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/Interfaces/IDialogService.cs
+++ b/InventoryManagementApp/Interfaces/IDialogService.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Documents;
+using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Interfaces
@@ -27,6 +29,17 @@ namespace InventoryManagementApp.Interfaces
 
         void ShowRentalsFilter(ManageRentalsViewModel viewModel);
         void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history);
+        void ShowCheckoutHistory(ItemModel item, IEnumerable<ActivityLog> logs)
+        {
+            ArgumentNullException.ThrowIfNull(item);
+            ArgumentNullException.ThrowIfNull(logs);
+
+            var rows = logs
+                .OrderByDescending(log => log.Timestamp)
+                .Take(500)
+                .Select(log => $"{log.Timestamp:yyyy-MM-dd HH:mm} - {(string.IsNullOrWhiteSpace(log.UserName) ? "Not recorded" : log.UserName)} - {log.Action}");
+            ShowInfo(string.Join(Environment.NewLine, rows), $"Checkout History - {(string.IsNullOrWhiteSpace(item.ItemNumber) ? "Not recorded" : item.ItemNumber)}");
+        }
         Dictionary<string, string>? ShowImportMapping(
             IEnumerable<string> headers,
             IEnumerable<string> properties,

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-checkout-history-dialog-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-checkout-history-dialog-responsiveness.md
@@ -1,0 +1,30 @@
+# Checkout History Dialog Responsiveness
+
+Date: 2026-07-05
+
+## Completed
+
+- Replaced the Item Details checkout-history plain info-message path with a structured checkout history dialog.
+- Added a compact checkout-history window sized for scaled desktop use with clipped root layout and wrapped header/footer text.
+- Sorted checkout history rows newest-first in the dialog before display.
+- Capped visible checkout history rows at 500 so large audit histories do not create an oversized dialog or long message body.
+- Added visible, loaded, and omitted row summary cards above the grid.
+- Added omitted-row guidance when older rows are intentionally held back for responsiveness.
+- Added a virtualized, read-only checkout history grid with automatic vertical and horizontal scrollbars.
+- Displayed professional checkout-history columns for timestamp, user, and action instead of newline-delimited text.
+- Focused the history grid after load for faster keyboard review.
+- Added Escape-to-close keyboard behavior and a clear Close action.
+- Routed checkout history creation through `DialogService` on the UI dispatcher with normal owner/error handling.
+- Added a default `IDialogService.ShowCheckoutHistory` fallback so existing test doubles keep compiling while the real app uses the structured dialog.
+- Aligned `ItemDetailsWindow` runtime responsive default size with its XAML default size.
+- Added source-contract coverage for the new dialog bounds, virtualization, row cap, omitted-row messaging, keyboard path, service routing, and Item Details sizing alignment.
+
+## Validation
+
+- Source-contract coverage was added in `InventoryManagementApp.Tests/CheckoutHistoryWindowResponsiveContractTests.cs` and extended in `InventoryManagementApp.Tests/ItemDetailsWindowResponsiveContractTests.cs`.
+- GitHub connector readback should be used to confirm the intended source changes because this scheduled Linux environment cannot clone the repository directly or run WPF/.NET validation.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test Item Details checkout-history opening with no history, a small history, and more than 500 audit rows at 1366x768 and higher Windows scaling.

--- a/InventoryManagementApp/Services/DialogService.cs
+++ b/InventoryManagementApp/Services/DialogService.cs
@@ -197,6 +197,23 @@ namespace InventoryManagementApp.Services
             catch (Exception ex) { _logger.LogError(ex, "Failed to show RentalHistoryWindow"); }
         }
 
+        public void ShowCheckoutHistory(ItemModel item, IEnumerable<ActivityLog> logs)
+        {
+            ArgumentNullException.ThrowIfNull(item);
+            ArgumentNullException.ThrowIfNull(logs);
+            InvokeOnDispatcher(() => ShowCheckoutHistoryCore(item, logs));
+        }
+
+        void ShowCheckoutHistoryCore(ItemModel item, IEnumerable<ActivityLog> logs)
+        {
+            var win = new CheckoutHistoryWindow(item, logs)
+            {
+                Title = $"Checkout History - {item.ItemNumber}"
+            };
+            TrySetOwner(win);
+            ShowDialogSafe(win);
+        }
+
         public Dictionary<string, string>? ShowImportMapping(
             IEnumerable<string> headers,
             IEnumerable<string> propertyNames,

--- a/InventoryManagementApp/ViewModels/ItemDetailsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemDetailsViewModel.cs
@@ -362,10 +362,7 @@ namespace InventoryManagementApp.ViewModels
                 return;
             }
 
-            var lines = logs
-                .OrderByDescending(log => log.Timestamp)
-                .Select(log => $"{log.Timestamp:yyyy-MM-dd HH:mm} - {ValueOrNotRecorded(log.UserName)} - {log.Action}");
-            await _dialogService.ShowInfoAsync(string.Join(Environment.NewLine, lines), $"Checkout History - {ValueOrNotRecorded(ItemModel.ItemNumber)}").ConfigureAwait(false);
+            _dialogService.ShowCheckoutHistory(ItemModel, logs);
         }
 
         async Task PlaceReservationAsync()

--- a/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml
@@ -59,7 +59,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Border Grid.Row="0" Style="{StaticResource InfoBanner}" Margin="0,0,0,8" Visibility="{Binding HasOmittedLogs, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Border Grid.Row="0" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource ControlBackgroundBrush}" Padding="10,8" Margin="0,0,0,8" Visibility="{Binding HasOmittedLogs, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock Text="{Binding OmittedLogSummary}" TextWrapping="Wrap"/>
             </Border>
 

--- a/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml
@@ -1,0 +1,100 @@
+<Window x:Class="InventoryManagementApp.Views.Windows.CheckoutHistoryWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Checkout History"
+        Width="820" Height="620" MinWidth="640" MinHeight="460"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}"
+        KeyDown="CheckoutHistoryWindow_OnKeyDown">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+    </Window.Resources>
+
+    <Grid Margin="10" ClipToBounds="True">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="14,12" MinWidth="0">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Left" MinWidth="220" MaxWidth="520" VerticalAlignment="Center">
+                    <TextBlock Text="Checkout History" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock Text="{Binding ItemSummaryText}" Style="{StaticResource HeadingTextBlock}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="Review recent check-out and check-in audit entries without loading an oversized message box." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                </StackPanel>
+                <Button DockPanel.Dock="Right" Style="{StaticResource PrimaryButton}" Content="Close" Click="CloseButton_Click" MinWidth="88" Margin="12,0,0,0" VerticalAlignment="Center"/>
+            </DockPanel>
+        </Border>
+
+        <WrapPanel Grid.Row="1" Margin="0,8,0,8">
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="150" MaxWidth="220" Margin="0,0,8,8">
+                <StackPanel>
+                    <TextBlock Text="Visible" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding VisibleLogCount}" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Rows shown now" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="150" MaxWidth="220" Margin="0,0,8,8">
+                <StackPanel>
+                    <TextBlock Text="Loaded" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding TotalLogCount}" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Rows returned by audit search" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="150" MaxWidth="240" Margin="0,0,8,8">
+                <StackPanel>
+                    <TextBlock Text="Omitted" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding OmittedLogCount}" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Rows held back for responsiveness" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
+        </WrapPanel>
+
+        <Grid Grid.Row="2" MinHeight="240">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0" Style="{StaticResource InfoBanner}" Margin="0,0,0,8" Visibility="{Binding HasOmittedLogs, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBlock Text="{Binding OmittedLogSummary}" TextWrapping="Wrap"/>
+            </Border>
+
+            <DataGrid x:Name="CheckoutHistoryGrid"
+                      Grid.Row="1"
+                      ItemsSource="{Binding VisibleLogs}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False"
+                      CanUserReorderColumns="False"
+                      SelectionMode="Single"
+                      SelectionUnit="FullRow"
+                      EnableRowVirtualization="True"
+                      EnableColumnVirtualization="True"
+                      VirtualizingPanel.IsVirtualizing="True"
+                      VirtualizingPanel.VirtualizationMode="Recycling"
+                      ScrollViewer.CanContentScroll="True"
+                      ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                      HeadersVisibility="Column"
+                      GridLinesVisibility="Horizontal">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="When" Binding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="150" MinWidth="130"/>
+                    <DataGridTextColumn Header="User" Binding="{Binding UserName, TargetNullValue=Not recorded}" Width="160" MinWidth="120"/>
+                    <DataGridTextColumn Header="Action" Binding="{Binding Action, TargetNullValue=Not recorded}" Width="*" MinWidth="260"/>
+                </DataGrid.Columns>
+            </DataGrid>
+        </Grid>
+
+        <Border Grid.Row="3" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
+            <WrapPanel>
+                <TextBlock Text="{Binding FooterStatusText}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,12,4"/>
+                <TextBlock Text="Esc closes this history window." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,0,4"/>
+            </WrapPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Utilities.Extensions;
+using InventoryManagementApp.ViewModels;
+
+namespace InventoryManagementApp.Views.Windows
+{
+    public partial class CheckoutHistoryWindow : Window
+    {
+        const int MaxVisibleHistoryRows = 500;
+
+        public CheckoutHistoryWindow(ItemModel item, IEnumerable<ActivityLog> logs)
+        {
+            ArgumentNullException.ThrowIfNull(item);
+            ArgumentNullException.ThrowIfNull(logs);
+
+            var orderedLogs = logs
+                .OrderByDescending(log => log.Timestamp)
+                .ToList();
+
+            ItemSummaryText = BuildItemSummary(item);
+            TotalLogCount = orderedLogs.Count;
+            VisibleLogs = new ObservableCollection<ActivityLog>(orderedLogs.Take(MaxVisibleHistoryRows));
+            VisibleLogCount = VisibleLogs.Count;
+            OmittedLogCount = Math.Max(0, TotalLogCount - VisibleLogCount);
+            HasOmittedLogs = OmittedLogCount > 0;
+            OmittedLogSummary = HasOmittedLogs
+                ? $"Showing the first {VisibleLogCount:N0} newest checkout history rows. {OmittedLogCount:N0} older rows are omitted from this dialog to keep review responsive."
+                : string.Empty;
+            FooterStatusText = TotalLogCount == 0
+                ? "No checkout or check-in history rows were returned for this item."
+                : $"Showing {VisibleLogCount:N0} of {TotalLogCount:N0} checkout history rows, newest first.";
+
+            InitializeComponent();
+            this.UseResponsiveDefaultSize(820, 620);
+            DataContext = this;
+            Loaded += (_, _) => CheckoutHistoryGrid.Focus();
+        }
+
+        public string ItemSummaryText { get; }
+        public ObservableCollection<ActivityLog> VisibleLogs { get; }
+        public int TotalLogCount { get; }
+        public int VisibleLogCount { get; }
+        public int OmittedLogCount { get; }
+        public bool HasOmittedLogs { get; }
+        public string OmittedLogSummary { get; }
+        public string FooterStatusText { get; }
+
+        void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+
+        void CheckoutHistoryWindow_OnKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                e.Handled = true;
+                Close();
+            }
+        }
+
+        static string BuildItemSummary(ItemModel item)
+        {
+            var number = string.IsNullOrWhiteSpace(item.ItemNumber) ? "Not recorded" : item.ItemNumber;
+            var name = string.IsNullOrWhiteSpace(item.Name) ? "Unnamed item" : item.Name;
+            return $"{number} - {name}";
+        }
+    }
+}

--- a/InventoryManagementApp/Views/Windows/ItemDetailsWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ItemDetailsWindow.xaml.cs
@@ -21,7 +21,7 @@ namespace InventoryManagementApp.Views.Windows
             ActivityLogService activityLogService)
         {
             InitializeComponent();
-            this.UseResponsiveDefaultSize(920, 820);
+            this.UseResponsiveDefaultSize(880, 760);
             DataContext = new ItemDetailsViewModel(item, itemService, customerService, rentalService, dialogService, () => Close(), reservationService, settingsService, activityLogService);
             this.DisposeDataContextOnUnload();
         }


### PR DESCRIPTION
## What changed

- Replaced the Item Details checkout-history long info-message path with a structured checkout history dialog.
- Added a compact, clipped checkout-history window sized for scaled desktop use.
- Displayed checkout history in a virtualized read-only grid with timestamp, user, and action columns.
- Sorted history rows newest-first before display.
- Capped visible checkout-history rows at 500 to avoid oversized dialogs and sluggish long text rendering.
- Added visible, loaded, and omitted row summary cards.
- Added omitted-row guidance when older rows are held back for responsiveness.
- Focused the history grid after load for faster keyboard review.
- Added Escape-to-close and a visible Close action.
- Routed the real dialog service through the UI dispatcher with normal owner/error handling.
- Added a default `IDialogService.ShowCheckoutHistory` fallback so existing test doubles remain compatible.
- Aligned `ItemDetailsWindow` runtime responsive default sizing with its XAML sizing.
- Added source-contract coverage for the dialog bounds, virtualization, row cap, omitted-row messaging, keyboard path, service routing, and Item Details sizing alignment.
- Recorded the completed workflow slice in progress notes.

## Why this was highest value

Recent runs covered many primary pages, grids, and shared print workflows. Item Details still had a concrete data-display responsiveness gap: checkout history was rendered as a newline-delimited modal info message, which becomes hard to scan and expensive to display as audit history grows. This is a central workflow reached from item review, so improving it strengthens a real existing path without inventing a new feature.

## Why this is real progress

This is a vertical workflow slice across view-model routing, dialog-service ownership/dispatcher handling, a new responsive WPF data-display window, keyboard behavior, row capping, source-contract coverage, and progress notes. It includes more than ten operator-facing improvements while staying inside the existing WPF/MVVM structure.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, 10 commits ahead, 0 behind, and focused to:
  - `InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml`
  - `InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml.cs`
  - `InventoryManagementApp/ViewModels/ItemDetailsViewModel.cs`
  - `InventoryManagementApp/Views/Windows/ItemDetailsWindow.xaml.cs`
  - `InventoryManagementApp/Interfaces/IDialogService.cs`
  - `InventoryManagementApp/Services/DialogService.cs`
  - `InventoryManagementApp.Tests/CheckoutHistoryWindowResponsiveContractTests.cs`
  - `InventoryManagementApp.Tests/ItemDetailsWindowResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-05-checkout-history-dialog-responsiveness.md`
- Connector readback confirmed the new virtualized grid, 500-row cap, omitted-row status, keyboard close path, dialog-service routing, Item Details structured-dialog call, and source-contract assertions are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs on branch head `d65d02e71bf69ebfd306ecca775cf1f87a604dc5` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Item Details checkout-history behavior with no rows, small histories, and 500+ audit rows

These require a Windows/.NET/WPF-capable checkout. Direct checkout is blocked in this scheduled Linux environment by GitHub HTTP `CONNECT tunnel failed, response 403`, and `gh`, `pwsh`, and Windows desktop tooling are unavailable.

## Follow-up

- Run the full Windows validation runner.
- Smoke test Item Details checkout-history opening at 1366x768 and higher Windows scaling with no history, a small history, and more than 500 audit rows.