### PR TITLE
Improve Item Search input responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ItemSearchInputResponsivenessContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemSearchInputResponsivenessContractTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemSearchInputResponsivenessContractTests
+    {
+        [Fact]
+        public void ItemSearchPage_FocusesSearchAndPreservesTextEditingKeys()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs");
+
+            Assert.Contains("FocusFirstSearchBox();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (IsTextEditingTarget(e.OriginalSource))\n                return;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("FindVisualParent<TextBoxBase>(dependencyObject) != null", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("FindVisualParent<PasswordBox>(dependencyObject) != null", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("FindVisualParent<ComboBox>(dependencyObject) != null", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("searchBox.SelectAll();", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemSearchPage_RetargetsInvokedRowsBeforeOpeningDetailsOrDemandItems()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs");
+
+            Assert.Contains("var item = SelectInvokedItem(grid, e) ?? grid.SelectedItem as ItemModel;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.SelectedItem = item;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("RepeatSearch(SelectInvokedSearchHistory(e) ?? RecentSearchGrid.SelectedItem as SearchHistoryEntry);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("OpenDemandItem(SelectInvokedDemand(e) ?? UnavailableDemandGrid.SelectedItem as UnavailableDemandEntry);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("RecentSearchGrid.SelectedItem = entry;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("UnavailableDemandGrid.SelectedItem = entry;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("FindVisualParent<DataGridRow>(e.OriginalSource as DependencyObject)", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemSearchPage_BlocksBusyMouseAndContextMenuInteraction()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs");
+
+            Assert.Contains("RecentSearchGrid.PreviewMouseRightButtonDown += SearchIntelligenceGrid_PreviewMouseRightButtonDown;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("UnavailableDemandGrid.PreviewMouseRightButtonDown += SearchIntelligenceGrid_PreviewMouseRightButtonDown;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void SearchIntelligenceGrid_PreviewMouseRightButtonDown", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n                ShowBusyInfo(\"Wait for the item search to finish before opening item details.\");", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n                ShowBusyInfo(\"Wait for the current search to finish before repeating another search.\");", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n                ShowBusyInfo(\"Wait for the item search to finish before opening unavailable-demand details.\");", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemSearchPage_UsesSharedVisualTreeHelpersForScaledGridSurfaces()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs");
+
+            Assert.Contains("using System.Windows.Controls.Primitives;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("using System.Windows.Media;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static T? FindVisualParent<T>(DependencyObject? current) where T : DependencyObject", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("current = VisualTreeHelper.GetParent(current);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("VisualTreeHelper.GetChildrenCount(parent)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("VisualTreeHelper.GetChild(parent, index)", codeBehind, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-item-search-input-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-item-search-input-responsiveness.md
@@ -1,0 +1,21 @@
+# Item Search Input Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Focuses the Item Search text box on first page paint and via Ctrl+F so operators can start searching immediately after navigation.
+- Preserves normal text-editing behavior in text boxes, password boxes, and combo boxes so Enter and command shortcuts do not hijack filter input.
+- Retargets item result double-clicks to the invoked row before opening details, preventing stale selection when a user double-clicks a different virtualized row.
+- Marks busy and completed item-result double-clicks handled so they do not bubble into duplicate row work.
+- Retargets recent-search double-clicks to the invoked row before repeating a search.
+- Retargets unavailable-demand double-clicks to the invoked row before opening item details.
+- Blocks recent-search and unavailable-demand context-menu row retargeting while item search work is running.
+- Keeps busy operator feedback for details, repeat-search, and unavailable-demand actions.
+- Adds shared visual-tree helpers for row and search-box lookup across virtualized/scaled WPF surfaces.
+- Adds source-contract coverage for search focus, text-edit preservation, invoked-row retargeting, busy mouse/context-menu guards, and visual-tree helpers.
+
+## Validation
+
+- Source inspected through GitHub connector readback.
+- Full Windows validation, .NET build/tests, WPF runtime smoke testing, screenshots, and live keyboard checks remain blocked in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -5,8 +5,10 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Threading;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
@@ -38,6 +40,8 @@ namespace InventoryManagementApp.Views.Pages
             UnavailableDemandGrid.ItemsSource = _unavailableDemand;
             ResultsGrid.PreviewMouseRightButtonDown += ItemGrid_PreviewMouseRightButtonDown;
             CheckedOutGrid.PreviewMouseRightButtonDown += ItemGrid_PreviewMouseRightButtonDown;
+            RecentSearchGrid.PreviewMouseRightButtonDown += SearchIntelligenceGrid_PreviewMouseRightButtonDown;
+            UnavailableDemandGrid.PreviewMouseRightButtonDown += SearchIntelligenceGrid_PreviewMouseRightButtonDown;
             DataContextChanged += ItemSearchPage_DataContextChanged;
             PreviewKeyDown += ItemSearchPage_PreviewKeyDown;
             UpdateSearchIntelligenceSummary();
@@ -46,7 +50,7 @@ namespace InventoryManagementApp.Views.Pages
         private async void Page_Loaded(object sender, RoutedEventArgs e)
         {
             UpdateState();
-            Focus();
+            FocusFirstSearchBox();
             if (DataContext is not ItemManagementViewModel vm)
                 return;
 
@@ -103,17 +107,23 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ItemGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is not ItemManagementViewModel vm || sender is not WpfDataGrid grid || grid.SelectedItem is not ItemModel item)
+            if (DataContext is not ItemManagementViewModel vm || sender is not WpfDataGrid grid)
                 return;
 
             if (IsSearchBusy(vm))
             {
+                e.Handled = true;
                 ShowBusyInfo("Wait for the item search to finish before opening item details.");
                 return;
             }
 
+            var item = SelectInvokedItem(grid, e) ?? grid.SelectedItem as ItemModel;
+            if (item == null)
+                return;
+
             vm.SelectedItem = item;
             UiActionGuard.Run(this, "Item Search", () => OpenSelectedItemDetails(vm));
+            e.Handled = true;
         }
 
         private void ItemGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
@@ -137,9 +147,30 @@ namespace InventoryManagementApp.Views.Pages
                 rowVm.SelectedItem = item;
         }
 
+        private void SearchIntelligenceGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is ItemManagementViewModel vm && IsSearchBusy(vm))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            GridContextMenuSelection.SelectRow(sender, e);
+        }
+
         private void ItemSearchPage_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
             if (DataContext is not ItemManagementViewModel vm)
+                return;
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
+            {
+                FocusFirstSearchBox();
+                e.Handled = true;
+                return;
+            }
+
+            if (IsTextEditingTarget(e.OriginalSource))
                 return;
 
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)
@@ -327,7 +358,15 @@ namespace InventoryManagementApp.Views.Pages
 
         private void RecentSearchGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            RepeatSearch(RecentSearchGrid.SelectedItem as SearchHistoryEntry);
+            if (DataContext is ItemManagementViewModel vm && IsSearchBusy(vm))
+            {
+                e.Handled = true;
+                ShowBusyInfo("Wait for the current search to finish before repeating another search.");
+                return;
+            }
+
+            RepeatSearch(SelectInvokedSearchHistory(e) ?? RecentSearchGrid.SelectedItem as SearchHistoryEntry);
+            e.Handled = true;
         }
 
         private void RepeatSearch(SearchHistoryEntry? entry)
@@ -355,7 +394,15 @@ namespace InventoryManagementApp.Views.Pages
 
         private void UnavailableDemandGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            OpenDemandItem(UnavailableDemandGrid.SelectedItem as UnavailableDemandEntry);
+            if (DataContext is ItemManagementViewModel vm && IsSearchBusy(vm))
+            {
+                e.Handled = true;
+                ShowBusyInfo("Wait for the item search to finish before opening unavailable-demand details.");
+                return;
+            }
+
+            OpenDemandItem(SelectInvokedDemand(e) ?? UnavailableDemandGrid.SelectedItem as UnavailableDemandEntry);
+            e.Handled = true;
         }
 
         private void OpenDemandItem(UnavailableDemandEntry? entry)
@@ -723,6 +770,88 @@ namespace InventoryManagementApp.Views.Pages
         private void ShowBusyInfo(string message)
         {
             ShowInfo(message, "Item Search");
+        }
+
+        private void FocusFirstSearchBox()
+        {
+            var searchBox = FindVisualChild<TextBox>(this);
+            if (searchBox == null)
+            {
+                Focus();
+                return;
+            }
+
+            searchBox.Focus();
+            searchBox.SelectAll();
+        }
+
+        private static ItemModel? SelectInvokedItem(WpfDataGrid grid, MouseButtonEventArgs e)
+        {
+            var row = FindVisualParent<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row?.Item is not ItemModel item)
+                return null;
+
+            grid.SelectedItem = item;
+            return item;
+        }
+
+        private SearchHistoryEntry? SelectInvokedSearchHistory(MouseButtonEventArgs e)
+        {
+            var row = FindVisualParent<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row?.Item is not SearchHistoryEntry entry)
+                return null;
+
+            RecentSearchGrid.SelectedItem = entry;
+            return entry;
+        }
+
+        private UnavailableDemandEntry? SelectInvokedDemand(MouseButtonEventArgs e)
+        {
+            var row = FindVisualParent<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row?.Item is not UnavailableDemandEntry entry)
+                return null;
+
+            UnavailableDemandGrid.SelectedItem = entry;
+            return entry;
+        }
+
+        private static bool IsTextEditingTarget(object source)
+        {
+            if (source is not DependencyObject dependencyObject)
+                return false;
+
+            return FindVisualParent<TextBoxBase>(dependencyObject) != null
+                || FindVisualParent<PasswordBox>(dependencyObject) != null
+                || FindVisualParent<ComboBox>(dependencyObject) != null;
+        }
+
+        private static T? FindVisualParent<T>(DependencyObject? current) where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T match)
+                    return match;
+
+                current = VisualTreeHelper.GetParent(current);
+            }
+
+            return null;
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (var index = 0; index < VisualTreeHelper.GetChildrenCount(parent); index++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, index);
+                if (child is T match)
+                    return match;
+
+                var descendant = FindVisualChild<T>(child);
+                if (descendant != null)
+                    return descendant;
+            }
+
+            return null;
         }
 
         private static bool IsSearchBusy(ItemManagementViewModel vm)


