### PR TITLE
Improve change password dialog responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ChangePasswordWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ChangePasswordWindowResponsiveContractTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ChangePasswordWindowResponsiveContractTests
+    {
+        [Fact]
+        public void ChangePasswordWindow_UsesCompactBoundedResponsiveShell()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ChangePasswordWindow.xaml");
+
+            Assert.Contains("Width=\"520\" Height=\"390\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"460\" MinHeight=\"340\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("UseLayoutRounding=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SnapsToDevicePixels=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Grid Margin=\"14\" ClipToBounds=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"560\" Height=\"410\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"520\" MinHeight=\"380\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ChangePasswordWindow_KeepsBodyScrollableAndFooterAnchored()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ChangePasswordWindow.xaml");
+
+            Assert.Contains("<RowDefinition Height=\"*\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<controls:DialogButtonBar Grid.Row=\"2\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<controls:DialogButtonBar Grid.Row=\"3\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ChangePasswordWindow_BoundsHeaderHelpAndPasswordInputsForScaledDesktop()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ChangePasswordWindow.xaml");
+
+            Assert.Contains("MaxHeight=\"118\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextTrimming=\"CharacterEllipsis\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxHeight=\"48\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"170\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"145\" MinWidth=\"108\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"180\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"420\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalAlignment=\"Stretch\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"170\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"260\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ChangePasswordWindow_ShowsReadinessAndValidationWithoutLayoutOverlap()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ChangePasswordWindow.xaml");
+
+            Assert.Contains("Text=\"{Binding PasswordReadinessSummary}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxHeight=\"54\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding ValidationMessage}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Visibility=\"{Binding HasValidationMessage, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("RightButtonText=\"Save Password\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("RightCommand=\"{Binding SaveCommand}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ChangePasswordWindow_CodeBehindFocusesPasswordFieldAndCancelsStaleFocus()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ChangePasswordWindow.xaml.cs");
+
+            Assert.Contains("using System.Windows.Threading;", source, StringComparison.Ordinal);
+            Assert.Contains("DispatcherOperation? _pendingFocusOperation;", source, StringComparison.Ordinal);
+            Assert.Contains("Loaded += ChangePasswordWindow_Loaded;", source, StringComparison.Ordinal);
+            Assert.Contains("Activated += ChangePasswordWindow_Activated;", source, StringComparison.Ordinal);
+            Assert.Contains("Unloaded += ChangePasswordWindow_Unloaded;", source, StringComparison.Ordinal);
+            Assert.Contains("FocusNewPasswordBox(selectAll: true);", source, StringComparison.Ordinal);
+            Assert.Contains("NewPasswordBox.Dispatcher.BeginInvoke", source, StringComparison.Ordinal);
+            Assert.Contains("Keyboard.Focus(NewPasswordBox);", source, StringComparison.Ordinal);
+            Assert.Contains("NewPasswordBox.SelectAll();", source, StringComparison.Ordinal);
+            Assert.Contains("AbortPendingFocus();", source, StringComparison.Ordinal);
+            Assert.Contains("DispatcherOperationStatus.Pending", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ChangePasswordWindow_CodeBehindSupportsEnterEscapeAndDisposesCleanly()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ChangePasswordWindow.xaml");
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "ChangePasswordWindow.xaml.cs");
+
+            Assert.True(CountOccurrences(xaml, "PreviewKeyDown=\"PasswordBox_PreviewKeyDown\"") >= 2);
+            Assert.Contains("void PasswordBox_PreviewKeyDown", source, StringComparison.Ordinal);
+            Assert.Contains("e.Key == Key.Enter && VM.SaveCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("VM.SaveCommand.Execute(null);", source, StringComparison.Ordinal);
+            Assert.Contains("e.Key == Key.Escape && VM.CancelCommand.CanExecute(null)", source, StringComparison.Ordinal);
+            Assert.Contains("VM.CancelCommand.Execute(null);", source, StringComparison.Ordinal);
+            Assert.Contains("AbortPendingFocus();\n            Close();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ChangePasswordViewModel_GatesSaveAndReportsReadiness()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ChangePasswordViewModel.cs");
+
+            Assert.Contains("public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);", source, StringComparison.Ordinal);
+            Assert.Contains("public bool CanAttemptSave =>", source, StringComparison.Ordinal);
+            Assert.Contains("!string.IsNullOrWhiteSpace(NewPassword) && !string.IsNullOrWhiteSpace(ConfirmPassword)", source, StringComparison.Ordinal);
+            Assert.Contains("public string PasswordReadinessSummary", source, StringComparison.Ordinal);
+            Assert.Contains("Enter and confirm the new password to enable Save Password.", source, StringComparison.Ordinal);
+            Assert.Contains("Ready to validate and save the new password.", source, StringComparison.Ordinal);
+            Assert.Contains("SaveCommand = new RelayCommand(() =>", source, StringComparison.Ordinal);
+            Assert.Contains("}, () => CanAttemptSave);", source, StringComparison.Ordinal);
+            Assert.Contains("SaveCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(PasswordReadinessSummary));", source, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            var count = 0;
+            var startIndex = 0;
+            while (true)
+            {
+                var index = text.IndexOf(value, startIndex, StringComparison.Ordinal);
+                if (index < 0)
+                    return count;
+
+                count++;
+                startIndex = index + value.Length;
+            }
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-change-password-dialog-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-change-password-dialog-responsiveness.md
@@ -1,0 +1,30 @@
+# Change Password Dialog Responsiveness
+
+Date: 2026-07-07
+
+## Completed
+
+- Reduced the Change Password dialog startup and minimum dimensions to fit scaled 1366 x 768 desktop use more safely.
+- Added layout rounding, device-pixel snapping, and root clipping so the dialog paints cleanly at Windows scaling levels.
+- Reworked the dialog into fixed header, scrollable body, and anchored footer regions so validation/help text cannot push Save and Cancel off-screen.
+- Bounded the header, helper chip, readiness text, and validation text with wrapping/trimming limits.
+- Reduced password-form column pressure with shrinkable labels, zero-minimum content columns, and bounded stretch password inputs.
+- Added a visible password readiness summary so operators know why Save Password is disabled or ready.
+- Added validation visibility state so stale/empty validation text does not reserve awkward space.
+- Gated Save Password until both password fields contain input and refreshed command availability as either field changes.
+- Kept existing password strength and matching validation behavior after Save is attempted.
+- Added first-paint and activation focus for the new-password field, including select-all on initial load.
+- Added Enter-to-save and Escape-to-cancel keyboard handling from both password boxes.
+- Canceled pending focus work on unload and dispose so stale dispatcher work cannot retarget a closing dialog.
+- Added source-contract coverage for responsive shell sizing, scroll/footer layout, bounded text and inputs, readiness/validation display, focus lifecycle, keyboard handling, disposal cleanup, and ViewModel save-readiness state.
+
+## Validation
+
+- GitHub connector read/write succeeded for the Change Password XAML, code-behind, ViewModel, source-contract test, and progress note.
+- Added `ChangePasswordWindowResponsiveContractTests` to guard the new contracts.
+- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, or Windows scaling checks in this scheduled Linux environment because direct checkout remains blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full validation runner on a Windows/.NET-capable checkout.
+- Smoke test Change Password at 125%, 150%, and 200% Windows scaling to confirm focus, Enter/Escape, disabled Save, validation, and footer visibility.

--- a/InventoryManagementApp/ViewModels/ChangePasswordViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ChangePasswordViewModel.cs
@@ -14,7 +14,10 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _newPassword, value))
+                {
                     ValidationMessage = string.Empty;
+                    NotifyPasswordEntryStateChanged();
+                }
             }
         }
 
