### PR TITLE
Improve maintenance and calibration input responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
@@ -168,6 +168,38 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("_loadCalibrationTask = null;", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void CalibrationPage_PreservesTextEditingSuppressesBusyMenusAndUsesIterativeLookup()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml.cs");
+            var keyHandler = ExtractSourceBlock(source, "private void CalibrationPage_PreviewKeyDown", "private static bool IsCalibrationActionShortcut");
+            var doubleClick = ExtractSourceBlock(source, "private void CalibrationRow_MouseDoubleClick", "private void CalibrationRow_PreviewMouseRightButtonDown");
+            var findDescendant = ExtractSourceBlock(source, "private static T? FindDescendant", "private static int GetVisualChildCount");
+
+            Assert.Contains("CalibrationGrid.ContextMenuOpening += CalibrationGrid_ContextMenuOpening;", source, StringComparison.Ordinal);
+            Assert.Contains("private void CalibrationGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Contains("CalibrationManagementViewModel { IsLoading: true }", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsTextInputFocused() && IsCalibrationActionShortcut(e))", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.FocusedElement is TextBoxBase or PasswordBox or ComboBox", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", keyHandler, StringComparison.Ordinal);
+            Assert.True(
+                keyHandler.IndexOf("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", StringComparison.Ordinal) <
+                keyHandler.IndexOf("if (IsTextInputFocused() && IsCalibrationActionShortcut(e))", StringComparison.Ordinal),
+                "Ctrl+F should keep focusing search before text-edit shortcuts are preserved.");
+            Assert.True(
+                keyHandler.IndexOf("if (IsTextInputFocused() && IsCalibrationActionShortcut(e))", StringComparison.Ordinal) <
+                keyHandler.IndexOf("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N", StringComparison.Ordinal),
+                "Text-edit guard should run before calibration action shortcuts dispatch.");
+            Assert.Contains("e.Handled = true;\n        }", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("using System.Collections.Generic;", source, StringComparison.Ordinal);
+            Assert.Contains("var pending = new Stack<DependencyObject>();", findDescendant, StringComparison.Ordinal);
+            Assert.Contains("while (pending.Count > 0)", findDescendant, StringComparison.Ordinal);
+            Assert.Contains("pending.Push(child);", findDescendant, StringComparison.Ordinal);
+            Assert.DoesNotContain("var nested = FindDescendant<T>(child);", findDescendant, StringComparison.Ordinal);
+            Assert.Contains("private static int GetVisualChildCount(DependencyObject current)", source, StringComparison.Ordinal);
+            Assert.Contains("catch (InvalidOperationException)", source, StringComparison.Ordinal);
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;
@@ -176,7 +208,7 @@ namespace InventoryManagementApp.Tests
             {
                 var candidate = Path.Combine(directory, Path.Combine(parts));
                 if (File.Exists(candidate))
-                    return File.ReadAllText(candidate);
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
 
                 var parent = Directory.GetParent(directory);
                 if (parent is null)
@@ -198,5 +230,8 @@ namespace InventoryManagementApp.Tests
 
             return source[start..end];
         }
+
+        private static string NormalizeLineEndings(string text)
+            => text.Replace("\r\n", "\n");
     }
 }

