### PR TITLE
Improve kit management input and menu responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
@@ -217,6 +217,60 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void KitManagementPage_SuppressesGridContextMenusDuringLoading()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs");
+            var helper = ExtractSourceBlock(source, "private bool SuppressContextMenuDuringLoading", "private static bool IsTextInputFocused");
+
+            Assert.Contains("KitsGrid.ContextMenuOpening += KitsGrid_ContextMenuOpening;", source, StringComparison.Ordinal);
+            Assert.Contains("KitItemsGrid.ContextMenuOpening += KitItemsGrid_ContextMenuOpening;", source, StringComparison.Ordinal);
+            Assert.Contains("private void KitsGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Contains("private void KitItemsGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(source, "SuppressContextMenuDuringLoading(e);"));
+            Assert.Contains("if (DataContext is KitManagementViewModel { IsKitItemInteractionBusy: true })", helper, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", helper, StringComparison.Ordinal);
+            Assert.Contains("return true;", helper, StringComparison.Ordinal);
+            Assert.Contains("return false;", helper, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitManagementPage_PreservesSearchAndFilterEditingBeforeShortcutsDispatch()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs");
+            var keyDown = ExtractSourceBlock(source, "private void KitManagementPage_PreviewKeyDown", "private static bool IsManagedKitShortcut");
+
+            Assert.Contains("using System.Windows.Controls.Primitives;", source, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsTextInputFocused()", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.FocusedElement is TextBoxBase or PasswordBox or ComboBox", source, StringComparison.Ordinal);
+            Assert.Contains("if (IsTextInputFocused() && IsManagedKitShortcut(e))", keyDown, StringComparison.Ordinal);
+            Assert.Contains("return;", keyDown, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", keyDown, StringComparison.Ordinal);
+            Assert.True(
+                keyDown.IndexOf("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", StringComparison.Ordinal) <
+                keyDown.IndexOf("if (IsTextInputFocused() && IsManagedKitShortcut(e))", StringComparison.Ordinal),
+                "Ctrl+F should keep focusing search before text-entry shortcuts are preserved.");
+            Assert.True(
+                keyDown.IndexOf("if (IsTextInputFocused() && IsManagedKitShortcut(e))", StringComparison.Ordinal) <
+                keyDown.IndexOf("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N", StringComparison.Ordinal),
+                "Text-entry guard should run before kit action shortcuts dispatch.");
+        }
+
+        [Fact]
+        public void KitManagementPage_HandlesUnavailableDoubleClicksAfterRetargetingRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs");
+            var kitDoubleClick = ExtractSourceBlock(source, "private void KitRow_MouseDoubleClick", "private void KitItemRow_MouseDoubleClick");
+            var itemDoubleClick = ExtractSourceBlock(source, "private void KitItemRow_MouseDoubleClick", "private void DataGridRow_PreviewMouseRightButtonDown");
+
+            Assert.Contains("vm.SelectedKit = kit;", kitDoubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n                return;", kitDoubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n        }", kitDoubleClick, StringComparison.Ordinal);
+            Assert.Contains("vm.SelectedKitItem = kitItem;", itemDoubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n                return;", itemDoubleClick, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n        }", itemDoubleClick, StringComparison.Ordinal);
+        }
+
         private static int CountOccurrences(string text, string value)
         {
             var count = 0;
@@ -239,7 +293,7 @@ namespace InventoryManagementApp.Tests
             {
                 var candidate = Path.Combine(directory, Path.Combine(parts));
                 if (File.Exists(candidate))
-                    return File.ReadAllText(candidate);
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
 
                 var parent = Directory.GetParent(directory);
                 if (parent is null)
@@ -250,5 +304,19 @@ namespace InventoryManagementApp.Tests
 
             throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
         }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find end marker after {startMarker}: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string NormalizeLineEndings(string text)
+            => text.Replace("\r\n", "\n");
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-kit-management-input-menu-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-kit-management-input-menu-responsiveness.md
@@ -1,0 +1,32 @@
+# Kit Management Input And Menu Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Suppressed Kit Directory context-menu opening while kit rows or membership rows are refreshing, including keyboard/menu invocation paths that bypass row right-click selection.
+- Suppressed Kit Item Membership context-menu opening while kit rows or membership rows are refreshing.
+- Added a shared kit loading-state context-menu guard so both kit grids use the same action-safety path.
+- Preserved Ctrl+F as the first keyboard route for fast kit search recovery.
+- Preserved normal TextBox, ComboBox, and PasswordBox editing before page-level kit shortcuts dispatch.
+- Kept Enter, Delete, F5, Ctrl+N, Ctrl+E, Ctrl+I, Ctrl+C, Ctrl+P, Ctrl+D, Ctrl+Shift+E, and Ctrl+Shift+C from interrupting search or filter editing.
+- Kept existing loading-era shortcut swallowing so keyboard actions wait while kit directory or membership rows refresh.
+- Marked kit row double-clicks handled after selecting the invoked virtualized row even when Details is temporarily unavailable.
+- Marked kit item row double-clicks handled after selecting the invoked virtualized membership row even when Edit Item is temporarily unavailable.
+- Preserved existing first-paint loading, active DataContext checks, virtualized kit/member grids, bounded loading overlays, print caps, and handoff summaries.
+- Extended Kit Management source-contract coverage for busy context-menu suppression, text-entry shortcut preservation, and unavailable double-click handling.
+
+## Why It Matters
+
+Kit Management is the staging workflow for reusable grouped item sets. The screen already had strong virtualized grids and loading overlays, but current source still allowed context menus to open during refresh through non-right-click routes and page-level shortcuts could interrupt search/filter editing. This keeps kit lookup, membership review, and print/handoff actions predictable while rows are loading or filters are being edited.
+
+## Validation
+
+- Added source-contract coverage in `KitManagementPageResponsiveContractTests` for both grid context-menu guards.
+- Added source-contract coverage for search/filter typing preservation before shortcut dispatch.
+- Added source-contract coverage for handled row double-click routing when commands are temporarily unavailable.
+- Connector readback and compare should confirm the changed files because this scheduled Linux environment cannot clone, build, or run WPF validation locally.
+
+## Follow-up
+
+Run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and smoke test Kit Management by opening the page, typing in search and status filters, pressing Ctrl+F, Enter, Delete, F5, Ctrl+N, Ctrl+E, Ctrl+I, Ctrl+P, Ctrl+D, Ctrl+Shift+E, and Ctrl+Shift+C while editing, opening context menus during refresh, right-clicking rows, double-clicking kit/member rows, checking availability, copying details, and printing kit/directory previews.

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
@@ -1,8 +1,9 @@
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Threading;
+using System.Threading.Tasks;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 
@@ -19,6 +20,8 @@ namespace InventoryManagementApp.Views.Pages
             Loaded += KitManagementPage_Loaded;
             DataContextChanged += KitManagementPage_DataContextChanged;
             PreviewKeyDown += KitManagementPage_PreviewKeyDown;
+            KitsGrid.ContextMenuOpening += KitsGrid_ContextMenuOpening;
+            KitItemsGrid.ContextMenuOpening += KitItemsGrid_ContextMenuOpening;
         }
 
         private async void KitManagementPage_Loaded(object sender, RoutedEventArgs e)
@@ -79,6 +82,11 @@ namespace InventoryManagementApp.Views.Pages
             if (vm.IsKitItemInteractionBusy && IsManagedKitShortcut(e))
             {
                 e.Handled = true;
+                return;
+            }
+
+            if (IsTextInputFocused() && IsManagedKitShortcut(e))
+            {
                 return;
             }
 
@@ -171,7 +179,10 @@ namespace InventoryManagementApp.Views.Pages
             {
                 UiActionGuard.Run(this, "Kit Management", () => vm.OpenKitDetailsCommand.Execute(null));
                 e.Handled = true;
+                return;
             }
+
+            e.Handled = true;
         }
 
         private void KitItemRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -194,7 +205,10 @@ namespace InventoryManagementApp.Views.Pages
             {
                 UiActionGuard.RunAsync(this, "Kit Management", async () => await vm.EditKitItemCommand.ExecuteAsync(null));
                 e.Handled = true;
+                return;
             }