@@ -25,7 +28,10 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _confirmPassword, value))
+                {
                     ValidationMessage = string.Empty;
+                    NotifyPasswordEntryStateChanged();
+                }
             }
         }
 
@@ -33,7 +39,39 @@ namespace InventoryManagementApp.ViewModels
         public string ValidationMessage
         {
             get => _validationMessage;
-            private set => SetProperty(ref _validationMessage, value);
+            private set
+            {
+                if (SetProperty(ref _validationMessage, value))
+                {
+                    OnPropertyChanged(nameof(HasValidationMessage));
+                    OnPropertyChanged(nameof(PasswordReadinessSummary));
+                }
+            }
+        }
+
+        public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+        public bool CanAttemptSave =>
+            !string.IsNullOrWhiteSpace(NewPassword) && !string.IsNullOrWhiteSpace(ConfirmPassword);
+
+        public string PasswordReadinessSummary
+        {
+            get
+            {
+                if (HasValidationMessage)
+                    return ValidationMessage;
+
+                if (string.IsNullOrWhiteSpace(NewPassword) && string.IsNullOrWhiteSpace(ConfirmPassword))
+                    return "Enter and confirm the new password to enable Save Password.";
+
+                if (string.IsNullOrWhiteSpace(NewPassword))
+                    return "Enter the new password before saving.";
+
+                if (string.IsNullOrWhiteSpace(ConfirmPassword))
+                    return "Confirm the new password before saving.";
+
+                return "Ready to validate and save the new password.";
+            }
         }
 
         public IRelayCommand SaveCommand { get; }
