### PR TITLE
Harden Settings lifecycle responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
@@ -101,12 +101,12 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("private bool _sensitiveFieldSyncQueued;", source, StringComparison.Ordinal);
             Assert.Contains("private void QueueSensitiveFieldSync(SettingsViewModel? sourceViewModel)", source, StringComparison.Ordinal);
-            Assert.Contains("sourceViewModel == null || _sensitiveFieldSyncQueued || !ReferenceEquals(_settingsViewModel, sourceViewModel)", source, StringComparison.Ordinal);
+            Assert.Contains("!_isLoaded || sourceViewModel == null || _sensitiveFieldSyncQueued || !ReferenceEquals(_settingsViewModel, sourceViewModel)", source, StringComparison.Ordinal);
             Assert.Contains("_sensitiveFieldSyncQueued = true;", source, StringComparison.Ordinal);
             Assert.Contains("Dispatcher.BeginInvoke(new Action(() => SyncSensitiveFieldsFromViewModel(sourceViewModel)), DispatcherPriority.Background);", source, StringComparison.Ordinal);
             Assert.Contains("_sensitiveFieldSyncQueued = false;", source, StringComparison.Ordinal);
             Assert.Contains("private void SyncSensitiveFieldsFromViewModel(SettingsViewModel sourceViewModel)", source, StringComparison.Ordinal);
-            Assert.Contains("if (!ReferenceEquals(_settingsViewModel, sourceViewModel))", source, StringComparison.Ordinal);
+            Assert.Contains("if (!_isLoaded || !ReferenceEquals(_settingsViewModel, sourceViewModel))", source, StringComparison.Ordinal);
             Assert.DoesNotContain("Dispatcher.Invoke(SyncSensitiveFieldsFromViewModel)", source, StringComparison.Ordinal);
         }
 
@@ -118,7 +118,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("private Task? _initializeSettingsTask;", source, StringComparison.Ordinal);
             Assert.Contains("StartSettingsInitialization();", source, StringComparison.Ordinal);
             Assert.Contains("private void StartSettingsInitialization()", source, StringComparison.Ordinal);
-            Assert.Contains("if (_settingsViewModel == null || _initializeSettingsTask != null)", source, StringComparison.Ordinal);
+            Assert.Contains("if (!_isLoaded || _settingsViewModel == null || _initializeSettingsTask != null)", source, StringComparison.Ordinal);
             Assert.Contains("_initializeSettingsCts = new CancellationTokenSource();", source, StringComparison.Ordinal);
             Assert.Contains("var version = ++_initializeSettingsVersion;", source, StringComparison.Ordinal);
             Assert.Contains("_initializeSettingsTask = InitializeSettingsAsync(_settingsViewModel, _initializeSettingsCts.Token, version);", source, StringComparison.Ordinal);
