### PR TITLE
Improve shell input timer responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs
@@ -121,6 +121,29 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void MainWindow_CoalescesHighFrequencyAutoLogoutInputResets()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml.cs");
+
+            Assert.Contains("static readonly TimeSpan AutoLogoutInputResetInterval = TimeSpan.FromSeconds(1);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DateTime _lastAutoLogoutResetUtc = DateTime.MinValue;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("InputManager.Current.PreProcessInput += InputManager_PreProcessInput;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("InputManager.Current.PreProcessInput -= InputManager_PreProcessInput;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ResetAutoLogoutTimerForInput(force: false);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ResetAutoLogoutTimerForInput(force: true);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (e.StagingItem.Input is KeyboardEventArgs or MouseButtonEventArgs)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (e.StagingItem.Input is MouseEventArgs)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("void ResetAutoLogoutTimerForInput(bool force)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var now = DateTime.UtcNow;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!force && now - _lastAutoLogoutResetUtc < AutoLogoutInputResetInterval)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_lastAutoLogoutResetUtc = now;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_mainViewModel.ResetAutoLogoutTimer();", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("MouseMove += (_, __) => vm.ResetAutoLogoutTimer();", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("KeyDown += (_, __) => vm.ResetAutoLogoutTimer();", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("MouseDown += (_, __) => vm.ResetAutoLogoutTimer();", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void MainWindow_PreservesCoreNavigationSearchUserAndWorkflowBindings()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");

--- a/InventoryManagementApp/MainWindow.xaml.cs
+++ b/InventoryManagementApp/MainWindow.xaml.cs
@@ -17,10 +17,12 @@ namespace InventoryManagementApp
     {
         const double CompactShellHeightThreshold = 820;
         const double CompactShellWidthThreshold = 1120;
+        static readonly TimeSpan AutoLogoutInputResetInterval = TimeSpan.FromSeconds(1);
         readonly IDatabaseService? _ownedDb;
         MainViewModel? _mainViewModel;
         bool? _isCompactShellLayout;
         double? _lastAdaptiveResourceScale;
+        DateTime _lastAutoLogoutResetUtc = DateTime.MinValue;
         readonly Dictionary<string, double> _baseAdaptiveDoubleResources = new(StringComparer.Ordinal);
         readonly Dictionary<string, Thickness> _baseAdaptiveThicknessResources = new(StringComparer.Ordinal);
 
@@ -55,9 +57,6 @@ namespace InventoryManagementApp
             {
                 _mainViewModel = vm;
                 _mainViewModel.PropertyChanged += MainViewModel_PropertyChanged;
-                MouseMove += (_, __) => vm.ResetAutoLogoutTimer();
-                KeyDown += (_, __) => vm.ResetAutoLogoutTimer();
-                MouseDown += (_, __) => vm.ResetAutoLogoutTimer();
                 InputManager.Current.PreProcessInput += InputManager_PreProcessInput;
             }
         }
@@ -189,12 +188,31 @@ namespace InventoryManagementApp
 
             if (e.StagingItem.Input is MouseWheelEventArgs wheelArgs && SmoothMouseWheelScroll.TryHandle(wheelArgs))
             {
-                _mainViewModel.ResetAutoLogoutTimer();
+                ResetAutoLogoutTimerForInput(force: false);
                 return;
             }
 
-            if (e.StagingItem.Input is MouseEventArgs or KeyboardEventArgs)
-                _mainViewModel.ResetAutoLogoutTimer();
+            if (e.StagingItem.Input is KeyboardEventArgs or MouseButtonEventArgs)
+            {
+                ResetAutoLogoutTimerForInput(force: true);
+                return;
+            }
+
+            if (e.StagingItem.Input is MouseEventArgs)
+                ResetAutoLogoutTimerForInput(force: false);
+        }
+
+        void ResetAutoLogoutTimerForInput(bool force)
+        {
+            if (_mainViewModel == null)
+                return;
+
+            var now = DateTime.UtcNow;
+            if (!force && now - _lastAutoLogoutResetUtc < AutoLogoutInputResetInterval)
+                return;
+
+            _lastAutoLogoutResetUtc = now;
+            _mainViewModel.ResetAutoLogoutTimer();
         }
 
         void SectionMenuItem_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-shell-input-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-shell-input-responsiveness.md
