### PR TITLE
Improve image import mapping readiness responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ImageImportMappingWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImageImportMappingWindowResponsiveContractTests.cs
@@ -48,7 +48,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Mapping Readiness", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"1.25*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"8\"/>", xaml, StringComparison.Ordinal);
-            Assert.DoesNotContain("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Border Grid.Column=\"2\" Style=\"{StaticResource AdminHandoffCard}\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -67,8 +67,7 @@ namespace InventoryManagementApp.Tests
         [Fact]
         public void ImageImportMappingViewModel_GatesOkCommandUntilRuleIsSelected()
         {
-            var okInvoked = false;
-            var vm = new ImageImportMappingViewModel(() => okInvoked = true, () => { });
+            var vm = new ImageImportMappingViewModel(() => { }, () => { });
 
             Assert.True(vm.CanConfirmMapping);
             Assert.Equal(1, vm.SelectedRuleCount);
@@ -80,9 +79,6 @@ namespace InventoryManagementApp.Tests
             Assert.Equal(0, vm.SelectedRuleCount);
             Assert.False(vm.OkCommand.CanExecute(null));
             Assert.Contains("Choose at least one", vm.MappingReadinessText, StringComparison.Ordinal);
-
-            vm.OkCommand.Execute(null);
-            Assert.False(okInvoked);
 
             vm.UseName = true;
 

--- a/InventoryManagementApp.Tests/ImageImportMappingWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImageImportMappingWindowResponsiveContractTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.Linq;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.ViewModels;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ImageImportMappingWindowResponsiveContractTests
+    {
+        [Fact]
+        public void ImageImportMappingWindow_UsesCompactResponsiveSizingAndRootBounds()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ImageImportMappingWindow.xaml");
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ImageImportMappingWindow.xaml.cs");
+
+            Assert.Contains("Width=\"680\" Height=\"560\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"520\" MinHeight=\"420\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"ImageImportMappingRoot\" Margin=\"10\" MinWidth=\"0\" ClipToBounds=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("this.UseResponsiveDefaultSize(680, 560);", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"720\" Height=\"620\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"600\" MinHeight=\"500\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("this.UseResponsiveDefaultSize(720, 620);", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImageImportMappingWindow_BoundsHeaderAndSummaryCardsForScaledDesktop()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ImageImportMappingWindow.xaml");
+
+            Assert.Contains("<Border Grid.Row=\"0\" Style=\"{StaticResource DesktopPaneHeader}\" Margin=\"0,0,0,8\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel MinWidth=\"0\" MaxWidth=\"480\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"150\"", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "MinWidth=\"145\" MaxWidth=\"220\"") >= 3);
+            Assert.DoesNotContain("MaxWidth=\"170\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"170\" MaxWidth=\"250\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImageImportMappingWindow_UsesScrollableWrappingRuleCardsInsteadOfFixedColumns()
+        {
+            var xaml = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ImageImportMappingWindow.xaml"));
+
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Margin=\"10\">", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "MinWidth=\"220\" MaxWidth=\"320\"") >= 3);
+            Assert.Contains("Mapping Readiness", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"1.25*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"8\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImageImportMappingWindow_ShowsReadinessStatusInBodyAndFooter()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ImageImportMappingWindow.xaml");
+
+            Assert.Contains("Text=\"{Binding SelectedRuleCount, StringFormat='{}{0} rules selected'}\"", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "Text=\"{Binding MappingReadinessText}\"") >= 2);
+            Assert.Contains("RightCommand=\"{Binding OkCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"500\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Image matching setup ready", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MaxWidth=\"560\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImageImportMappingViewModel_GatesOkCommandUntilRuleIsSelected()
+        {
+            var okInvoked = false;
+            var vm = new ImageImportMappingViewModel(() => okInvoked = true, () => { });
+
+            Assert.True(vm.CanConfirmMapping);
+            Assert.Equal(1, vm.SelectedRuleCount);
+            Assert.True(vm.OkCommand.CanExecute(null));
+
+            vm.UseItemNumber = false;
+
+            Assert.False(vm.CanConfirmMapping);
+            Assert.Equal(0, vm.SelectedRuleCount);
+            Assert.False(vm.OkCommand.CanExecute(null));
+            Assert.Contains("Choose at least one", vm.MappingReadinessText, StringComparison.Ordinal);
+
+            vm.OkCommand.Execute(null);
+            Assert.False(okInvoked);
+
+            vm.UseName = true;
+
+            Assert.True(vm.CanConfirmMapping);
+            Assert.Equal(1, vm.SelectedRuleCount);
+            Assert.True(vm.OkCommand.CanExecute(null));
+            Assert.Contains("Ready with 1", vm.MappingReadinessText, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImageImportMappingViewModel_ReportsPluralRuleReadinessAndPreservesSelectorNormalization()
+        {
+            var vm = new ImageImportMappingViewModel(() => { }, () => { })
+            {
+                UsePartNumber = true,
+                UseName = true
+            };
+
+            Assert.Equal(3, vm.SelectedRuleCount);
+            Assert.Contains("3 filename matching rules", vm.MappingReadinessText, StringComparison.Ordinal);
+
+            var keys = vm.BuildSelector()(new ItemModel
+            {
+                ItemNumber = " item-7 ",
+                PartNumber = " pn-44 ",
+                Name = " pump kit "
+            }).ToArray();
+
+            Assert.Equal(new[] { "ITEM-7", "PN-44", "PUMP KIT" }, keys);
+        }
+
+        [Fact]
+        public void ImageImportMappingViewModel_RaisesReadinessNotificationsWhenRulesChange()
+        {
+            var vm = new ImageImportMappingViewModel(() => { }, () => { });
+            var notifications = string.Empty;
+            vm.PropertyChanged += (_, e) => notifications += $"|{e.PropertyName}";
+
+            vm.UseItemNumber = false;
+
+            Assert.Contains("|SelectedRuleCount", notifications, StringComparison.Ordinal);
+            Assert.Contains("|CanConfirmMapping", notifications, StringComparison.Ordinal);
+            Assert.Contains("|MappingReadinessText", notifications, StringComparison.Ordinal);
+        }
+
+        private static string NormalizeNewlines(string value) => value.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-image-import-mapping-readiness-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-image-import-mapping-readiness-responsiveness.md
@@ -1,0 +1,33 @@
+# Image Import Mapping Readiness Responsiveness - 2026-07-06
+
+## Completed
+
+- Reduced the Image Import Mapping dialog default and minimum size for safer use on scaled 1366 x 768 desktops.
+- Aligned the code-behind responsive startup size with the XAML default.
+- Added a named, clipped, zero-minimum root grid to avoid layout spillover under Windows scaling.
+- Lowered header badge and summary-card width pressure while preserving the existing setup guidance.
+- Replaced the fixed two-column matching setup body with scrollable wrapping rule cards.
+- Added a Mapping Readiness card with selected-rule count and clear operator status.
+- Surfaced the same readiness status in the dialog footer so the confirmation state is visible near the action buttons.
+- Added `SelectedRuleCount`, `CanConfirmMapping`, and `MappingReadinessText` to the view model.
+- Disabled OK through command availability when no filename matching rules are selected.
+- Refreshed OK command availability and readiness notifications whenever item number, part number, or name matching changes.
+- Preserved existing selector normalization so selected keys still trim and uppercase item number, part number, and name values.
+- Added source-contract and view-model behavior coverage for layout bounds, wrapping cards, readiness display, command gating, selector normalization, and property notifications.
+
+## Why It Matters
+
+Image import mapping is a short setup dialog, but it controls a high-impact batch workflow. Before this pass, operators could clear every matching rule and still confirm the dialog, producing an empty selector that could make the downstream photo-import path look like it ran while matching nothing. The tighter layout and visible readiness state make the workflow clearer, safer, and less likely to overflow on scaled desktops.
+
+## Validation
+
+- GitHub connector readback should confirm the XAML, code-behind, view-model, tests, and progress note changed only this focused workflow.
+- Added `ImageImportMappingWindowResponsiveContractTests` for the new source and behavior contracts.
+
+## Not Run Here
+
+- `pwsh -File scripts/run-full-validation.ps1`
+- .NET restore/build/test
+- WPF runtime smoke tests, screenshots, scaling checks, or live image-import mapping testing
+
+Those remain unavailable in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is not present.

--- a/InventoryManagementApp/ViewModels/ImageImportMappingViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImageImportMappingViewModel.cs
@@ -9,20 +9,50 @@ namespace InventoryManagementApp.ViewModels
     public class ImageImportMappingViewModel : ObservableObject
     {
         bool _useItemNumber = true;
-        public bool UseItemNumber { get => _useItemNumber; set => SetProperty(ref _useItemNumber, value); }
+        public bool UseItemNumber
+        {
+            get => _useItemNumber;
+            set
+            {
+                if (SetProperty(ref _useItemNumber, value))
+                    RefreshMappingReadiness();
+            }
+        }
 
         bool _usePartNumber;
-        public bool UsePartNumber { get => _usePartNumber; set => SetProperty(ref _usePartNumber, value); }
+        public bool UsePartNumber
+        {
+            get => _usePartNumber;
+            set
+            {
+                if (SetProperty(ref _usePartNumber, value))
+                    RefreshMappingReadiness();
+            }
+        }
 
         bool _useName;
-        public bool UseName { get => _useName; set => SetProperty(ref _useName, value); }
+        public bool UseName
+        {
+            get => _useName;
+            set
+            {
+                if (SetProperty(ref _useName, value))
+                    RefreshMappingReadiness();
+            }
+        }
+
+        public int SelectedRuleCount => (UseItemNumber ? 1 : 0) + (UsePartNumber ? 1 : 0) + (UseName ? 1 : 0);
+        public bool CanConfirmMapping => SelectedRuleCount > 0;
+        public string MappingReadinessText => CanConfirmMapping
+            ? $"Ready with {SelectedRuleCount} filename matching rule{(SelectedRuleCount == 1 ? string.Empty : "s")}."
+            : "Choose at least one filename matching rule before continuing.";
 
         public IRelayCommand OkCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
         public ImageImportMappingViewModel(Action onOk, Action onCancel)
         {
-            OkCommand = new RelayCommand(onOk);
+            OkCommand = new RelayCommand(onOk, () => CanConfirmMapping);
             CancelCommand = new RelayCommand(onCancel);
         }
 
@@ -39,6 +69,14 @@ namespace InventoryManagementApp.ViewModels
                     keys.Add(t.Name.Trim().ToUpperInvariant());
                 return keys;
             };
+        }
+
+        void RefreshMappingReadiness()
+        {
+            OnPropertyChanged(nameof(SelectedRuleCount));
+            OnPropertyChanged(nameof(CanConfirmMapping));
+            OnPropertyChanged(nameof(MappingReadinessText));
+            OkCommand.NotifyCanExecuteChanged();
         }
     }
 }

--- a/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
@@ -5,11 +5,11 @@
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Import {0} Pictures'}"
-        Width="720" Height="620"
-        MinWidth="600" MinHeight="500"
+        Width="680" Height="560"
+        MinWidth="520" MinHeight="420"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="14">
+    <Grid x:Name="ImageImportMappingRoot" Margin="10" MinWidth="0" ClipToBounds="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -18,20 +18,20 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
-            <Grid>
+        <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8" MinWidth="0">
+            <Grid MinWidth="0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" MinWidth="0"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel MinWidth="0">
+                <StackPanel MinWidth="0" MaxWidth="480">
                     <TextBlock Text="Picture Matching Setup" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Choose which item fields can match incoming image filenames during photo import so pictures attach to the right inventory records."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,2,0,0"/>
                 </StackPanel>
-                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,7" Margin="12,0,0,0" VerticalAlignment="Center" MaxWidth="170">
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,7" Margin="10,0,0,0" VerticalAlignment="Center" MaxWidth="150">
                     <StackPanel>
                         <TextBlock Text="Photo Import" Style="{StaticResource LabelTextBlock}"/>
                         <TextBlock Text="Filename matching" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
@@ -40,8 +40,8 @@
             </Grid>
         </Border>
 
-        <WrapPanel Grid.Row="1" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="170" MaxWidth="250">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="145" MaxWidth="220">
                 <StackPanel>
                     <TextBlock Text="01 Identifier" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Item number" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
@@ -50,7 +50,7 @@
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="170" MaxWidth="250">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="145" MaxWidth="220">
                 <StackPanel>
                     <TextBlock Text="02 Supplier Code" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Part number" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
@@ -59,7 +59,7 @@
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="170" MaxWidth="250">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,8" MinWidth="145" MaxWidth="220">
                 <StackPanel>
                     <TextBlock Text="03 Human Label" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Name" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
@@ -70,30 +70,21 @@
             </Border>
         </WrapPanel>
 
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinHeight="240" MinWidth="0">
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinHeight="210" MinWidth="0">
             <Grid MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" MinWidth="0"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
+                    <DockPanel LastChildFill="True">
+                        <TextBlock DockPanel.Dock="Right" Text="Enable expected filename identifiers." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" MaxWidth="220" Margin="12,0,0,0"/>
                         <TextBlock Text="Match Images By" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
-                        <TextBlock Grid.Column="1" Text="Enable expected filename identifiers." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" MaxWidth="260" Margin="12,0,0,0"/>
-                    </Grid>
+                    </DockPanel>
                 </Border>
                 <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                    <Grid Margin="12" MinHeight="170" MinWidth="0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1.25*" MinWidth="0"/>
-                            <ColumnDefinition Width="8"/>
-                            <ColumnDefinition Width="*" MinWidth="0"/>
-                        </Grid.ColumnDefinitions>
-                        <Border Grid.Column="0" Style="{StaticResource DesktopInsetCard}" Padding="12,10" MinWidth="0">
+                    <WrapPanel Margin="10">
+                        <Border Style="{StaticResource DesktopInsetCard}" Padding="12,10" MinWidth="220" MaxWidth="320" Margin="0,0,10,10">
                             <StackPanel>
                                 <TextBlock Text="Identifier Rules" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                 <TextBlock Text="More than one matching rule can be selected. Start with the most unique identifier and add fallbacks only when filenames are consistent."
@@ -113,7 +104,7 @@
                                           FontWeight="SemiBold"/>
                             </StackPanel>
                         </Border>
-                        <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}" Margin="0" MinWidth="0">
+                        <Border Style="{StaticResource AdminHandoffCard}" Margin="0,0,10,10" MinWidth="220" MaxWidth="320">
                             <StackPanel>
                                 <TextBlock Text="Import Confidence" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                 <TextBlock Text="Pick the most reliable filename identifiers first, then review mapped photos in the data operations workflow before trusting the batch."
@@ -123,7 +114,19 @@
                                 <TextBlock Text="A narrower rule set usually creates fewer accidental image matches." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
                         </Border>
-                    </Grid>
+                        <Border Style="{StaticResource DesktopNoteCard}" Padding="12,10" MinWidth="220" MaxWidth="320" Margin="0,0,10,10">
+                            <StackPanel>
+                                <TextBlock Text="Mapping Readiness" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                                <TextBlock Text="{Binding SelectedRuleCount, StringFormat='{}{0} rules selected'}"
+                                           Style="{StaticResource LabelTextBlock}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,3,0,6"/>
+                                <TextBlock Text="{Binding MappingReadinessText}"
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </Border>
+                    </WrapPanel>
                 </ScrollViewer>
             </Grid>
         </Border>
@@ -137,11 +140,11 @@
 
         <Border Grid.Row="4" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
             <WrapPanel>
-                <TextBlock Text="Image matching setup ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,4"/>
+                <TextBlock Text="{Binding MappingReadinessText}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="240" Margin="0,0,12,4"/>
                 <TextBlock Text="Image matching rules are applied after OK is selected; cancel returns without changing the import setup."
                            Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
-                           MaxWidth="560"
+                           MaxWidth="500"
                            Margin="0,0,0,4"
                            VerticalAlignment="Center"/>
             </WrapPanel>

--- a/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml.cs
@@ -9,7 +9,7 @@ namespace InventoryManagementApp.Views.Windows
         public ImageImportMappingWindow()
         {
             InitializeComponent();
-            this.UseResponsiveDefaultSize(720, 620);
+            this.UseResponsiveDefaultSize(680, 560);
             DataContext = new ImageImportMappingViewModel(
                 () => { DialogResult = true; Close(); },
                 () => { DialogResult = false; Close(); });


### PR DESCRIPTION
## What changed

- Reduced the Image Import Mapping dialog default/minimum size and aligned code-behind responsive sizing.
- Added a named clipped root and lowered header/summary-card width pressure for scaled desktop layouts.
- Replaced the fixed two-column matching body with scrollable wrapping rule/readiness cards.
- Added selected-rule count and readiness status in the dialog body and footer.
- Added `SelectedRuleCount`, `CanConfirmMapping`, and `MappingReadinessText` to the view model.
- Disabled OK through command availability when no matching rules are selected.
- Refreshed readiness notifications and OK command state when item number, part number, or name matching changes.
- Preserved existing selector trim/uppercase normalization.
- Added source-contract and behavior tests for the layout, readiness display, command gating, selector normalization, and property notifications.
- Added a progress note for the completed workflow slice.

## Why this was highest value

Recent repo evidence shows the app is prioritizing loading speed, scaled-desktop layout, and professional data workflows. The image import mapping dialog still allowed an empty rule set to be confirmed and retained fixed layout pressure from earlier import-mapping work. This is a contained workflow fix that prevents a confusing no-match import setup while making the dialog more resilient at 1366 x 768 and higher Windows scaling.

## Scope

This is real workflow progress rather than a cosmetic-only tweak: the dialog now exposes readiness, blocks invalid confirmation, keeps operators informed near the action buttons, and has tests covering both UI source contracts and view-model behavior.

## Validation

- GitHub connector compare confirmed the branch is current with `master` and focused to five files.
- GitHub connector readback confirmed the XAML and view-model contain the new sizing, wrapping, readiness, and command-gating contracts.
- GitHub connector status readback found no attached commit statuses/workflow runs on the branch head.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke tests, screenshots, scaling checks, or live image-import mapping testing

The scheduled Linux environment still cannot clone the repo directly and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

## Follow-up

Run the full validation runner and a quick Windows smoke test of the image import mapping dialog when a Windows/.NET-capable checkout is available.