### PR TITLE
Guard rental filter input during refresh

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsPageLoadingInputContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageLoadingInputContractTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ManageRentalsPageLoadingInputContractTests
+    {
+        [Fact]
+        public void ManageRentalsPage_FreezesFilterEditorsDuringRefreshButKeepsNavigationKeys()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
+            var keyDownBlock = ExtractSourceBlock(source, "private void ManageRentalsPage_PreviewKeyDown", "private static bool IsRentalActionShortcut");
+
+            Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", keyDownBlock, StringComparison.Ordinal);
+            Assert.Contains("if (vm.IsLoading && IsTextEditingElement(e.OriginalSource) && e.Key is not Key.Tab and not Key.Escape)", keyDownBlock, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;\n                return;", keyDownBlock, StringComparison.Ordinal);
+            Assert.True(
+                keyDownBlock.IndexOf("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", StringComparison.Ordinal) <
+                keyDownBlock.IndexOf("if (vm.IsLoading && IsTextEditingElement(e.OriginalSource)", StringComparison.Ordinal),
+                "Ctrl+F should still move focus to search while the rental desk refreshes.");
+            Assert.True(
+                keyDownBlock.IndexOf("if (vm.IsLoading && IsTextEditingElement(e.OriginalSource)", StringComparison.Ordinal) <
+                keyDownBlock.IndexOf("if (IsTextEditingElement(e.OriginalSource) && IsRentalActionShortcut(e))", StringComparison.Ordinal),
+                "Busy editor suppression should run before normal text-edit shortcut preservation.");
+            Assert.True(
+                keyDownBlock.IndexOf("if (vm.IsLoading && IsTextEditingElement(e.OriginalSource)", StringComparison.Ordinal) <
+                keyDownBlock.IndexOf("if (vm.IsLoading && IsRentalActionShortcut(e))", StringComparison.Ordinal),
+                "Filter-editor input should be paused before command shortcut handling during refresh.");
+        }
+
+        [Fact]
+        public void ManageRentalsPage_LoadingEditorGuardCoversSearchDatesStatusAndPasswordEditors()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
+            var editBlock = ExtractSourceBlock(source, "private static bool IsTextEditingElement", "private void OpenFocusedDetails");
+
+            Assert.Contains("source is TextBox or ComboBox or DatePicker or PasswordBox", editBlock, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<TextBox>(element) != null", editBlock, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<ComboBox>(element) != null", editBlock, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<DatePicker>(element) != null", editBlock, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<PasswordBox>(element) != null", editBlock, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string NormalizeLineEndings(string text)
+            => text.Replace("\r\n", "\n");
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-rentals-refresh-input-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-rentals-refresh-input-guards.md
@@ -1,0 +1,27 @@
+# Rentals Refresh Input Guards - 2026-07-06
+
+## Completed
+
+- Kept Ctrl+F available to move focus to rental search while the rental desk is refreshing.
+- Paused typed filter/date/status editor input while `IsLoading` is true so operators cannot queue stale search, date-range, or status changes against rows that are mid-refresh.
+- Preserved Tab and Escape during refresh so keyboard navigation and dismissal flows do not trap focus.
+- Reused the existing nested editor detection for text boxes, combo boxes, date pickers, and password boxes instead of adding another visual-tree path.
+- Kept the existing rental and request command shortcut guards in place for print, details, check-in, extend, request, history, enter, and delete paths.
+- Added focused source-contract tests for the busy editor guard, Ctrl+F ordering, normal shortcut ordering, and covered editor types.
+
+## Why It Matters
+
+The Rentals page is a dense, high-traffic workflow with live filters, two grids, print actions, row gestures, and request handling. The page already paused row actions and context menus during refreshes, but filter editors could still receive keyboard input while data was loading. This pass keeps the visible rows, filters, and command state aligned during refresh so the screen feels less jumpy and avoids stale filter work while operators are moving quickly.
+
+## Validation
+
+- GitHub connector readback should confirm `ManageRentalsPage.xaml.cs` now swallows non-navigation editor keys during `IsLoading` after Ctrl+F handling and before normal shortcut dispatch.
+- Added source-contract coverage in `ManageRentalsPageLoadingInputContractTests` for loading editor suppression, keyboard ordering, and editor coverage.
+
+## Not Run Here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- .NET restore/build/test
+- WPF runtime smoke tests, screenshots, scaling checks, or live keyboard testing
+
+Those remain unavailable in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is not present.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -205,6 +205,12 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
+            if (vm.IsLoading && IsTextEditingElement(e.OriginalSource) && e.Key is not Key.Tab and not Key.Escape)
+            {
+                e.Handled = true;
+                return;
+            }
+
             if (IsTextEditingElement(e.OriginalSource) && IsRentalActionShortcut(e))
                 return;
 


### PR DESCRIPTION
## Summary

- Pause non-navigation keyboard input in Rentals page editor controls while `IsLoading` is true, so search/date/status filter changes cannot queue against rows that are mid-refresh.
- Keep Ctrl+F available during refresh so operators can still move focus to search, while preserving Tab/Escape for navigation and dismissal.
- Add focused source-contract coverage for the loading editor guard, guard ordering, and covered editor types.
- Record completed progress in the Rentals progress notes.

## Why This Was Highest Value

Recent repo evidence shows sustained work on screen loading, responsive grids, busy-state safety, and professional data display. The Rentals page is a high-traffic workflow with two grids, live filters, print actions, request handling, and existing loading overlays. It already blocked row actions and context menus during refresh, but editor input could still change filters while data was loading. This closes that stale-input path without broad rewrites.

## Why This Is Real Progress

This is a workflow-level guard across the Rentals desk: search, date, status, row actions, request actions, and keyboard shortcuts now stay aligned while refresh work is active. It includes app code, source-contract tests, and a progress note.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by 3 commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs`
  - `InventoryManagementApp.Tests/ManageRentalsPageLoadingInputContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-06-rentals-refresh-input-guards.md`
- GitHub connector readback confirmed the loading editor guard runs after Ctrl+F handling and before normal shortcut dispatch.
- GitHub connector readback confirmed the new source-contract tests cover Ctrl+F ordering, busy editor suppression, shortcut ordering, and nested editor detection.

## Not Run

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, scaling checks, or live keyboard testing

This scheduled Linux environment cannot clone the repository directly due GitHub HTTP 403, and `dotnet`/`pwsh` are not installed.

## Follow-up

- Run the full validation runner on a Windows/.NET-capable checkout.
- Consider moving the same busy-state contract into the Rentals view model command availability if future work touches that class in a normal checkout.