@@ -1,0 +1,27 @@
+# Shell Input Responsiveness - 2026-07-06
+
+## Completed
+
+- Removed duplicate direct shell `MouseMove`, `KeyDown`, and `MouseDown` auto-logout timer resets now that shell input is already observed through WPF pre-process input.
+- Added a one-second coalescing window for high-frequency mouse movement and wheel activity so continuous pointer movement does not repeatedly stop/start the auto-logout timer on every input packet.
+- Kept keyboard input and mouse-button input as immediate activity signals so deliberate operator actions still extend the session without waiting for the coalescing window.
+- Preserved smooth mouse-wheel handling while routing its activity update through the shared coalesced reset path.
+- Kept pre-process input subscription cleanup on window close so the shell does not retain stale input handlers.
+- Extended `MainWindowResponsiveContractTests` to guard the throttle interval, last-reset timestamp, pre-process subscription, forced keyboard/mouse-button behavior, coalesced mouse behavior, and removal of duplicate direct event handlers.
+
+## Why It Matters
+
+The shell is present for every workflow. Before this change, ordinary mouse and keyboard activity could reset the auto-logout timer through both direct window events and the global pre-process input hook, and high-frequency pointer movement could repeatedly stop/start the timer while operators were simply moving across dense tables, menus, and dialogs. Coalescing passive input keeps the shell lighter during navigation, searching, tab switching, grid scrolling, and data review while preserving immediate session extension for intentional keyboard and click activity.
+
+## Validation
+
+- GitHub connector readback should confirm `MainWindow.xaml.cs` now uses `AutoLogoutInputResetInterval`, `_lastAutoLogoutResetUtc`, and `ResetAutoLogoutTimerForInput(...)` through the existing pre-process input path.
+- Source-contract coverage in `MainWindowResponsiveContractTests` now guards the new input-throttle behavior and rejects the removed duplicate direct input event handlers.
+
+## Not Run Here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- .NET restore/build/test
+- WPF runtime smoke tests, screenshots, Windows scaling checks, or live shell input testing
+
+Those remain unavailable in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is not present.


### PR DESCRIPTION
## Summary

- Coalesces high-frequency shell mouse/wheel auto-logout timer resets through the existing pre-process input hook.
- Removes duplicate direct `MouseMove`, `KeyDown`, and `MouseDown` timer reset handlers from `MainWindow`.
- Keeps keyboard and mouse-button activity as immediate session extension signals while passive mouse movement uses a one-second throttle.
- Adds source-contract coverage for the throttle, forced input paths, handler cleanup, and removed duplicate event subscriptions.
- Records progress in `InventoryManagementApp/ProgressNotes/2026-07-06-shell-input-responsiveness.md`.

## Why This Was Highest Value

The shell wraps every workflow, and its input handling runs while operators navigate screens, switch tabs, scroll grids, search, filter, and review dense data. Current source evidence showed auto-logout resets could be dispatched by both direct window handlers and global pre-process input, with no coalescing for high-frequency mouse movement. Tightening that shared path improves responsiveness without touching page-specific workflows that were already improved in recent runs.

## Scope And Progress

This is a focused workflow-level shell responsiveness slice: it changes the shared runtime input path, preserves intentional activity behavior, adds regression coverage, and documents the completed work. It avoids repeating the recent Dashboard, Rentals, Reports, Labels, Kits, and Item Details work unless fresh evidence appears.

## Validation

- Connector readback will be used to confirm the changed files and source markers because this scheduled environment cannot clone the repo directly.
- Added `MainWindowResponsiveContractTests.MainWindow_CoalescesHighFrequencyAutoLogoutInputResets` source-contract coverage.

## Not Run

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, Windows scaling checks, or live shell input testing

These remain unavailable in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is not present.

## Follow-up

Run the full validation script on a Windows/.NET-capable checkout and smoke test shell navigation/input behavior under normal pointer movement, keyboard shortcuts, menu use, and long-running grid review.