@@ -57,8 +95,15 @@ namespace InventoryManagementApp.ViewModels
 
                 ValidationMessage = string.Empty;
                 onSave();
-            });
+            }, () => CanAttemptSave);
             CancelCommand = new RelayCommand(onCancel);
+        }
+
+        private void NotifyPasswordEntryStateChanged()
+        {
+            OnPropertyChanged(nameof(CanAttemptSave));
+            OnPropertyChanged(nameof(PasswordReadinessSummary));
+            SaveCommand.NotifyCanExecuteChanged();
         }
     }
 }

--- a/InventoryManagementApp/Views/Windows/ChangePasswordWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ChangePasswordWindow.xaml
@@ -4,58 +4,115 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Change Password"
-        Width="560" Height="410"
-        MinWidth="520" MinHeight="380"
+        Width="520" Height="390"
+        MinWidth="460" MinHeight="340"
         WindowStartupLocation="CenterScreen"
-        Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="16">
+        Background="{DynamicResource BackgroundBrush}"
+        UseLayoutRounding="True"
+        SnapsToDevicePixels="True">
+    <Grid Margin="14" ClipToBounds="True">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
-            <StackPanel>
-                <TextBlock Text="Set A New Password" Style="{StaticResource PageTitleTextBlock}"/>
-                <TextBlock Text="Use a strong password so this workstation can keep rental, customer, and admin records protected." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,4,0,0"/>
-            </StackPanel>
-        </Border>
-
-        <Border Grid.Row="1" Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
-            <TextBlock Text="Passwords should be at least 8 characters and include uppercase, lowercase, and a number." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-        </Border>
-
-        <Border Grid.Row="2" Style="{StaticResource DesktopInsetCard}" Padding="14">
+        <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10" MaxHeight="118">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="170"/>
-                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-
-                <StackPanel Grid.Row="0">
-                    <TextBlock Text="New Password" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Enter the replacement password" Style="{StaticResource CaptionTextBlock}" Margin="0,3,0,0"/>
+                <StackPanel MinWidth="0">
+                    <TextBlock Text="Set A New Password" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Use a strong password so this workstation can keep rental, customer, and admin records protected."
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="Wrap"
+                               TextTrimming="CharacterEllipsis"
+                               MaxHeight="48"
+                               Margin="0,4,0,0"/>
                 </StackPanel>
-                <PasswordBox Grid.Row="0" Grid.Column="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" MinWidth="260" Margin="10,2,0,12"/>
-
-                <StackPanel Grid.Row="1">
-                    <TextBlock Text="Confirm Password" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Repeat it to avoid typos" Style="{StaticResource CaptionTextBlock}" Margin="0,3,0,0"/>
-                </StackPanel>
-                <PasswordBox Grid.Row="1" Grid.Column="1" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" MinWidth="260" Margin="10,2,0,12"/>
-
-                <TextBlock Grid.Row="2" Grid.ColumnSpan="2" Text="{Binding ValidationMessage}" Style="{StaticResource ErrorTextBlock}" TextWrapping="Wrap"/>
+                <Border Grid.Column="1"
+                        Style="{StaticResource DesktopNoteCard}"
+                        Padding="10,6"
+                        Margin="12,0,0,0"
+                        MaxWidth="170"
+                        VerticalAlignment="Top">
+                    <TextBlock Text="Password update" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                </Border>
             </Grid>
         </Border>
 
