### PR TITLE
Improve dashboard row invocation responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -196,13 +196,28 @@ namespace InventoryManagementApp.Tests
 
             Assert.True(CountOccurrences(codeBehind, "if (_isLoadingDashboard)") >= 7);
             Assert.True(CountOccurrences(codeBehind, "e.Handled = true;\n                return;") >= 7);
-            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedCommonItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedCheckedOutItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedRentalCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenActivityDestinationCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("DataContext is not DashboardViewModel vm || !vm.OpenSelectedIncompleteItemCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (DataContext is not DashboardViewModel vm)\n                return;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private static T? SelectInvokedDashboardRow<T>(object sender, MouseButtonEventArgs e) where T : class", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("grid.SelectedItem = item;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("private void DashboardGrid_PreviewMouseRightButtonDown", codeBehind, StringComparison.Ordinal);
             Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_RetargetsInvokedDoubleClickRowsBeforeOpeningWorkflows()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("var item = SelectInvokedDashboardRow<ItemModel>(sender, e);\n            if (item != null)\n                vm.SelectedCommonlyUsedItem = item;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var item = SelectInvokedDashboardRow<ItemModel>(sender, e);\n            if (item != null)\n                vm.SelectedCheckedOutItem = item;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var rental = SelectInvokedDashboardRow<RentalModel>(sender, e);\n            if (rental != null)\n                vm.SelectedRental = rental;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var activity = SelectInvokedDashboardRow<ActivityLog>(sender, e);\n            if (activity != null)\n                vm.SelectedActivity = activity;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var item = SelectInvokedDashboardRow<ItemModel>(sender, e);\n            if (item != null)\n                vm.SelectedIncompleteItem = item;", codeBehind, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(codeBehind, "e.Handled = true;") >= 13);
+            Assert.True(CountOccurrences(codeBehind, "e.Handled = item != null;") >= 3);
+            Assert.Contains("e.Handled = rental != null;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = activity != null;", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-dashboard-row-invocation-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-dashboard-row-invocation-responsiveness.md
@@ -1,0 +1,21 @@
+# Dashboard Row Invocation Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Retargets Commonly Used double-click actions to the invoked virtualized row before opening the item workflow.
+- Retargets Checked-Out double-click actions to the invoked virtualized row before opening item details.
+- Retargets Active Rental double-click actions to the invoked virtualized row before opening the rentals workflow.
+- Retargets Recent Activity double-click actions to the invoked audit row before opening the related workflow.
+- Retargets Items With Issues double-click actions to the invoked item row before opening item details.
+- Keeps row double-clicks handled after successful command dispatch so routed input does not trigger duplicate work.
+- Keeps row double-clicks handled after selecting an invoked row even when the selected-row command is unavailable.
+- Preserves existing loading guards so row actions remain blocked while dashboard data is refreshing.
+- Adds a shared invoked-row helper that works with the existing virtualized DataGrid row lookup path.
+- Extends Dashboard source-contract coverage for invoked-row retargeting, handled double-clicks, and shared row-selection helpers.
+
+## Validation
+
+- Source inspected through GitHub connector readback and compare.
+- Full Windows validation, .NET build/tests, WPF runtime smoke testing, screenshots, and live dashboard row testing remain blocked in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
@@ -249,10 +249,21 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (DataContext is not DashboardViewModel vm || !vm.OpenSelectedCommonItemCommand.CanExecute(null))
+            if (DataContext is not DashboardViewModel vm)
                 return;
 
+            var item = SelectInvokedDashboardRow<ItemModel>(sender, e);
+            if (item != null)
+                vm.SelectedCommonlyUsedItem = item;
+
+            if (!vm.OpenSelectedCommonItemCommand.CanExecute(null))
+            {
+                e.Handled = item != null;
+                return;
+            }
+
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedCommonItemCommand.Execute(null));
+            e.Handled = true;
         }
 
         private void CheckedOutItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -263,10 +274,21 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (DataContext is not DashboardViewModel vm || !vm.OpenSelectedCheckedOutItemCommand.CanExecute(null))
+            if (DataContext is not DashboardViewModel vm)
                 return;
 
+            var item = SelectInvokedDashboardRow<ItemModel>(sender, e);
+            if (item != null)
+                vm.SelectedCheckedOutItem = item;
+
+            if (!vm.OpenSelectedCheckedOutItemCommand.CanExecute(null))
+            {
+                e.Handled = item != null;
+                return;
+            }
+
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedCheckedOutItemCommand.Execute(null));
+            e.Handled = true;
         }
 
         private void RentedItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -277,10 +299,21 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (DataContext is not DashboardViewModel vm || !vm.OpenSelectedRentalCommand.CanExecute(null))