--- a/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
@@ -163,6 +163,38 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("_loadMaintenanceTask = null;", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void MaintenancePage_PreservesTextEditingSuppressesBusyMenusAndUsesIterativeLookup()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml.cs");
+            var keyHandler = ExtractSourceBlock(source, "private void MaintenancePage_PreviewKeyDown", "private static bool IsMaintenanceActionShortcut");
+            var doubleClick = ExtractSourceBlock(source, "private void MaintenanceRow_MouseDoubleClick", "private void MaintenanceRow_PreviewMouseRightButtonDown");
+            var findDescendant = ExtractSourceBlock(source, "private static T? FindDescendant", "private static int GetVisualChildCount");
+
+            Assert.Contains("MaintenanceGrid.ContextMenuOpening += MaintenanceGrid_ContextMenuOpening;", source, StringComparison.Ordinal);
+            Assert.Contains("private void MaintenanceGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Contains("MaintenanceManagementViewModel { IsLoading: true }", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsTextInputFocused() && IsMaintenanceActionShortcut(e))", keyHandler, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.FocusedElement is TextBoxBase or PasswordBox or ComboBox", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", keyHandler, StringComparison.Ordinal);
+            Assert.True(
+                keyHandler.IndexOf("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", StringComparison.Ordinal) <
+                keyHandler.IndexOf("if (IsTextInputFocused() && IsMaintenanceActionShortcut(e))", StringComparison.Ordinal),
+                "Ctrl+F should keep focusing search before text-edit shortcuts are preserved.");
+            Assert.True(
+                keyHandler.IndexOf("if (IsTextInputFocused() && IsMaintenanceActionShortcut(e))", StringComparison.Ordinal) <
+                keyHandler.IndexOf("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N", StringComparison.Ordinal),
+                "Text-edit guard should run before maintenance action shortcuts dispatch.");
+            Assert.Contains("e.Handled = true;\n        }", doubleClick, StringComparison.Ordinal);
+            Assert.Contains("using System.Collections.Generic;", source, StringComparison.Ordinal);
+            Assert.Contains("var pending = new Stack<DependencyObject>();", findDescendant, StringComparison.Ordinal);
+            Assert.Contains("while (pending.Count > 0)", findDescendant, StringComparison.Ordinal);
+            Assert.Contains("pending.Push(child);", findDescendant, StringComparison.Ordinal);
+            Assert.DoesNotContain("var nested = FindDescendant<T>(child);", findDescendant, StringComparison.Ordinal);
+            Assert.Contains("private static int GetVisualChildCount(DependencyObject current)", source, StringComparison.Ordinal);
+            Assert.Contains("catch (InvalidOperationException)", source, StringComparison.Ordinal);
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;
@@ -171,7 +203,7 @@ namespace InventoryManagementApp.Tests
             {
                 var candidate = Path.Combine(directory, Path.Combine(parts));
                 if (File.Exists(candidate))
-                    return File.ReadAllText(candidate);
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
 
                 var parent = Directory.GetParent(directory);
                 if (parent is null)
@@ -182,5 +214,19 @@ namespace InventoryManagementApp.Tests
 
             throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
         }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string NormalizeLineEndings(string text)
+            => text.Replace("\r\n", "\n");
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-maintenance-calibration-input-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-maintenance-calibration-input-responsiveness.md
@@ -1,0 +1,31 @@
+# Maintenance And Calibration Input Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Preserved normal filter text entry and combo-box selection behavior before Maintenance page action shortcuts dispatch.
+- Preserved normal filter text entry and combo-box selection behavior before Calibration page action shortcuts dispatch.
+- Kept Ctrl+F as the first keyboard path on both workbenches so operators can recover search focus quickly.
+- Suppressed Maintenance grid context menus while schedule rows are loading, including keyboard/menu invocation paths that bypass row right-click selection.
+- Suppressed Calibration grid context menus while register rows are loading, including keyboard/menu invocation paths that bypass row right-click selection.
+- Marked Maintenance row double-clicks handled after the invoked row is selected even when Details is temporarily unavailable.
+- Marked Calibration row double-clicks handled after the invoked row is selected even when Details is temporarily unavailable.
+- Replaced Maintenance recursive search-box discovery with iterative visual-tree traversal.
+- Replaced Calibration recursive search-box discovery with iterative visual-tree traversal.
+- Added defensive visual-child count handling for unsupported visual nodes during first-paint search focus.
+- Extended Maintenance and Calibration source-contract coverage for text-entry preservation, busy context-menu suppression, unavailable double-click handling, iterative lookup, and defensive traversal.
+
+## Why It Matters
+
+Maintenance and Calibration are dense operational-record workbenches. The screens already use virtualized grids and bounded layouts, but source evidence still allowed page shortcuts to interrupt filter editing, context menus to open during row refresh through non-mouse routes, and recursive visual-tree traversal during first-paint focus. This keeps search, filtering, loading, and row review responsive without changing the existing MVVM workflow.
+
+## Validation
+
+- Added source-contract coverage in `MaintenancePageResponsiveContractTests`.
+- Added source-contract coverage in `CalibrationPageResponsiveContractTests`.
+- Connector readback should confirm the changed files because this scheduled Linux environment cannot clone, build, or run WPF validation locally.
+
+## Follow-up
+
+Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and smoke test Maintenance and Calibration with search typing, combo-box filtering, Ctrl+F, Enter/Delete/Ctrl shortcuts, context-menu key/right-click, row double-click, and slow row refreshes.

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -25,6 +26,7 @@ namespace InventoryManagementApp.Views.Pages
             Unloaded += CalibrationPage_Unloaded;
             DataContextChanged += CalibrationPage_DataContextChanged;
             PreviewKeyDown += CalibrationPage_PreviewKeyDown;
+            CalibrationGrid.ContextMenuOpening += CalibrationGrid_ContextMenuOpening;
         }
 
         private async void CalibrationPage_Loaded(object sender, RoutedEventArgs e)
