### PR TITLE
Improve checkout history overflow responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -221,15 +221,17 @@ namespace InventoryManagementApp.Tests
                 "public virtual async Task<Result<List<ActivityLog>>> GetCheckoutHistoryForItemAsync",
                 "public virtual async Task<Result> PurgeOldLogsAsync");
 
-            Assert.Contains("const int MaxCheckoutHistoryLogCount = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("const int MaxCheckoutHistoryVisibleLogCount = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("const int MaxCheckoutHistoryReadLogCount = MaxCheckoutHistoryVisibleLogCount + 1;", source, StringComparison.Ordinal);
             Assert.Contains("ORDER BY Timestamp DESC LIMIT @CheckoutHistoryLimit", method, StringComparison.Ordinal);
-            Assert.Contains("new SqliteParameter(\"@CheckoutHistoryLimit\", MaxCheckoutHistoryLogCount)", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@CheckoutHistoryLimit\", MaxCheckoutHistoryReadLogCount)", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("MaxCheckoutHistoryLogCount", source, StringComparison.Ordinal);
             Assert.True(
                 method.IndexOf("ORDER BY Timestamp DESC LIMIT @CheckoutHistoryLimit", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
                 "The checkout-history read cap should be part of the SQL before the database connection opens.");
             Assert.True(
-                method.IndexOf("new SqliteParameter(\"@CheckoutHistoryLimit\", MaxCheckoutHistoryLogCount)", StringComparison.Ordinal) < method.IndexOf("parameters.ToArray()", StringComparison.Ordinal),
-                "The checkout-history cap parameter should be included in the executed parameter set.");
+                method.IndexOf("new SqliteParameter(\"@CheckoutHistoryLimit\", MaxCheckoutHistoryReadLogCount)", StringComparison.Ordinal) < method.IndexOf("parameters.ToArray()", StringComparison.Ordinal),
+                "The checkout-history overflow-sentinel cap parameter should be included in the executed parameter set.");
         }
 
         private static void AssertCancellationGuardBeforeSqlWork(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp.Tests/CheckoutHistoryWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CheckoutHistoryWindowResponsiveContractTests.cs
@@ -43,13 +43,21 @@ namespace InventoryManagementApp.Tests
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CheckoutHistoryWindow.xaml");
 
             Assert.Contains("const int MaxVisibleHistoryRows = 500;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("const int MaxLoadedHistoryRows = MaxVisibleHistoryRows + 1;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("OrderByDescending(log => log.Timestamp)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains(".Take(MaxLoadedHistoryRows)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("orderedLogs.Take(MaxVisibleHistoryRows)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("OmittedLogCount = Math.Max(0, TotalLogCount - VisibleLogCount);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("HasOmittedLogs = TotalLogCount > VisibleLogCount;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("OmittedLogCount = HasOmittedLogs ? 1 : 0;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("OlderHistoryIndicator = HasOmittedLogs ? \"Yes\" : \"No\";", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("At least one older checkout history row exists", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Showing newest {VisibleLogCount:N0} checkout history rows", codeBehind, StringComparison.Ordinal);
             Assert.Contains("HasOmittedLogs", xaml, StringComparison.Ordinal);
             Assert.Contains("OmittedLogSummary", xaml, StringComparison.Ordinal);
+            Assert.Contains("OlderHistoryIndicator", xaml, StringComparison.Ordinal);
+            Assert.Contains("Older rows available", xaml, StringComparison.Ordinal);
             Assert.Contains("FooterStatusText", xaml, StringComparison.Ordinal);
-            Assert.Contains("Showing {VisibleLogCount:N0} of {TotalLogCount:N0}", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("Showing {VisibleLogCount:N0} of {TotalLogCount:N0}", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -61,7 +69,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,8,0,8\">", xaml, StringComparison.Ordinal);
             Assert.Contains("VisibleLogCount", xaml, StringComparison.Ordinal);
             Assert.Contains("TotalLogCount", xaml, StringComparison.Ordinal);
-            Assert.Contains("OmittedLogCount", xaml, StringComparison.Ordinal);
+            Assert.Contains("OlderHistoryIndicator", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel>", xaml, StringComparison.Ordinal);
             Assert.Contains("Esc closes this history window.", xaml, StringComparison.Ordinal);
         }

--- a/InventoryManagementApp.Tests/ItemDetailsWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemDetailsWindowResponsiveContractTests.cs
@@ -103,6 +103,7 @@ namespace InventoryManagementApp.Tests
             var dialogService = ReadRepoFile("InventoryManagementApp", "Services", "DialogService.cs");
             var dialogInterface = ReadRepoFile("InventoryManagementApp", "Interfaces", "IDialogService.cs");
 
+            Assert.Contains("_activityLogService.GetCheckoutHistoryForItemAsync(ItemModel.ItemID, ItemModel.ItemNumber)", viewModel, StringComparison.Ordinal);
             Assert.Contains("_dialogService.ShowCheckoutHistory(ItemModel, logs);", viewModel, StringComparison.Ordinal);
             Assert.DoesNotContain("string.Join(Environment.NewLine, lines)", viewModel, StringComparison.Ordinal);
             Assert.DoesNotContain("Select(log => $\"{log.Timestamp:yyyy-MM-dd HH:mm} -", viewModel, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-checkout-history-overflow-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-checkout-history-overflow-responsiveness.md
@@ -1,0 +1,23 @@
+# Checkout History Overflow Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Changed item checkout-history reads from a hard 500-row cap to a capped-plus-one read so the app can detect when older audit rows exist without loading the full audit trail.
+- Kept the visible checkout-history grid capped at 500 rows for fast dialog opening and keyboard review.
+- Added a 501-row maximum inside the checkout-history dialog as a defensive cap for any direct caller that bypasses the service path.
+- Updated the dialog to treat the extra row as an overflow sentinel instead of rendering it as a normal visible history row.
+- Replaced the misleading exact omitted-row count display with a clear More Yes/No indicator.
+- Updated the overflow banner to say at least one older checkout-history row exists outside the responsive review set.
+- Updated the footer status so capped histories read as newest 500 rows with more older rows available, while small histories still show an exact count.
+- Preserved newest-first ordering, grid virtualization, row/column scrollbars, Escape-to-close, and scaled-desktop sizing.
+- Extended activity-log source-contract coverage for the visible cap, read cap, SQL LIMIT parameter, and removal of the old single hard-cap constant.
+- Extended checkout-history window source-contract coverage for the defensive loaded cap, overflow sentinel, More indicator, banner text, and footer wording.
+- Extended Item Details source-contract coverage so checkout-history still routes through the bounded service query and structured dialog.
+
+## Validation
+
+- GitHub connector readback/compare was used to inspect the intended file changes and branch scope.
+- Source-contract tests were updated for the affected service, dialog, and Item Details routing contracts.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime smoke testing, screenshots, scaling checks, and live large-history testing could not run in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -16,7 +16,8 @@ namespace InventoryManagementApp.Services.Users
     public class ActivityLogService
     {
         const int MaxRecentLogCount = 500;
-        const int MaxCheckoutHistoryLogCount = 500;
+        const int MaxCheckoutHistoryVisibleLogCount = 500;
+        const int MaxCheckoutHistoryReadLogCount = MaxCheckoutHistoryVisibleLogCount + 1;
 
         readonly DatabaseService _dbService;
         readonly ILogger<ActivityLogService> _logger;
@@ -142,7 +143,7 @@ namespace InventoryManagementApp.Services.Users
                 }
 
                 sql += " ORDER BY Timestamp DESC LIMIT @CheckoutHistoryLimit";
-                parameters.Add(new SqliteParameter("@CheckoutHistoryLimit", MaxCheckoutHistoryLogCount));
+                parameters.Add(new SqliteParameter("@CheckoutHistoryLimit", MaxCheckoutHistoryReadLogCount));
 
                 using var conn = _dbService.CreateConnection();
                 var logs = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapLog, parameters.ToArray(), cancellationToken).ConfigureAwait(false);

--- a/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml
@@ -46,9 +46,9 @@
             </Border>
             <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="150" MaxWidth="240" Margin="0,0,8,8">
                 <StackPanel>
-                    <TextBlock Text="Omitted" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding OmittedLogCount}" Style="{StaticResource HeadingTextBlock}"/>
-                    <TextBlock Text="Rows held back for responsiveness" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock Text="More" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding OlderHistoryIndicator}" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Older rows available" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
         </WrapPanel>

--- a/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/CheckoutHistoryWindow.xaml.cs
@@ -13,6 +13,7 @@ namespace InventoryManagementApp.Views.Windows
     public partial class CheckoutHistoryWindow : Window
     {
         const int MaxVisibleHistoryRows = 500;
+        const int MaxLoadedHistoryRows = MaxVisibleHistoryRows + 1;
 
         public CheckoutHistoryWindow(ItemModel item, IEnumerable<ActivityLog> logs)
         {
@@ -21,20 +22,24 @@ namespace InventoryManagementApp.Views.Windows
 
             var orderedLogs = logs
                 .OrderByDescending(log => log.Timestamp)
+                .Take(MaxLoadedHistoryRows)
                 .ToList();
 
             ItemSummaryText = BuildItemSummary(item);
             TotalLogCount = orderedLogs.Count;
             VisibleLogs = new ObservableCollection<ActivityLog>(orderedLogs.Take(MaxVisibleHistoryRows));
             VisibleLogCount = VisibleLogs.Count;
-            OmittedLogCount = Math.Max(0, TotalLogCount - VisibleLogCount);
-            HasOmittedLogs = OmittedLogCount > 0;
+            HasOmittedLogs = TotalLogCount > VisibleLogCount;
+            OmittedLogCount = HasOmittedLogs ? 1 : 0;
+            OlderHistoryIndicator = HasOmittedLogs ? "Yes" : "No";
             OmittedLogSummary = HasOmittedLogs
-                ? $"Showing the first {VisibleLogCount:N0} newest checkout history rows. {OmittedLogCount:N0} older rows are omitted from this dialog to keep review responsive."
+                ? $"Showing the newest {VisibleLogCount:N0} checkout history rows. At least one older checkout history row exists outside this responsive review set."
                 : string.Empty;
             FooterStatusText = TotalLogCount == 0
                 ? "No checkout or check-in history rows were returned for this item."
-                : $"Showing {VisibleLogCount:N0} of {TotalLogCount:N0} checkout history rows, newest first.";
+                : HasOmittedLogs
+                    ? $"Showing newest {VisibleLogCount:N0} checkout history rows; more older rows are available in the audit trail."
+                    : $"Showing {VisibleLogCount:N0} checkout history row{(VisibleLogCount == 1 ? string.Empty : "s")}, newest first.";
 
             InitializeComponent();
             this.UseResponsiveDefaultSize(820, 620);
@@ -47,6 +52,7 @@ namespace InventoryManagementApp.Views.Windows
         public int TotalLogCount { get; }
         public int VisibleLogCount { get; }
         public int OmittedLogCount { get; }
+        public string OlderHistoryIndicator { get; }
         public bool HasOmittedLogs { get; }
         public string OmittedLogSummary { get; }
         public string FooterStatusText { get; }


### PR DESCRIPTION
## What changed

- Changed checkout-history audit reads to fetch the newest 500 visible rows plus one overflow sentinel, instead of a hard 500 that made large histories look exact.
- Kept the checkout-history dialog grid capped to 500 visible rows and added a defensive 501-row loaded cap for direct callers.
- Replaced the misleading omitted-count card with a More Yes/No indicator and updated the banner/footer wording for capped histories.
- Preserved newest-first ordering, virtualized grid display, scrollbars, keyboard close behavior, and scaled desktop sizing.
- Extended source-contract coverage for the service SQL cap, dialog overflow display, and Item Details route through the bounded service query.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-checkout-history-overflow-responsiveness.md`.

## Why this was highest value

Recent checkout-history work made the dialog fast by capping display rows, and current repo evidence showed the service already had a hard SQL cap. The remaining workflow issue was professional data display: with exactly 500 rows returned, the UI could imply the history was complete even when older audit rows existed. A capped-plus-one read keeps loading bounded while giving operators honest overflow feedback.

## Why this is real progress

This is an end-to-end workflow slice across the database read, dialog rendering, operator-facing status, and tests. It improves responsiveness and data display without introducing new dependencies or broad rewrites.

## Validation

- GitHub connector compare confirmed the branch is current with `master` and limited to seven intended files.
- Connector status/workflow readback found no attached commit statuses or workflow runs for the branch head.
- Source-contract coverage was updated for `ActivityLogService`, `CheckoutHistoryWindow`, and `ItemDetailsWindowResponsiveContractTests`.

## Not run

- Local `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime smoke tests, screenshots, scaling checks, and live large-history testing could not run here because direct checkout is blocked by GitHub HTTP 403 and this scheduled Linux environment lacks Windows/.NET/WPF tooling.

## Follow-up

- Run the full Windows/.NET validation runner from a capable checkout.
- Smoke test checkout-history opening with fewer than 500 rows, exactly 500 rows, and more than 500 rows.