### PR TITLE
Guard Activity Logs stale startup and filter work

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
@@ -102,12 +102,41 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DataContextChanged += ActivityLogsPage_DataContextChanged;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Unloaded += ActivityLogsPage_Unloaded;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("ReferenceEquals(_loadedViewModel, vm)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("ActivitySearchBox.Focus();", codeBehind, StringComparison.Ordinal);
             Assert.Contains("!vm.RefreshCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DataContext is ActivityLogsViewModel { IsBusy: true }", codeBehind, StringComparison.Ordinal);
             Assert.Contains("if (vm.IsBusy)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("vm.PrintStatusText", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsPage_CodeBehindInvalidatesStaleStartupLoads()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("private int _loadVersion;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var loadVersion = _loadVersion;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!IsCurrentActivityLoad(vm, loadVersion) || !vm.RefreshCommand.CanExecute(null))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var loaded = await vm.LoadLogsAsync();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!IsCurrentActivityLoad(vm, loadVersion))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private bool IsCurrentActivityLoad(ActivityLogsViewModel vm, int loadVersion)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("return loadVersion == _loadVersion && ReferenceEquals(DataContext, vm);", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsPage_CodeBehindCancelsStaleWorkOnUnloadAndDataContextChange()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("private void ActivityLogsPage_Unloaded", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadVersion++;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_hasLoadedLogs = false;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadedViewModel = null;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.CancelPendingFilterRefresh();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (e.OldValue is ActivityLogsViewModel oldVm && !ReferenceEquals(oldVm, e.NewValue))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("oldVm.CancelPendingFilterRefresh();", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -158,6 +187,20 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("await Task.Run(() => rows.Where", viewModel, StringComparison.Ordinal);
             Assert.Contains("PreserveActivityLogRowsAfterLoadFailure", viewModel, StringComparison.Ordinal);
             Assert.DoesNotContain("ClearActivityLogRowsAfterLoadFailure", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsViewModel_CancelsPendingFilterRefreshWhenPageContextExpires()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
+
+            Assert.Contains("public void CancelPendingFilterRefresh()", viewModel, StringComparison.Ordinal);
+            Assert.Contains("var cts = Interlocked.Exchange(ref _filterRefreshCts, null);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("cts?.Cancel();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (IsFiltering)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("IsFiltering = false;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Activity filtering was canceled before rows were loaded.", viewModel, StringComparison.Ordinal);
+            Assert.Contains("NotifyActivityStateChanged();", viewModel, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-activity-logs-stale-load-filter-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-activity-logs-stale-load-filter-guard.md
@@ -1,0 +1,35 @@
+# Activity Logs Stale Load And Filter Guard
+
+Date: 2026-07-06
+
+## Completed
+
+- Added Activity Logs page-owned load versioning so stale dispatcher-yield or refresh completions cannot mark an old navigation as loaded.
+- Reset Activity Logs startup-load tracking when the page unloads.
+- Reset Activity Logs startup-load tracking when the page receives a different view model.
+- Cancel pending Activity Logs filter refresh work when the page unloads.
+- Cancel pending Activity Logs filter refresh work when the page swaps to another view model.
+- Guarded manual Refresh completion so a stale refresh cannot update page-owned load tracking after navigation.
+- Preserved first-paint search focus, dispatcher yield before initial load, busy gesture guards, row retargeting, keyboard shortcut guards, virtualized grid display, and capped print output.
+- Added a view-model cancellation hook that clears stale filtering state and leaves visible rows in place.
+- Extended Activity Logs source-contract coverage for load versioning, unload invalidation, DataContext invalidation, stale completion checks, and filter cancellation.
+
+## Validation
+
+- GitHub connector read/update flow confirmed the branch is based on `master` and contains the intended Activity Logs page, ViewModel, contract test, and progress-note changes.
+- Source-contract assertions were added for the new lifecycle and cancellation behavior.
+
+## Not run
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- Local .NET restore/build/test
+- WPF runtime smoke testing
+- Screenshots/scaling checks
+- Live Activity Logs navigation/filter stress testing
+
+These checks require a Windows/.NET/WPF-capable checkout. The scheduled Linux environment could not clone the repository directly because GitHub HTTP access returned `CONNECT tunnel failed, response 403`.
+
+## Follow-up
+
+- Run the full Windows validation runner.
+- Smoke test opening Activity Logs, typing filters, navigating away during refresh/filtering, and returning to confirm the grid stays responsive and does not reuse stale load state.

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -298,6 +298,21 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        public void CancelPendingFilterRefresh()
+        {
+            var cts = Interlocked.Exchange(ref _filterRefreshCts, null);
+            cts?.Cancel();
+
+            if (IsFiltering)
+            {
+                IsFiltering = false;
+                StatusMessage = Logs.Count == 0
+                    ? "Activity filtering was canceled before rows were loaded."
+                    : $"{FilteredLogs.Count} visible activity row(s).";
+                NotifyActivityStateChanged();
+            }
+        }
+
         private void PreserveActivityLogRowsAfterLoadFailure(string message)
         {
             if (Logs.Count == 0)

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -17,12 +17,14 @@ namespace InventoryManagementApp.Views.Pages
     {
         private const int MaxActivityPrintRows = 250;
         private bool _hasLoadedLogs;
+        private int _loadVersion;
         private ActivityLogsViewModel? _loadedViewModel;
 
         public ActivityLogsPage()
         {
             InitializeComponent();
             Loaded += ActivityLogsPage_Loaded;
+            Unloaded += ActivityLogsPage_Unloaded;
             DataContextChanged += ActivityLogsPage_DataContextChanged;
             PreviewKeyDown += ActivityLogsPage_PreviewKeyDown;
         }
@@ -40,16 +42,38 @@ namespace InventoryManagementApp.Views.Pages
             if (!vm.RefreshCommand.CanExecute(null))
                 return;
 
+            var loadVersion = _loadVersion;
             await Dispatcher.Yield(DispatcherPriority.Background);
-            if (!ReferenceEquals(DataContext, vm) || !vm.RefreshCommand.CanExecute(null))
+            if (!IsCurrentActivityLoad(vm, loadVersion) || !vm.RefreshCommand.CanExecute(null))
                 return;
 
             _loadedViewModel = vm;
-            _hasLoadedLogs = await vm.LoadLogsAsync();
+            var loaded = await vm.LoadLogsAsync();
+            if (!IsCurrentActivityLoad(vm, loadVersion))
+            {
+                if (ReferenceEquals(_loadedViewModel, vm))
+                    _hasLoadedLogs = false;
+                return;
+            }
+
+            _hasLoadedLogs = loaded;
+        }
+
+        private void ActivityLogsPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            _loadVersion++;
+            _hasLoadedLogs = false;
+            _loadedViewModel = null;
+            if (DataContext is ActivityLogsViewModel vm)
+                vm.CancelPendingFilterRefresh();
         }
 
         private void ActivityLogsPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
+            _loadVersion++;
+            if (e.OldValue is ActivityLogsViewModel oldVm && !ReferenceEquals(oldVm, e.NewValue))
+                oldVm.CancelPendingFilterRefresh();
+
             if (!ReferenceEquals(e.NewValue, _loadedViewModel))
             {
                 _hasLoadedLogs = false;
@@ -85,8 +109,12 @@ namespace InventoryManagementApp.Views.Pages
         {
             if (DataContext is ActivityLogsViewModel vm && vm.RefreshCommand.CanExecute(null))
             {
+                var loadVersion = _loadVersion;
                 _hasLoadedLogs = false;
                 var loaded = await vm.LoadLogsAsync();
+                if (!IsCurrentActivityLoad(vm, loadVersion))
+                    return;
+
                 _hasLoadedLogs = loaded;
                 _loadedViewModel = vm;
             }
@@ -278,6 +306,11 @@ namespace InventoryManagementApp.Views.Pages
         }
 
         private bool IsActivityDirectoryBusy() => DataContext is ActivityLogsViewModel { IsBusy: true };
+
+        private bool IsCurrentActivityLoad(ActivityLogsViewModel vm, int loadVersion)
+        {
+            return loadVersion == _loadVersion && ReferenceEquals(DataContext, vm);
+        }
 
         private void RetargetActivitySelectionFromEvent(RoutedEventArgs e)
         {


### PR DESCRIPTION
## What changed

- Added Activity Logs page-owned load versioning so stale dispatcher-yield startup work cannot mark an old navigation as loaded.
- Added unload invalidation for Activity Logs startup-load tracking.
- Added DataContext-change invalidation for Activity Logs startup-load tracking.
- Guarded initial load completion so stale refresh results do not update page-owned loaded state after navigation.
- Guarded manual Refresh completion with the same current-page/current-view-model check.
- Added a current-load helper to keep page lifecycle checks consistent.
- Added a ViewModel cancellation hook for pending debounced filter refresh work.
- Canceled pending filter work when Activity Logs unloads.
- Canceled pending filter work when Activity Logs swaps away from an old ViewModel.
- Cleared stale filtering state with a visible status message while keeping existing visible rows in place.
- Preserved first-paint search focus, dispatcher yield before loading, virtualized grid display, busy gesture guards, keyboard shortcut behavior, row retargeting, and capped print output.
- Extended Activity Logs source-contract coverage for load versioning, unload invalidation, DataContext invalidation, stale completion checks, filter cancellation, and progress-note documentation.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-activity-logs-stale-load-filter-guard.md`.

## Why this was highest value

Recent Activity Logs work improved input responsiveness, row gestures, filtering, and print handoff, but current source evidence still showed page-owned startup loading could be completed by stale work after the page unloaded or changed DataContext. The ViewModel also had debounced filter work with no page lifecycle cancellation path. This is a concrete responsiveness and reliability follow-up for a data-heavy audit screen without repeating unrelated layout or print work.

## Why this is real progress

This is a workflow-level lifecycle slice across Activity Logs startup load, manual refresh, navigation away/back, DataContext swaps, debounced filtering, user-facing busy state, source-contract coverage, and progress notes. It protects screen opening, tab switching, filtering, refresh, and preserved row display as one coherent path.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, four commits ahead, and limited to Activity Logs page code-behind, Activity Logs ViewModel, Activity Logs source-contract tests, and one progress note.
- GitHub connector readback confirmed `_loadVersion`, `ActivityLogsPage_Unloaded`, `IsCurrentActivityLoad(...)`, stale completion guards, manual refresh guards, and DataContext/unload filter cancellation are present.
- GitHub connector readback confirmed `CancelPendingFilterRefresh()` clears pending filter work and stale filtering state while preserving visible rows.
- GitHub connector readback confirmed source-contract assertions cover stale startup loads, unload/DataContext cleanup, filter cancellation, and the preserved existing interaction contracts.
- Connector status readback found no attached commit statuses for the branch head before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Activity Logs navigation/filter stress testing

Those remain unavailable in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403` and Windows/.NET/WPF tooling is not installed.

## Follow-up

- Run the full Windows validation runner on a Windows/.NET-capable checkout.
- Smoke test Activity Logs by opening the screen, typing filters, refreshing, navigating away during refresh/filtering, and returning to confirm the grid stays responsive and does not reuse stale load state.