@@ -130,7 +132,10 @@ namespace InventoryManagementApp.Views.Pages
             {
                 UiActionGuard.Run(this, "Calibration", () => vm.OpenCalibrationDetailsCommand.Execute(null));
                 e.Handled = true;
+                return;
             }
+
+            e.Handled = true;
         }
 
         private void CalibrationRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
@@ -144,6 +149,14 @@ namespace InventoryManagementApp.Views.Pages
             GridContextMenuSelection.SelectRow(sender, e);
         }
 
+        private void CalibrationGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            if (DataContext is CalibrationManagementViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+            }
+        }
+
         private void CalibrationPage_PreviewKeyDown(object sender, KeyEventArgs e)
         {
             if (DataContext is not CalibrationManagementViewModel vm)
@@ -153,6 +166,11 @@ namespace InventoryManagementApp.Views.Pages
             {
                 FocusFirstSearchBox();
                 e.Handled = true;
+                return;
+            }
+
+            if (IsTextInputFocused() && IsCalibrationActionShortcut(e))
+            {
                 return;
             }
 
@@ -190,7 +208,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopySelectedCalibrationCommand.CanExecute(null))
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopySelectedCalibrationCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Calibration", () => vm.CopySelectedCalibrationCommand.Execute(null));
                 e.Handled = true;
@@ -252,23 +270,42 @@ namespace InventoryManagementApp.Views.Pages
 
         private static bool IsTextInputFocused()
         {
-            return Keyboard.FocusedElement is TextBoxBase or PasswordBox;
+            return Keyboard.FocusedElement is TextBoxBase or PasswordBox or ComboBox;
         }
 
         private static T? FindDescendant<T>(DependencyObject current) where T : DependencyObject
         {
-            for (var index = 0; index < VisualTreeHelper.GetChildrenCount(current); index++)
-            {
-                var child = VisualTreeHelper.GetChild(current, index);
-                if (child is T match)
-                    return match;
+            var pending = new Stack<DependencyObject>();
+            pending.Push(current);
 
-                var nested = FindDescendant<T>(child);
-                if (nested != null)
-                    return nested;
+            while (pending.Count > 0)
+            {
+                var parent = pending.Pop();
+                var childCount = GetVisualChildCount(parent);
+
+                for (var index = childCount - 1; index >= 0; index--)
+                {
+                    var child = VisualTreeHelper.GetChild(parent, index);
+                    if (child is T match)
+                        return match;
+
+                    pending.Push(child);
+                }
             }
 
             return null;
+        }
+
+        private static int GetVisualChildCount(DependencyObject current)
+        {
+            try
+            {
+                return VisualTreeHelper.GetChildrenCount(current);
+            }
+            catch (InvalidOperationException)
+            {
+                return 0;
+            }
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -25,6 +26,7 @@ namespace InventoryManagementApp.Views.Pages
             Unloaded += MaintenancePage_Unloaded;
             DataContextChanged += MaintenancePage_DataContextChanged;
             PreviewKeyDown += MaintenancePage_PreviewKeyDown;
+            MaintenanceGrid.ContextMenuOpening += MaintenanceGrid_ContextMenuOpening;
         }
 
         private async void MaintenancePage_Loaded(object sender, RoutedEventArgs e)
@@ -130,7 +132,10 @@ namespace InventoryManagementApp.Views.Pages
             {
                 UiActionGuard.Run(this, "Maintenance", () => vm.OpenMaintenanceDetailsCommand.Execute(null));
                 e.Handled = true;
+                return;
             }
+
+            e.Handled = true;
         }
 
         private void MaintenanceRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
@@ -144,6 +149,14 @@ namespace InventoryManagementApp.Views.Pages
             GridContextMenuSelection.SelectRow(sender, e);
         }
 
