### PR TITLE
Improve rental desk loading action states

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
@@ -94,7 +94,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Border Grid.Column=\"0\" MaxWidth=\"330\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border MaxHeight=\"156\" Padding=\"0\" Margin=\"0,0,0,8\" ClipToBounds=\"True\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel Margin=\"0,4,0,0\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<WrapPanel>\n                            <Button Style=\"{StaticResource GhostButton}\" Content=\"History\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel>\n                            <Button Style=\"{StaticResource RentalBusyGhostButton}\" Content=\"History\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Column=\"0\" Width=\"320\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Columns=\"2\" Margin=\"0,4,0,0\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Columns=\"2\">", xaml, StringComparison.Ordinal);
@@ -166,6 +166,38 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("e.Handled = true;", selectionBlock, StringComparison.Ordinal);
             Assert.Contains("return row;", selectionBlock, StringComparison.Ordinal);
             Assert.DoesNotContain("private void SelectRowForContextMenu", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageRentalsPage_DisablesRentalActionsAndGridsDuringLoading()
+        {
+            var xaml = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml"));
+
+            Assert.Contains("<Style x:Key=\"RentalBusyPrimaryButton\" TargetType=\"Button\" BasedOn=\"{StaticResource PrimaryButton}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"RentalBusyGhostButton\" TargetType=\"Button\" BasedOn=\"{StaticResource GhostButton}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"RentalBusyDataGridStyle\" TargetType=\"DataGrid\" BasedOn=\"{StaticResource VirtualizedDataGridStyle}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<DataTrigger Binding=\"{Binding IsLoading}\" Value=\"True\">\n                    <Setter Property=\"IsEnabled\" Value=\"False\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"Opacity\" Value=\"0.72\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource RentalBusyDataGridStyle}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource RentalBusyPrimaryButton}\" Content=\"Check In\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource RentalBusyGhostButton}\" Content=\"Print Queue\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Style=\"{StaticResource PrimaryButton}\" Content=\"Check In\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Style=\"{StaticResource VirtualizedDataGridStyle}\">", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageRentalsPage_SuppressesEmptyStatesAndShowsBoundedLoadingOverlaysDuringRefresh()
+        {
+            var xaml = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml"));
+
+            Assert.Contains("<MultiDataTrigger>\n                                        <MultiDataTrigger.Conditions>\n                                            <Condition Binding=\"{Binding Rentals.Count}\" Value=\"0\"/>\n                                            <Condition Binding=\"{Binding IsLoading}\" Value=\"False\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<MultiDataTrigger>\n                                        <MultiDataTrigger.Conditions>\n                                            <Condition Binding=\"{Binding PendingRequests.Count}\" Value=\"0\"/>\n                                            <Condition Binding=\"{Binding IsLoading}\" Value=\"False\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"360\" MinHeight=\"104\" Margin=\"12\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Center\" Visibility=\"{Binding IsLoading, Converter={StaticResource BoolToVis}}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Column=\"0\" MaxWidth=\"360\" MinHeight=\"104\" Margin=\"12\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Center\" Visibility=\"{Binding IsLoading, Converter={StaticResource BoolToVis}}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Refreshing rental desk\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Refreshing request queue\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Keeping the current rows visible while rental, request, and print actions pause until the refresh completes.", xaml, StringComparison.Ordinal);
+            Assert.Contains("Request rows remain visible while details, status changes, and print actions pause for the latest rental state.", xaml, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-05-rental-desk-loading-action-states.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-05-rental-desk-loading-action-states.md
@@ -1,0 +1,20 @@
+# Rental Desk Loading And Action State Polish - 2026-07-05
+
+## Completed
+
+- Added loading-aware rental desk button styles so primary rental actions pause while rows refresh.
+- Added loading-aware ghost/action button styling so print, history, delete, and queue actions pause during refresh.
+- Applied the busy button styles to toolbar, advisor handoff, footer, request queue, and request-detail action surfaces.
+- Added a loading-aware data-grid style that keeps rental and request rows visible while disabling row interaction during refresh.
+- Kept virtualized rental and request grids on the shared virtualized grid style through the busy-grid wrapper.
+- Suppressed the rental empty state while `IsLoading` is true so operators do not see a false no-results card during refresh.
+- Suppressed the request queue empty state while `IsLoading` is true so request refreshes do not flash a false empty queue.
+- Added a bounded rental-desk loading overlay explaining that rows stay visible and actions pause until refresh completes.
+- Added a bounded request-queue loading overlay explaining that details, status changes, and print actions pause until state is current.
+- Preserved filter/search input access and the existing top progress indicator while making expensive row/document actions visibly unavailable.
+- Extended source-contract coverage for busy styles, disabled grids, loading overlays, and empty-state suppression.
+
+## Validation
+
+- GitHub connector readback and comparison were used to review the XAML and source-contract changes on the branch.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime walkthrough, screenshots, and scaling checks could not be run because this scheduled Linux environment cannot clone the repository directly and does not provide Windows/.NET/WPF tooling.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -49,6 +49,33 @@
         <Style x:Key="RentalFilterButton" TargetType="Button" BasedOn="{StaticResource GhostButton}">
             <Setter Property="MinHeight" Value="30"/>
             <Setter Property="Margin" Value="0,0,6,4"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsLoading}" Value="True">
+                    <Setter Property="IsEnabled" Value="False"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="RentalBusyPrimaryButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsLoading}" Value="True">
+                    <Setter Property="IsEnabled" Value="False"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="RentalBusyGhostButton" TargetType="Button" BasedOn="{StaticResource GhostButton}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsLoading}" Value="True">
+                    <Setter Property="IsEnabled" Value="False"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="RentalBusyDataGridStyle" TargetType="DataGrid" BasedOn="{StaticResource VirtualizedDataGridStyle}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsLoading}" Value="True">
+                    <Setter Property="IsEnabled" Value="False"/>
+                    <Setter Property="Opacity" Value="0.72"/>
+                </DataTrigger>
+            </Style.Triggers>
         </Style>
     </Page.Resources>
 
@@ -68,14 +95,14 @@
                     <TextBlock Text="Run active checkouts, returns, customer documents, and follow-up requests from one rental desk." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
                 <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="12,0,0,0">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRentalDetailsCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Request" Command="{Binding PlaceRequestCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Pick Slip" Command="{Binding PrintPickingSlipCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Invoice" Command="{Binding PrintInvoiceCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteRentalCommand}" Margin="0,0,0,6"/>
+                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Details" Command="{Binding OpenRentalDetailsCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Request" Command="{Binding PlaceRequestCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="Pick Slip" Command="{Binding PrintPickingSlipCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="Invoice" Command="{Binding PrintInvoiceCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="Delete" Command="{Binding DeleteRentalCommand}" Margin="0,0,0,6"/>
                 </WrapPanel>
             </DockPanel>
         </Border>
@@ -161,7 +188,7 @@
                               ScrollViewer.CanContentScroll="True"
                               ScrollViewer.HorizontalScrollBarVisibility="Auto"
                               ScrollViewer.VerticalScrollBarVisibility="Auto"
-                              Style="{StaticResource VirtualizedDataGridStyle}">
+                              Style="{StaticResource RentalBusyDataGridStyle}">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
                                 <EventSetter Event="MouseDoubleClick" Handler="RentalRow_MouseDoubleClick"/>
@@ -197,15 +224,29 @@
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Rentals.Count}" Value="0">
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding Rentals.Count}" Value="0"/>
+                                            <Condition Binding="{Binding IsLoading}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
                                         <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
+                                    </MultiDataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
                             <TextBlock Text="No rentals found" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
                             <TextBlock Text="Adjust the search, date range, or status filter to find an active or returned rental." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Row="2" MaxWidth="360" MinHeight="104" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}"/>
+                        </Border.Style>
+                        <StackPanel>
+                            <ProgressBar IsIndeterminate="True" Height="6" Margin="0,0,0,10"/>
+                            <TextBlock Text="Refreshing rental desk" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="Keeping the current rows visible while rental, request, and print actions pause until the refresh completes." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
                 </Grid>
@@ -264,12 +305,12 @@
                             </Border>
 
                             <WrapPanel Margin="0,0,0,8">
-                                <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,4,4"/>
-                                <Button Style="{StaticResource PrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,4,4"/>
-                                <Button Style="{StaticResource PrimaryButton}" Content="Request" Command="{Binding PlaceRequestCommand}" Margin="0,0,4,4"/>
-                                <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRentalDetailsCommand}" Margin="0,0,4,4"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Pick Slip" Command="{Binding PrintPickingSlipCommand}" Margin="0,0,4,4"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Invoice" Command="{Binding PrintInvoiceCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Request" Command="{Binding PlaceRequestCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Details" Command="{Binding OpenRentalDetailsCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource RentalBusyGhostButton}" Content="Pick Slip" Command="{Binding PrintPickingSlipCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource RentalBusyGhostButton}" Content="Invoice" Command="{Binding PrintInvoiceCommand}" Margin="0,0,4,4"/>
                             </WrapPanel>
 
                             <Border Style="{StaticResource DesktopNoteCard}" Margin="0,6,0,0">
@@ -282,10 +323,10 @@
                     </ScrollViewer>
                     <Border Grid.Row="2" Style="{StaticResource DesktopPaneSubheader}">
                         <WrapPanel>
-                            <Button Style="{StaticResource GhostButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Rental" Command="{Binding PrintRentalCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Checked Out" Command="{Binding PrintCheckedOutCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Clear Filter" Command="{Binding ClearFilterCommand}" Margin="0,0,0,4"/>
+                            <Button Style="{StaticResource RentalBusyGhostButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource RentalBusyGhostButton}" Content="Print Rental" Command="{Binding PrintRentalCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource RentalBusyGhostButton}" Content="Print Checked Out" Command="{Binding PrintCheckedOutCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource RentalBusyGhostButton}" Content="Clear Filter" Command="{Binding ClearFilterCommand}" Margin="0,0,0,4"/>
                         </WrapPanel>
                     </Border>
                 </Grid>
@@ -307,11 +348,11 @@
                             <TextBlock Text="Confirm, cancel, print, and route customer holds tied to unavailable rental items." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                         <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="12,0,0,0">
-                            <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="0,0,4,6"/>
-                            <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,6"/>
-                            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,4,6"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Request" Command="{Binding PrintRequestCommand}" Margin="0,0,4,6"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Queue" Command="{Binding PrintRequestsCommand}" Margin="0,0,0,6"/>
+                            <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="0,0,4,6"/>
+                            <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,6"/>
+                            <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,4,6"/>
+                            <Button Style="{StaticResource RentalBusyGhostButton}" Content="Print Request" Command="{Binding PrintRequestCommand}" Margin="0,0,4,6"/>
+                            <Button Style="{StaticResource RentalBusyGhostButton}" Content="Print Queue" Command="{Binding PrintRequestsCommand}" Margin="0,0,0,6"/>
                         </WrapPanel>
                     </DockPanel>
                 </Border>
@@ -334,7 +375,7 @@
                               ScrollViewer.CanContentScroll="True"
                               ScrollViewer.HorizontalScrollBarVisibility="Auto"
                               ScrollViewer.VerticalScrollBarVisibility="Auto"
-                              Style="{StaticResource VirtualizedDataGridStyle}">
+                              Style="{StaticResource RentalBusyDataGridStyle}">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
                                 <EventSetter Event="MouseDoubleClick" Handler="RequestRow_MouseDoubleClick"/>
@@ -409,10 +450,10 @@
                                     </StackPanel>
                                 </Border>
                                 <WrapPanel Margin="0,4,0,0">
-                                    <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="0,0,4,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintRequestCommand}" Margin="0,0,0,4"/>
+                                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="0,0,4,4"/>
+                                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="Print" Command="{Binding PrintRequestCommand}" Margin="0,0,0,4"/>
                                 </WrapPanel>
                             </StackPanel>
                         </ScrollViewer>
@@ -422,15 +463,29 @@
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding PendingRequests.Count}" Value="0">
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding PendingRequests.Count}" Value="0"/>
+                                            <Condition Binding="{Binding IsLoading}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
                                         <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
+                                    </MultiDataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
                         <StackPanel>
                             <TextBlock Text="No open requests" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
                             <TextBlock Text="Requests placed from active unavailable rentals will appear here for confirm, cancel, print, and customer follow-up actions." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="0" MaxWidth="360" MinHeight="104" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}"/>
+                        </Border.Style>
+                        <StackPanel>
+                            <ProgressBar IsIndeterminate="True" Height="6" Margin="0,0,0,10"/>
+                            <TextBlock Text="Refreshing request queue" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="Request rows remain visible while details, status changes, and print actions pause for the latest rental state." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                     </Border>
                 </Grid>


### PR DESCRIPTION
## What changed

- Added loading-aware rental desk button styles for primary and secondary actions.
- Disabled rental and request grids during `IsLoading` while keeping existing rows visible for context.
- Suppressed false empty-state cards during active rental/request refreshes.
- Added bounded rental-desk and request-queue loading overlays with operator-facing status text.
- Preserved search/filter access and the existing top progress indicator while expensive row, status, and print actions pause.
- Extended source-contract coverage for busy button styles, disabled grids, loading overlays, and empty-state suppression.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-05-rental-desk-loading-action-states.md`.

## Why this was highest value

Recent work hardened Manage Rentals startup and keyboard paths, but the visible page still allowed action surfaces to look available while rental/request data was refreshing and could show misleading empty cards during load. This completes the user-facing loading/action-state side of that workflow without revisiting unrelated screens.

## Why this is real progress

This is a complete UI responsiveness slice for the rental desk: toolbar actions, handoff actions, footer actions, request queue actions, both grids, empty states, loading indicators, and source-contract coverage now agree on the same refresh behavior.

## Validation

- GitHub connector compare confirmed the branch is current with `master` and limited to three files.
- GitHub connector readback confirmed the busy styles, disabled grid wrapper, loading overlays, empty-state suppression, and new source-contract assertions are present.

Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime checks, screenshots, or scaling checks because this scheduled Linux environment cannot clone the repository directly and does not provide Windows/.NET/WPF tooling.

## Follow-up

- Run the full validation runner on a Windows/.NET-capable checkout.
- Smoke test Manage Rentals at 1366x768 and higher Windows scaling while refreshing, filtering, printing, and opening request/rental actions.