### PR TITLE
Improve Manage Rentals menu and input responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
@@ -174,6 +174,38 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ManageRentalsPage_SuppressesGridContextMenusDuringLoading()
+        {
+            var codeBehind = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs"));
+            var helperBlock = ExtractSourceBlock(codeBehind, "private bool SuppressContextMenuDuringLoading", "private void ManageRentalsPage_PreviewKeyDown");
+
+            Assert.Contains("RentalDeskGrid.ContextMenuOpening += RentalDeskGrid_ContextMenuOpening;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("RequestQueueGrid.ContextMenuOpening += RequestQueueGrid_ContextMenuOpening;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void RentalDeskGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void RequestQueueGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("SuppressContextMenuDuringLoading(e);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (DataContext is ManageRentalsViewModel { IsLoading: true })", helperBlock, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", helperBlock, StringComparison.Ordinal);
+            Assert.Contains("return true;", helperBlock, StringComparison.Ordinal);
+            Assert.Contains("return false;", helperBlock, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageRentalsPage_TextEditingShortcutGuardIncludesNestedEditors()
+        {
+            var codeBehind = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs"));
+            var editBlock = ExtractSourceBlock(codeBehind, "private static bool IsTextEditingElement", "private void OpenFocusedDetails");
+
+            Assert.Contains("if (source is TextBox or ComboBox or DatePicker or PasswordBox)", editBlock, StringComparison.Ordinal);
+            Assert.Contains("if (source is not DependencyObject element)", editBlock, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<TextBox>(element) != null", editBlock, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<ComboBox>(element) != null", editBlock, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<DatePicker>(element) != null", editBlock, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<PasswordBox>(element) != null", editBlock, StringComparison.Ordinal);
+            Assert.DoesNotContain("return source is TextBox or ComboBox or DatePicker;", editBlock, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ManageRentalsPage_RowGesturesSelectInvokedRowsAndStopDuringLoading()
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-manage-rentals-menu-input-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-manage-rentals-menu-input-responsiveness.md
@@ -1,0 +1,30 @@
+# Manage Rentals Menu And Input Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Suppressed Rental Desk context-menu opening while rental rows are refreshing, including keyboard/menu invocation paths outside row right-click selection.
+- Suppressed Open Request Queue context-menu opening while request rows are refreshing.
+- Added a shared loading-state context-menu guard so both rental and request grids use the same action-safety path.
+- Preserved Ctrl+F as the first keyboard path for fast rental search recovery.
+- Preserved normal direct TextBox, ComboBox, DatePicker, and PasswordBox editing before rental-page action shortcuts dispatch.
+- Preserved nested editor text entry by checking visual ancestors for TextBox, ComboBox, DatePicker, and PasswordBox controls.
+- Kept Enter, Delete, Ctrl+D, Ctrl+H, Ctrl+I, Ctrl+E, Ctrl+R, Ctrl+P, Ctrl+Shift+P, and Ctrl+Shift+R from interrupting nested rental filter/date/combo editing.
+- Kept loading-era keyboard shortcuts swallowed while row refresh is active.
+- Preserved existing first-paint search focus, page-owned startup load reuse, compact-height layout, virtualized rental/request grids, busy row gesture suppression, and bounded loading overlays.
+- Extended Manage Rentals source-contract coverage for busy context-menu suppression and nested text-edit shortcut preservation.
+
+## Why It Matters
+
+Manage Rentals is a high-frequency operational desk for check-in, extension, history, documents, and customer follow-up requests. The screen already had strong layout and row-loading protections, but source evidence still allowed context menus to open during refresh through keyboard/menu routes and treated only the immediate original source as text editing. This keeps search, date filters, combo-box editing, row refresh, and grid actions predictable without changing the existing MVVM workflow.
+
+## Validation
+
+- Added source-contract coverage in `ManageRentalsPageResponsiveContractTests` for the grid context-menu opening guards.
+- Added source-contract coverage for nested editor shortcut preservation through visual-ancestor checks.
+- Connector readback should confirm the changed files because this scheduled Linux environment cannot clone, build, or run WPF validation locally.
+
+## Follow-up
+
+Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and smoke test Manage Rentals with search typing, date picker editing, status combo selection, Ctrl+F, Enter/Delete/Ctrl shortcuts, context-menu key/right-click during refresh, row double-click, print actions, and request queue actions.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -24,6 +24,8 @@ namespace InventoryManagementApp.Views.Pages
             DataContextChanged += ManageRentalsPage_DataContextChanged;
             SizeChanged += ManageRentalsPage_SizeChanged;
             PreviewKeyDown += ManageRentalsPage_PreviewKeyDown;
+            RentalDeskGrid.ContextMenuOpening += RentalDeskGrid_ContextMenuOpening;
+            RequestQueueGrid.ContextMenuOpening += RequestQueueGrid_ContextMenuOpening;
         }
 
         private async void ManageRentalsPage_Loaded(object sender, RoutedEventArgs e)
@@ -169,6 +171,27 @@ namespace InventoryManagementApp.Views.Pages
             SelectRowForContextMenu(sender, e);
         }
 
+        private void RentalDeskGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            SuppressContextMenuDuringLoading(e);
+        }
+
+        private void RequestQueueGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            SuppressContextMenuDuringLoading(e);
+        }
+
+        private bool SuppressContextMenuDuringLoading(ContextMenuEventArgs e)
+        {
+            if (DataContext is ManageRentalsViewModel { IsLoading: true })
+            {
+                e.Handled = true;
+                return true;
+            }
+
+            return false;
+        }
+
         private void ManageRentalsPage_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
             if (DataContext is not ManageRentalsViewModel vm)
@@ -278,7 +301,16 @@ namespace InventoryManagementApp.Views.Pages
 
         private static bool IsTextEditingElement(object? source)
         {
-            return source is TextBox or ComboBox or DatePicker;
+            if (source is TextBox or ComboBox or DatePicker or PasswordBox)
+                return true;
+
+            if (source is not DependencyObject element)
+                return false;
+
+            return GridContextMenuSelection.FindAncestor<TextBox>(element) != null
+                || GridContextMenuSelection.FindAncestor<ComboBox>(element) != null
+                || GridContextMenuSelection.FindAncestor<DatePicker>(element) != null
+                || GridContextMenuSelection.FindAncestor<PasswordBox>(element) != null;
         }
 
         private void OpenFocusedDetails(ManageRentalsViewModel vm)


### PR DESCRIPTION
## What changed

- Suppressed Rental Desk context-menu opening while rental rows are refreshing, including keyboard/menu invocation paths that bypass row right-click selection.
- Suppressed Open Request Queue context-menu opening while request rows are refreshing.
- Added a shared `SuppressContextMenuDuringLoading(...)` guard so both rental and request grids use the same loading-state action-safety path.
- Preserved Ctrl+F as the first keyboard route for fast rental search recovery.
- Preserved direct TextBox, ComboBox, DatePicker, and PasswordBox editing before rental action shortcuts dispatch.
- Preserved nested editor text entry by checking visual ancestors for TextBox, ComboBox, DatePicker, and PasswordBox controls.
- Kept Enter, Delete, Ctrl+D, Ctrl+H, Ctrl+I, Ctrl+E, Ctrl+R, Ctrl+P, Ctrl+Shift+P, and Ctrl+Shift+R from interrupting nested filter/date/combo editing.
- Preserved existing loading-era shortcut swallowing, first-paint search focus, page-owned startup load reuse, compact-height layout, virtualized rental/request grids, busy row gesture suppression, and bounded loading overlays.
- Extended `ManageRentalsPageResponsiveContractTests` for busy context-menu suppression and nested text-edit shortcut preservation.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-manage-rentals-menu-input-responsiveness.md`.

## Why this was highest value

Recent repository work covered broad shell, settings, dashboard, activity-log, customer, category, maintenance, calibration, password, reports, labels, users, reservation, and Manage Rentals startup/keyboard paths. Current Manage Rentals source still showed grid context menus could open during refresh through keyboard/menu routes and the text-edit guard only checked the immediate original source. This is a focused follow-up for a high-frequency rental desk workflow without repeating the earlier stale-load or basic keyboard work.

## Why this is real progress

This is a workflow-level rental desk slice across loading-state menu safety, nested editor input preservation, keyboard action routing, rental/request grids, source-contract coverage, and progress notes. It improves operator responsiveness and action safety while preserving the existing WPF/MVVM layout and command structure.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, zero behind, and limited to Manage Rentals code-behind, Manage Rentals source-contract tests, and one progress note.
- Connector readback confirmed the rental/request grid context-menu handlers, shared loading guard, nested text-editor ancestor checks, and source-contract assertions are present.
- Connector status/workflow readback found no attached commit statuses or workflow runs for branch head `7cd1aa60ce63ce9b6c3883f5d9ed823f5c4d469c` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Manage Rentals keyboard, context-menu, date-picker, combo-box, and slow-refresh testing

These remain blocked in this scheduled Linux environment because direct checkout/raw access is blocked by GitHub HTTP 403, `gh` is unavailable, and Windows/.NET/WPF tooling is not installed.

## Follow-up

Run the full Windows validation runner and smoke test Manage Rentals by opening the page, typing in search/date/status filters, pressing Ctrl+F, Enter, Delete, Ctrl+D, Ctrl+H, Ctrl+I, Ctrl+E, Ctrl+R, Ctrl+P, Ctrl+Shift+P, and Ctrl+Shift+R while editing, opening context menus during refresh, right-clicking rows, and double-clicking rental/request rows.