+
+            e.Handled = true;
         }
 
         private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
@@ -206,6 +220,32 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             GridContextMenuSelection.SelectRow(sender, e);
+        }
+
+        private void KitsGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            SuppressContextMenuDuringLoading(e);
+        }
+
+        private void KitItemsGrid_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            SuppressContextMenuDuringLoading(e);
+        }
+
+        private bool SuppressContextMenuDuringLoading(ContextMenuEventArgs e)
+        {
+            if (DataContext is KitManagementViewModel { IsKitItemInteractionBusy: true })
+            {
+                e.Handled = true;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsTextInputFocused()
+        {
+            return Keyboard.FocusedElement is TextBoxBase or PasswordBox or ComboBox;
         }
     }
 }


### PR DESCRIPTION
## What changed

- Suppressed Kit Directory context-menu opening while kit rows or membership rows are refreshing, including keyboard/menu invocation paths that bypass row right-click selection.
- Suppressed Kit Item Membership context-menu opening while kit rows or membership rows are refreshing.
- Added a shared loading-state context-menu guard so both kit grids use the same action-safety path.
- Preserved Ctrl+F as the first keyboard route for fast kit search recovery.
- Preserved normal TextBox, ComboBox, and PasswordBox editing before page-level kit shortcuts dispatch.
- Kept Enter, Delete, F5, Ctrl+N, Ctrl+E, Ctrl+I, Ctrl+C, Ctrl+P, Ctrl+D, Ctrl+Shift+E, and Ctrl+Shift+C from interrupting search/filter editing when the page is not busy.
- Preserved existing loading-era shortcut swallowing while kit directory or membership rows refresh.
- Marked kit row double-clicks handled after selecting the invoked virtualized row even when Details is temporarily unavailable.
- Marked kit item row double-clicks handled after selecting the invoked virtualized membership row even when Edit Item is temporarily unavailable.
- Preserved existing first-paint loading, active DataContext checks, virtualized kit/member grids, bounded loading overlays, print caps, and handoff summaries.
- Extended Kit Management source-contract coverage for busy context-menu suppression, text-entry shortcut preservation, and unavailable double-click handling.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-06-kit-management-input-menu-responsiveness.md`.

## Why this was highest value

Recent merged work already covered dashboard, customer, maintenance, calibration, rentals, reports, labels, users, reservations, and Manage Items responsiveness. Current Kit Management source still showed a similar remaining gap: context menus could open during refresh through non-right-click routes, page-level shortcuts could interrupt search/filter editing, and row double-clicks were not always marked handled after row retargeting. Kit Management is an existing operational staging workflow, so this improves a real screen without inventing new scope or repeating the most recent areas.

## Why this is real progress

This is a workflow-level Kit Management slice across both virtualized grids, keyboard search/filter input, loading-state menu safety, row gesture routing, tests/source-contract coverage, and progress notes. It includes more than ten focused operator-facing and maintainability improvements while preserving the existing WPF/MVVM structure.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, zero behind, and limited to Kit Management code-behind, Kit Management source-contract tests, and one progress note.
- Connector readback confirmed the grid context-menu handlers, shared loading guard, text-entry shortcut guard, handled double-click fallbacks, and progress note are present.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- Local .NET restore/build/test
- WPF runtime smoke testing
- Screenshots/scaling checks
- Live Kit Management keyboard, context-menu, loading, print-preview, and scaling testing

These remain blocked in this scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is not installed.

## Follow-up

Run the full Windows validation runner and smoke test Kit Management by opening the page, typing in search and status filters, pressing Ctrl+F, Enter, Delete, F5, Ctrl+N, Ctrl+E, Ctrl+I, Ctrl+P, Ctrl+D, Ctrl+Shift+E, and Ctrl+Shift+C while editing, opening context menus during refresh, right-clicking rows, double-clicking kit/member rows, checking availability, copying details, and printing kit/directory previews.