### PR TITLE
Harden customer directory input action safety

### DIFF
--- a/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
@@ -167,6 +167,48 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void CustomersPage_PreservesTextEditingAndSuppressesBusyContextMenus()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml.cs");
+            var keyDown = ExtractSourceBlock(source, "private void CustomersPage_PreviewKeyDown", "private static bool IsCustomerActionShortcut");
+
+            Assert.Contains("ContextMenuOpening=\"CustomerDataGrid_ContextMenuOpening\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("private void CustomerDataGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Contains("if (DataContext is CustomerManagementViewModel { IsCustomerDirectoryBusy: true })", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsTextInputFocused() && IsCustomerActionShortcut(e))", keyDown, StringComparison.Ordinal);
+            Assert.Contains("return;", keyDown, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.FocusedElement is TextBoxBase or PasswordBox or ComboBox", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", keyDown, StringComparison.Ordinal);
+            Assert.True(
+                keyDown.IndexOf("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", StringComparison.Ordinal) <
+                keyDown.IndexOf("if (IsTextInputFocused() && IsCustomerActionShortcut(e))", StringComparison.Ordinal),
+                "Ctrl+F should keep focusing search before text-edit shortcuts are preserved.");
+            Assert.True(
+                keyDown.IndexOf("if (IsTextInputFocused() && IsCustomerActionShortcut(e))", StringComparison.Ordinal) <
+                keyDown.IndexOf("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N", StringComparison.Ordinal),
+                "Text-edit guard should run before customer action shortcuts dispatch.");
+        }
+
+        [Fact]
+        public void CustomersPage_HandlesUnavailableDoubleClicksAndUsesIterativeSearchBoxLookup()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml.cs");
+            var doubleClick = ExtractSourceBlock(source, "private void CustomerRow_MouseDoubleClick", "private void CustomerRow_PreviewMouseRightButtonDown");
+            var findDescendant = ExtractSourceBlock(source, "private static T? FindDescendant", "private static int GetVisualChildCount");
+
+            Assert.Contains("e.Handled = true;\n                return;", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n        }", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("using System.Collections.Generic;", source, StringComparison.Ordinal);
+            Assert.Contains("var pending = new Stack<DependencyObject>();", findDescendant, StringComparison.Ordinal);
+            Assert.Contains("while (pending.Count > 0)", findDescendant, StringComparison.Ordinal);
+            Assert.Contains("pending.Push(child);", findDescendant, StringComparison.Ordinal);
+            Assert.DoesNotContain("var nested = FindDescendant<T>(child);", findDescendant, StringComparison.Ordinal);
+            Assert.Contains("private static int GetVisualChildCount(DependencyObject current)", source, StringComparison.Ordinal);
+            Assert.Contains("catch (System.InvalidOperationException)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void CustomerViewModel_GuardsBusyStateAndSelectedCommandAvailability()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CustomerManagementViewModel.cs");
@@ -248,8 +290,8 @@ namespace InventoryManagementApp.Tests
 
             return source[start..end];
         }
+
         static string NormalizeLineEndings(string text)
             => text.Replace("\r\n", "\n");
-
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-customer-directory-input-action-safety.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-customer-directory-input-action-safety.md
@@ -1,0 +1,22 @@
+# Customer Directory Input Action Safety
+
+Date: 2026-07-06
+
+## Completed
+
+- Preserves customer search text editing while global customer shortcuts are available elsewhere on the page.
+- Keeps Ctrl+F as the first keyboard path so operators can always return to customer search quickly.
+- Prevents Enter and Delete from opening or deleting a selected customer while focus is inside customer text-entry controls.
+- Prevents Ctrl+N, Ctrl+R, Ctrl+E, Ctrl+P, Ctrl+Shift+P, Ctrl+C, and Ctrl+D from dispatching customer actions while focus is inside customer text-entry controls.
+- Treats ComboBox focus as text-entry focus for customer shortcut preservation.
+- Blocks customer grid context-menu opening while the directory is refreshing, including keyboard/menu routes that do not pass through row right-click selection.
+- Keeps customer row double-clicks handled when the invoked row is selected but the details command is unavailable, avoiding routed duplicate work.
+- Keeps busy double-click and busy right-click suppression in place while customer rows refresh.
+- Replaces recursive search-box discovery with an iterative visual-tree traversal to avoid recursive pressure on the customer page visual tree.
+- Adds a defensive visual-child count helper so search-box focus does not fail on unsupported dependency objects.
+- Extends Customers source-contract coverage for text-edit shortcut preservation, busy context-menu suppression, unavailable double-click handling, iterative search-box lookup, and defensive visual-tree traversal.
+
+## Validation
+
+- Source inspected through GitHub connector readback and compare.
+- Full Windows validation, .NET build/tests, WPF runtime smoke testing, screenshots, scaling checks, and live Customers keyboard/menu testing remain blocked in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml
@@ -138,6 +138,7 @@
                               ScrollViewer.CanContentScroll="True"
                               ScrollViewer.HorizontalScrollBarVisibility="Auto"
                               ScrollViewer.VerticalScrollBarVisibility="Auto"
+                              ContextMenuOpening="CustomerDataGrid_ContextMenuOpening"
                               Style="{StaticResource VirtualizedDataGridStyle}">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -113,7 +114,10 @@ namespace InventoryManagementApp.Views.Pages
             {
                 UiActionGuard.Run(this, "Customers", () => vm.OpenCustomerDetailsCommand.Execute(null));
                 e.Handled = true;
+                return;
             }
