### PR TITLE
[codex] Improve shared popup chrome responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ThemePopupChromeResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ThemePopupChromeResponsiveContractTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ThemePopupChromeResponsiveContractTests
+    {
+        [Fact]
+        public void App_LoadsPopupChromeAfterControlOverridesSoSharedPopupsWin()
+        {
+            var app = ReadRepoFile("InventoryManagementApp", "App.xaml");
+
+            var controlOverrides = app.IndexOf("Resources/Theme.ControlCustomizationOverrides.xaml", StringComparison.Ordinal);
+            var popupOverrides = app.IndexOf("Resources/Theme.PopupChromeOverrides.xaml", StringComparison.Ordinal);
+            var converters = app.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
+
+            Assert.True(controlOverrides >= 0);
+            Assert.True(popupOverrides > controlOverrides);
+            Assert.True(converters > popupOverrides);
+        }
+
+        [Fact]
+        public void PopupChrome_ContextMenusUseDropdownBrushAndBoundedScrollableTemplate()
+        {
+            var xaml = ReadPopupChrome();
+
+            Assert.Contains("<Style TargetType=\"ContextMenu\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Background\" Value=\"{DynamicResource ThemeMenuDropDownBackgroundBrush}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"180\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"440\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxHeight\" Value=\"420\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ControlTemplate TargetType=\"ContextMenu\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer MaxHeight=\"{TemplateBinding MaxHeight}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("KeyboardNavigation.DirectionalNavigation=\"Contained\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Background\" Value=\"{DynamicResource ThemePopupSurfaceBrush}\"/>\n        <Setter Property=\"BorderBrush\" Value=\"{DynamicResource BorderBrushAlt}\"/>\n        <Setter Property=\"BorderThickness\" Value=\"{DynamicResource ThemeBorderThickness}\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PopupChrome_MenuAndContextMenuForceThemedSystemSelectionBrushes()
+        {
+            var xaml = ReadPopupChrome();
+
+            Assert.Contains("{x:Static SystemColors.HighlightBrushKey}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{x:Static SystemColors.HighlightTextBrushKey}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{x:Static SystemColors.ControlTextBrushKey}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{x:Static SystemColors.GrayTextBrushKey}", xaml, StringComparison.Ordinal);
+            Assert.Contains("Color=\"{DynamicResource Col.Accent}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Color=\"{DynamicResource Col.OnAccent}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Color=\"{DynamicResource Col.Fg}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Color=\"{DynamicResource Col.FgMuted}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PopupChrome_MenuItemsTrimLongLabelsAndKeepDisabledTextReadable()
+        {
+            var xaml = ReadPopupChrome();
+
+            Assert.Contains("<Style x:Key=\"ThemePopupMenuItemStyle\" TargetType=\"MenuItem\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"140\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"420\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"TextBlock.TextWrapping\" Value=\"NoWrap\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"TextBlock.TextTrimming\" Value=\"CharacterEllipsis\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Trigger Property=\"IsHighlighted\" Value=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"Foreground\" Value=\"{DynamicResource ItemHoverForegroundBrush}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Trigger Property=\"IsSubmenuOpen\" Value=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"Foreground\" Value=\"{DynamicResource ForegroundMutedBrush}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"Opacity\" Value=\"{DynamicResource ThemeDisabledOpacity}\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PopupChrome_ComboBoxesUseVirtualizedBoundedDropDowns()
+        {
+            var xaml = ReadPopupChrome();
+
+            Assert.Contains("<Style x:Key=\"ThemeResponsiveComboBoxStyle\" TargetType=\"ComboBox\" BasedOn=\"{StaticResource ThemedComboBoxStyle}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"ItemContainerStyle\" Value=\"{StaticResource ThemePopupComboBoxItemStyle}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxDropDownHeight\" Value=\"320\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"VirtualizingPanel.IsVirtualizing\" Value=\"True\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"VirtualizingPanel.VirtualizationMode\" Value=\"Recycling\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<VirtualizingStackPanel/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"420\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxHeight=\"{TemplateBinding MaxDropDownHeight}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ScrollViewer>\n                                    <ItemsPresenter", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PopupChrome_ComboBoxItemsTrimLongValuesAndUseFocusReadableColors()
+        {
+            var xaml = ReadPopupChrome();
+
+            Assert.Contains("<Style x:Key=\"ThemePopupComboBoxItemStyle\" TargetType=\"ComboBoxItem\" BasedOn=\"{StaticResource DropdownItemStyle}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"420\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"HorizontalContentAlignment\" Value=\"Stretch\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"TextBlock.TextWrapping\" Value=\"NoWrap\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"TextBlock.TextTrimming\" Value=\"CharacterEllipsis\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Trigger Property=\"IsKeyboardFocusWithin\" Value=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"Foreground\" Value=\"{DynamicResource ItemHoverForegroundBrush}\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PopupChrome_ToolTipsAndStatusBarsUseLayoutRoundingAndProfessionalTextBounds()
+        {
+            var xaml = ReadPopupChrome();
+
+            Assert.Contains("<Style TargetType=\"ToolTip\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"420\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"TextBlock.TextWrapping\" Value=\"Wrap\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"SnapsToDevicePixels\" Value=\"True\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"UseLayoutRounding\" Value=\"True\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style TargetType=\"StatusBar\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style TargetType=\"StatusBarItem\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"TextBlock.TextTrimming\" Value=\"CharacterEllipsis\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ThemeService_KeepsMenuDropdownOpacityIndependentForMenusAndComboBoxes()
+        {
+            var service = ReadRepoFile("InventoryManagementApp", "Services", "ThemeService.cs");
+            var tests = ReadRepoFile("InventoryManagementApp.Tests", "ThemeServiceTests.cs");
+
+            Assert.Contains("Set(resources, \"ThemeMenuDropDownBackgroundBrush\", CreateBrush(settings.SurfaceAltColor, settings.MenuDropDownOpacity));", service, StringComparison.Ordinal);
+            Assert.Contains("Set(resources, \"ComboBoxPopupBackgroundBrush\", CreateBrush(settings.SurfaceAltColor, settings.MenuDropDownOpacity));", service, StringComparison.Ordinal);
+            Assert.Contains("ApplyCustomTheme_MenuDropdownOpacityIsIndependentFromMainSurfaces", tests, StringComparison.Ordinal);
+            Assert.Contains("Assert.Equal(0xEB, ((SolidColorBrush)app.Resources[\"ThemeMenuDropDownBackgroundBrush\"]).Color.A);", tests, StringComparison.Ordinal);
+            Assert.Contains("Assert.Equal(0xEB, ((SolidColorBrush)app.Resources[\"ComboBoxPopupBackgroundBrush\"]).Color.A);", tests, StringComparison.Ordinal);
+        }
+
+        private static string ReadPopupChrome()
+            => ReadRepoFile("InventoryManagementApp", "Resources", "Theme.PopupChromeOverrides.xaml");
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-popup-chrome-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-popup-chrome-responsiveness.md
@@ -1,0 +1,21 @@
+# Popup Chrome Responsiveness
+
+Completed in this pass:
+
+- Routed shared context-menu surfaces through the independent menu dropdown background brush so admin-controlled dropdown opacity affects menus consistently with combo-box dropdowns.
+- Added a bounded context-menu template with maximum width/height, disabled horizontal scrolling, vertical scrolling, layout rounding, and contained keyboard navigation.
+- Added themed system selection brush resources for menus, context menus, and popup item containers so dark-theme selection and disabled text stay readable.
+- Added a shared popup combo-box item style that trims long values, stretches item content, keeps keyboard focus readable, and preserves disabled-state opacity.
+- Kept combo-box dropdowns virtualized with recycling panels, capped dropdown height, disabled horizontal scrolling, and bounded popup width.
+- Tightened menu item display with bounded widths, ellipsis trimming, hover foreground, submenu selected foreground, and muted disabled foreground.
+- Added tooltip/status-bar layout rounding and status text trimming so popup-adjacent surfaces stay crisp and bounded at scaled desktop sizes.
+- Added source-contract coverage for popup dictionary ordering, context-menu bounds, menu selection resources, menu item trimming, virtualized combo-box dropdowns, combo-box item trimming/focus state, tooltip/status text bounds, and ThemeService dropdown opacity resources.
+
+Validation:
+
+- Source inspection confirmed `Theme.PopupChromeOverrides.xaml` remains loaded after control customization overrides in `App.xaml`.
+- Local XML parse was used for the edited popup resource dictionary in the scheduled Linux environment.
+
+Not run here:
+
+- `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime smoke testing, screenshots, and Windows scaling checks remain unavailable because this scheduled Linux environment cannot clone the repository directly and does not include the required Windows/.NET/WPF tooling.

--- a/InventoryManagementApp/Resources/Theme.PopupChromeOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.PopupChromeOverrides.xaml
@@ -20,7 +20,39 @@
         </Setter>
     </Style>
 
+    <Style x:Key="ThemePopupComboBoxItemStyle" TargetType="ComboBoxItem" BasedOn="{StaticResource DropdownItemStyle}">
+        <Style.Resources>
+            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{DynamicResource Col.Accent}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="{DynamicResource Col.OnAccent}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="{DynamicResource Col.Fg}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.GrayTextBrushKey}" Color="{DynamicResource Col.FgMuted}"/>
+        </Style.Resources>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="MaxWidth" Value="420"/>
+        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="TextBlock.TextWrapping" Value="NoWrap"/>
+        <Setter Property="TextBlock.TextTrimming" Value="CharacterEllipsis"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="ThemePopupMenuItemStyle" TargetType="MenuItem">
+        <Style.Resources>
+            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{DynamicResource Col.Accent}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="{DynamicResource Col.OnAccent}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="{DynamicResource Col.Fg}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.GrayTextBrushKey}" Color="{DynamicResource Col.FgMuted}"/>
+        </Style.Resources>
         <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeTransparentBrush}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
@@ -28,26 +60,32 @@
         <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
-        <Setter Property="MaxWidth" Value="360"/>
+        <Setter Property="MinWidth" Value="140"/>
+        <Setter Property="MaxWidth" Value="420"/>
         <Setter Property="Padding" Value="10,5"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="TextBlock.TextWrapping" Value="NoWrap"/>
+        <Setter Property="TextBlock.TextTrimming" Value="CharacterEllipsis"/>
         <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
         <Style.Triggers>
             <Trigger Property="IsHighlighted" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsSubmenuOpen" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
                 <Setter Property="Foreground" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
                 <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
 
     <Style x:Key="ThemeResponsiveComboBoxStyle" TargetType="ComboBox" BasedOn="{StaticResource ThemedComboBoxStyle}">
+        <Setter Property="ItemContainerStyle" Value="{StaticResource ThemePopupComboBoxItemStyle}"/>
         <Setter Property="MaxDropDownHeight" Value="320"/>
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
@@ -131,12 +169,14 @@
                                Focusable="False"
                                PopupAnimation="None">
                             <Border MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                    MaxWidth="420"
                                     MaxHeight="{TemplateBinding MaxDropDownHeight}"
                                     Background="{DynamicResource ComboBoxPopupBackgroundBrush}"
                                     BorderBrush="{DynamicResource BorderBrushAlt}"
-                                    BorderThickness="1"
-                                    CornerRadius="{StaticResource RadiusSmall}"
-                                    SnapsToDevicePixels="True">
+                                    BorderThickness="{DynamicResource ThemeControlBorderThickness}"
+                                    CornerRadius="{DynamicResource ThemeInputCornerRadius}"
+                                    SnapsToDevicePixels="True"
+                                    UseLayoutRounding="True">
                                 <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}"
                                               VerticalScrollBarVisibility="Auto"
                                               HorizontalScrollBarVisibility="Disabled"
@@ -154,7 +194,7 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="ToggleButton" Property="Foreground" Value="{DynamicResource DisabledForegroundBrush}"/>
                             <Setter TargetName="ToggleButton" Property="Background" Value="{DynamicResource DisabledBackgroundBrush}"/>
-                            <Setter TargetName="ToggleButton" Property="BorderBrush" Value="#333"/>
+                            <Setter TargetName="ToggleButton" Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
                         </Trigger>
                         <Trigger Property="IsKeyboardFocusWithin" Value="True">
                             <Setter TargetName="ToggleButton" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
@@ -166,13 +206,22 @@
     </Style>
 
     <Style TargetType="ContextMenu">
-        <Setter Property="Background" Value="{DynamicResource ThemePopupSurfaceBrush}"/>
+        <Style.Resources>
+            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{DynamicResource Col.Accent}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="{DynamicResource Col.OnAccent}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="{DynamicResource Col.Fg}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.GrayTextBrushKey}" Color="{DynamicResource Col.FgMuted}"/>
+        </Style.Resources>
+        <Setter Property="Background" Value="{DynamicResource ThemeMenuDropDownBackgroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
         <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="MinWidth" Value="180"/>
+        <Setter Property="MaxWidth" Value="440"/>
         <Setter Property="MaxHeight" Value="420"/>
+        <Setter Property="Padding" Value="4"/>
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
         <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>
@@ -180,9 +229,37 @@
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="UseLayoutRounding" Value="True"/>
         <Setter Property="Effect" Value="{x:Null}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ContextMenu">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{DynamicResource ThemePanelCornerRadius}"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True"
+                            UseLayoutRounding="True">
+                        <ScrollViewer MaxHeight="{TemplateBinding MaxHeight}"
+                                      VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled"
+                                      CanContentScroll="True"
+                                      KeyboardNavigation.DirectionalNavigation="Contained">
+                            <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                        </ScrollViewer>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="Menu">
+        <Style.Resources>
+            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{DynamicResource Col.Accent}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="{DynamicResource Col.OnAccent}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="{DynamicResource Col.Fg}"/>
+            <SolidColorBrush x:Key="{x:Static SystemColors.GrayTextBrushKey}" Color="{DynamicResource Col.FgMuted}"/>
+        </Style.Resources>
         <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
@@ -192,6 +269,7 @@
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
     </Style>
 
     <Style TargetType="ComboBox" BasedOn="{StaticResource ThemeResponsiveComboBoxStyle}"/>
@@ -200,7 +278,7 @@
     <Style TargetType="ToolTip">
         <Setter Property="Background" Value="{DynamicResource ThemePopupSurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
@@ -208,6 +286,8 @@
         <Setter Property="Padding" Value="8,5"/>
         <Setter Property="TextBlock.TextWrapping" Value="Wrap"/>
         <Setter Property="HasDropShadow" Value="False"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
         <Setter Property="Effect" Value="{x:Null}"/>
     </Style>
 
@@ -219,6 +299,8 @@
         <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
         <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
         <Setter Property="Effect" Value="{x:Null}"/>
     </Style>
 
@@ -227,6 +309,7 @@
         <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
         <Setter Property="Padding" Value="8,2"/>
+        <Setter Property="TextBlock.TextTrimming" Value="CharacterEllipsis"/>
     </Style>
 
     <Style TargetType="Separator" BasedOn="{StaticResource ThemePopupSeparatorStyle}"/>


### PR DESCRIPTION
## What changed

- Routed shared context menu surfaces through the independent menu dropdown background brush so admin-controlled dropdown opacity now affects menus consistently with combo-box dropdowns.
- Added a bounded, scrollable context-menu template with disabled horizontal scrolling, contained keyboard navigation, layout rounding, maximum width, and maximum height.
- Added themed system selection brush resources across menus, context menus, and popup item containers so dark-theme selection and disabled text remain readable.
- Added a shared popup combo-box item style with trimmed long values, stretched content, keyboard-focus readability, and disabled-state opacity.
- Kept combo-box dropdowns virtualized with recycling panels, bounded popup width, capped dropdown height, and disabled horizontal scrolling.
- Tightened menu item display with bounded widths, ellipsis trimming, hover foreground, submenu selected foreground, and muted disabled foreground.
- Added tooltip/status-bar layout rounding and status text trimming for crisper popup-adjacent surfaces at scaled desktop sizes.
- Added source-contract coverage for popup dictionary ordering, context-menu bounds, menu selection resources, menu item trimming, virtualized combo-box dropdowns, combo-box item trimming/focus state, tooltip/status bounds, and ThemeService dropdown opacity resources.
- Recorded the completed work in `InventoryManagementApp/ProgressNotes/2026-07-05-popup-chrome-responsiveness.md`.

## Why this was highest value

The current ToDo calls out visual QA risk around dark-theme top navigation dropdowns, context menus, combo boxes, and theme-customized popup surfaces. This is a shared UI responsiveness/data-display slice that improves those surfaces once instead of repeating page-specific loading guard work already completed in recent PRs.

## Why the scope is real progress

This touches the shared popup chrome used across the app: context menus, top-level menus, combo-box dropdowns, tooltips, and status surfaces. It improves bounded layout, readable theming, keyboard navigation containment, virtualization, and trimmed display for long operational values.

## Validation

- Parsed `InventoryManagementApp/Resources/Theme.PopupChromeOverrides.xaml` locally as XML.
- Source-inspected the edited popup dictionary and the new contract tests.
- GitHub compare/readback confirmed the branch is current with `master`, ahead by three commits, and focused to the intended three files.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke testing
- screenshots and Windows scaling checks

Those remain unavailable in this scheduled Linux environment because direct clone is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and `dotnet`, `pwsh`, `gh`, and a WPF runtime are not installed.

## Follow-up

Run the full validation runner and a Windows WPF smoke test for dark-theme top navigation dropdowns, context menus, combo boxes, and tooltip/status surfaces when a Windows/.NET-capable checkout is available.