### PR TITLE
Guard Manage Rentals stale startup loads

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
@@ -107,17 +107,41 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("Task? _loadRentalsTask;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("ManageRentalsViewModel? _loadedViewModel;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("int _loadVersion;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += ManageRentalsPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Unloaded += ManageRentalsPage_Unloaded;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("SearchTextBox.Focus();", codeBehind, StringComparison.Ordinal);
             Assert.Contains("UpdateCompactHeightMode();", codeBehind, StringComparison.Ordinal);
             Assert.Contains("await LoadRentalsOnceAsync(vm);", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (ReferenceEquals(_loadedViewModel, vm) && _loadRentalsTask is { IsCompleted: false })", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (ReferenceEquals(_loadedViewModel, vm) && _loadRentalsTask is { IsCompletedSuccessfully: true })", codeBehind, StringComparison.Ordinal);
             Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("if (!ReferenceEquals(DataContext, vm) || vm.IsLoading)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!IsCurrentLoad(vm, loadVersion) || vm.IsLoading)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("_loadRentalsTask = vm.LoadRentalsAsync();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!IsCurrentLoad(vm, loadVersion))\n                    _loadRentalsTask = null;", NormalizeNewlines(codeBehind), StringComparison.Ordinal);
             Assert.Contains("_loadRentalsTask = null;", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (!ReferenceEquals(DataContext, vm) || vm.IsLoading)", codeBehind, StringComparison.Ordinal);
             Assert.DoesNotContain("if (DataContext is ManageRentalsViewModel vm && !ReferenceEquals(_loadedViewModel, vm))", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageRentalsPage_InvalidatesStartupLoadsOnUnloadAndDataContextReplacement()
+        {
+            var codeBehind = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs"));
+            var unloadBlock = ExtractSourceBlock(codeBehind, "private void ManageRentalsPage_Unloaded", "private void ManageRentalsPage_DataContextChanged");
+            var dataContextBlock = ExtractSourceBlock(codeBehind, "private void ManageRentalsPage_DataContextChanged", "private async Task LoadRentalsOnceAsync");
+            var loadBlock = ExtractSourceBlock(codeBehind, "private async Task LoadRentalsOnceAsync", "private bool IsCurrentLoad");
+            var currentLoadBlock = ExtractSourceBlock(codeBehind, "private bool IsCurrentLoad", "private void ManageRentalsPage_SizeChanged");
+
+            Assert.Contains("_loadVersion++;", unloadBlock, StringComparison.Ordinal);
+            Assert.Contains("_loadedViewModel = null;", unloadBlock, StringComparison.Ordinal);
+            Assert.Contains("_loadRentalsTask = null;", unloadBlock, StringComparison.Ordinal);
+            Assert.Contains("_loadVersion++;", dataContextBlock, StringComparison.Ordinal);
+            Assert.Contains("var loadVersion = _loadVersion;", loadBlock, StringComparison.Ordinal);
+            Assert.Contains("if (!IsCurrentLoad(vm, loadVersion) || vm.IsLoading)", loadBlock, StringComparison.Ordinal);
+            Assert.Contains("finally", loadBlock, StringComparison.Ordinal);
+            Assert.Contains("if (!IsCurrentLoad(vm, loadVersion))\n                    _loadRentalsTask = null;", loadBlock, StringComparison.Ordinal);
+            Assert.Contains("return loadVersion == _loadVersion && ReferenceEquals(DataContext, vm);", currentLoadBlock, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-manage-rentals-stale-load-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-manage-rentals-stale-load-guard.md
@@ -1,0 +1,14 @@
+# Manage Rentals Stale Load Guard
+
+## Completed
+
+- Invalidated Manage Rentals startup-load tracking whenever the page unloads so a background refresh from a previous navigation cannot be reused as the completed load for a later visit.
+- Versioned page-owned startup loading so the first-paint dispatcher yield rechecks that the same view model is still active before starting rental refresh work.
+- Cleared stale startup-load task tracking when a load completes after the page has unloaded or the DataContext has changed.
+- Preserved the existing once-per-view-model load reuse for current active pages, compact-height layout behavior, search focus, row gesture guards, keyboard guards, and busy-state action blocking.
+- Added source-contract coverage for unload invalidation, DataContext invalidation, load-version capture, current-load rechecks, and stale-task cleanup.
+
+## Validation
+
+- Source readback and contract-test updates confirm the page now uses `_loadVersion`, `ManageRentalsPage_Unloaded`, `IsCurrentLoad(...)`, and stale-task cleanup around `LoadRentalsOnceAsync(...)`.
+- Local Windows/.NET validation, WPF runtime smoke testing, screenshots, scaling checks, and `pwsh -File scripts/run-full-validation.ps1` could not be run in this scheduled Linux environment because direct checkout and Windows/.NET/WPF tooling are unavailable.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -14,11 +14,13 @@ namespace InventoryManagementApp.Views.Pages
         bool _isCompactHeight;
         Task? _loadRentalsTask;
         ManageRentalsViewModel? _loadedViewModel;
+        int _loadVersion;
 
         public ManageRentalsPage()
         {
             InitializeComponent();
             Loaded += ManageRentalsPage_Loaded;
+            Unloaded += ManageRentalsPage_Unloaded;
             DataContextChanged += ManageRentalsPage_DataContextChanged;
             SizeChanged += ManageRentalsPage_SizeChanged;
             PreviewKeyDown += ManageRentalsPage_PreviewKeyDown;
@@ -37,10 +39,18 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
+        private void ManageRentalsPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            _loadVersion++;
+            _loadedViewModel = null;
+            _loadRentalsTask = null;
+        }
+
         private void ManageRentalsPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (!ReferenceEquals(e.NewValue, _loadedViewModel))
             {
+                _loadVersion++;
                 _loadedViewModel = null;
                 _loadRentalsTask = null;
             }
@@ -48,6 +58,8 @@ namespace InventoryManagementApp.Views.Pages
 
         private async Task LoadRentalsOnceAsync(ManageRentalsViewModel vm)
         {
+            var loadVersion = _loadVersion;
+
             if (ReferenceEquals(_loadedViewModel, vm) && _loadRentalsTask is { IsCompleted: false })
             {
                 await _loadRentalsTask;
@@ -62,13 +74,26 @@ namespace InventoryManagementApp.Views.Pages
             _loadedViewModel = vm;
             await Dispatcher.Yield(DispatcherPriority.Background);
 
-            if (!ReferenceEquals(DataContext, vm) || vm.IsLoading)
+            if (!IsCurrentLoad(vm, loadVersion) || vm.IsLoading)
             {
                 return;
             }
 
             _loadRentalsTask = vm.LoadRentalsAsync();
-            await _loadRentalsTask;
+            try
+            {
+                await _loadRentalsTask;
+            }
+            finally
+            {
+                if (!IsCurrentLoad(vm, loadVersion))
+                    _loadRentalsTask = null;
+            }
+        }
+
+        private bool IsCurrentLoad(ManageRentalsViewModel vm, int loadVersion)
+        {
+            return loadVersion == _loadVersion && ReferenceEquals(DataContext, vm);
         }
 
         private void ManageRentalsPage_SizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
## What changed

- Invalidated Manage Rentals startup-load tracking when the page unloads.
- Added a load-version check around the first-paint dispatcher yield so stale navigation/DataContext work cannot start or be reused as the completed startup load.
- Cleared stale startup task tracking if a load completes after the page is no longer current.
- Preserved the existing active-page once-per-view-model load reuse, compact-height behavior, search focus, row gesture guards, keyboard guards, and busy-state action blocking.
- Extended Manage Rentals source-contract coverage for unload invalidation, DataContext invalidation, load-version capture, current-load checks, and stale-task cleanup.
- Added a progress note for this completed workflow slice.

## Why this was highest value

Recent repo evidence shows Manage Rentals had already been tightened for keyboard/filter responsiveness, but the page-owned startup loader could still treat an old navigation refresh as current once the dispatcher yield or background task completed. This is a focused reliability and responsiveness follow-up for a core rental workflow: opening the screen, switching away, returning, and avoiding stale load state.

## Why this is real progress

This is a vertical page-host lifecycle fix rather than a cosmetic change. It protects screen opening, repeated navigation, DataContext swaps, load reuse, busy-state action safety, and the source-contract guardrails that keep those behaviors from regressing.

## Validation

- GitHub connector compare confirmed the branch is current with `master` and limited to Manage Rentals page host code, source-contract tests, and one progress note.
- Connector readback confirmed `_loadVersion`, `ManageRentalsPage_Unloaded`, `IsCurrentLoad(...)`, and stale-task cleanup are present in `ManageRentalsPage.xaml.cs`.
- Connector readback confirmed source-contract assertions cover unload invalidation, DataContext invalidation, load-version capture, current-load checks, and stale-task cleanup.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET build/test execution
- WPF runtime smoke testing
- screenshots, scaling checks, and live Manage Rentals navigation testing

Those remain blocked in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run the full Windows validation runner on a Windows/.NET-capable checkout.
- Smoke test Manage Rentals navigation away/back during a slow rental refresh to confirm the runtime behavior visually.