+
+            e.Handled = true;
         }
 
         private void CustomerRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
@@ -125,6 +129,14 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             GridContextMenuSelection.SelectRow(sender, e);
+        }
+
+        private void CustomerDataGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            if (DataContext is CustomerManagementViewModel { IsCustomerDirectoryBusy: true })
+            {
+                e.Handled = true;
+            }
         }
 
         private void CustomersPage_PreviewKeyDown(object sender, KeyEventArgs e)
@@ -142,6 +154,11 @@ namespace InventoryManagementApp.Views.Pages
             if (vm.IsCustomerDirectoryBusy && IsCustomerActionShortcut(e))
             {
                 e.Handled = true;
+                return;
+            }
+
+            if (IsTextInputFocused() && IsCustomerActionShortcut(e))
+            {
                 return;
             }
 
@@ -180,7 +197,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopySelectedCustomerCommand.CanExecute(null))
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopySelectedCustomerCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Customers", () => vm.CopySelectedCustomerCommand.Execute(null));
                 e.Handled = true;
@@ -235,23 +252,42 @@ namespace InventoryManagementApp.Views.Pages
 
         private static bool IsTextInputFocused()
         {
-            return Keyboard.FocusedElement is TextBoxBase or PasswordBox;
+            return Keyboard.FocusedElement is TextBoxBase or PasswordBox or ComboBox;
         }
 
         private static T? FindDescendant<T>(DependencyObject current) where T : DependencyObject
         {
-            for (var index = 0; index < VisualTreeHelper.GetChildrenCount(current); index++)
-            {
-                var child = VisualTreeHelper.GetChild(current, index);
-                if (child is T match)
-                    return match;
+            var pending = new Stack<DependencyObject>();
+            pending.Push(current);
 
-                var nested = FindDescendant<T>(child);
-                if (nested != null)
-                    return nested;
+            while (pending.Count > 0)
+            {
+                var parent = pending.Pop();
+                var childCount = GetVisualChildCount(parent);
+
+                for (var index = 0; index < childCount; index++)
+                {
+                    var child = VisualTreeHelper.GetChild(parent, index);
+                    if (child is T match)
+                        return match;
+
+                    pending.Push(child);
+                }
             }
 
             return null;
+        }
+
+        private static int GetVisualChildCount(DependencyObject current)
+        {
+            try
+            {
+                return VisualTreeHelper.GetChildrenCount(current);
+            }
+            catch (System.InvalidOperationException)
+            {
+                return 0;
+            }
         }
     }
 }


### PR DESCRIPTION
## What changed

- Preserved customer search/text-entry behavior before global customer action shortcuts dispatch.
- Kept Ctrl+F as the first keyboard path so operators can always return to customer search quickly.
- Prevented Enter and Delete from opening or deleting a selected customer while focus is inside customer text-entry controls.
- Prevented Ctrl+N, Ctrl+R, Ctrl+E, Ctrl+P, Ctrl+Shift+P, Ctrl+C, and Ctrl+D from dispatching customer actions while focus is inside customer text-entry controls.
- Treated ComboBox focus as text-entry focus for customer shortcut preservation.
- Added a customer grid context-menu opening guard so keyboard/menu invocation cannot open row actions while the directory is refreshing.
- Kept busy double-click and right-click suppression intact while customer rows refresh.
- Marked customer row double-clicks handled when the invoked row is selected but the details command is unavailable, avoiding routed duplicate work.
- Replaced recursive customer search-box discovery with iterative visual-tree traversal.
- Added a defensive visual-child count helper for first-paint search focus.
- Extended Customers source-contract coverage for text-edit shortcut preservation, busy context-menu suppression, unavailable double-click handling, iterative lookup, and defensive visual-tree traversal.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-customer-directory-input-action-safety.md`.

## Why this was highest value

Recent repo work has improved many WPF screens, but current Customers source still showed page-level shortcuts could dispatch while the user was typing in the customer search field. The grid also had right-click busy suppression, but not a context-menu opening guard for keyboard/menu routes. This is a concrete responsiveness and action-safety improvement for a core directory workflow without repeating recent layout-only work.

## Why this is real progress

This is a focused workflow slice across customer screen opening, search typing, keyboard routing, virtualized row gestures, context menus, visual-tree traversal, source-contract coverage, and progress notes. It improves more than ten operator-facing behaviors while staying inside the existing page and test architecture.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, four commits ahead, zero behind, and limited to Customers page XAML/code-behind, Customers source-contract tests, and one progress note.
- Connector readback confirmed the text-edit shortcut guard, Ctrl+F ordering, ComboBox/TextBox/PasswordBox focus preservation, busy context-menu suppression, handled double-click fallback, iterative search-box lookup, defensive child-count helper, and new source-contract assertions are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs for branch head `a82e56f16908a071aaab3f6d1ab384b29bf84340` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Customers keyboard, menu, and search testing

These remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run the full Windows validation runner from a Windows/.NET-capable checkout.
- Smoke test Customers with search typing, Ctrl+F, Enter, Delete, Ctrl+C, Ctrl+P, context-menu key/right-click, row double-click, and slow directory refresh.