### PR TITLE
Improve import/export run log responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ImportExportViewModelRunLogResponsivenessContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportViewModelRunLogResponsivenessContractTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ImportExportViewModelRunLogResponsivenessContractTests
+    {
+        [Fact]
+        public void ImportExportViewModel_BoundsVisibleRunLogRowsForGridResponsiveness()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("private const int MaxVisibleImportExportLogRows = 500;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public int VisibleImportExportLogCount => ImportExportLogs.Count;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public int OmittedImportExportLogCount => _omittedImportExportLogCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool HasOmittedImportExportLogs => _omittedImportExportLogCount > 0;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("while (ImportExportLogs.Count >= MaxVisibleImportExportLogRows)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ImportExportLogs.RemoveAt(0);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_omittedImportExportLogCount++;", viewModel, StringComparison.Ordinal);
+            Assert.DoesNotContain("ImportExportLogs.Add(message);\n            SelectedImportExportLog = message;\n            ClearImportExportLogsCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ReportsVisibleAndOmittedRunLogCounts()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("var visibleCount = VisibleImportExportLogCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("var totalCount = visibleCount + OmittedImportExportLogCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (HasOmittedImportExportLogs)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("visible of {totalCount} operation log", viewModel, StringComparison.Ordinal);
+            Assert.Contains("kept out of the grid for responsiveness", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(VisibleImportExportLogCount));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(OmittedImportExportLogCount));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(HasOmittedImportExportLogs));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(LogSummary));", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ClearsOmittedRunLogCountWithVisibleRows()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("void ClearImportExportLogs()", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ImportExportLogs.Clear();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_omittedImportExportLogCount = 0;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("SelectedImportExportLog = null;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ClearImportExportLogsCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_BoundsSelectedLogInlinePreviewButPreservesFullSelection()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("private const int MaxSelectedLogDetailCharacters = 1800;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string SelectedLogDetail", viewModel, StringComparison.Ordinal);
+            Assert.Contains("BuildSelectedLogDetailPreview(SelectedImportExportLog)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private static string BuildSelectedLogDetailPreview(string? value)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (text.Length <= MaxSelectedLogDetailCharacters)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("text.Substring(0, MaxSelectedLogDetailCharacters).TrimEnd();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("characters omitted from this inline preview", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Use Copy Result or Open Log Detail for the complete operation text.", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportPage_StillUsesCompleteSelectedLogForCopyDetailAndPrintHandoff()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
+
+            Assert.Contains("private string GetSelectedLogForAction()", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ImportExportLogGrid.SelectedItem is string gridLog", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("vm.SelectedImportExportLog", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Clipboard.SetText(log);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("BuildBoundedLogText(log, MaxDetailLogCharacters", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("new[] { selectedLog }", codeBehind, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-import-export-run-log-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-import-export-run-log-responsiveness.md
@@ -1,0 +1,22 @@
+# Import / Export Run Log Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Kept the Import / Export run-log grid bounded to the latest 500 visible rows so very large customer/item import skip lists do not keep growing the WPF `ObservableCollection` indefinitely.
+- Added visible, total, and omitted run-log accounting so operators can tell when older session rows were kept out of the grid for responsiveness.
+- Updated log clearing so the omitted-row count resets with the visible grid rows.
+- Bounded the selected-result inline handoff preview to 1,800 characters with an explicit truncation notice.
+- Preserved full-fidelity selected log text for Copy Result, Open Log Detail, and selected-result print handoff paths.
+- Added source-contract coverage for bounded visible run-log rows, omitted-row accounting, clear-state reset, selected-result preview truncation, and full selected-log copy/detail/print handoff preservation.
+
+## Validation
+
+- Added `ImportExportViewModelRunLogResponsivenessContractTests` to guard the new run-log responsiveness contracts.
+- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, or print-preview checks in this scheduled Linux environment because direct checkout remains blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full validation runner on a Windows/.NET-capable checkout.
+- Smoke test a large customer or item import with more than 500 skipped rows to confirm the run-log grid remains responsive and the omitted-row summary is clear.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -21,6 +21,9 @@ namespace InventoryManagementApp.ViewModels
 {
     public class ImportExportViewModel : ObservableObject
     {
+        private const int MaxVisibleImportExportLogRows = 500;
+        private const int MaxSelectedLogDetailCharacters = 1800;
+
         private readonly IItemService _itemService;
         private readonly ICustomerService _customerService;
         private readonly IFileDialogService _fileDialogService;
@@ -30,6 +33,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly IUserContext _userContext;
         private readonly RentalConfigurationService? _rentalConfigService;
         private int _activeDataOperationCount;
+        private int _omittedImportExportLogCount;
         private string? _currentDataOperation;
 
         public IAsyncRelayCommand ImportItemsCommand { get; }
@@ -43,6 +47,9 @@ namespace InventoryManagementApp.ViewModels
         public bool CanImportImages => _userContext.IsAdmin || _userContext.CurrentUser?.HasPermission(User.PermissionImportExport) == true;
         public bool IsCurrentUserAdmin => CanImportImages;
         public bool HasLogEntries => ImportExportLogs.Count > 0;
+        public int VisibleImportExportLogCount => ImportExportLogs.Count;
+        public int OmittedImportExportLogCount => _omittedImportExportLogCount;
+        public bool HasOmittedImportExportLogs => _omittedImportExportLogCount > 0;
         public bool IsDataOperationBusy => _activeDataOperationCount > 0;
         public bool IsDataOperationReady => !IsDataOperationBusy;
         public bool CanReviewSelectedLog => !IsDataOperationBusy && !string.IsNullOrWhiteSpace(SelectedImportExportLog);
@@ -53,9 +60,24 @@ namespace InventoryManagementApp.ViewModels
         public string DataOperationSummary => IsDataOperationBusy
             ? "Finish or cancel the current data operation before starting another import, export, backup, restore, copy, or print handoff."
             : "Ready for the next import, export, backup, restore, image mapping, copy, or print handoff.";
-        public string LogSummary => HasLogEntries
-            ? $"{ImportExportLogs.Count} operation log entr{(ImportExportLogs.Count == 1 ? "y" : "ies")} recorded this session."
-            : "No import, export, image, or backup operations have been run in this session.";
+        public string LogSummary
+        {
+            get
+            {
+                if (!HasLogEntries)
+                    return "No import, export, image, or backup operations have been run in this session.";
+
+                var visibleCount = VisibleImportExportLogCount;
+                var totalCount = visibleCount + OmittedImportExportLogCount;
+                var entryText = totalCount == 1 ? "entry" : "entries";
+                if (HasOmittedImportExportLogs)
+                {
+                    return $"{visibleCount} visible of {totalCount} operation log {entryText} are available this session. {OmittedImportExportLogCount} older entr{(OmittedImportExportLogCount == 1 ? "y was" : "ies were")} kept out of the grid for responsiveness.";
+                }
+
+                return $"{visibleCount} operation log entr{(visibleCount == 1 ? "y" : "ies")} recorded this session.";
+            }
+        }
 
         public string ItemDataSummary =>
             $"Import {LabelProvider.Instance.ItemLabelPlural} from CSV with mapping, JSON, or XML. Export the current item catalog to CSV, JSON, or XML.";
@@ -91,7 +113,7 @@ namespace InventoryManagementApp.ViewModels
 
         public string SelectedLogDetail => string.IsNullOrWhiteSpace(SelectedImportExportLog)
             ? "Run an import, export, image import, or backup action. Select a log row to copy or print the exact result."
-            : SelectedImportExportLog;
+            : BuildSelectedLogDetailPreview(SelectedImportExportLog);
 
         /// <summary>
         /// Command that triggers an asynchronous database backup.
@@ -139,6 +161,7 @@ namespace InventoryManagementApp.ViewModels
             ImportExportLogs.CollectionChanged += (_, _) =>
             {
                 OnPropertyChanged(nameof(HasLogEntries));
+                OnPropertyChanged(nameof(VisibleImportExportLogCount));
                 OnPropertyChanged(nameof(LogSummary));
                 OnPropertyChanged(nameof(CanPrintImportExportLogs));
             };
@@ -241,8 +264,17 @@ namespace InventoryManagementApp.ViewModels
 
         void AddLog(string message)
         {
+            while (ImportExportLogs.Count >= MaxVisibleImportExportLogRows)
+            {
+                ImportExportLogs.RemoveAt(0);
+                _omittedImportExportLogCount++;
+            }
+
             ImportExportLogs.Add(message);
             SelectedImportExportLog = message;
+            OnPropertyChanged(nameof(OmittedImportExportLogCount));
+            OnPropertyChanged(nameof(HasOmittedImportExportLogs));
+            OnPropertyChanged(nameof(LogSummary));
             ClearImportExportLogsCommand.NotifyCanExecuteChanged();
         }
 
@@ -252,7 +284,11 @@ namespace InventoryManagementApp.ViewModels
                 return;
 
             ImportExportLogs.Clear();
+            _omittedImportExportLogCount = 0;
             SelectedImportExportLog = null;
+            OnPropertyChanged(nameof(OmittedImportExportLogCount));
+            OnPropertyChanged(nameof(HasOmittedImportExportLogs));
+            OnPropertyChanged(nameof(LogSummary));
             ClearImportExportLogsCommand.NotifyCanExecuteChanged();
         }
 
@@ -685,6 +721,20 @@ namespace InventoryManagementApp.ViewModels
             {
                 EndDataOperation();
             }
+        }
+
+        private static string BuildSelectedLogDetailPreview(string? value)
+        {
+            var text = ValueOrDefault(value, "Not recorded");
+            if (text.Length <= MaxSelectedLogDetailCharacters)
+                return text;
+
+            var visibleText = text.Substring(0, MaxSelectedLogDetailCharacters).TrimEnd();
+            var omittedCharacters = text.Length - visibleText.Length;
+            return string.Join(Environment.NewLine,
+                visibleText,
+                string.Empty,
+                $"... {omittedCharacters:N0} characters omitted from this inline preview. Use Copy Result or Open Log Detail for the complete operation text.");
         }
 
         private static string ValueOrDefault(string? value, string fallback) =>


### PR DESCRIPTION
## What changed

- Bounded the Import / Export session run-log grid to the latest 500 visible rows so very large import skip lists do not grow the WPF `ObservableCollection` indefinitely.
- Added visible, total, omitted, and omitted-state run-log properties for honest data display.
- Updated `LogSummary` so operators can see when older session rows were kept out of the grid for responsiveness.
- Reset omitted-row accounting when the run log is cleared.
- Bounded the selected-result inline preview to 1,800 characters with a clear truncation notice.
- Preserved full selected log text for Copy Result, Open Log Detail, and selected-result print handoff paths.
- Added focused source-contract coverage for bounded visible rows, omitted-row reporting, clear-state reset, inline preview truncation, and full-fidelity selected-log handoff preservation.
- Recorded the completed workflow slice in `InventoryManagementApp/ProgressNotes/2026-07-06-import-export-run-log-responsiveness.md`.

## Why this was highest value

The current Import / Export workflow already guards busy operations, but repo evidence showed a remaining responsiveness risk: customer/item imports can produce many skipped-row messages, and those messages were all kept in the live grid collection. That can slow row rendering, selection, tab switching, copy/print preparation, and inline result display during exactly the workflows where operators need the app to stay responsive.

## Why this is real progress

This is a complete workflow-level improvement rather than a cosmetic tweak: it bounds grid data growth, keeps user-facing counts honest, preserves exact handoff text where it matters, adds tests, and records the completed work. It improves loading/rendering responsiveness, data display clarity, copy/detail/print handoff safety, and maintainability in one focused slice.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, three files changed, and the scope is limited to the Import / Export view model, a new source-contract test file, and a progress note.
- Read back the modified view-model source from the branch to inspect the bounded row logic, omitted-row summary, clear reset, and selected-log preview helper.
- Read back the new test source from the branch to inspect the source-contract coverage.
- Checked the branch head commit status; no statuses were attached.

## Could not check

- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET build/tests, WPF runtime smoke tests, screenshots, scaling checks, large-import manual testing, or print-preview rendering because this scheduled Linux environment cannot clone the repo directly (`CONNECT tunnel failed, response 403`) and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

## Follow-up

- Run the full validation runner on a Windows/.NET-capable checkout.
- Smoke test a large item/customer import with more than 500 skipped rows and verify the grid remains responsive, the omitted-row summary is clear, and Copy/Open Detail still expose the full selected result.