### PR TITLE
[codex] improve import export run log handoff responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
@@ -169,6 +169,25 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ImportExportPage_CodeBehindBoundsLongRunLogHandoffText()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
+
+            Assert.Contains("private const int MaxPrintedLogCharacters = 1200;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private const int MaxDetailLogCharacters = 6000;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("BuildBoundedLogText(log, MaxDetailLogCharacters", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("The selected result was shortened for dialog responsiveness.", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var truncatedPrintedLogCount = CountTruncatedLogEntries(printedLogs, MaxPrintedLogCharacters);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("BuildSummarySection(title, summary, safeLogs.Count, printedLogs.Count, omittedLogCount, truncatedPrintedLogCount)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("BuildBoundedLogText(log, MaxPrintedLogCharacters", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("This row was shortened for print-preview responsiveness.", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Shortened Log Rows", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("shortened-row counts", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static int CountTruncatedLogEntries", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static string BuildBoundedLogText", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ImportExportPage_CodeBehindGuardsBusyRowGesturesAndKeyboardShortcuts()
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-import-export-run-log-handoff-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-import-export-run-log-handoff-responsiveness.md
@@ -1,0 +1,23 @@
+# Import Export Run Log Handoff Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Bounded selected run-log detail dialogs to the first 6,000 characters so a very large skipped-row or failure message does not make the detail window sluggish.
+- Added an explicit selected-result truncation notice that tells operators to copy the selected row when exact full troubleshooting text is needed.
+- Kept Copy Selected as the full-fidelity path so bounded display does not silently lose operational detail.
+- Bounded each printed run-log row to the first 1,200 characters so print preview stays responsive even when an import produces unusually long skipped-row text.
+- Kept the existing 250 printed-row cap and added per-row text shortening on top of it for large-session safety.
+- Added shortened-row accounting to the print packet summary so operators can distinguish omitted rows from shortened visible rows.
+- Added a print-preview note when one or more printed rows were shortened.
+- Updated the print footer guidance to include shortened-row counts before clearing the run log.
+- Trimmed run-log rows once before print-packet preparation so summary counts and displayed rows use consistent text.
+- Extended Import/Export source-contract coverage for selected-detail bounds, print row character caps, shortened-row accounting, helper methods, and guidance text.
+
+## Validation
+
+- Source inspection confirmed `ImportExportPage.xaml.cs` keeps full clipboard copying while bounding detail-dialog and print-preview text paths.
+- Source inspection confirmed the print packet now reports visible, printed, omitted, and shortened row counts separately.
+- Source-contract tests in `ImportExportPageResponsiveContractTests` were updated to guard the bounded handoff behavior and existing busy-state/run-log action protections.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime smoke testing, screenshots, scaling checks, print-preview rendering, and live Import/Export responsiveness checks could not run in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -16,6 +16,8 @@ namespace InventoryManagementApp.Views.Pages
     public partial class ImportExportPage : Page
     {
         private const int MaxPrintedLogRows = 250;
+        private const int MaxPrintedLogCharacters = 1200;
+        private const int MaxDetailLogCharacters = 6000;
 
         public ImportExportPage()
         {
@@ -106,11 +108,12 @@ namespace InventoryManagementApp.Views.Pages
                     return;
                 }
 
+                var detailText = BuildBoundedLogText(log, MaxDetailLogCharacters, "The selected result was shortened for dialog responsiveness. Copy the selected log when the full message is needed for deeper troubleshooting.");
                 DetailDialogWindow.ShowDialogFor(
                     Window.GetWindow(this),
                     "Import / Export Result",
                     "Import / Export Result",
-                    log,
+                    detailText,
                     "Review the selected operation result before copying, printing, or continuing the data workflow.",
                     "Run Log",
                     "Close returns to the run log with the selected result still available for copy, print, or review.");
@@ -234,9 +237,10 @@ namespace InventoryManagementApp.Views.Pages
             string summary,
             string title = "Import / Export Operation Log")
         {
-            var safeLogs = logs?.Where(log => !string.IsNullOrWhiteSpace(log)).ToList() ?? new List<string>();
+            var safeLogs = logs?.Where(log => !string.IsNullOrWhiteSpace(log)).Select(log => log.Trim()).ToList() ?? new List<string>();
             var printedLogs = safeLogs.Take(MaxPrintedLogRows).ToList();
             var omittedLogCount = Math.Max(0, safeLogs.Count - printedLogs.Count);
+            var truncatedPrintedLogCount = CountTruncatedLogEntries(printedLogs, MaxPrintedLogCharacters);
             var document = new FlowDocument
             {
                 FontFamily = new FontFamily("Segoe UI"),
@@ -258,7 +262,7 @@ namespace InventoryManagementApp.Views.Pages
                 Margin = new Thickness(0, 0, 0, 2)
             });
 
-            document.Blocks.Add(BuildSummarySection(title, summary, safeLogs.Count, printedLogs.Count, omittedLogCount));
+            document.Blocks.Add(BuildSummarySection(title, summary, safeLogs.Count, printedLogs.Count, omittedLogCount, truncatedPrintedLogCount));
 
             if (printedLogs.Count == 0)
             {
@@ -292,7 +296,7 @@ namespace InventoryManagementApp.Views.Pages
                 var row = new TableRow();
                 rowGroup.Rows.Add(row);
                 AddCell(row, number.ToString());
-                AddCell(row, log.Trim());
+                AddCell(row, BuildBoundedLogText(log, MaxPrintedLogCharacters, "This row was shortened for print-preview responsiveness. Copy the selected log for the complete operation text."));
                 number++;
             }
 
@@ -307,7 +311,17 @@ namespace InventoryManagementApp.Views.Pages
                 });
             }
 
-            document.Blocks.Add(new Paragraph(new Run("Review skipped rows, failures, backup paths, restore notices, and omitted-row counts before clearing the in-app run log."))
+            if (truncatedPrintedLogCount > 0)
+            {
+                document.Blocks.Add(new Paragraph(new Run($"{truncatedPrintedLogCount} printed log row{(truncatedPrintedLogCount == 1 ? " was" : "s were")} shortened to keep print preview responsive. Copy selected rows when exact full text is required."))
+                {
+                    FontSize = 10,
+                    FontStyle = FontStyles.Italic,
+                    Margin = new Thickness(0, 8, 0, 0)
+                });
+            }
+
+            document.Blocks.Add(new Paragraph(new Run("Review skipped rows, failures, backup paths, restore notices, omitted-row counts, and shortened-row counts before clearing the in-app run log."))
             {
                 FontSize = 10,
                 FontStyle = FontStyles.Italic,
@@ -316,7 +330,7 @@ namespace InventoryManagementApp.Views.Pages
             return document;
         }
 
-        private static Section BuildSummarySection(string title, string summary, int logCount, int printedLogCount, int omittedLogCount)
+        private static Section BuildSummarySection(string title, string summary, int logCount, int printedLogCount, int omittedLogCount, int truncatedLogCount)
         {
             var section = new Section
             {
@@ -341,6 +355,7 @@ namespace InventoryManagementApp.Views.Pages
             AddKeyValueRow(group, "Visible Log Rows", logCount.ToString());
             AddKeyValueRow(group, "Printed Log Rows", printedLogCount.ToString());
             AddKeyValueRow(group, "Omitted Log Rows", omittedLogCount.ToString());
+            AddKeyValueRow(group, "Shortened Log Rows", truncatedLogCount.ToString());
             AddKeyValueRow(group, "Session Summary", ValueOrNotRecorded(summary));
 
             section.Blocks.Add(table);
@@ -368,6 +383,23 @@ namespace InventoryManagementApp.Views.Pages
                 Padding = new Thickness(4, 3, 4, 3),
                 FontWeight = isHeader ? FontWeights.SemiBold : FontWeights.Normal
             });
+        }
+
+        private static int CountTruncatedLogEntries(IEnumerable<string> logs, int maxCharacters) =>
+            logs.Count(log => !string.IsNullOrWhiteSpace(log) && log.Trim().Length > maxCharacters);
+
+        private static string BuildBoundedLogText(string? value, int maxCharacters, string truncationNotice)
+        {
+            var text = ValueOrNotRecorded(value);
+            if (text.Length <= maxCharacters)
+                return text;
+
+            var visibleText = text.Substring(0, maxCharacters).TrimEnd();
+            var omittedCharacters = text.Length - visibleText.Length;
+            return string.Join(Environment.NewLine,
+                visibleText,
+                string.Empty,
+                $"... {omittedCharacters:N0} characters omitted. {truncationNotice}");
         }
 
         private static string ValueOrNotRecorded(string? value) =>


### PR DESCRIPTION
## What changed

- Bounded selected Import/Export run-log detail dialogs to the first 6,000 characters with an explicit truncation notice.
- Preserved Copy Selected as the full-fidelity handoff path for exact troubleshooting text.
- Bounded printed run-log row text to 1,200 characters while keeping the existing 250-row print cap.
- Added print-packet accounting for shortened rows separately from omitted rows.
- Added print-preview guidance for shortened-row counts before clearing the in-app run log.
- Added source-contract coverage for the new detail bounds, print row character cap, shortened-row accounting, helper methods, and guidance text.
- Recorded the completed workflow slice in `InventoryManagementApp/ProgressNotes/2026-07-06-import-export-run-log-handoff-responsiveness.md`.

## Why this was highest value

Recent work already hardened broad Import/Export busy-state and run-log actions. The remaining evidence-backed risk in this workflow was professional display and responsiveness when an import/export operation creates very large log rows, especially skipped-row or exception text. This keeps the screen, detail dialog, and print preview usable without hiding the full log from copy workflows.

## Scope and progress

This is a focused workflow-level slice across UI action handling, print output, source-contract coverage, and progress notes. It avoids adding new services or unrelated screens and improves an existing high-traffic data workflow.

## Validation

- GitHub connector compare confirmed the branch is current with `master` and changes only three intended files.
- GitHub connector readback confirmed the code-behind contains the new selected-detail cap, print row character cap, shortened-row accounting, and print guidance.
- GitHub connector status/workflow readback found no attached commit statuses or workflow runs for the branch head.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET compile/tests
- WPF runtime smoke test
- Screenshots/scaling checks
- Print-preview rendering

Those remain unavailable in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is not installed.

## Follow-up

Run the full validation runner and a Windows WPF smoke test when a Windows/.NET-capable checkout is available, especially opening a large Import/Export run log row and printing a large run-log packet.