### PR TITLE
Improve Dashboard row action readiness

### DIFF
--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -222,6 +222,26 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void DashboardPage_BindsRowActionsToSelectionReadiness()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");
+
+            Assert.Contains("Content=\"Open\" Command=\"{Binding OpenSelectedRentalCommand}\" IsEnabled=\"{Binding HasSelectedRental}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Return\" Command=\"{Binding ReturnSelectedRentalCommand}\" IsEnabled=\"{Binding HasSelectedRental}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Open\" Command=\"{Binding OpenSelectedCheckedOutItemCommand}\" IsEnabled=\"{Binding HasSelectedCheckedOutItem}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Check In\" Command=\"{Binding CheckInSelectedItemCommand}\" IsEnabled=\"{Binding HasSelectedCheckedOutItem}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Open Related\" Command=\"{Binding OpenActivityDestinationCommand}\" IsEnabled=\"{Binding HasSelectedActivity}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Open\" Command=\"{Binding OpenSelectedIncompleteItemCommand}\" IsEnabled=\"{Binding HasSelectedIncompleteItem}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Open\" Command=\"{Binding OpenSelectedCommonItemCommand}\" IsEnabled=\"{Binding HasSelectedCommonItem}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Check Out / In\" Command=\"{Binding ToggleSelectedCommonItemCommand}\" IsEnabled=\"{Binding HasSelectedCommonItem}\"", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "PlacementTarget.DataContext.HasSelectedRental") >= 2);
+            Assert.True(CountOccurrences(xaml, "PlacementTarget.DataContext.HasSelectedCheckedOutItem") >= 2);
+            Assert.True(CountOccurrences(xaml, "PlacementTarget.DataContext.HasSelectedActivity") >= 1);
+            Assert.True(CountOccurrences(xaml, "PlacementTarget.DataContext.HasSelectedIncompleteItem") >= 1);
+            Assert.True(CountOccurrences(xaml, "PlacementTarget.DataContext.HasSelectedCommonItem") >= 2);
+        }
+
+        [Fact]
         public void DashboardPage_PreservesPrimaryDashboardActionsAndRowHandoff()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-dashboard-row-action-readiness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-dashboard-row-action-readiness.md
@@ -1,0 +1,27 @@
+# Dashboard Row Action Readiness
+
+Completed on 2026-07-06.
+
+## What changed
+
+- Bound Active Rentals pane Open and Return buttons to `HasSelectedRental` so they read as unavailable until a rental row is selected.
+- Bound Active Rentals context-menu Open Rentals Workflow and Return Rental actions to the same selected-rental readiness state.
+- Bound Checked-Out Items pane Open and Check In buttons to `HasSelectedCheckedOutItem` so row actions do not appear available without a selected checked-out item.
+- Bound Checked-Out Items context-menu Open Item Workflow and Check In actions to the same selected checked-out item readiness state.
+- Bound Recent Activity Open Related to `HasSelectedActivity` so audit handoff is visibly unavailable before a row is selected.
+- Bound Recent Activity context-menu Open Related Workflow to the same selected-activity readiness state.
+- Bound Items With Issues Open to `HasSelectedIncompleteItem` so issue workflow handoff waits for an issue row selection.
+- Bound Items With Issues context-menu Open Item Workflow to the same selected-incomplete-item readiness state.
+- Bound Commonly Used Open and Check Out / In buttons to `HasSelectedCommonItem` so common-item actions do not appear active without a selected item.
+- Bound Commonly Used context-menu Open Item Workflow and Check Out / In actions to the same selected-common-item readiness state.
+- Added source-contract coverage for the Dashboard selected-row action bindings across visible buttons and context menus.
+
+## Why it matters
+
+The Dashboard is a high-traffic first screen with five dense operational grids. The commands already guarded execution, but visible row actions looked available before the operator selected a row. Binding the button and context-menu availability to the existing selection state makes the screen faster to scan, reduces dead-clicks, and keeps row handoff actions aligned with current grid selection while preserving the existing loading and keyboard guards.
+
+## Validation
+
+- Source-contract coverage was added in `DashboardPageResponsiveContractTests` for all selected-row action bindings.
+- Remote-only source inspection confirmed the changes are limited to Dashboard XAML, Dashboard responsive contract tests, and this progress note.
+- Full `pwsh -File scripts/run-full-validation.ps1`, WPF runtime, screenshot, scaling, and print-preview validation could not be run in this scheduled Linux environment because direct checkout is blocked and Windows/.NET/WPF tooling is unavailable.

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -149,8 +149,8 @@
                                 <TextBlock Text="Due dates needing follow-up." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
                             <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