+        private void MaintenanceGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            if (DataContext is MaintenanceManagementViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+            }
+        }
+
         private void MaintenancePage_PreviewKeyDown(object sender, KeyEventArgs e)
         {
             if (DataContext is not MaintenanceManagementViewModel vm)
@@ -153,6 +166,11 @@ namespace InventoryManagementApp.Views.Pages
             {
                 FocusFirstSearchBox();
                 e.Handled = true;
+                return;
+            }
+
+            if (IsTextInputFocused() && IsMaintenanceActionShortcut(e))
+            {
                 return;
             }
 
@@ -190,7 +208,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            if (!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopySelectedMaintenanceCommand.CanExecute(null))
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopySelectedMaintenanceCommand.CanExecute(null))
             {
                 UiActionGuard.Run(this, "Maintenance", () => vm.CopySelectedMaintenanceCommand.Execute(null));
                 e.Handled = true;
@@ -259,23 +277,42 @@ namespace InventoryManagementApp.Views.Pages
 
         private static bool IsTextInputFocused()
         {
-            return Keyboard.FocusedElement is TextBoxBase or PasswordBox;
+            return Keyboard.FocusedElement is TextBoxBase or PasswordBox or ComboBox;
         }
 
         private static T? FindDescendant<T>(DependencyObject current) where T : DependencyObject
         {
-            for (var index = 0; index < VisualTreeHelper.GetChildrenCount(current); index++)
-            {
-                var child = VisualTreeHelper.GetChild(current, index);
-                if (child is T match)
-                    return match;
+            var pending = new Stack<DependencyObject>();
+            pending.Push(current);
 
-                var nested = FindDescendant<T>(child);
-                if (nested != null)
-                    return nested;
+            while (pending.Count > 0)
+            {
+                var parent = pending.Pop();
+                var childCount = GetVisualChildCount(parent);
+
+                for (var index = childCount - 1; index >= 0; index--)
+                {
+                    var child = VisualTreeHelper.GetChild(parent, index);
+                    if (child is T match)
+                        return match;
+
+                    pending.Push(child);
+                }
             }
 
             return null;
+        }
+
+        private static int GetVisualChildCount(DependencyObject current)
+        {
+            try
+            {
+                return VisualTreeHelper.GetChildrenCount(current);
+            }
+            catch (InvalidOperationException)
+            {
+                return 0;
+            }
         }
     }
 }


### PR DESCRIPTION
## What changed

- Preserved normal text entry and combo-box editing on the Maintenance workbench before page-level action shortcuts dispatch.
- Preserved normal text entry and combo-box editing on the Calibration workbench before page-level action shortcuts dispatch.
- Kept Ctrl+F as the first keyboard path on both workbenches for quick search recovery.
- Suppressed Maintenance grid context-menu opening while schedule rows are loading, including keyboard/menu invocation paths that bypass row right-click guards.
- Suppressed Calibration grid context-menu opening while register rows are loading, including keyboard/menu invocation paths that bypass row right-click guards.
- Marked Maintenance row double-clicks handled after selecting the invoked virtualized row even when Details is temporarily unavailable.
- Marked Calibration row double-clicks handled after selecting the invoked virtualized row even when Details is temporarily unavailable.
- Replaced Maintenance recursive search-box visual-tree discovery with iterative stack traversal.
- Replaced Calibration recursive search-box visual-tree discovery with iterative stack traversal.
- Added defensive visual-child count handling for unsupported visual nodes during first-paint search focus.
- Extended Maintenance source-contract coverage for text-entry preservation, busy context-menu suppression, unavailable double-click handling, iterative lookup, and defensive traversal.
- Extended Calibration source-contract coverage for text-entry preservation, busy context-menu suppression, unavailable double-click handling, iterative lookup, and defensive traversal.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-maintenance-calibration-input-responsiveness.md`.

## Why this was highest value

Recent hourly runs already covered many high-traffic screens and shared shell paths. Current source evidence still showed Maintenance and Calibration action shortcuts could interrupt filter text/combo editing, context menus could open during row refresh through non-right-click routes, and first-paint search focus still used recursive visual-tree traversal. These are compact but important operational-record workflows, so tightening both together improves loading-era action safety and UI responsiveness without repeating recently completed areas.

## Why this is real progress

This is a complete workflow slice across two related workbenches: search/filter typing, combo-box filtering, keyboard shortcuts, loading-state context menus, virtualized row double-clicks, first-paint focus traversal, test contracts, and progress notes. It includes more than ten focused operator-facing and maintainability improvements while preserving the existing MVVM and WPF layout structure.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, five commits ahead, zero behind, and limited to Maintenance/Calibration page code-behind, their source-contract tests, and one progress note.
- Connector readback confirmed text-entry guards, Ctrl+F ordering, busy context-menu suppression, handled unavailable double-clicks, iterative visual-tree traversal, defensive visual-child count handling, and source-contract assertions are present.
- Connector status readback found no attached commit statuses for branch head `e9f2d1b34145bdf001c6b52f2eaa6621c11416ff` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Maintenance/Calibration keyboard, menu, filter, and slow-refresh testing

These remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP `CONNECT tunnel failed, response 403`, `gh` is unavailable, and Windows/.NET/WPF tooling is not installed.

## Follow-up

Run the full Windows validation runner and smoke test Maintenance and Calibration by opening each workbench, typing in search, changing filter combo boxes, pressing Ctrl+F, Enter, Delete, Ctrl+C, Ctrl+D, Ctrl+E, Ctrl+P, right-clicking rows, using the context-menu key during refresh, and double-clicking rows while commands are temporarily unavailable.