-        <controls:DialogButtonBar Grid.Row="3"
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled"
+                      CanContentScroll="True"
+                      Focusable="False">
+            <StackPanel>
+                <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
+                    <TextBlock Text="Passwords should be at least 8 characters and include uppercase, lowercase, and a number."
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="Wrap"/>
+                </Border>
+
+                <Border Style="{StaticResource DesktopInsetCard}" Padding="14">
+                    <Grid MinWidth="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="145" MinWidth="108"/>
+                            <ColumnDefinition Width="*" MinWidth="0"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <StackPanel Grid.Row="0" MinWidth="0">
+                            <TextBlock Text="New Password" Style="{StaticResource LabelTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Enter the replacement password" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                        </StackPanel>
+                        <PasswordBox Grid.Row="0"
+                                     Grid.Column="1"
+                                     x:Name="NewPasswordBox"
+                                     PasswordChanged="NewPasswordBox_PasswordChanged"
+                                     PreviewKeyDown="PasswordBox_PreviewKeyDown"
+                                     MinWidth="180"
+                                     MaxWidth="420"
+                                     HorizontalAlignment="Stretch"
+                                     Margin="10,2,0,12"/>
+
+                        <StackPanel Grid.Row="1" MinWidth="0">
+                            <TextBlock Text="Confirm Password" Style="{StaticResource LabelTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Repeat it to avoid typos" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                        </StackPanel>
+                        <PasswordBox Grid.Row="1"
+                                     Grid.Column="1"
+                                     x:Name="ConfirmPasswordBox"
+                                     PasswordChanged="ConfirmPasswordBox_PasswordChanged"
+                                     PreviewKeyDown="PasswordBox_PreviewKeyDown"
+                                     MinWidth="180"
+                                     MaxWidth="420"
+                                     HorizontalAlignment="Stretch"
+                                     Margin="10,2,0,0"/>
+                    </Grid>
+                </Border>
+
+                <Border Style="{StaticResource DesktopNoteCard}" Margin="0,10,0,0" Padding="10,6">
+                    <TextBlock Text="{Binding PasswordReadinessSummary}"
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="Wrap"
+                               TextTrimming="CharacterEllipsis"
+                               MaxHeight="54"/>
+                </Border>
+
+                <TextBlock Text="{Binding ValidationMessage}"
+                           Style="{StaticResource ErrorTextBlock}"
+                           Visibility="{Binding HasValidationMessage, Converter={StaticResource BoolToVis}}"
+                           TextWrapping="Wrap"
+                           Margin="2,10,0,0"/>
+            </StackPanel>
+        </ScrollViewer>
+
+        <controls:DialogButtonBar Grid.Row="2"
                                   Margin="0,12,0,0"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"

--- a/InventoryManagementApp/Views/Windows/ChangePasswordWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ChangePasswordWindow.xaml.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Utilities.Extensions;
 
@@ -10,6 +12,8 @@ namespace InventoryManagementApp.Views.Windows
     public partial class ChangePasswordWindow : Window, IDisposable
     {
         bool _disposed;
+        bool _isUnloaded;
+        DispatcherOperation? _pendingFocusOperation;
 
         public ChangePasswordViewModel VM => (ChangePasswordViewModel)DataContext;
         public string NewPassword => VM.NewPassword;
@@ -19,6 +23,26 @@ namespace InventoryManagementApp.Views.Windows
             InitializeComponent();
             DataContext = new ChangePasswordViewModel(() => DialogResult = true, () => DialogResult = false);
             this.DisposeDataContextOnUnload();
+            Loaded += ChangePasswordWindow_Loaded;
+            Activated += ChangePasswordWindow_Activated;
+            Unloaded += ChangePasswordWindow_Unloaded;
+        }
+
+        void ChangePasswordWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            _isUnloaded = false;
+            FocusNewPasswordBox(selectAll: true);
+        }
+
+        void ChangePasswordWindow_Activated(object? sender, EventArgs e)
+        {
+            FocusNewPasswordBox();
+        }
+
+        void ChangePasswordWindow_Unloaded(object sender, RoutedEventArgs e)
+        {
+            _isUnloaded = true;
+            AbortPendingFocus();
         }
 
         void NewPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