-                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedRentalCommand}" Margin="0,0,4,4"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Return" Command="{Binding ReturnSelectedRentalCommand}" Margin="0,0,0,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedRentalCommand}" IsEnabled="{Binding HasSelectedRental}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Return" Command="{Binding ReturnSelectedRentalCommand}" IsEnabled="{Binding HasSelectedRental}" Margin="0,0,0,4"/>
                             </WrapPanel>
                         </DockPanel>
                     </Border>
@@ -193,8 +193,8 @@
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
-                                <MenuItem Header="Open Rentals Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedRentalCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                <MenuItem Header="Return Rental" Command="{Binding PlacementTarget.DataContext.ReturnSelectedRentalCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Open Rentals Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedRentalCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" IsEnabled="{Binding PlacementTarget.DataContext.HasSelectedRental, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Return Rental" Command="{Binding PlacementTarget.DataContext.ReturnSelectedRentalCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" IsEnabled="{Binding PlacementTarget.DataContext.HasSelectedRental, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                 <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                             </ContextMenu>
                         </DataGrid.ContextMenu>
@@ -213,8 +213,8 @@
                                 <TextBlock Text="Away from shelf with holder context." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
                             <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
-                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCheckedOutItemCommand}" Margin="0,0,4,4"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Check In" Command="{Binding CheckInSelectedItemCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCheckedOutItemCommand}" IsEnabled="{Binding HasSelectedCheckedOutItem}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Check In" Command="{Binding CheckInSelectedItemCommand}" IsEnabled="{Binding HasSelectedCheckedOutItem}" Margin="0,0,4,4"/>
                                 <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintCheckedOutItemsCommand}" Margin="0,0,0,4"/>
                             </WrapPanel>
                         </DockPanel>
@@ -260,8 +260,8 @@
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
-                                <MenuItem Header="Open Item Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedCheckedOutItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                <MenuItem Header="Check In" Command="{Binding PlacementTarget.DataContext.CheckInSelectedItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Open Item Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedCheckedOutItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" IsEnabled="{Binding PlacementTarget.DataContext.HasSelectedCheckedOutItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Check In" Command="{Binding PlacementTarget.DataContext.CheckInSelectedItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" IsEnabled="{Binding PlacementTarget.DataContext.HasSelectedCheckedOutItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                 <MenuItem Header="Print Checked-Out Items" Command="{Binding PlacementTarget.DataContext.PrintCheckedOutItemsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                 <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                             </ContextMenu>
@@ -280,7 +280,7 @@
                                         <TextBlock Text="Audit Trail" Style="{StaticResource SubheadingTextBlock}" TextTrimming="CharacterEllipsis"/>
                                         <TextBlock Text="Open the selected activity workflow." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                                     </StackPanel>
-                                    <Button Style="{StaticResource GhostButton}" Content="Open Related" Command="{Binding OpenActivityDestinationCommand}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Open Related" Command="{Binding OpenActivityDestinationCommand}" IsEnabled="{Binding HasSelectedActivity}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                                 </DockPanel>
                             </Border>
                             <Border DockPanel.Dock="Top" Style="{StaticResource DesktopPaneSubheader}" Margin="0">
@@ -309,7 +309,7 @@
                                 </DataGrid.Columns>
                                 <DataGrid.ContextMenu>
                                     <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
-                                        <MenuItem Header="Open Related Workflow" Command="{Binding PlacementTarget.DataContext.OpenActivityDestinationCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                        <MenuItem Header="Open Related Workflow" Command="{Binding PlacementTarget.DataContext.OpenActivityDestinationCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" IsEnabled="{Binding PlacementTarget.DataContext.HasSelectedActivity, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                         <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                     </ContextMenu>
                                 </DataGrid.ContextMenu>
@@ -324,7 +324,7 @@
                                         <TextBlock Text="Needs Attention" Style="{StaticResource SubheadingTextBlock}" TextTrimming="CharacterEllipsis"/>
                                         <TextBlock Text="Incomplete records and missing-component notes for follow-up." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                                     </StackPanel>
-                                    <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedIncompleteItemCommand}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedIncompleteItemCommand}" IsEnabled="{Binding HasSelectedIncompleteItem}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
                                 </DockPanel>
                             </Border>
                             <DataGrid x:Name="IncompleteItemsGrid"
@@ -350,7 +350,7 @@
                                 </DataGrid.Columns>
                                 <DataGrid.ContextMenu>
                                     <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
-                                        <MenuItem Header="Open Item Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedIncompleteItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                        <MenuItem Header="Open Item Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedIncompleteItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" IsEnabled="{Binding PlacementTarget.DataContext.HasSelectedIncompleteItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                         <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                     </ContextMenu>
                                 </DataGrid.ContextMenu>
@@ -366,8 +366,8 @@
                                         <TextBlock Text="High-frequency counter items." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                                     </StackPanel>
                                     <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
-                                        <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCommonItemCommand}" Margin="0,0,4,4"/>
-                                        <Button Style="{StaticResource GhostButton}" Content="Check Out / In" Command="{Binding ToggleSelectedCommonItemCommand}" Margin="0,0,0,4"/>
+                                        <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCommonItemCommand}" IsEnabled="{Binding HasSelectedCommonItem}" Margin="0,0,4,4"/>
+                                        <Button Style="{StaticResource GhostButton}" Content="Check Out / In" Command="{Binding ToggleSelectedCommonItemCommand}" IsEnabled="{Binding HasSelectedCommonItem}" Margin="0,0,0,4"/>
                                     </WrapPanel>
                                 </DockPanel>
                             </Border>
@@ -421,8 +421,8 @@
                                 </DataGrid.Columns>
                                 <DataGrid.ContextMenu>
                                     <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
-                                        <MenuItem Header="Open Item Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedCommonItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                        <MenuItem Header="Check Out / In" Command="{Binding PlacementTarget.DataContext.ToggleSelectedCommonItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                        <MenuItem Header="Open Item Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedCommonItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" IsEnabled="{Binding PlacementTarget.DataContext.HasSelectedCommonItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                        <MenuItem Header="Check Out / In" Command="{Binding PlacementTarget.DataContext.ToggleSelectedCommonItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" IsEnabled="{Binding PlacementTarget.DataContext.HasSelectedCommonItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                         <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                     </ContextMenu>
                                 </DataGrid.ContextMenu>


### PR DESCRIPTION
## What changed

- Bound Active Rentals Open/Return buttons and context-menu actions to the selected rental state.
- Bound Checked-Out Items Open/Check In buttons and context-menu actions to the selected checked-out item state.
- Bound Recent Activity Open Related button and context-menu action to the selected activity state.
- Bound Items With Issues Open button and context-menu action to the selected incomplete item state.
- Bound Commonly Used Open and Check Out / In buttons and context-menu actions to the selected common item state.
- Added Dashboard source-contract coverage for all selected-row readiness bindings.
- Recorded a progress note for the completed Dashboard workflow slice.

## Why this was highest value

The Dashboard is the app's first high-traffic operational screen and already had multiple dense, virtualized grids. Current code guarded command execution, but row-specific actions still looked available before a row was selected, especially in pane headers and context menus. This change makes the data display more professional and reduces dead-clicks without changing workflow scope or adding risky new dependencies.

## Why this is real progress

This is a complete UI-to-test slice across all five Dashboard row-action areas: active rentals, checked-out items, recent activity, items with issues, and commonly used items. It keeps existing loading, keyboard, and row-retargeting guards in place while making visible action readiness match the current grid selection.

## Validation

- Remote connector compare confirmed the branch is current with `master`, ahead by 3 commits, and limited to Dashboard XAML, Dashboard responsive contract tests, and a progress note.
- Remote source readback confirmed the selected-row readiness bindings and contract assertions are present.
- Could not run `pwsh -File scripts/run-full-validation.ps1`, local .NET tests, WPF runtime checks, screenshots, scaling checks, or print-preview checks because this scheduled Linux environment cannot clone GitHub directly and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

## Follow-up

- Run the full validation script on a Windows/.NET-capable checkout.
- Continue shifting Dashboard loading readiness from code-behind visual-tree walking into ViewModel command state when a Windows validation environment is available.