### PR TITLE
Improve categories lifecycle and input responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/CategoriesPageLifecycleInputContractTests.cs
+++ b/InventoryManagementApp.Tests/CategoriesPageLifecycleInputContractTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CategoriesPageLifecycleInputContractTests
+    {
+        [Fact]
+        public void CategoriesPage_InvalidatesPageOwnedStartupWorkOnUnloadAndDataContextChanges()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+
+            Assert.Contains("using System.Threading;", source, StringComparison.Ordinal);
+            Assert.Contains("private CancellationTokenSource? _initializeCategoriesCancellation;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _initializeCategoriesVersion;", source, StringComparison.Ordinal);
+            Assert.Contains("Unloaded += CategoriesPage_Unloaded;", source, StringComparison.Ordinal);
+            Assert.Contains("private void CategoriesPage_Unloaded", source, StringComparison.Ordinal);
+            Assert.Contains("CancelPageOwnedInitialization();", source, StringComparison.Ordinal);
+            Assert.Contains("private void CancelPageOwnedInitialization()", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeCategoriesVersion++;", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeCategoriesCancellation?.Cancel();", source, StringComparison.Ordinal);
+            Assert.Contains("_initializeCategoriesCancellation?.Dispose();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_GatesStartupRefreshThroughCurrentPageVersionAndCancellation()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+            var initialization = ExtractSourceBlock(source, "private async Task InitializeCategoriesOnceAsync", "private bool IsCurrentCategoryInitialization");
+            var currentCheck = ExtractSourceBlock(source, "private bool IsCurrentCategoryInitialization", "private void CancelPageOwnedInitialization");
+
+            Assert.Contains("CancelPageOwnedInitialization();", initialization, StringComparison.Ordinal);
+            Assert.Contains("var loadVersion = ++_initializeCategoriesVersion;", initialization, StringComparison.Ordinal);
+            Assert.Contains("_initializeCategoriesCancellation = new CancellationTokenSource();", initialization, StringComparison.Ordinal);
+            Assert.Contains("var cancellationToken = _initializeCategoriesCancellation.Token;", initialization, StringComparison.Ordinal);
+            Assert.Contains("await Dispatcher.Yield(DispatcherPriority.Background);", initialization, StringComparison.Ordinal);
+            Assert.Contains("!IsCurrentCategoryInitialization(vm, loadVersion, cancellationToken) || vm.IsCategoryInteractionBusy", initialization, StringComparison.Ordinal);
+            Assert.Contains("_initializeCategoriesTask = vm.InitializeAsync();", initialization, StringComparison.Ordinal);
+            Assert.Contains("await _initializeCategoriesTask;", initialization, StringComparison.Ordinal);
+            Assert.Contains("!IsCurrentCategoryInitialization(vm, loadVersion, cancellationToken)", initialization, StringComparison.Ordinal);
+            Assert.Contains("!cancellationToken.IsCancellationRequested", currentCheck, StringComparison.Ordinal);
+            Assert.Contains("loadVersion == _initializeCategoriesVersion", currentCheck, StringComparison.Ordinal);
+            Assert.Contains("ReferenceEquals(DataContext, vm)", currentCheck, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_PreservesTextEditingBeforeGlobalCategoryShortcuts()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+            var keyHandler = ExtractSourceBlock(source, "private void Page_PreviewKeyDown", "private static bool IsCategoryActionShortcut");
+            var shortcut = ExtractSourceBlock(source, "private static bool IsCategoryActionShortcut", "private static bool IsTextInputFocused");
+
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("ViewModel.IsCategoryInteractionBusy && IsCategoryActionShortcut(e)", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("if (IsTextInputFocused() && IsCategoryActionShortcut(e))", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("return;", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.S", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("e.Key == Key.Delete", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("e.Key == Key.Enter", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("e.Key is Key.R or Key.S or Key.P or Key.C", shortcut, StringComparison.Ordinal);
+            Assert.Contains("e.Key is Key.Enter or Key.Delete", shortcut, StringComparison.Ordinal);
+            Assert.DoesNotContain("!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C", keyHandler, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (e.Key == Key.Enter && !IsTextInputFocused())", keyHandler, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_BlocksContextMenuInvocationWhileRowsAreBusy()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+            var contextMenu = ExtractSourceBlock(source, "private void CategoryGrid_ContextMenuOpening", "private void OpenCategoryDetail_Click");
+
+            Assert.Contains("CategoryGrid.ContextMenuOpening += CategoryGrid_ContextMenuOpening;", source, StringComparison.Ordinal);
+            Assert.Contains("ViewModel is { IsCategoryInteractionBusy: true }", contextMenu, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", contextMenu, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesPage_KeepsExistingFirstPaintAndBusyGestureProtections()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+            var loaded = ExtractSourceBlock(source, "private async void CategoriesPage_Loaded", "private void CategoriesPage_Unloaded");
+            var doubleClick = ExtractSourceBlock(source, "private void CategoryRow_MouseDoubleClick", "private void CategoryRow_PreviewMouseRightButtonDown");
+            var rightClick = ExtractSourceBlock(source, "private void CategoryRow_PreviewMouseRightButtonDown", "private void CategoryGrid_ContextMenuOpening");
+
+            Assert.Contains("FindBox.Focus();", loaded, StringComparison.Ordinal);
+            Assert.Contains("FindBox.SelectAll();", loaded, StringComparison.Ordinal);
+            Assert.Contains("await InitializeCategoriesOnceAsync(vm);", loaded, StringComparison.Ordinal);
+            Assert.Contains("ViewModel is { IsCategoryInteractionBusy: true }", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e) == null", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("OpenCategoryDetail_Click(sender, e);", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("ViewModel is { IsCategoryInteractionBusy: true }", rightClick, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", rightClick, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
+
+            return source[start..end];
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-categories-lifecycle-input-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-categories-lifecycle-input-responsiveness.md
@@ -1,0 +1,27 @@
+# Categories Lifecycle And Input Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Added Categories page unload tracking so page-owned startup work is invalidated when the operator navigates away.
+- Added a startup initialization version counter so stale dispatcher-yield work cannot start or complete as the current page load after navigation or DataContext changes.
+- Added a page-owned cancellation source for Categories startup initialization and disposed it during unload/DataContext cleanup.
+- Kept first-paint search focus before category initialization so operators can start filtering immediately after navigation.
+- Guarded Categories startup initialization through current DataContext, load version, cancellation state, and existing busy state before refreshing rows.
+- Rechecked the same current-page/current-view-model state after initialization completes so stale work cannot mark old navigation paths as current.
+- Preserved normal text-entry behavior before global category shortcuts dispatch, preventing Enter, Delete, Ctrl+C, Ctrl+P, Ctrl+R, and Ctrl+S from hijacking category-name or filter editing.
+- Preserved fast Ctrl+F filter focus and Ctrl+N category-name focus before the text-entry guard.
+- Added a Categories grid context-menu opening guard so keyboard/menu invocation cannot expose row actions while category rows are refreshing.
+- Preserved existing double-click and right-click busy suppression for virtualized category rows.
+- Added source-contract coverage for unload invalidation, startup version/cancellation checks, text-entry shortcut preservation, context-menu busy suppression, first-paint focus, and existing busy row gesture behavior.
+
+## Validation
+
+- Source-contract coverage was added in `InventoryManagementApp.Tests/CategoriesPageLifecycleInputContractTests.cs`.
+- GitHub connector readback/compare was used in this scheduled environment because direct checkout and Windows/.NET/WPF tooling are unavailable.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test Categories by opening the page, typing in the filter and category-name boxes, pressing Enter/Delete/Ctrl+C/Ctrl+P/Ctrl+R/Ctrl+S while editing, opening context menus during refresh, and navigating away during startup load.

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
@@ -36,6 +36,7 @@ namespace InventoryManagementApp.Views.Pages
             Loaded += CategoriesPage_Loaded;
             Unloaded += CategoriesPage_Unloaded;
             DataContextChanged += CategoriesPage_DataContextChanged;
+            CategoryGrid.ContextMenuOpening += CategoryGrid_ContextMenuOpening;
         }
 
         private CategoryManagementViewModel? ViewModel => DataContext as CategoryManagementViewModel;

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -22,6 +23,8 @@ namespace InventoryManagementApp.Views.Pages
         private readonly int _inventoryId;
         private Task? _initializeCategoriesTask;
         private CategoryManagementViewModel? _initializedViewModel;
+        private CancellationTokenSource? _initializeCategoriesCancellation;
+        private int _initializeCategoriesVersion;
 
         public CategoriesPage(int inventoryId)
         {
@@ -31,6 +34,7 @@ namespace InventoryManagementApp.Views.Pages
             var vm = sp.GetRequiredService<CategoryManagementViewModel>();
             DataContext = vm;
             Loaded += CategoriesPage_Loaded;
+            Unloaded += CategoriesPage_Unloaded;
             DataContextChanged += CategoriesPage_DataContextChanged;
         }
 
@@ -48,10 +52,16 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
+        private void CategoriesPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            CancelPageOwnedInitialization();
+        }
+
         private void CategoriesPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (!ReferenceEquals(_initializedViewModel, e.NewValue))
             {
+                CancelPageOwnedInitialization();
                 _initializedViewModel = null;
                 _initializeCategoriesTask = null;
             }
@@ -70,17 +80,42 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
+            CancelPageOwnedInitialization();
             _initializedViewModel = vm;
             vm.SelectedInventoryId = _inventoryId;
+            var loadVersion = ++_initializeCategoriesVersion;
+            _initializeCategoriesCancellation = new CancellationTokenSource();
+            var cancellationToken = _initializeCategoriesCancellation.Token;
+
             await Dispatcher.Yield(DispatcherPriority.Background);
 
-            if (!ReferenceEquals(DataContext, vm) || vm.IsCategoryInteractionBusy)
+            if (!IsCurrentCategoryInitialization(vm, loadVersion, cancellationToken) || vm.IsCategoryInteractionBusy)
             {
                 return;
             }
 
             _initializeCategoriesTask = vm.InitializeAsync();
             await _initializeCategoriesTask;
+
+            if (!IsCurrentCategoryInitialization(vm, loadVersion, cancellationToken))
+            {
+                return;
+            }
+        }
+
+        private bool IsCurrentCategoryInitialization(CategoryManagementViewModel vm, int loadVersion, CancellationToken cancellationToken)
+        {
+            return !cancellationToken.IsCancellationRequested &&
+                   loadVersion == _initializeCategoriesVersion &&
+                   ReferenceEquals(DataContext, vm);
+        }
+
+        private void CancelPageOwnedInitialization()
+        {
+            _initializeCategoriesVersion++;
+            _initializeCategoriesCancellation?.Cancel();
+            _initializeCategoriesCancellation?.Dispose();
+            _initializeCategoriesCancellation = null;
         }
 
         private void Page_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
@@ -109,6 +144,11 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
+            if (IsTextInputFocused() && IsCategoryActionShortcut(e))
+            {
+                return;
+            }
+
             if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R && ViewModel.RefreshCommand.CanExecute(null))
             {
                 ViewModel.RefreshCommand.Execute(null);
@@ -130,7 +170,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C)
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C)
             {
                 CopyCategory_Click(sender, e);
                 e.Handled = true;
@@ -144,7 +184,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (e.Key == Key.Enter && !IsTextInputFocused())
+            if (e.Key == Key.Enter)
             {
                 OpenCategoryDetail_Click(sender, e);
                 e.Handled = true;
@@ -190,6 +230,14 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             GridContextMenuSelection.SelectRow(sender, e);
+        }
+
+        private void CategoryGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            if (ViewModel is { IsCategoryInteractionBusy: true })
+            {
+                e.Handled = true;
+            }
         }
 
         private void OpenCategoryDetail_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## What changed

- Added Categories page unload invalidation for page-owned startup initialization.
- Added startup initialization versioning so stale dispatcher-yield work cannot start as the current page load after navigation or DataContext changes.
- Added a page-owned cancellation source for Categories startup work and disposed it during unload/DataContext cleanup.
- Preserved first-paint filter focus before category initialization work.
- Guarded Categories startup initialization through current DataContext, load version, cancellation state, and existing busy state before refreshing rows.
- Rechecked current-page/current-view-model state after initialization completes.
- Preserved normal text-entry behavior before global category shortcuts dispatch, including Enter, Delete, Ctrl+C, Ctrl+P, Ctrl+R, and Ctrl+S while editing category-name/filter fields.
- Kept Ctrl+F filter focus and Ctrl+N category-name focus as first-class fast paths.
- Added a Categories grid context-menu opening guard so keyboard/menu invocation cannot expose row actions while category rows refresh.
- Preserved existing virtualized row double-click/right-click busy suppression and invoked-row retargeting behavior.
- Added source-contract coverage for lifecycle invalidation, version/cancellation checks, text-entry shortcut preservation, busy context-menu suppression, first-paint focus, and busy row gesture behavior.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-categories-lifecycle-input-responsiveness.md`.

## Why this was highest value

Recent work already covered many larger screens and shared shell paths. Current Categories evidence still showed page-owned startup work could outlive navigation, global shortcuts could hijack normal text editing, and context menus could be invoked through routes outside the row right-click guard while rows were refreshing. Categories is a compact but common setup workflow, so tightening opening, filtering, editing, row actions, and refresh behavior improves responsiveness without repeating recently completed screens.

## Why this is real progress

This is a focused workflow slice across Categories screen opening, navigation away/back, DataContext swaps, first-paint filter use, keyboard filtering/editing, virtualized grid context menus, row gestures, source-contract coverage, and project progress notes. It completes more than ten operator-facing or maintainability improvements while staying inside the existing WPF/MVVM page structure.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, four commits ahead, zero behind, and limited to Categories page code-behind, one new Categories source-contract test file, and one progress note.
- Connector readback confirmed the lifecycle fields, unload handler, version/cancellation startup checks, text-entry guard, context-menu busy guard, and source-contract assertions are present.
- Connector status readback found no attached commit statuses for branch head `7081fd362bf3a69623a34ce1115f9f6468499647` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Categories keyboard, menu, and navigation testing

These remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, and Windows/.NET/WPF tooling is unavailable.

## Follow-up

Run the full Windows validation runner and smoke test Categories by opening the page, navigating away during startup load, typing in both text boxes, pressing Enter/Delete/Ctrl+C/Ctrl+P/Ctrl+R/Ctrl+S while editing, opening context menus during refresh, and printing a filtered directory.