### PR TITLE
[codex] Improve Activity Logs filter responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
@@ -233,7 +233,9 @@ namespace InventoryManagementApp.Tests
             Assert.Contains(".Select(ActivityLogSearchRow.Create)", viewModel, StringComparison.Ordinal);
             Assert.Contains("_searchRows = refreshedSearchRows;", viewModel, StringComparison.Ordinal);
             Assert.Contains("private IReadOnlyList<ActivityLogSearchRow> GetSearchRowsSnapshot()", viewModel, StringComparison.Ordinal);
-            Assert.Contains("if (_searchRows.Count == Logs.Count)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (SearchRowsMatchLogs())", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private bool SearchRowsMatchLogs()", viewModel, StringComparison.Ordinal);
+            Assert.Contains("!ReferenceEquals(_searchRows[i].Log, Logs[i])", viewModel, StringComparison.Ordinal);
             Assert.Contains("_searchRows = Logs.Select(ActivityLogSearchRow.Create).ToList();", viewModel, StringComparison.Ordinal);
             Assert.Contains("private sealed class ActivityLogSearchRow", viewModel, StringComparison.Ordinal);
             Assert.Contains("public bool Matches(string selectedUserFilter, string selectedActionFilter, string search)", viewModel, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
@@ -184,7 +184,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("CancellationTokenSource? _filterRefreshCts", viewModel, StringComparison.Ordinal);
             Assert.Contains("Interlocked.Exchange(ref _filterRefreshCts, cts)", viewModel, StringComparison.Ordinal);
             Assert.Contains("await Task.Delay(FilterDebounceMilliseconds, cts.Token);", viewModel, StringComparison.Ordinal);
-            Assert.Contains("await Task.Run(() => rows.Where", viewModel, StringComparison.Ordinal);
+            Assert.Contains("await Task.Run(() => rows", viewModel, StringComparison.Ordinal);
             Assert.Contains("PreserveActivityLogRowsAfterLoadFailure", viewModel, StringComparison.Ordinal);
             Assert.DoesNotContain("ClearActivityLogRowsAfterLoadFailure", viewModel, StringComparison.Ordinal);
         }
@@ -197,6 +197,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("public void CancelPendingFilterRefresh()", viewModel, StringComparison.Ordinal);
             Assert.Contains("var cts = Interlocked.Exchange(ref _filterRefreshCts, null);", viewModel, StringComparison.Ordinal);
             Assert.Contains("cts?.Cancel();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("cts?.Dispose();", viewModel, StringComparison.Ordinal);
             Assert.Contains("if (IsFiltering)", viewModel, StringComparison.Ordinal);
             Assert.Contains("IsFiltering = false;", viewModel, StringComparison.Ordinal);
             Assert.Contains("Activity filtering was canceled before rows were loaded.", viewModel, StringComparison.Ordinal);
@@ -219,8 +220,41 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("public string ActivityEmptyStateTitle", viewModel, StringComparison.Ordinal);
             Assert.Contains("public string ActivityEmptyStateMessage", viewModel, StringComparison.Ordinal);
             Assert.Contains("public string PrintStatusText", viewModel, StringComparison.Ordinal);
-            Assert.Contains("log.UserID.ToString().Contains(search, StringComparison.OrdinalIgnoreCase)", viewModel, StringComparison.Ordinal);
             Assert.Contains("OrderByDescending(log => log.Timestamp)", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsViewModel_CachesSearchRowsForFastFilterPasses()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
+
+            Assert.Contains("private IReadOnlyList<ActivityLogSearchRow> _searchRows = Array.Empty<ActivityLogSearchRow>();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("var refreshedSearchRows = refreshedRows", viewModel, StringComparison.Ordinal);
+            Assert.Contains(".Select(ActivityLogSearchRow.Create)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_searchRows = refreshedSearchRows;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private IReadOnlyList<ActivityLogSearchRow> GetSearchRowsSnapshot()", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (_searchRows.Count == Logs.Count)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_searchRows = Logs.Select(ActivityLogSearchRow.Create).ToList();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private sealed class ActivityLogSearchRow", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool Matches(string selectedUserFilter, string selectedActionFilter, string search)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("SearchText.Contains(search, StringComparison.OrdinalIgnoreCase)", viewModel, StringComparison.Ordinal);
+            Assert.DoesNotContain("SafeText(log.UserName).Contains(search, StringComparison.OrdinalIgnoreCase)", viewModel, StringComparison.Ordinal);
+            Assert.DoesNotContain("BuildDestinationName(BuildDestinationKey(log.Action)).Contains(search, StringComparison.OrdinalIgnoreCase)", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsViewModel_ReusesFilteredRowsAndPreservesSelectionWhenFilterOutputIsSame()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
+
+            Assert.Contains("ReplaceFilteredLogs(filtered, previousSelection);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private void ReplaceFilteredLogs(IReadOnlyList<ActivityLog> filtered, ActivityLog? previousSelection)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (!HasSameRows(FilteredLogs, filtered))", viewModel, StringComparison.Ordinal);
+            Assert.Contains("SelectedLog = previousSelection != null && FilteredLogs.Contains(previousSelection)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private static bool HasSameRows(IReadOnlyList<ActivityLog> currentRows, IReadOnlyList<ActivityLog> nextRows)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (!ReferenceEquals(currentRows[i], nextRows[i]))", viewModel, StringComparison.Ordinal);
+            Assert.Contains("previousCts?.Dispose();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_searchRows = Array.Empty<ActivityLogSearchRow>();", viewModel, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-activity-log-filter-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-activity-log-filter-responsiveness.md
@@ -1,0 +1,24 @@
+# Activity Log Filter Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Cached per-row Activity Logs search metadata after refresh so repeated search/filter passes reuse normalized user, action group, destination, user ID, and timestamp text instead of rebuilding it for every predicate check.
+- Reused the cached row metadata when rebuilding user/action filter lists so filter dropdown refreshes avoid repeating action classification work.
+- Moved Activity Logs filtering to the cached projection while preserving the existing async debounce, cancellation, and off-UI-thread filtering behavior.
+- Added a filtered-row replacement guard so unchanged filter output does not clear and repopulate the virtualized grid, reducing UI churn during repeated refreshes or equivalent filter text.
+- Preserved the previous selected audit row when it remains visible after a filter pass, falling back to the first visible row only when needed.
+- Disposed canceled filter refresh tokens from both the normal debounce-replacement path and page-context cancellation path.
+- Reset the cached search projection when an empty load failure clears activity rows.
+- Kept the existing loading/filtering busy states, print readiness messages, first-paint load behavior, virtualized grid, and bounded print packet behavior intact.
+- Extended source-contract coverage for cached search rows, fast search matching, canceled-token disposal, no-op filtered-list replacement, and selection preservation.
+
+## Validation
+
+- Could not run local `pwsh -File scripts/run-full-validation.ps1`, .NET build/tests, WPF runtime checks, screenshots, scaling checks, or live Activity Logs typing/filtering tests in the scheduled Linux environment because direct checkout is blocked by GitHub HTTP 403 and the environment lacks `dotnet`, `pwsh`, `gh`, and a WPF runtime.
+- GitHub connector readback/compare should be used before merge to confirm the branch contains only the Activity Logs view-model, Activity Logs responsive contract tests, and this progress note.
+
+## Follow-up
+
+- Run the full Windows/.NET validation runner and manually smoke test Activity Logs rapid typing, user/action filter changes, row selection retention, context menu behavior, print-preview readiness, and scaled desktop layout when a Windows-capable checkout is available.

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
@@ -23,6 +24,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly ILogger<ActivityLogsViewModel> _logger;
         private CancellationTokenSource? _filterRefreshCts;
         private bool _suppressFilterRefresh;
+        private IReadOnlyList<ActivityLogSearchRow> _searchRows = Array.Empty<ActivityLogSearchRow>();
 
         public ObservableCollection<ActivityLog> Logs { get; } = new();
         public ObservableCollection<ActivityLog> FilteredLogs { get; } = new();
@@ -276,9 +278,14 @@ namespace InventoryManagementApp.ViewModels
                     .ThenBy(log => SafeText(log.Action), StringComparer.OrdinalIgnoreCase)
                     .ToList();
 
+                var refreshedSearchRows = refreshedRows
+                    .Select(ActivityLogSearchRow.Create)
+                    .ToList();
+
                 Logs.Clear();
                 foreach (var log in refreshedRows)
                     Logs.Add(log);
+                _searchRows = refreshedSearchRows;
 
                 LastLoadedAt = DateTime.Now;
                 RebuildFilterLists();
@@ -302,6 +309,7 @@ namespace InventoryManagementApp.ViewModels
         {
             var cts = Interlocked.Exchange(ref _filterRefreshCts, null);
             cts?.Cancel();
+            cts?.Dispose();
 
             if (IsFiltering)
             {
@@ -318,6 +326,7 @@ namespace InventoryManagementApp.ViewModels
             if (Logs.Count == 0)
             {
                 FilteredLogs.Clear();
+                _searchRows = Array.Empty<ActivityLogSearchRow>();
                 SelectedLog = null;
                 LastLoadedAt = null;
                 RebuildFilterLists();
@@ -329,6 +338,9 @@ namespace InventoryManagementApp.ViewModels
 
         private void ClearFilters()
         {
+            if (IsLoading)
+                return;
+
             _suppressFilterRefresh = true;
             SearchText = string.Empty;
             SelectedUserFilter = AllUsersFilter;
@@ -346,14 +358,16 @@ namespace InventoryManagementApp.ViewModels
 
         private void RebuildFilterLists()
         {
+            var searchRows = GetSearchRowsSnapshot();
+
             UserFilters.Clear();
             UserFilters.Add(AllUsersFilter);
-            foreach (var userName in Logs.Select(l => l.UserName).Where(u => !string.IsNullOrWhiteSpace(u)).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(u => u))
+            foreach (var userName in searchRows.Select(l => l.UserName).Where(u => !string.IsNullOrWhiteSpace(u)).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(u => u))
                 UserFilters.Add(userName);
 
             ActionFilters.Clear();
             ActionFilters.Add(AllActionsFilter);
-            foreach (var actionGroup in Logs.Select(l => ClassifyAction(l.Action)).Distinct().OrderBy(g => g))
+            foreach (var actionGroup in searchRows.Select(l => l.ActionGroup).Distinct().OrderBy(g => g))
                 ActionFilters.Add(actionGroup);
 
             if (!UserFilters.Contains(SelectedUserFilter))
@@ -396,28 +410,15 @@ namespace InventoryManagementApp.ViewModels
                 var selectedUserFilter = SelectedUserFilter;
                 var selectedActionFilter = SelectedActionFilter;
                 var previousSelection = SelectedLog;
-                var rows = Logs.ToList();
+                var rows = GetSearchRowsSnapshot();
 
-                var filtered = await Task.Run(() => rows.Where(log =>
-                    (selectedUserFilter == AllUsersFilter || string.Equals(log.UserName, selectedUserFilter, StringComparison.OrdinalIgnoreCase)) &&
-                    (selectedActionFilter == AllActionsFilter || string.Equals(ClassifyAction(log.Action), selectedActionFilter, StringComparison.OrdinalIgnoreCase)) &&
-                    (string.IsNullOrWhiteSpace(search) ||
-                        SafeText(log.UserName).Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                        SafeText(log.Action).Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                        ClassifyAction(log.Action).Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                        BuildDestinationName(BuildDestinationKey(log.Action)).Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                        log.UserID.ToString().Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                        log.Timestamp.ToString("g").Contains(search, StringComparison.OrdinalIgnoreCase)))
+                var filtered = await Task.Run(() => rows
+                    .Where(row => row.Matches(selectedUserFilter, selectedActionFilter, search))
+                    .Select(row => row.Log)
                     .ToList(), cts.Token);
 
                 cts.Token.ThrowIfCancellationRequested();
-                FilteredLogs.Clear();
-                foreach (var log in filtered)
-                    FilteredLogs.Add(log);
-
-                SelectedLog = previousSelection != null && FilteredLogs.Contains(previousSelection)
-                    ? previousSelection
-                    : FilteredLogs.FirstOrDefault();
+                ReplaceFilteredLogs(filtered, previousSelection);
 
                 NotifyActivityStateChanged();
                 StatusMessage = HasActiveFilter()
@@ -438,6 +439,43 @@ namespace InventoryManagementApp.ViewModels
 
                 cts.Dispose();
             }
+        }
+
+        private IReadOnlyList<ActivityLogSearchRow> GetSearchRowsSnapshot()
+        {
+            if (_searchRows.Count == Logs.Count)
+                return _searchRows;
+
+            _searchRows = Logs.Select(ActivityLogSearchRow.Create).ToList();
+            return _searchRows;
+        }
+
+        private void ReplaceFilteredLogs(IReadOnlyList<ActivityLog> filtered, ActivityLog? previousSelection)
+        {
+            if (!HasSameRows(FilteredLogs, filtered))
+            {
+                FilteredLogs.Clear();
+                foreach (var log in filtered)
+                    FilteredLogs.Add(log);
+            }
+
+            SelectedLog = previousSelection != null && FilteredLogs.Contains(previousSelection)
+                ? previousSelection
+                : FilteredLogs.FirstOrDefault();
+        }
+
+        private static bool HasSameRows(IReadOnlyList<ActivityLog> currentRows, IReadOnlyList<ActivityLog> nextRows)
+        {
+            if (currentRows.Count != nextRows.Count)
+                return false;
+
+            for (var i = 0; i < currentRows.Count; i++)
+            {
+                if (!ReferenceEquals(currentRows[i], nextRows[i]))
+                    return false;
+            }
+
+            return true;
         }
 
         private void NotifyActivityStateChanged()
@@ -539,6 +577,48 @@ namespace InventoryManagementApp.ViewModels
         private static string SafeText(string? text, string fallback = "")
         {
             return string.IsNullOrWhiteSpace(text) ? fallback : text.Trim();
+        }
+
+        private sealed class ActivityLogSearchRow
+        {
+            private ActivityLogSearchRow(ActivityLog log, string userName, string actionGroup, string searchText)
+            {
+                Log = log;
+                UserName = userName;
+                ActionGroup = actionGroup;
+                SearchText = searchText;
+            }
+
+            public ActivityLog Log { get; }
+            public string UserName { get; }
+            public string ActionGroup { get; }
+            private string SearchText { get; }
+
+            public static ActivityLogSearchRow Create(ActivityLog log)
+            {
+                var userName = SafeText(log.UserName);
+                var action = SafeText(log.Action);
+                var actionGroup = ClassifyAction(action);
+                var destinationName = BuildDestinationName(BuildDestinationKey(action));
+                var searchText = string.Join("\n", new[]
+                {
+                    userName,
+                    action,
+                    actionGroup,
+                    destinationName,
+                    log.UserID.ToString(),
+                    log.Timestamp.ToString("g")
+                });
+
+                return new ActivityLogSearchRow(log, userName, actionGroup, searchText);
+            }
+
+            public bool Matches(string selectedUserFilter, string selectedActionFilter, string search)
+            {
+                return (selectedUserFilter == AllUsersFilter || string.Equals(UserName, selectedUserFilter, StringComparison.OrdinalIgnoreCase))
+                    && (selectedActionFilter == AllActionsFilter || string.Equals(ActionGroup, selectedActionFilter, StringComparison.OrdinalIgnoreCase))
+                    && (string.IsNullOrWhiteSpace(search) || SearchText.Contains(search, StringComparison.OrdinalIgnoreCase));
+            }
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -443,11 +443,25 @@ namespace InventoryManagementApp.ViewModels
 
         private IReadOnlyList<ActivityLogSearchRow> GetSearchRowsSnapshot()
         {
-            if (_searchRows.Count == Logs.Count)
+            if (SearchRowsMatchLogs())
                 return _searchRows;
 
             _searchRows = Logs.Select(ActivityLogSearchRow.Create).ToList();
             return _searchRows;
+        }
+
+        private bool SearchRowsMatchLogs()
+        {
+            if (_searchRows.Count != Logs.Count)
+                return false;
+
+            for (var i = 0; i < Logs.Count; i++)
+            {
+                if (!ReferenceEquals(_searchRows[i].Log, Logs[i]))
+                    return false;
+            }
+
+            return true;
         }
 
         private void ReplaceFilteredLogs(IReadOnlyList<ActivityLog> filtered, ActivityLog? previousSelection)


### PR DESCRIPTION
## What changed

- Cached per-row Activity Logs search metadata after refresh so repeated search/filter passes reuse normalized user, action group, destination, user ID, and timestamp text.
- Reused the cached metadata when rebuilding user/action filter dropdowns, avoiding repeated action classification work.
- Moved filter matching to the cached projection while preserving the existing async debounce, cancellation, and off-UI-thread filtering behavior.
- Added row-identity validation before reusing the cache so same-sized public `Logs` collection changes still rebuild metadata safely.
- Added a filtered-row replacement guard so unchanged filter output does not clear and repopulate the virtualized grid.
- Preserved the previous selected audit row when it remains visible after filtering.
- Disposed canceled filter refresh tokens in both replacement and page-context cancellation paths.
- Reset cached search projection when an empty load failure clears Activity Logs rows.
- Kept existing busy/loading states, print readiness messaging, first-paint load behavior, virtualization, and bounded print packet behavior intact.
- Extended Activity Logs source-contract coverage for cached filtering, cache identity checks, selection preservation, filtered-list reuse, and cancellation cleanup.
- Added a progress note for the completed Activity Logs responsiveness slice.

## Why this was highest value

Current repo evidence shows loading speed, UI responsiveness, and professional data display are the active priority. Activity Logs already had a responsive layout and async filtering, but the filter path still rebuilt derived strings and classifications for every row on each search/filter pass and repopulated the visible grid even when output was unchanged. This PR improves the concrete screen operators use for audit search, row handoff, related-workflow routing, and print readiness without inventing unrelated features.

## Why this is real progress

This is a vertical Activity Logs workflow slice: data preparation, search/filter execution, UI collection churn, selection behavior, cancellation cleanup, test coverage, and progress tracking all move together. The change is scoped to the Activity Logs view-model and its source-contract tests.

## Validation

- GitHub connector compare/readback confirmed the branch is based on current `master` and touches only:
  - `InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs`
  - `InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-06-activity-log-filter-responsiveness.md`
- Connector workflow lookup found no attached workflow runs for the branch head before PR creation.

## Could not check

- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime smoke tests, screenshots, scaling checks, or live Activity Logs rapid typing/filtering checks because this scheduled Linux environment cannot clone the repo directly (`CONNECT tunnel failed, response 403`) and lacks `dotnet`, `pwsh`, `gh`, and a WPF runtime.

## Follow-up

- Run the full Windows/.NET validation runner from a Windows-capable checkout.
- Smoke test Activity Logs rapid search typing, user/action filter changes, selected-row retention, context menu behavior, print-preview readiness, and scaled desktop layout.