@@ -27,11 +51,57 @@ namespace InventoryManagementApp.Views.Windows
         void ConfirmPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
             => VM.ConfirmPassword = ((PasswordBox)sender).Password;
 
+        void PasswordBox_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter && VM.SaveCommand.CanExecute(null))
+            {
+                VM.SaveCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (e.Key == Key.Escape && VM.CancelCommand.CanExecute(null))
+            {
+                VM.CancelCommand.Execute(null);
+                e.Handled = true;
+            }
+        }
+
+        void FocusNewPasswordBox(bool selectAll = false)
+        {
+            if (_isUnloaded || !IsLoaded)
+                return;
+
+            AbortPendingFocus();
+            _pendingFocusOperation = NewPasswordBox.Dispatcher.BeginInvoke(() =>
+            {
+                _pendingFocusOperation = null;
+
+                if (_isUnloaded || !IsLoaded)
+                    return;
+
+                NewPasswordBox.Focus();
+                Keyboard.Focus(NewPasswordBox);
+
+                if (selectAll)
+                    NewPasswordBox.SelectAll();
+            }, DispatcherPriority.Input);
+        }
+
+        void AbortPendingFocus()
+        {
+            if (_pendingFocusOperation is { Status: DispatcherOperationStatus.Pending })
+                _pendingFocusOperation.Abort();
+
+            _pendingFocusOperation = null;
+        }
+
         public void Dispose()
         {
             if (_disposed)
                 return;
             _disposed = true;
+            AbortPendingFocus();
             Close();
         }
     }


### PR DESCRIPTION
## What changed

- Reduced the Change Password dialog startup/minimum dimensions for 1366 x 768 and scaled Windows desktops.
- Reworked the dialog into a bounded header, scrollable body, and anchored footer so helper/validation text cannot push actions off-screen.
- Bounded header copy, helper chip, readiness copy, validation text, and password input width for cleaner high-scale display.
- Added a visible password readiness summary and validation visibility state.
- Gated Save Password until both password fields contain input, while preserving existing password strength and match validation after save is attempted.
- Added first-paint and activation focus for the new-password box, Enter-to-save, Escape-to-cancel, and cleanup for pending dispatcher focus work on unload/dispose.
- Added `ChangePasswordWindowResponsiveContractTests` and a progress note.

## Why this was highest value

The password prompt was recently improved, but the matching Change Password dialog still had older fixed layout pressure, no first-paint focus, no keyboard submit/cancel path, and no dedicated responsive contract coverage. This is a small but important blocking workflow: if it clips or feels slow at Windows scaling, users cannot safely complete credential changes.

## Why this is real progress

This is a complete workflow slice across XAML layout, ViewModel readiness/validation state, code-behind focus/keyboard behavior, source-contract coverage, and progress notes. It avoids revisiting the heavily touched Import / Export and Dashboard surfaces without fresh evidence.

## Validation

- GitHub connector compare/readback confirmed the branch is 5 focused files ahead of `master` and not behind.
- GitHub connector status readback found no attached commit statuses for the branch head before PR creation.
- Connector readback confirmed the revised Change Password XAML and source-contract test content on the branch.
- Python XML parsing confirmed the revised `ChangePasswordWindow.xaml` is well-formed.

## Could not check

- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, or Windows scaling checks in this scheduled Linux environment because direct checkout remains blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run the full validation runner on a Windows/.NET-capable checkout.
- Smoke test Change Password at 125%, 150%, and 200% Windows scaling for focus, Enter/Escape, disabled Save, validation, and footer visibility.