+            if (DataContext is not DashboardViewModel vm)
                 return;
 
+            var rental = SelectInvokedDashboardRow<RentalModel>(sender, e);
+            if (rental != null)
+                vm.SelectedRental = rental;
+
+            if (!vm.OpenSelectedRentalCommand.CanExecute(null))
+            {
+                e.Handled = rental != null;
+                return;
+            }
+
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedRentalCommand.Execute(null));
+            e.Handled = true;
         }
 
         private void RecentActivityGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -291,10 +324,21 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (DataContext is not DashboardViewModel vm || !vm.OpenActivityDestinationCommand.CanExecute(null))
+            if (DataContext is not DashboardViewModel vm)
                 return;
 
+            var activity = SelectInvokedDashboardRow<ActivityLog>(sender, e);
+            if (activity != null)
+                vm.SelectedActivity = activity;
+
+            if (!vm.OpenActivityDestinationCommand.CanExecute(null))
+            {
+                e.Handled = activity != null;
+                return;
+            }
+
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenActivityDestinationCommand.Execute(null));
+            e.Handled = true;
         }
 
         private void IncompleteItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -305,10 +349,34 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (DataContext is not DashboardViewModel vm || !vm.OpenSelectedIncompleteItemCommand.CanExecute(null))
+            if (DataContext is not DashboardViewModel vm)
                 return;
 
+            var item = SelectInvokedDashboardRow<ItemModel>(sender, e);
+            if (item != null)
+                vm.SelectedIncompleteItem = item;
+
+            if (!vm.OpenSelectedIncompleteItemCommand.CanExecute(null))
+            {
+                e.Handled = item != null;
+                return;
+            }
+
             UiActionGuard.Run(this, "Dashboard", () => vm.OpenSelectedIncompleteItemCommand.Execute(null));
+            e.Handled = true;
+        }
+
+        private static T? SelectInvokedDashboardRow<T>(object sender, MouseButtonEventArgs e) where T : class
+        {
+            if (sender is not DataGrid grid)
+                return null;
+
+            var row = GridContextMenuSelection.FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row?.Item is not T item)
+                return null;
+
+            grid.SelectedItem = item;
+            return item;
         }
 
         private void DashboardGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## What changed

- Retargeted Commonly Used double-click actions to the invoked virtualized row before opening the item workflow.
- Retargeted Checked-Out double-click actions to the invoked virtualized row before opening item details.
- Retargeted Active Rental double-click actions to the invoked virtualized row before opening the rentals workflow.
- Retargeted Recent Activity double-click actions to the invoked audit row before opening the related workflow.
- Retargeted Items With Issues double-click actions to the invoked item row before opening item details.
- Marked successful dashboard row double-click actions handled so routed input does not trigger duplicate work.
- Marked invoked-row double-clicks handled when the row is selected but the selected-row command is unavailable.
- Preserved the existing loading guard behavior so row actions remain blocked while dashboard data refreshes.
- Added a shared invoked-row helper that uses the existing virtualized DataGrid row lookup path.
- Extended Dashboard source-contract coverage for row retargeting, handled double-clicks, and the shared invoked-row helper.
- Recorded the completed workflow slice in `InventoryManagementApp/ProgressNotes/2026-07-06-dashboard-row-invocation-responsiveness.md`.

## Why this was highest value

Recent work already improved Dashboard startup loading, stale-load protection, and layout responsiveness. Current source evidence still showed double-click actions opening whatever row was already selected instead of first selecting the virtualized row that was actually invoked. On a dense dashboard with five grids, that can open stale item, rental, or activity context and makes the screen feel unreliable under fast operator input.

## Why this scope is real progress

This is a focused workflow slice across all Dashboard row-opening grids, shared helper logic, source-contract coverage, and progress notes. It improves an existing high-traffic operational screen without adding unrelated features or repeating recent loading/layout work.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, and limited to the Dashboard code-behind, Dashboard responsive contract tests, and one progress note.
- GitHub connector readback confirmed invoked-row retargeting and handled double-click behavior are present for Commonly Used, Checked-Out, Active Rentals, Recent Activity, and Items With Issues.
- Connector status readback found no attached commit statuses for the branch head before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET build/tests
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Dashboard double-click testing

These remain unavailable in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is not installed.

## Follow-up

- Run the full Windows validation runner on a Windows/.NET-capable checkout.
- Smoke test Dashboard double-clicks across all five grids, especially after selecting one row and double-clicking a different virtualized row.