### PR TITLE
Improve password prompt entry responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/PasswordPromptWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PasswordPromptWindowXamlTests.cs
@@ -15,7 +15,27 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("Password Reset Request", xaml, StringComparison.Ordinal);
             Assert.Contains("ResetRecoveryPanel", xaml, StringComparison.Ordinal);
             Assert.Contains("Request Reset", xaml, StringComparison.Ordinal);
-            Assert.Contains("Auth footer status", xaml, StringComparison.Ordinal);
+            Assert.Contains("StatusTextBlock", xaml, StringComparison.Ordinal);
+            Assert.Contains("{Binding StatusMessage}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{Binding FailureSummary}", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PasswordPromptWindow_UsesResponsiveScrollableScaledDesktopLayout()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PasswordPromptWindow.xaml");
+
+            Assert.Contains("Width=\"600\" Height=\"420\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"520\" MinHeight=\"360\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("UseLayoutRounding=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SnapsToDevicePixels=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"260\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"150\" MinWidth=\"120\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"220\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Grid.Row=\"5\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -27,6 +47,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("x:Name=\"PromptTextBlock\"", xaml, StringComparison.Ordinal);
             Assert.Contains("x:Name=\"PasswordBox\"", xaml, StringComparison.Ordinal);
             Assert.Contains("PasswordChanged=\"PasswordBox_PasswordChanged\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("PreviewKeyDown=\"PasswordBox_PreviewKeyDown\"", xaml, StringComparison.Ordinal);
             Assert.Contains("x:Name=\"ForgotPasswordButton\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ResetPasswordCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("CancelCommand", xaml, StringComparison.Ordinal);
@@ -36,6 +57,45 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("FocusPasswordBox", codeBehind, StringComparison.Ordinal);
             Assert.Contains("Keyboard.Focus(PasswordBox)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("DispatcherPriority.Input", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PasswordPromptWindow_CoalescesFocusAndHandlesPasswordKeyboardFlow()
+        {
+            var codeBehind = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PasswordPromptWindow.xaml.cs");
+
+            Assert.Contains("private DispatcherOperation? _pendingFocusOperation;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private bool _isUnloaded;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Unloaded += OnUnloaded;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void AbortPendingFocus()", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_pendingFocusOperation.Abort();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("FocusPasswordBox(selectAll: true);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("PasswordBox.SelectAll();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void PasswordBox_PreviewKeyDown", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Key == Key.Enter && VM.OkCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Key == Key.Escape && VM.CancelCommand.CanExecute(null)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PasswordPromptViewModel_GatesUnlockAndResetBusyState()
+        {
+            var viewModel = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "PasswordPromptViewModel.cs");
+
+            Assert.Contains("private bool _isResetInProgress;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string StatusMessage", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string FailureSummary", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OkCommand = new RelayCommand(OnOk, CanSubmitPassword);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ResetPasswordCommand = new AsyncRelayCommand(OnResetPasswordAsync, CanRequestReset);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OkCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ResetPasswordCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("!IsResetInProgress && !string.IsNullOrWhiteSpace(EnteredPassword)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (IsResetInProgress)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("try", viewModel, StringComparison.Ordinal);
+            Assert.Contains("finally", viewModel, StringComparison.Ordinal);
+            Assert.Contains("IsResetInProgress = false;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("RegisterFailedAttempt", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ClearPasswordFeedback", viewModel, StringComparison.Ordinal);
         }
 
         static string ReadRepositoryFile(params string[] relativePathParts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-password-prompt-entry-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-password-prompt-entry-responsiveness.md
@@ -1,0 +1,31 @@
+# Password Prompt Entry Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Reduced password prompt default and minimum sizing for scaled desktop use.
+- Reworked the prompt into a fixed header, scrollable body, and anchored footer so recovery guidance stays reachable at 1366 x 768 and high Windows scaling.
+- Enabled layout rounding and device-pixel snapping for cleaner entry-path rendering.
+- Bounded long prompt, status, and badge text to avoid clipping or pushing the unlock controls off-screen.
+- Lowered password form column pressure and kept the password box at a practical minimum width.
+- Added visible status and failed-attempt summary bindings so reset availability is displayed without modal-only feedback.
+- Added Enter-to-unlock and Escape-to-cancel handling directly on the password box.
+- Coalesced queued password-box focus work from Loaded and Activated events so repeated activations do not stack dispatcher focus operations.
+- Aborted pending focus work on unload to avoid stale focus dispatch after the window closes.
+- Selected the password on first paint for faster retry/edit flow.
+- Cleared visible error text once the operator starts typing again.
+- Gated Unlock command availability on non-blank password text and reset busy state.
+- Added reset-request busy state and command gating so repeated clicks cannot open overlapping confirmation dialogs.
+- Added reset status messaging for denied, canceled, in-progress, and requested paths.
+- Extended source-contract coverage for responsive layout, command wiring, keyboard flow, focus coalescing, unload cleanup, busy reset gating, status text, and failed-attempt summaries.
+
+## Validation
+
+- Source-contract coverage was updated in `InventoryManagementApp.Tests/ViewModels/PasswordPromptWindowXamlTests.cs`.
+- GitHub connector readback/compare was used in this scheduled environment because direct checkout and Windows/.NET/WPF tooling are unavailable.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.
+- Smoke test the password prompt at 1366 x 768 and 125%, 150%, and 200% scaling with valid password, invalid password, repeated failures, reset request denial, reset cancellation, Enter, Escape, close/unload, and repeated activation paths.

--- a/InventoryManagementApp/ViewModels/PasswordPromptViewModel.cs
+++ b/InventoryManagementApp/ViewModels/PasswordPromptViewModel.cs
@@ -9,10 +9,61 @@ namespace InventoryManagementApp.ViewModels
 {
     public class PasswordPromptViewModel : ObservableObject
     {
-        public string EnteredPassword { get; set; } = string.Empty;
-        public bool IsPasswordResetRequested { get; set; }
+        private string _enteredPassword = string.Empty;
+        private bool _isPasswordResetRequested;
+        private bool _isResetInProgress;
+        private User? _selectedUser;
+        private string _statusMessage = "Ready to unlock.";
+        private string _failureSummary = "No failed attempts.";
+
+        public string EnteredPassword
+        {
+            get => _enteredPassword;
+            set
+            {
+                if (SetProperty(ref _enteredPassword, value ?? string.Empty))
+                    OkCommand.NotifyCanExecuteChanged();
+            }
+        }
+
+        public bool IsPasswordResetRequested
+        {
+            get => _isPasswordResetRequested;
+            set => SetProperty(ref _isPasswordResetRequested, value);
+        }
+
+        public bool IsResetInProgress
+        {
+            get => _isResetInProgress;
+            private set
+            {
+                if (SetProperty(ref _isResetInProgress, value))
+                {
+                    OkCommand.NotifyCanExecuteChanged();
+                    ResetPasswordCommand.NotifyCanExecuteChanged();
+                }
+            }
+        }
+
+        public string StatusMessage
+        {
+            get => _statusMessage;
+            private set => SetProperty(ref _statusMessage, value);
+        }
+
+        public string FailureSummary
+        {
+            get => _failureSummary;
+            private set => SetProperty(ref _failureSummary, value);
+        }
+
         public Func<string, bool> ValidatePassword { get; set; } = _ => true;
-        public User? SelectedUser { get; set; }
+
+        public User? SelectedUser
+        {
+            get => _selectedUser;
+            set => SetProperty(ref _selectedUser, value);
+        }
 
         public IRelayCommand OkCommand { get; }
         public IRelayCommand CancelCommand { get; }
@@ -30,16 +81,46 @@ namespace InventoryManagementApp.ViewModels
             _onCancel = onCancel;
             _showError = showError;
 
-            OkCommand = new RelayCommand(OnOk);
+            OkCommand = new RelayCommand(OnOk, CanSubmitPassword);
             CancelCommand = new RelayCommand(() => _onCancel());
-            ResetPasswordCommand = new AsyncRelayCommand(OnResetPasswordAsync);
+            ResetPasswordCommand = new AsyncRelayCommand(OnResetPasswordAsync, CanRequestReset);
+        }
+
+        public void RegisterFailedAttempt(int attemptCount, int resetThreshold)
+        {
+            var safeAttemptCount = Math.Max(0, attemptCount);
+            var safeResetThreshold = Math.Max(1, resetThreshold);
+            FailureSummary = $"Failed attempts: {safeAttemptCount} of {safeResetThreshold}.";
+            StatusMessage = safeAttemptCount >= safeResetThreshold
+                ? "Reset assistance is available for admin users."
+                : "Password was not accepted. Try again.";
+        }
+
+        public void ClearPasswordFeedback()
+        {
+            if (!string.IsNullOrEmpty(EnteredPassword))
+                StatusMessage = "Ready to unlock. Press Enter or choose Unlock.";
+        }
+
+        private bool CanSubmitPassword()
+        {
+            return !IsResetInProgress && !string.IsNullOrWhiteSpace(EnteredPassword);
+        }
+
+        private bool CanRequestReset()
+        {
+            return !IsResetInProgress;
         }
 
         private void OnOk()
         {
+            if (!CanSubmitPassword())
+                return;
+
             var pwd = EnteredPassword ?? string.Empty;
             if (ValidatePassword?.Invoke(pwd) == true)
             {
+                StatusMessage = "Password accepted.";
                 _onSuccess();
                 return;
             }
@@ -49,22 +130,39 @@ namespace InventoryManagementApp.ViewModels
 
         async Task OnResetPasswordAsync()
         {
-            if (SelectedUser?.IsAdmin != true)
+            if (IsResetInProgress)
+                return;
+
+            IsResetInProgress = true;
+            StatusMessage = "Preparing reset confirmation...";
+
+            try
             {
-                await _dialogService.ShowInfoAsync(
-                    "Password recovery is only available for admin users.",
-                    "Not Allowed");
-                return;
+                if (SelectedUser?.IsAdmin != true)
+                {
+                    StatusMessage = "Password recovery is only available for admin users.";
+                    await _dialogService.ShowInfoAsync(
+                        "Password recovery is only available for admin users.",
+                        "Not Allowed");
+                    return;
+                }
+
+                if (!await _dialogService.ShowConfirmationAsync(
+                    "You have entered the wrong password multiple times. Reset to default and change it after login?",
+                    "Reset Password"))
+                {
+                    StatusMessage = "Password reset was canceled.";
+                    return;
+                }
+
+                IsPasswordResetRequested = true;
+                StatusMessage = "Password reset requested.";
+                _onSuccess();
             }
-
-            if (!await _dialogService.ShowConfirmationAsync(
-                "You have entered the wrong password multiple times. Reset to default and change it after login?",
-                "Reset Password"))
-                return;
-
-            IsPasswordResetRequested = true;
-            _onSuccess();
+            finally
+            {
+                IsResetInProgress = false;
+            }
         }
     }
 }
-

--- a/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml
@@ -4,15 +4,14 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Enter Password"
-        Width="620" Height="440"
-        MinWidth="560" MinHeight="400"
+        Width="600" Height="420"
+        MinWidth="520" MinHeight="360"
         WindowStartupLocation="CenterScreen"
-        Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="16">
+        Background="{DynamicResource BackgroundBrush}"
+        UseLayoutRounding="True"
+        SnapsToDevicePixels="True">
+    <Grid Margin="14">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
@@ -21,7 +20,7 @@
         <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*" MinWidth="260"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel>
@@ -29,76 +28,92 @@
                     <TextBlock x:Name="PromptTextBlock"
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
+                               TextTrimming="CharacterEllipsis"
+                               MaxHeight="54"
                                Margin="0,4,0,0"/>
                 </StackPanel>
                 <Border Grid.Column="1"
                         Style="{StaticResource DesktopNoteCard}"
                         Padding="10,6"
                         Margin="12,0,0,0"
+                        MaxWidth="180"
                         VerticalAlignment="Top">
-                    <TextBlock Text="Password required" Style="{StaticResource CaptionTextBlock}"/>
+                    <TextBlock Text="Password required" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </Border>
             </Grid>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource DesktopInsetCard}" Padding="14">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="170"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <StackPanel>
-                    <TextBlock Text="Password" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Required to unlock this profile" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
-                </StackPanel>
-                <PasswordBox x:Name="PasswordBox"
-                             Grid.Column="1"
-                             PasswordChar="•"
-                             Margin="12,2,0,0"
-                             MinWidth="300"
-                             PasswordChanged="PasswordBox_PasswordChanged"/>
-            </Grid>
-        </Border>
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled"
+                      CanContentScroll="True"
+                      Focusable="False">
+            <StackPanel>
+                <Border Style="{StaticResource DesktopInsetCard}" Padding="14">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150" MinWidth="120"/>
+                            <ColumnDefinition Width="*" MinWidth="220"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel>
+                            <TextBlock Text="Password" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="Required to unlock this profile" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                        </StackPanel>
+                        <PasswordBox x:Name="PasswordBox"
+                                     Grid.Column="1"
+                                     PasswordChar="•"
+                                     Margin="12,2,0,0"
+                                     MinWidth="220"
+                                     PasswordChanged="PasswordBox_PasswordChanged"
+                                     PreviewKeyDown="PasswordBox_PreviewKeyDown"/>
+                    </Grid>
+                </Border>
 
-        <TextBlock x:Name="ErrorTextBlock"
-                   Grid.Row="2"
-                   Style="{StaticResource ErrorTextBlock}"
-                   Visibility="Collapsed"
-                   Margin="2,10,0,0"
-                   TextWrapping="Wrap"/>
+                <TextBlock x:Name="ErrorTextBlock"
+                           Style="{StaticResource ErrorTextBlock}"
+                           Visibility="Collapsed"
+                           Margin="2,10,0,0"
+                           TextWrapping="Wrap"/>
 
-        <Border x:Name="ResetRecoveryPanel"
-                Grid.Row="3"
-                Style="{StaticResource DesktopNoteCard}"
-                Visibility="Collapsed"
-                Margin="0,10,0,0"
-                Padding="14">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <StackPanel>
-                    <TextBlock Text="Password Reset Request" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="After multiple failed attempts, admins can reset to the default password and change it immediately after login. This keeps the reset path visible without hiding the normal unlock action." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,4,18,0"/>
-                </StackPanel>
-                <Button x:Name="ForgotPasswordButton"
-                        Grid.Column="1"
-                        Content="Request Reset"
-                        MinWidth="130"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource GhostButton}"
-                        Command="{Binding ResetPasswordCommand}"/>
-            </Grid>
-        </Border>
+                <Border x:Name="ResetRecoveryPanel"
+                        Style="{StaticResource DesktopNoteCard}"
+                        Visibility="Collapsed"
+                        Margin="0,10,0,0"
+                        Padding="14">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" MinWidth="260"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel>
+                            <TextBlock Text="Password Reset Request" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="After multiple failed attempts, admins can reset to the default password and change it immediately after login. This keeps the reset path visible without hiding the normal unlock action." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,4,18,0"/>
+                            <TextBlock Text="{Binding FailureSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,6,18,0"/>
+                        </StackPanel>
+                        <Button x:Name="ForgotPasswordButton"
+                                Grid.Column="1"
+                                Content="Request Reset"
+                                MinWidth="122"
+                                VerticalAlignment="Center"
+                                Style="{StaticResource GhostButton}"
+                                Command="{Binding ResetPasswordCommand}"/>
+                    </Grid>
+                </Border>
+            </StackPanel>
+        </ScrollViewer>
 
-        <StackPanel Grid.Row="5" Margin="0,12,0,0">
+        <StackPanel Grid.Row="2" Margin="0,12,0,0">
             <controls:DialogButtonBar LeftButtonText="Cancel"
                                       LeftCommand="{Binding CancelCommand}"
                                       RightButtonText="Unlock"
                                       RightCommand="{Binding OkCommand}"/>
             <Border Style="{StaticResource DesktopNoteCard}" Margin="0,10,0,0" Padding="10,6">
-                <TextBlock Text="Auth footer status: failed attempts reveal the reset request panel while keeping Cancel and Unlock anchored in the same place." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                <TextBlock x:Name="StatusTextBlock"
+                           Text="{Binding StatusMessage}"
+                           Style="{StaticResource CaptionTextBlock}"
+                           TextWrapping="Wrap"
+                           TextTrimming="CharacterEllipsis"
+                           MaxHeight="44"/>
             </Border>
         </StackPanel>
     </Grid>

--- a/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Views/PasswordPromptWindow.xaml.cs
+// Views/PasswordPromptWindow.xaml.cs
 using System;
 using System.Windows;
 using System.Windows.Input;
@@ -15,6 +15,8 @@ namespace InventoryManagementApp.Views.Windows
         private const int MaxAttempts = 2;
         private int _attemptCount;
         private readonly IDialogService _dialogService;
+        private DispatcherOperation? _pendingFocusOperation;
+        private bool _isUnloaded;
 
         public PasswordPromptViewModel VM => (PasswordPromptViewModel)DataContext;
         public string EnteredPassword => VM.EnteredPassword;
@@ -46,16 +48,19 @@ namespace InventoryManagementApp.Views.Windows
             this.DisposeDataContextOnUnload();
             Loaded += OnLoaded;
             Activated += OnActivated;
+            Unloaded += OnUnloaded;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
+            _isUnloaded = false;
+
             if (SelectedUser != null)
                 PromptTextBlock.Text = $"{SelectedUser.UserName}, please enter your password:";
             else
                 PromptTextBlock.Text = "Please enter your password:";
 
-            FocusPasswordBox();
+            FocusPasswordBox(selectAll: true);
         }
 
         private void OnActivated(object? sender, EventArgs e)
@@ -63,23 +68,70 @@ namespace InventoryManagementApp.Views.Windows
             FocusPasswordBox();
         }
 
-        private void FocusPasswordBox()
+        private void OnUnloaded(object sender, RoutedEventArgs e)
         {
-            PasswordBox.Dispatcher.BeginInvoke(() =>
+            _isUnloaded = true;
+            AbortPendingFocus();
+        }
+
+        private void FocusPasswordBox(bool selectAll = false)
+        {
+            if (_isUnloaded || !IsLoaded)
+                return;
+
+            AbortPendingFocus();
+            _pendingFocusOperation = PasswordBox.Dispatcher.BeginInvoke(() =>
             {
+                _pendingFocusOperation = null;
+
+                if (_isUnloaded || !IsLoaded)
+                    return;
+
                 PasswordBox.Focus();
                 Keyboard.Focus(PasswordBox);
+
+                if (selectAll)
+                    PasswordBox.SelectAll();
             }, DispatcherPriority.Input);
+        }
+
+        private void AbortPendingFocus()
+        {
+            if (_pendingFocusOperation is { Status: DispatcherOperationStatus.Pending })
+                _pendingFocusOperation.Abort();
+
+            _pendingFocusOperation = null;
         }
 
         private void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
         {
             VM.EnteredPassword = PasswordBox.Password;
+            VM.ClearPasswordFeedback();
+
+            if (!string.IsNullOrEmpty(PasswordBox.Password))
+                ErrorTextBlock.Visibility = Visibility.Collapsed;
+        }
+
+        private void PasswordBox_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter && VM.OkCommand.CanExecute(null))
+            {
+                VM.OkCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (e.Key == Key.Escape && VM.CancelCommand.CanExecute(null))
+            {
+                VM.CancelCommand.Execute(null);
+                e.Handled = true;
+            }
         }
 
         private void ShowError(string message)
         {
             _attemptCount++;
+            VM.RegisterFailedAttempt(_attemptCount, MaxAttempts);
             ErrorTextBlock.Text = message;
             ErrorTextBlock.Visibility = Visibility.Visible;
 


### PR DESCRIPTION
## What changed

- Reduced the Password Prompt default/minimum window size for scaled desktop use.
- Reworked the prompt into a fixed header, scrollable body, and anchored footer so recovery guidance remains reachable at 1366 x 768 and high Windows scaling.
- Enabled layout rounding and device-pixel snapping for cleaner entry-path rendering.
- Bounded long prompt, status, and badge text to avoid clipping or pushing unlock controls off-screen.
- Lowered password form column pressure and kept the password box at a practical minimum width.
- Added visible status and failed-attempt summary bindings for professional reset/readiness display.
- Added Enter-to-unlock and Escape-to-cancel handling directly on the password box.
- Coalesced queued password-box focus work from Loaded and Activated events so repeated activations do not stack dispatcher focus operations.
- Aborted pending focus work on unload to avoid stale focus dispatch after close/navigation.
- Selected the password field on first paint for faster retry/edit flow.
- Cleared visible error text once the operator starts typing again.
- Gated Unlock command availability on non-blank password text and reset busy state.
- Added reset-request busy state and command gating so repeated clicks cannot open overlapping confirmation dialogs.
- Added reset status messaging for denied, canceled, in-progress, and requested paths.
- Extended source-contract coverage for responsive layout, command wiring, keyboard flow, focus coalescing, unload cleanup, busy reset gating, status text, and failed-attempt summaries.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-password-prompt-entry-responsiveness.md`.

## Why this was highest value

Recent runs heavily improved the main data workbenches, grids, print flows, and shared shell paths. The password prompt is still an app entry workflow and current source evidence showed fixed layout pressure, duplicate queued focus work, no direct password-box Enter/Escape path, and no reset busy guard. This improves opening, retrying, reset recovery, keyboard flow, high-scaling layout, and stale dispatcher work without repeating the recently completed screens.

## Why this is real progress

This is a complete workflow slice across the entry dialog UI, code-behind focus lifecycle, ViewModel command readiness/reset state, source-contract coverage, and progress notes. It includes more than ten focused operator-facing and maintainability improvements while staying within the existing WPF/MVVM structure.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, five commits ahead, zero behind, and limited to the password prompt XAML/code-behind, password prompt ViewModel, source-contract tests, and one progress note.
- Connector readback confirmed the responsive scrollable layout, status/failure bindings, keyboard handler, focus coalescing/unload cleanup, command gating, reset busy state, and source-contract assertions are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs for branch head `c5ced0cf4db566057104d3176a6c7a9dcfeb320b` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- Local XAML parsing
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live password prompt valid/invalid/reset/keyboard testing

These remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, `gh` is unavailable, and Windows/.NET/WPF tooling is not installed.

## Follow-up

Run the full Windows validation runner and smoke test the password prompt at 1366 x 768 and 125%, 150%, and 200% scaling with valid password, invalid password, repeated failures, reset request denial, reset cancellation, Enter, Escape, close/unload, and repeated activation paths.