### PR TITLE
Harden rentals keyboard and filter responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsKeyboardShortcutContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsKeyboardShortcutContractTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests;
+
+public class ManageRentalsKeyboardShortcutContractTests
+{
+    private static string ReadRepoFile(string relativePath)
+    {
+        var baseDir = AppContext.BaseDirectory;
+        var root = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", ".."));
+        var path = Path.Combine(root, relativePath);
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void ManageRentalsShortcuts_DoNotHijackTextEditingControls()
+    {
+        var source = ReadRepoFile("InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs");
+        var handler = ExtractBlock(source, "private void ManageRentalsPage_PreviewKeyDown");
+
+        Assert.Contains("if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)", handler);
+        Assert.Contains("SearchTextBox.Focus();", handler);
+        Assert.Contains("SearchTextBox.SelectAll();", handler);
+        Assert.Contains("if (IsTextEditingElement(e.OriginalSource) && IsRentalActionShortcut(e))", handler);
+        Assert.Contains("if (vm.IsLoading && IsRentalActionShortcut(e))", handler);
+
+        Assert.True(
+            handler.IndexOf("if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)", StringComparison.Ordinal)
+                < handler.IndexOf("if (IsTextEditingElement(e.OriginalSource) && IsRentalActionShortcut(e))", StringComparison.Ordinal));
+        Assert.True(
+            handler.IndexOf("if (IsTextEditingElement(e.OriginalSource) && IsRentalActionShortcut(e))", StringComparison.Ordinal)
+                < handler.IndexOf("if (vm.IsLoading && IsRentalActionShortcut(e))", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ManageRentalsShortcuts_TreatsFilterInputsAsTextEditingSurfaces()
+    {
+        var source = ReadRepoFile("InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs");
+        var helper = ExtractBlock(source, "private static bool IsTextEditingElement");
+
+        Assert.Contains("object? source", helper);
+        Assert.Contains("source is TextBox or ComboBox or DatePicker", helper);
+    }
+
+    [Fact]
+    public void ManageRentalsRowDoubleClick_StopsAfterSelectionEvenWhenCommandsAreUnavailable()
+    {
+        var source = ReadRepoFile("InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs");
+        var rentalHandler = ExtractBlock(source, "private void RentalRow_MouseDoubleClick");
+        var requestHandler = ExtractBlock(source, "private void RequestRow_MouseDoubleClick");
+
+        AssertHandledBeforeCommandAvailability(rentalHandler, "vm.OpenRentalDetailsCommand.CanExecute(null)");
+        AssertHandledBeforeCommandAvailability(requestHandler, "vm.OpenRequestDetailsCommand.CanExecute(null)");
+    }
+
+    private static void AssertHandledBeforeCommandAvailability(string handler, string commandAvailabilityCheck)
+    {
+        var selectIndex = handler.IndexOf("if (SelectRowForContextMenu(sender, e) == null)", StringComparison.Ordinal);
+        var handledIndex = handler.IndexOf("e.Handled = true;", selectIndex, StringComparison.Ordinal);
+        var canExecuteIndex = handler.IndexOf(commandAvailabilityCheck, StringComparison.Ordinal);
+
+        Assert.True(selectIndex >= 0);
+        Assert.True(handledIndex > selectIndex);
+        Assert.True(canExecuteIndex > handledIndex);
+    }
+
+    private static string ExtractBlock(string source, string signature)
+    {
+        var start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find '{signature}'.");
+
+        var braceStart = source.IndexOf('{', start);
+        Assert.True(braceStart >= 0, $"Could not find body for '{signature}'.");
+
+        var depth = 0;
+        for (var i = braceStart; i < source.Length; i++)
+        {
+            if (source[i] == '{')
+                depth++;
+            else if (source[i] == '}')
+                depth--;
+
+            if (depth == 0)
+                return source.Substring(start, i - start + 1);
+        }
+
+        throw new InvalidOperationException($"Could not parse body for '{signature}'.");
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-rentals-keyboard-filter-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-rentals-keyboard-filter-responsiveness.md
@@ -1,0 +1,28 @@
+# 2026-07-06 Rentals Keyboard and Filter Responsiveness
+
+Completed a focused rentals workflow hardening pass so the page stays predictable while users search, filter, and act on rental rows.
+
+## Completed
+
+- Preserved the existing `Ctrl+F` fast-search shortcut so users can always jump back to rental search quickly.
+- Added a text-editing shortcut guard for rental action hotkeys.
+- Prevented rental action shortcuts from hijacking typing in search text boxes.
+- Prevented rental action shortcuts from hijacking date filter editing.
+- Prevented rental action shortcuts from hijacking status combo box editing.
+- Kept the existing loading-state action shortcut block for non-editing surfaces.
+- Ensured rental row double-clicks are marked handled after a row is selected.
+- Ensured request row double-clicks are marked handled after a row is selected.
+- Avoided bubbling duplicate double-click work when a selected row command is temporarily unavailable.
+- Added source-contract coverage for filter editing shortcut behavior.
+- Added source-contract coverage for the text-editing surface helper.
+- Added source-contract coverage for row double-click handling order.
+
+## Validation
+
+- Added tests in `ManageRentalsKeyboardShortcutContractTests` for the code-behind source contract.
+- Static validation only in this Linux container; WPF runtime, Windows screenshot checks, and `scripts/run-full-validation.ps1` require a Windows/PowerShell/.NET desktop environment.
+
+## Follow-up
+
+- Run the full Windows validation script on a Windows agent.
+- Consider debouncing `ManageRentalsViewModel` search/date/status filtering if realistic rental volumes show filter typing lag.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -5,11 +5,9 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
+
 namespace InventoryManagementApp.Views.Pages
 {
-    /// <summary>
-    /// Interaction logic for ManageRentalsPage.xaml
-    /// </summary>
     public partial class ManageRentalsPage : Page
     {
         const double CompactHeightThreshold = 650;
@@ -109,10 +107,11 @@ namespace InventoryManagementApp.Views.Pages
             if (SelectRowForContextMenu(sender, e) == null)
                 return;
 
+            e.Handled = true;
+
             if (DataContext is ManageRentalsViewModel vm && vm.OpenRentalDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Rentals", () => vm.OpenRentalDetailsCommand.Execute(null));
-                e.Handled = true;
             }
         }
 
@@ -132,10 +131,11 @@ namespace InventoryManagementApp.Views.Pages
             if (SelectRowForContextMenu(sender, e) == null)
                 return;
 
+            e.Handled = true;
+
             if (DataContext is ManageRentalsViewModel vm && vm.OpenRequestDetailsCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Rentals", () => vm.OpenRequestDetailsCommand.Execute(null));
-                e.Handled = true;
             }
         }
 
@@ -156,6 +156,9 @@ namespace InventoryManagementApp.Views.Pages
                 e.Handled = true;
                 return;
             }
+
+            if (IsTextEditingElement(e.OriginalSource) && IsRentalActionShortcut(e))
+                return;
 
             if (vm.IsLoading && IsRentalActionShortcut(e))
             {
@@ -246,6 +249,11 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             return Keyboard.Modifiers == ModifierKeys.None && e.Key is Key.Enter or Key.Delete;
+        }
+
+        private static bool IsTextEditingElement(object? source)
+        {
+            return source is TextBox or ComboBox or DatePicker;
         }
 
         private void OpenFocusedDetails(ManageRentalsViewModel vm)


### PR DESCRIPTION
## What changed

- Added a rentals page text-editing guard so action shortcuts no longer hijack typing in search, date filters, or the status combo box.
- Preserved the existing `Ctrl+F` search focus shortcut before the text-editing guard so fast search access still works.
- Kept loading-state shortcut suppression for non-editing surfaces.
- Marked rental and request row double-clicks handled after row selection so unavailable commands do not bubble into duplicate work.
- Added source-contract tests for shortcut ordering, text-editing surfaces, and double-click handling order.
- Added a progress note documenting the completed rentals workflow improvements and follow-up validation.

## Why this was highest value

Recent runs already improved rentals loading, compact layout, and row action guards. The remaining evidence in `ManageRentalsPage.xaml.cs` showed global rental shortcuts could still intercept Enter/Delete/Ctrl actions while users were editing filter controls, which makes search/filter work feel jumpy and unprofessional on a data-heavy page.

## Why this scope is real progress

This completes a focused vertical slice across runtime behavior, source-contract coverage, and project notes. It improves the rental workflow during search, filtering, row selection, details opening, request details opening, printing shortcuts, and loading-state actions without expanding into unrelated screens.

## Validation

- Inspected the changed code and tests locally in the Linux workspace.
- Used a scoped GitHub compare to verify only the intended files changed.
- Added `ManageRentalsKeyboardShortcutContractTests` to lock the intended behavior.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1` could not be run in this Linux container because the WPF/Windows desktop validation path requires a Windows/PowerShell/.NET desktop environment.
- No WPF runtime, screenshot, print-preview, packaging, or publish validation was available from this environment.

## Follow-up

- Run the full Windows validation script on a Windows runner.
- Consider debouncing `ManageRentalsViewModel` filter changes if realistic rental volumes show typing lag.