@@ -150,14 +150,54 @@ namespace InventoryManagementApp.Tests
         {
             var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml.cs");
 
-            Assert.True(CountOccurrences(source, "version != _initializeSettingsVersion") >= 3);
-            Assert.True(CountOccurrences(source, "!ReferenceEquals(_settingsViewModel, viewModel)") >= 3);
+            Assert.Contains("private bool IsCurrentSettingsInitialization(SettingsViewModel viewModel, int version)", source, StringComparison.Ordinal);
+            Assert.Contains("&& ReferenceEquals(_settingsViewModel, viewModel)", source, StringComparison.Ordinal);
+            Assert.Contains("&& version == _initializeSettingsVersion;", source, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(source, "IsCurrentSettingsInitialization(viewModel, version)") >= 3);
+            Assert.Contains("private void CompleteSettingsInitialization(SettingsViewModel viewModel, int version)", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeSettingsCts?.Dispose();", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeSettingsTask = null;", source, StringComparison.Ordinal);
             Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", source, StringComparison.Ordinal);
             Assert.Contains("MessageBox.Show(", source, StringComparison.Ordinal);
             Assert.Contains("$\"Failed to load settings: {ex.Message}\"", source, StringComparison.Ordinal);
             Assert.Contains("MessageBoxImage.Error", source, StringComparison.Ordinal);
             Assert.Contains("_settingsViewModel.PropertyChanged -= SettingsViewModel_PropertyChanged;", source, StringComparison.Ordinal);
             Assert.Contains("_settingsViewModel.PropertyChanged += SettingsViewModel_PropertyChanged;", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SettingsPage_CodeBehindCancelsQueuedThemeTabWorkAfterUnload()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml.cs");
+
+            Assert.Contains("private bool _isLoaded;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _themeDesignerTabVersion;", source, StringComparison.Ordinal);
+            Assert.Contains("_isLoaded = true;", source, StringComparison.Ordinal);
+            Assert.Contains("_isLoaded = false;", source, StringComparison.Ordinal);
+            Assert.Contains("_themeDesignerTabVersion++;", source, StringComparison.Ordinal);
+            Assert.Contains("_themeDesignerTabRetryQueued = false;", source, StringComparison.Ordinal);
+            Assert.Contains("if (_themeDesignerTabRetryQueued || !_isLoaded)", source, StringComparison.Ordinal);
+            Assert.Contains("var version = ++_themeDesignerTabVersion;", source, StringComparison.Ordinal);
+            Assert.Contains("if (!_isLoaded || version != _themeDesignerTabVersion)", source, StringComparison.Ordinal);
+            Assert.Contains("AddThemeDesignerTab();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SettingsPage_CodeBehindUsesIterativeVisualTraversalForThemeTabLookup()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml.cs");
+
+            Assert.Contains("using System.Collections.Generic;", source, StringComparison.Ordinal);
+            Assert.Contains("var pending = new Stack<DependencyObject>();", source, StringComparison.Ordinal);
+            Assert.Contains("pending.Push(parent);", source, StringComparison.Ordinal);
+            Assert.Contains("while (pending.Count > 0)", source, StringComparison.Ordinal);
+            Assert.Contains("var current = pending.Pop();", source, StringComparison.Ordinal);
+            Assert.Contains("var childCount = GetVisualChildrenCount(current);", source, StringComparison.Ordinal);
+            Assert.Contains("for (var i = childCount - 1; i >= 0; i--)", source, StringComparison.Ordinal);
+            Assert.Contains("pending.Push(child);", source, StringComparison.Ordinal);
+            Assert.Contains("private static int GetVisualChildrenCount(DependencyObject parent)", source, StringComparison.Ordinal);
+            Assert.Contains("catch (InvalidOperationException)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("var nested = FindVisualChild<T>(child);", source, StringComparison.Ordinal);
         }
 
         private static int CountOccurrences(string text, string value)

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-settings-lifecycle-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-settings-lifecycle-responsiveness.md
@@ -1,0 +1,33 @@
+# Settings Lifecycle Responsiveness - 2026-07-06
+
+## Completed
+
+- Added loaded/unloaded state tracking to Settings so deferred startup work only runs while the page is current.
+- Invalidated queued theme-designer tab retries on unload so a recycled page cannot inject tabs after navigation away.
+- Guarded theme-designer tab retry dispatch with a version check before retrying the insertion.
+- Replaced recursive Settings visual-tree traversal with an iterative stack walk for the injected theme tab lookup.
+- Added defensive visual-child count handling so unsupported visual nodes do not break the lookup path.
+- Kept theme tab insertion bounded to the loaded page and preserved tab renumbering after insertion.
+- Blocked sensitive password/API-key sync queueing while Settings is unloaded.
+- Guarded queued sensitive field synchronization so stale DataContext work cannot write password boxes after navigation.
+- Centralized Settings initialization currency checks through `IsCurrentSettingsInitialization(...)`.
+- Cleared completed initialization task and cancellation-source state after current initialization finishes.
+- Preserved first-paint dispatcher yielding, duplicate initialization suppression, DataContext swap cancellation, and user-facing initialization error handling.
+- Extended `SettingsPageResponsiveContractTests` to cover stale retry cancellation, iterative traversal, defensive child-count handling, loaded-state gates, initialization completion cleanup, and sensitive-field queue guards.
+
+## Why It Matters
+
+Settings is an admin-heavy screen with database, branding, email, messaging, backup, and security controls. The page already deferred initialization for first paint, but queued theme-tab and sensitive-field work could still outlive navigation. Tightening these lifecycle paths keeps tab switching and Settings reopening responsive and avoids stale UI work touching a page that is no longer visible.
+
+## Validation
+
+- Source-contract coverage now guards the loaded-state gates, theme retry versioning, iterative visual traversal, initialization cleanup, and sensitive-field stale-work checks.
+- GitHub connector compare/readback should confirm the branch is limited to Settings page host code, Settings responsive contracts, and this progress note.
+
+## Not Run Here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- .NET restore/build/test
+- WPF runtime smoke tests, screenshots, scaling checks, or live Settings navigation testing
+
+Those remain unavailable in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is not present.

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -16,10 +17,12 @@ namespace InventoryManagementApp.Views.Pages
         private SettingsViewModel? _settingsViewModel;
         private bool _themeDesignerTabAdded;
         private bool _themeDesignerTabRetryQueued;
+        private bool _isLoaded;
         private bool _sensitiveFieldSyncQueued;
         private Task? _initializeSettingsTask;
         private CancellationTokenSource? _initializeSettingsCts;
         private int _initializeSettingsVersion;
+        private int _themeDesignerTabVersion;
 
         public SettingsPage()
         {
@@ -31,6 +34,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void SettingsPage_Loaded(object sender, RoutedEventArgs e)
         {
+            _isLoaded = true;
             AddThemeDesignerTab();
             AttachViewModel(DataContext as SettingsViewModel);
             QueueSensitiveFieldSync(_settingsViewModel);
@@ -39,6 +43,10 @@ namespace InventoryManagementApp.Views.Pages
 
         private void SettingsPage_Unloaded(object sender, RoutedEventArgs e)
         {
+            _isLoaded = false;
+            _themeDesignerTabVersion++;
+            _themeDesignerTabRetryQueued = false;
+            _sensitiveFieldSyncQueued = false;
             CancelSettingsInitialization();
             AttachViewModel(null);
         }
@@ -52,7 +60,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void AddThemeDesignerTab()
         {
-            if (_themeDesignerTabAdded)
+            if (_themeDesignerTabAdded || !_isLoaded)
                 return;
 
             var tabControl = FindVisualChild<TabControl>(this);
@@ -77,11 +85,21 @@ namespace InventoryManagementApp.Views.Pages
 
         private void QueueThemeDesignerTabRetry()
         {
-            if (_themeDesignerTabRetryQueued)
+            if (_themeDesignerTabRetryQueued || !_isLoaded)
                 return;
 
             _themeDesignerTabRetryQueued = true;
-            Dispatcher.BeginInvoke(AddThemeDesignerTab, DispatcherPriority.Loaded);
+            var version = ++_themeDesignerTabVersion;
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                if (!_isLoaded || version != _themeDesignerTabVersion)
+                {
+                    _themeDesignerTabRetryQueued = false;
+                    return;
+                }
+
+                AddThemeDesignerTab();
+            }), DispatcherPriority.Loaded);
         }
 
         private static void RenumberTabs(TabControl tabControl)
@@ -101,18 +119,36 @@ namespace InventoryManagementApp.Views.Pages
 
         private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
         {
-            for (var i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
-            {
-                var child = VisualTreeHelper.GetChild(parent, i);
-                if (child is T typed)
-                    return typed;
+            var pending = new Stack<DependencyObject>();
+            pending.Push(parent);
 
-                var nested = FindVisualChild<T>(child);
-                if (nested != null)
-                    return nested;
+            while (pending.Count > 0)
+            {
+                var current = pending.Pop();
+                var childCount = GetVisualChildrenCount(current);
+                for (var i = childCount - 1; i >= 0; i--)
+                {
+                    var child = VisualTreeHelper.GetChild(current, i);
+                    if (child is T typed)
+                        return typed;
+
+                    pending.Push(child);
+                }
             }
 
             return null;
+        }
+
+        private static int GetVisualChildrenCount(DependencyObject parent)
+        {
+            try
+            {
+                return VisualTreeHelper.GetChildrenCount(parent);
+            }
+            catch (InvalidOperationException)
+            {
+                return 0;
+            }
         }
 
         private void AttachViewModel(SettingsViewModel? viewModel)
@@ -145,6 +181,23 @@ namespace InventoryManagementApp.Views.Pages
             _initializeSettingsTask = null;
         }
 
+        private void CompleteSettingsInitialization(SettingsViewModel viewModel, int version)
+        {
+            if (!IsCurrentSettingsInitialization(viewModel, version))
+                return;
+
+            _initializeSettingsCts?.Dispose();
+            _initializeSettingsCts = null;
+            _initializeSettingsTask = null;
+        }
+
+        private bool IsCurrentSettingsInitialization(SettingsViewModel viewModel, int version)
+        {
+            return _isLoaded
+                && ReferenceEquals(_settingsViewModel, viewModel)
+                && version == _initializeSettingsVersion;
+        }
+
         private void SettingsViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             if (e.PropertyName is nameof(SettingsViewModel.SmtpPassword) or nameof(SettingsViewModel.SmsApiKey)
@@ -156,7 +209,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void QueueSensitiveFieldSync(SettingsViewModel? sourceViewModel)
         {
-            if (sourceViewModel == null || _sensitiveFieldSyncQueued || !ReferenceEquals(_settingsViewModel, sourceViewModel))
+            if (!_isLoaded || sourceViewModel == null || _sensitiveFieldSyncQueued || !ReferenceEquals(_settingsViewModel, sourceViewModel))
             {
                 return;
             }
@@ -169,7 +222,7 @@ namespace InventoryManagementApp.Views.Pages
         {
             _sensitiveFieldSyncQueued = false;
 
-            if (!ReferenceEquals(_settingsViewModel, sourceViewModel))
+            if (!_isLoaded || !ReferenceEquals(_settingsViewModel, sourceViewModel))
             {
                 return;
             }
@@ -187,7 +240,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void StartSettingsInitialization()
         {
-            if (_settingsViewModel == null || _initializeSettingsTask != null)
+            if (!_isLoaded || _settingsViewModel == null || _initializeSettingsTask != null)
             {
                 return;
             }
@@ -204,19 +257,20 @@ namespace InventoryManagementApp.Views.Pages
             {
                 await Dispatcher.Yield(DispatcherPriority.Background);
                 cancellationToken.ThrowIfCancellationRequested();
-                if (!ReferenceEquals(_settingsViewModel, viewModel) || version != _initializeSettingsVersion)
+                if (!IsCurrentSettingsInitialization(viewModel, version))
                 {
                     return;
                 }
 
                 await viewModel.InitializeAsync().ConfigureAwait(true);
                 cancellationToken.ThrowIfCancellationRequested();
-                if (!ReferenceEquals(_settingsViewModel, viewModel) || version != _initializeSettingsVersion)
+                if (!IsCurrentSettingsInitialization(viewModel, version))
                 {
                     return;
                 }
 
                 QueueSensitiveFieldSync(viewModel);
+                CompleteSettingsInitialization(viewModel, version);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -224,9 +278,9 @@ namespace InventoryManagementApp.Views.Pages
             }
             catch (Exception ex)
             {
-                _initializeSettingsTask = null;
+                CompleteSettingsInitialization(viewModel, version);
 
-                if (!ReferenceEquals(_settingsViewModel, viewModel) || version != _initializeSettingsVersion)
+                if (!IsCurrentSettingsInitialization(viewModel, version))
                 {
                     return;
                 }


### PR DESCRIPTION
## What changed

- Added Settings loaded/unloaded state tracking so deferred startup work only runs while the page is current.
- Invalidated queued theme-designer tab retries on unload.
- Guarded theme tab retry dispatch with a version check before re-entering insertion.
- Replaced recursive Settings visual-tree lookup with an iterative stack-based traversal for the injected theme tab.
- Added defensive visual-child count handling for unsupported visual nodes.
- Kept theme tab insertion bounded to the loaded page while preserving tab renumbering.
- Blocked sensitive SMTP password/API-key sync queueing while Settings is unloaded.
- Guarded queued sensitive field synchronization against stale DataContext/page instances.
- Centralized current initialization checks through `IsCurrentSettingsInitialization(...)`.
- Cleared completed initialization task/cancellation-source state after current initialization finishes.
- Preserved first-paint dispatcher yielding, duplicate initialization suppression, DataContext swap cancellation, and user-facing initialization error handling.
- Extended Settings source-contract tests for loaded-state gates, stale retry cancellation, iterative traversal, defensive visual-child counts, initialization cleanup, and sensitive-field stale-work guards.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-settings-lifecycle-responsiveness.md`.

## Why this was highest value

Recent runs have already covered Dashboard, Activity Logs, rentals, customers, item search, reports, labels, users, kits, print preview, and shell input. Current Settings evidence still showed recursive visual-tree traversal and deferred theme/sensitive-field work that could outlive page navigation. Settings is an admin-heavy workflow, so keeping page opening, tab injection, navigation away/back, and protected-field sync lightweight and current is a useful responsiveness/reliability improvement without repeating recent areas.

## Why this is real progress

This is a coherent Settings lifecycle slice across page load, unload, DataContext changes, deferred tab injection, visual-tree traversal, sensitive protected-field synchronization, startup initialization cleanup, source-contract coverage, and progress notes. It improves more than ten operator-facing or maintenance behaviors while staying inside the existing WPF/MVVM page host.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, zero behind, and limited to Settings page code-behind, Settings source-contract tests, and one progress note.
- Connector readback confirmed loaded-state gates, theme retry versioning, iterative visual traversal, defensive child-count handling, initialization cleanup, and stale sensitive-field sync guards are present.
- Connector status readback found no attached commit statuses for branch head `5b739172540ffaa6b7147924aadf04b89836285e` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Settings navigation, tab injection, or protected-field testing

These remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, `gh` is unavailable, and Windows/.NET/WPF tooling is not installed.

## Follow-up

Run the full Windows validation runner and smoke test Settings by opening the page, switching away during initial load, returning, checking the Themes tab appears once, and confirming SMTP/API-key fields still sync correctly after saved settings load.