### PR TITLE
Harden dashboard loading action safety

### DIFF
--- a/InventoryManagementApp.Tests/DashboardPageLoadingSafetyContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageLoadingSafetyContractTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class DashboardPageLoadingSafetyContractTests
+    {
+        [Fact]
+        public void DashboardPage_BlocksContextMenusWhileRowsRefresh()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("AddHandler(ContextMenuService.ContextMenuOpeningEvent, new ContextMenuEventHandler(DashboardPage_ContextMenuOpening), true);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void DashboardPage_ContextMenuOpening(object sender, ContextMenuEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (_isLoadingDashboard)\n            {\n                e.Handled = true;\n            }", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_ClearsStaleLoadStatusWhenUnloaded()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("private void DashboardPage_Unloaded(object sender, RoutedEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_loadCts?.Cancel();\n            _loadCts?.Dispose();\n            _loadCts = null;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_isLoadingDashboard = false;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SetDashboardInteractiveActionsEnabled(true);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SetDashboardLoadStatus(null, showRetry: false);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Cursor = null;", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardPage_UsesIterativeVisualTraversalWhenTogglingActions()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
+
+            Assert.Contains("private static IEnumerable<DependencyObject> EnumerateVisualDescendants(DependencyObject parent)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var pending = new Stack<DependencyObject>();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("pending.Push(parent);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("while (pending.Count > 0)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var current = pending.Pop();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("for (var index = childCount - 1; index >= 0; index--)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("pending.Push(child);", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var descendant in EnumerateVisualDescendants(child))", codeBehind, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text)
+            => text.Replace("\r\n", "\n");
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-dashboard-loading-action-safety.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-dashboard-loading-action-safety.md
@@ -1,0 +1,17 @@
+# Dashboard Loading Action Safety
+
+Date: 2026-07-06
+
+## Completed
+
+- Blocks Dashboard context-menu opening while dashboard rows are refreshing so keyboard/menu invocation cannot dispatch stale row actions during a load.
+- Clears the Dashboard loading banner and retry state when the page unloads so recycled page instances do not carry stale load messages into the next navigation.
+- Keeps the existing retry button exception while visible actions are disabled during refresh.
+- Replaces recursive Dashboard visual-tree traversal with an iterative stack-based traversal when toggling visible buttons and menu items during refresh.
+- Preserves existing startup load reuse, stale load cancellation, retry, row double-click, right-click row retargeting, keyboard shortcut, and print shortcut behavior.
+- Adds Dashboard source-contract coverage for loading-state context-menu blocking, unload cleanup, and iterative action traversal.
+
+## Validation
+
+- Source inspected through GitHub connector readback and compare.
+- Full Windows validation, .NET build/tests, WPF runtime smoke testing, screenshots, scaling checks, and live Dashboard loading/menu testing remain blocked in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
@@ -28,6 +28,7 @@ namespace InventoryManagementApp.Views.Pages
             Unloaded += DashboardPage_Unloaded;
             DataContextChanged += DashboardPage_DataContextChanged;
             PreviewKeyDown += DashboardPage_PreviewKeyDown;
+            AddHandler(ContextMenuService.ContextMenuOpeningEvent, new ContextMenuEventHandler(DashboardPage_ContextMenuOpening), true);
         }
 
         private async void DashboardPage_Loaded(object sender, RoutedEventArgs e)
@@ -155,14 +156,20 @@ namespace InventoryManagementApp.Views.Pages
 
         private static IEnumerable<DependencyObject> EnumerateVisualDescendants(DependencyObject parent)
         {
-            var childCount = VisualTreeHelper.GetChildrenCount(parent);
-            for (var index = 0; index < childCount; index++)
-            {
-                var child = VisualTreeHelper.GetChild(parent, index);
-                yield return child;
+            var pending = new Stack<DependencyObject>();
+            pending.Push(parent);
 
-                foreach (var descendant in EnumerateVisualDescendants(child))
-                    yield return descendant;
+            while (pending.Count > 0)
+            {
+                var current = pending.Pop();
+                var childCount = VisualTreeHelper.GetChildrenCount(current);
+
+                for (var index = childCount - 1; index >= 0; index--)
+                {
+                    var child = VisualTreeHelper.GetChild(current, index);
+                    pending.Push(child);
+                    yield return child;
+                }
             }
         }
 
@@ -174,7 +181,16 @@ namespace InventoryManagementApp.Views.Pages
             _loadCts = null;
             _isLoadingDashboard = false;
             SetDashboardInteractiveActionsEnabled(true);
+            SetDashboardLoadStatus(null, showRetry: false);
             Cursor = null;
+        }
+
+        private void DashboardPage_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            if (_isLoadingDashboard)
+            {
+                e.Handled = true;
+            }
         }
 
         private void DashboardPage_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)


### PR DESCRIPTION
## What changed

- Blocked Dashboard context-menu opening while dashboard rows are refreshing so keyboard/menu invocation cannot dispatch stale row actions during a load.
- Cleared Dashboard loading banner/retry state on unload so recycled page instances do not carry stale messages into later navigations.
- Replaced recursive Dashboard visual-tree traversal with an iterative stack-based traversal when toggling visible actions during refresh.
- Added source-contract coverage for the loading-state context-menu guard, unload cleanup, and iterative traversal.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-dashboard-loading-action-safety.md`.

## Why this was highest value

Recent work has improved Dashboard startup and row invocation safety. This follow-up closes a remaining action-safety gap: context menus can be opened through routes that are not guaranteed to be covered by visual-tree button/menu toggling, and recursive visual traversal is unnecessary pressure on a busy Dashboard visual tree.

## Why this is real progress

The change improves a complete Dashboard loading workflow: refresh starts, visible actions are paused, context menus are suppressed during the busy window, stale load UI is cleared on navigation away, and action toggling remains predictable without recursive traversal.

## Validation

- GitHub connector compare confirmed the branch is current with `master` and focused to three files.
- GitHub connector readback confirmed the code-behind changes, new source-contract tests, and progress note.

Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET build/tests, WPF runtime smoke tests, screenshots, scaling checks, or live Dashboard menu testing because this scheduled Linux environment cannot clone the repo directly and does not provide Windows/.NET/WPF tooling.

## Follow-up

Run the full Windows validation runner and Dashboard loading/context-menu smoke test from a Windows-capable checkout.