### PR DESCRIPTION
## What changed

- Focused the Item Search text box on page load so operators can begin typing immediately after navigation.
- Added Ctrl+F search focus with select-all behavior for fast filter recovery.
- Preserved normal text-editing behavior inside text boxes, password boxes, and combo boxes so Enter and managed shortcuts do not hijack filter input.
- Retargeted item result double-clicks to the invoked virtualized row before opening item details.
- Marked busy and completed item-result double-clicks handled to avoid duplicate routed work.
- Added invoked-row retargeting for recent-search double-click repeat actions.
- Added invoked-row retargeting for unavailable-demand double-click detail actions.
- Added right-click row selection for recent-search and unavailable-demand grids.
- Blocked search-intelligence context-menu retargeting while item search is busy.
- Preserved busy operator messages for details, repeat-search, unavailable-demand, clear, and print actions.
- Added shared visual-tree helpers for search-box focus and virtualized row lookup.
- Added source-contract coverage for search focus, text-edit preservation, invoked-row retargeting, busy mouse/context-menu guards, and visual-tree helpers.
- Recorded the completed workflow slice in `InventoryManagementApp/ProgressNotes/2026-07-06-item-search-input-responsiveness.md`.

## Why this was highest value

Recent work improved many primary screens and print/data-display paths. Item Search still had concrete interaction evidence: keyboard Enter could open stale selected details while typing in filter controls, double-clicks used the current selected row instead of the invoked virtualized row, and search-intelligence grids lacked the same right-click/busy interaction safety as the main result grids.

## Why this is real progress

This is a focused workflow slice across first-paint search input, keyboard routing, virtualized grid row selection, busy-state interaction guards, tests, and progress notes. It improves the existing Item Search desk without adding unrelated screens or dependencies.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, and limited to Item Search code-behind, a new source-contract test file, and a progress note.
- GitHub connector readback confirmed the search focus, Ctrl+F path, text-edit guard, invoked-row retargeting, busy handling, context-menu selection, and source-contract assertions are present.
- Connector status readback found no attached commit statuses or workflow runs for the branch head before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET build/tests
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Item Search keyboard/mouse testing

These remain unavailable in this scheduled Linux environment because direct checkout/raw GitHub access is blocked by HTTP 403 and Windows/.NET/WPF tooling is not installed.

## Follow-up

- Run the full Windows validation runner on a Windows/.NET-capable checkout.
- Smoke test Item Search with typing in the search box, changing the brand combo box, Ctrl+F, Enter-to-details, result double-click, recent-search repeat, unavailable-demand open, and context menus while search is loading.