### PR TITLE
Improve users editor responsiveness and save state

### DIFF
--- a/InventoryManagementApp.Tests/UsersEditViewModelTests.cs
+++ b/InventoryManagementApp.Tests/UsersEditViewModelTests.cs
@@ -22,9 +22,71 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void SaveCommand_RequiresUsernameAndRefreshesReadiness()
+        {
+            var user = new User { UserName = "   " };
+            var dialog = new DummyFileDialogService();
+            var vm = new UsersEditViewModel(user, dialog, onSave: () => Task.CompletedTask, onCancel: () => { });
+
+            Assert.False(vm.CanSaveUserProfile);
+            Assert.False(vm.SaveCommand.CanExecute(null));
+            Assert.Contains("Enter a username", vm.SaveStatusText);
+
+            user.UserName = "workshop-manager";
+
+            Assert.True(vm.CanSaveUserProfile);
+            Assert.True(vm.SaveCommand.CanExecute(null));
+            Assert.Contains("User profile ready", vm.SaveStatusText);
+        }
+
+        [Fact]
+        public async Task SaveCommand_ExposesBusyStateAndDisablesEditorActionsWhileRunning()
+        {
+            var user = new User { UserName = "workshop-manager" };
+            var dialog = new DummyFileDialogService();
+            var saveStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseSave = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var saveCalls = 0;
+            var vm = new UsersEditViewModel(user, dialog, onSave: async () =>
+            {
+                saveCalls++;
+                saveStarted.SetResult();
+                await releaseSave.Task;
+            }, onCancel: () => { });
+
+            var saveTask = vm.SaveCommand.ExecuteAsync(null);
+            await saveStarted.Task;
+
+            Assert.True(vm.IsSaving);
+            Assert.False(vm.CanEditProfile);
+            Assert.False(vm.CanSaveUserProfile);
+            Assert.False(vm.SaveCommand.CanExecute(null));
+            Assert.False(vm.CancelCommand.CanExecute(null));
+            Assert.False(vm.BrowseImageCommand.CanExecute(null));
+            Assert.False(vm.RemoveImageCommand.CanExecute(null));
+            Assert.False(vm.SelectAdvisorPresetCommand.CanExecute(null));
+            Assert.False(vm.SelectTechnicianPresetCommand.CanExecute(null));
+            Assert.False(vm.SelectAdminPresetCommand.CanExecute(null));
+            Assert.False(vm.ClearPermissionsCommand.CanExecute(null));
+            Assert.Contains("Saving user profile", vm.SaveStatusText);
+            Assert.Equal(1, saveCalls);
+
+            releaseSave.SetResult();
+            await saveTask;
+
+            Assert.False(vm.IsSaving);
+            Assert.True(vm.CanEditProfile);
+            Assert.True(vm.SaveCommand.CanExecute(null));
+            Assert.True(vm.CancelCommand.CanExecute(null));
+            Assert.True(vm.BrowseImageCommand.CanExecute(null));
+            Assert.Contains("User profile ready", vm.SaveStatusText);
+            Assert.Equal(1, saveCalls);
+        }
+
+        [Fact]
         public void BrowseImageCommand_UsesRelativePathForBaseDirectoryFile()
         {
-            var user = new User();
+            var user = new User { UserName = "photo-user" };
             var dialog = new DummyFileDialogService();
             var baseDir = AppDomain.CurrentDomain.BaseDirectory;
             var filePath = Path.Combine(baseDir, Guid.NewGuid() + ".png");
@@ -44,7 +106,7 @@ namespace InventoryManagementApp.Tests
         [Fact]
         public void BrowseImageCommand_CopiesExternalFileToAssets()
         {
-            var user = new User();
+            var user = new User { UserName = "photo-user" };
             var dialog = new DummyFileDialogService();
             var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
             File.WriteAllText(tempFile, "test");
@@ -53,7 +115,6 @@ namespace InventoryManagementApp.Tests
 
             vm.BrowseImageCommand.Execute(null);
 
-            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
             var destPath = AppAssetHelper.ResolveAssetPath(user.UserPhotoPath);
 
             Assert.StartsWith(Path.Combine("Assets", "UserPhotos"), user.UserPhotoPath);
@@ -67,7 +128,7 @@ namespace InventoryManagementApp.Tests
         [Fact]
         public void RemoveImageCommand_ClearsPhotoPath()
         {
-            var user = new User { UserPhotoPath = "test.png" };
+            var user = new User { UserName = "photo-user", UserPhotoPath = "test.png" };
             var dialog = new DummyFileDialogService();
             var vm = new UsersEditViewModel(user, dialog, onSave: () => Task.CompletedTask, onCancel: () => { });
 
@@ -79,7 +140,7 @@ namespace InventoryManagementApp.Tests
         [Fact]
         public void RemoveImageCommand_SetsInitialsBrushToVisibleBrush()
         {
-            var user = new User { UserPhotoPath = "test.png", InitialsBrush = Brushes.Transparent };
+            var user = new User { UserName = "photo-user", UserPhotoPath = "test.png", InitialsBrush = Brushes.Transparent };
             var dialog = new DummyFileDialogService();
             var vm = new UsersEditViewModel(user, dialog, onSave: () => Task.CompletedTask, onCancel: () => { });
 

--- a/InventoryManagementApp.Tests/UsersEditWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/UsersEditWindowResponsiveContractTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UsersEditWindowResponsiveContractTests
+    {
+        [Fact]
+        public void UsersEditWindow_UsesCompactBoundedResponsiveShell()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "UsersEditWindow.xaml");
+            var code = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "UsersEditWindow.xaml.cs");
+
+            Assert.Contains("Width=\"900\" Height=\"680\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"640\" MinHeight=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("UseLayoutRounding=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SnapsToDevicePixels=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Grid Margin=\"12\" ClipToBounds=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("this.UseResponsiveDefaultSize(920, 700);", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"1080\" Height=\"820\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"860\" MinHeight=\"680\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("this.UseResponsiveDefaultSize(1120, 880);", code, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersEditWindow_WrapsHeaderActionsAndStepCards()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "UsersEditWindow.xaml");
+
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxHeight=\"126\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"1\" VerticalAlignment=\"Center\" HorizontalAlignment=\"Right\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"260\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"UserEditorStepCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,2\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"178\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"238\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<UniformGrid Grid.Row=\"1\" Columns=\"4\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersEditWindow_LowersEditorSplitPressureAndKeepsBodyScrollable()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "UsersEditWindow.xaml");
+
+            Assert.Contains("<ScrollViewer VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding CanEditProfile}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"160\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.02*\" MinWidth=\"250\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.48*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<GridSplitter Grid.Column=\"1\" Width=\"8\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Grid MinHeight=\"520\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"190\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"*\" MinWidth=\"610\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersEditWindow_BoundsProfileFieldsAndPermissionChecklist()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "UsersEditWindow.xaml");
+
+            Assert.Contains("<Border Grid.Column=\"0\" Style=\"{StaticResource AdminHandoffCard}\" Margin=\"0\" MaxWidth=\"180\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Width=\"112\" Height=\"112\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"92\" MinWidth=\"78\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"120\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"62\" MaxHeight=\"96\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"2\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\" CanContentScroll=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"1.05*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"96\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Height=\"72\" TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"12\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersEditWindow_ShowsSaveReadinessAndSavingOverlay()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "UsersEditWindow.xaml");
+
+            Assert.Contains("Text=\"{Binding SaveStatusText}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Visibility=\"{Binding IsSaving, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Saving user profile\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding CanEditProfile}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<controls:SaveCancelBar Grid.Row=\"3\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Text=\"User profile ready\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersEditViewModel_GatesSaveAndEditorCommandsDuringSave()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "UsersEditViewModel.cs");
+
+            Assert.Contains("private bool _isSaving;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsSaving", source, StringComparison.Ordinal);
+            Assert.Contains("public bool CanEditProfile => !IsSaving;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool CanSaveUserProfile =>", source, StringComparison.Ordinal);
+            Assert.Contains("!string.IsNullOrWhiteSpace(EditingUser.UserName)", source, StringComparison.Ordinal);
+            Assert.Contains("public string SaveStatusText", source, StringComparison.Ordinal);
+            Assert.Contains("SaveCommand = new AsyncRelayCommand(SaveAsync, () => CanSaveUserProfile);", source, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand = new RelayCommand(onCancel, () => CanEditProfile);", source, StringComparison.Ordinal);
+            Assert.Contains("BrowseImageCommand = new RelayCommand(BrowseImage, () => CanEditProfile);", source, StringComparison.Ordinal);
+            Assert.Contains("SelectAdvisorPresetCommand = new RelayCommand", source, StringComparison.Ordinal);
+            Assert.Contains("NotifyEditorCommandStatesChanged();", source, StringComparison.Ordinal);
+            Assert.Contains("async Task SaveAsync()", source, StringComparison.Ordinal);
+            Assert.Contains("IsSaving = true;", source, StringComparison.Ordinal);
+            Assert.Contains("await _onSave();", source, StringComparison.Ordinal);
+            Assert.Contains("IsSaving = false;", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SaveCancelBar_UsesResponsiveWrappingActions()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Controls", "SaveCancelBar.xaml");
+
+            Assert.Contains("ClipToBounds=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Grid MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextTrimming=\"CharacterEllipsis\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxHeight=\"42\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"96\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<StackPanel Grid.Column=\"1\" Orientation=\"Horizontal\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"104\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-users-editor-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-users-editor-responsiveness.md
@@ -1,0 +1,31 @@
+# Users Editor Responsiveness
+
+Date: 2026-07-07
+
+## Completed
+
+- Reduced the Users Edit dialog startup and minimum dimensions for safer 1366 x 768 and scaled Windows desktop use.
+- Aligned the code-behind responsive default sizing with the smaller XAML shell.
+- Added layout rounding, device-pixel snapping, and root clipping for cleaner scaled rendering.
+- Replaced the fixed four-column workflow summary strip with wrapping bounded step cards.
+- Reworked the header into shrinkable text plus wrapping photo actions so long title/help text cannot force controls off-screen.
+- Lowered the editor split pressure by reducing fixed avatar/sidebar width, splitter width, and profile/permission pane minimums.
+- Removed the fixed body minimum height so the scrollable editor can shrink within smaller work areas.
+- Bounded avatar, profile label, input, address, and permission checklist regions for more stable high-scale layout.
+- Disabled profile editing controls while save work is active and surfaced a saving overlay with clear status text.
+- Added ViewModel save readiness state, including username-required save gating and a visible no-access-account readiness message.
+- Gated Save, Cancel, image, and permission preset commands while a save is in progress so repeated clicks cannot queue duplicate updates.
+- Made the shared Save/Cancel bar wrap-friendly by replacing fixed-width horizontal actions with bounded wrapping controls.
+- Added behavior tests for save readiness, username gating, busy-state command disabling, and save-status transitions.
+- Added source-contract coverage for the responsive Users Edit shell, wrapped summary cards, reduced split pressure, bounded profile/permission regions, saving overlay, ViewModel busy-state contracts, and shared Save/Cancel bar layout.
+
+## Validation
+
+- GitHub connector read/write succeeded for the Users Edit window XAML/code-behind, Users Edit ViewModel, shared Save/Cancel bar, tests, and progress note.
+- Added `UsersEditWindowResponsiveContractTests` and extended `UsersEditViewModelTests` for the new layout and save-state contracts.
+- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, or Windows scaling checks in this scheduled Linux environment because direct checkout remains blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full validation runner on a Windows/.NET-capable checkout.
+- Smoke test the Users Edit dialog at 125%, 150%, and 200% Windows scaling for scrolling, Save/Cancel reachability, disabled duplicate-save behavior, image actions, preset actions, and no-access account messaging.

--- a/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
@@ -22,6 +22,45 @@ namespace InventoryManagementApp.ViewModels
         public User EditingUser { get; }
 
         private readonly IFileDialogService _fileDialog;
+        private readonly Func<Task> _onSave;
+
+        private bool _isSaving;
+        public bool IsSaving
+        {
+            get => _isSaving;
+            private set
+            {
+                if (SetProperty(ref _isSaving, value))
+                {
+                    NotifySaveStateChanged();
+                    NotifyEditorCommandStatesChanged();
+                }
+            }
+        }
+
+        public bool CanEditProfile => !IsSaving;
+
+        public bool CanSaveUserProfile =>
+            !IsSaving && !string.IsNullOrWhiteSpace(EditingUser.UserName);
+
+        public string SaveStatusText
+        {
+            get
+            {
+                if (IsSaving)
+                    return "Saving user profile - account actions are paused until the update finishes.";
+
+                if (string.IsNullOrWhiteSpace(EditingUser.UserName))
+                    return "Enter a username before saving this profile.";
+
+                if (!EditingUser.IsAdmin && !GetAllowedPermissionLabels().Any())
+                    return "Ready to save with no app sections assigned; confirm this limited account is intentional.";
+
+                return "User profile ready - save applies identity, photo, status, and permission changes.";
+            }
+        }
+
+        public bool HasSaveStatus => !string.IsNullOrWhiteSpace(SaveStatusText);
 
         public string AccessSummary => EditingUser.AccessSummary;
 
@@ -91,49 +130,60 @@ namespace InventoryManagementApp.ViewModels
             EditingUser = user ?? new User();
             EditingUser.PropertyChanged += EditingUser_PropertyChanged;
             _fileDialog = fileDialog;
+            _onSave = onSave;
             Title = (EditingUser.UserID == 0) ? "Add User" : "Edit User";
-            BrowseImageCommand = new RelayCommand(BrowseImage);
-            RemoveImageCommand = new RelayCommand(RemoveImage);
-            SaveCommand = new AsyncRelayCommand(onSave);
-            CancelCommand = new RelayCommand(onCancel);
+            BrowseImageCommand = new RelayCommand(BrowseImage, () => CanEditProfile);
+            RemoveImageCommand = new RelayCommand(RemoveImage, () => CanEditProfile);
+            SaveCommand = new AsyncRelayCommand(SaveAsync, () => CanSaveUserProfile);
+            CancelCommand = new RelayCommand(onCancel, () => CanEditProfile);
             SelectAdvisorPresetCommand = new RelayCommand(() => ApplyPreset(
                 User.PermissionRentals,
                 User.PermissionCustomers,
                 User.PermissionReservations,
                 User.PermissionKits,
                 User.PermissionPrintLabels,
-                User.PermissionReports));
+                User.PermissionReports), () => CanEditProfile);
             SelectTechnicianPresetCommand = new RelayCommand(() => ApplyPreset(
                 User.PermissionRentals,
                 User.PermissionMaintenance,
                 User.PermissionCalibration,
                 User.PermissionKits,
                 User.PermissionCategories,
-                User.PermissionPrintLabels));
+                User.PermissionPrintLabels), () => CanEditProfile);
             SelectAdminPresetCommand = new RelayCommand(() =>
             {
                 EditingUser.IsAdmin = true;
                 NotifyAllPermissionProperties();
-            });
-            ClearPermissionsCommand = new RelayCommand(() => ApplyPreset(Array.Empty<string>()));
+            }, () => CanEditProfile);
+            ClearPermissionsCommand = new RelayCommand(() => ApplyPreset(Array.Empty<string>()), () => CanEditProfile);
         }
 
         void EditingUser_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(User.IsAdmin) || e.PropertyName == nameof(User.Permissions) || e.PropertyName == nameof(User.UserName))
+            {
                 NotifyAllPermissionProperties();
+                NotifySaveStateChanged();
+                SaveCommand.NotifyCanExecuteChanged();
+            }
         }
 
         bool Has(string permissionKey) => EditingUser.HasPermission(permissionKey);
 
         void Set(string permissionKey, bool allowed)
         {
+            if (IsSaving)
+                return;
+
             EditingUser.SetPermission(permissionKey, allowed);
             NotifyAllPermissionProperties();
         }
 
         void ApplyPreset(params string[] permissionKeys)
         {
+            if (IsSaving)
+                return;
+
             EditingUser.IsAdmin = false;
             EditingUser.Permissions = User.BuildPermissions(permissionKeys);
             NotifyAllPermissionProperties();
@@ -204,6 +254,22 @@ namespace InventoryManagementApp.ViewModels
             return list.Count == 0 ? emptyText : string.Join(Environment.NewLine, list.Select(line => $"- {line}"));
         }
 
+        async Task SaveAsync()
+        {
+            if (!CanSaveUserProfile)
+                return;
+
+            IsSaving = true;
+            try
+            {
+                await _onSave();
+            }
+            finally
+            {
+                IsSaving = false;
+            }
+        }
+
         void NotifyAllPermissionProperties()
         {
             OnPropertyChanged(nameof(CanManageItems));
@@ -227,10 +293,34 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(WorkflowImpactSummary));
             OnPropertyChanged(nameof(GuardedActionSummary));
             OnPropertyChanged(nameof(AdminNextStepSummary));
+            NotifySaveStateChanged();
+        }
+
+        void NotifySaveStateChanged()
+        {
+            OnPropertyChanged(nameof(CanEditProfile));
+            OnPropertyChanged(nameof(CanSaveUserProfile));
+            OnPropertyChanged(nameof(SaveStatusText));
+            OnPropertyChanged(nameof(HasSaveStatus));
+        }
+
+        void NotifyEditorCommandStatesChanged()
+        {
+            BrowseImageCommand.NotifyCanExecuteChanged();
+            RemoveImageCommand.NotifyCanExecuteChanged();
+            SaveCommand.NotifyCanExecuteChanged();
+            CancelCommand.NotifyCanExecuteChanged();
+            SelectAdvisorPresetCommand.NotifyCanExecuteChanged();
+            SelectTechnicianPresetCommand.NotifyCanExecuteChanged();
+            SelectAdminPresetCommand.NotifyCanExecuteChanged();
+            ClearPermissionsCommand.NotifyCanExecuteChanged();
         }
 
         void BrowseImage()
         {
+            if (IsSaving)
+                return;
+
             var path = _fileDialog.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
             if (string.IsNullOrEmpty(path))
             {
@@ -242,6 +332,9 @@ namespace InventoryManagementApp.ViewModels
 
         void RemoveImage()
         {
+            if (IsSaving)
+                return;
+
             EditingUser.UserPhotoPath = string.Empty;
             var brush = Application.Current?.TryFindResource("ForegroundBrush") as MediaBrush;
             EditingUser.InitialsBrush = brush ?? MediaBrushes.Black;

--- a/InventoryManagementApp/Views/Controls/SaveCancelBar.xaml
+++ b/InventoryManagementApp/Views/Controls/SaveCancelBar.xaml
@@ -2,10 +2,10 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              MinHeight="56">
-    <Border Style="{StaticResource ToolbarCard}" Margin="0,10,0,0" Padding="10,8">
-        <Grid>
+    <Border Style="{StaticResource ToolbarCard}" Margin="0,8,0,0" Padding="10,8" ClipToBounds="True">
+        <Grid MinWidth="0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*" MinWidth="0"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
@@ -13,19 +13,22 @@
                        Style="{StaticResource CaptionTextBlock}"
                        VerticalAlignment="Center"
                        TextWrapping="Wrap"
+                       TextTrimming="CharacterEllipsis"
+                       MaxHeight="42"
                        Margin="0,0,12,0"/>
 
-            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+            <WrapPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center">
                 <Button Style="{StaticResource PrimaryButton}"
-                        Width="104"
+                        MinWidth="96"
                         Content="Save"
                         Command="{Binding SaveCommand}"
-                        Margin="0,0,8,0"/>
+                        Margin="0,0,8,4"/>
                 <Button Style="{StaticResource GhostButton}"
-                        Width="104"
+                        MinWidth="96"
                         Content="Cancel"
-                        Command="{Binding CancelCommand}"/>
-            </StackPanel>
+                        Command="{Binding CancelCommand}"
+                        Margin="0,0,0,4"/>
+            </WrapPanel>
         </Grid>
     </Border>
 </UserControl>

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
@@ -3,8 +3,13 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
-        Title="User Profile" Width="1080" Height="820" MinWidth="860" MinHeight="680" WindowStartupLocation="CenterOwner"
-        Background="{DynamicResource BackgroundBrush}">
+        Title="User Profile"
+        Width="900" Height="680"
+        MinWidth="640" MinHeight="520"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}"
+        UseLayoutRounding="True"
+        SnapsToDevicePixels="True">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -13,9 +18,15 @@
                 <ResourceDictionary Source="pack://application:,,,/InventoryManagementApp;component/Resources/PolishedVisualHierarchy.xaml"/>
                 <ResourceDictionary Source="pack://application:,,,/InventoryManagementApp;component/Resources/Theme.FullCustomizationOverrides.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+            <Style x:Key="UserEditorStepCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
+                <Setter Property="MinWidth" Value="178"/>
+                <Setter Property="MaxWidth" Value="238"/>
+                <Setter Property="MinHeight" Value="82"/>
+                <Setter Property="Margin" Value="0,0,8,8"/>
+            </Style>
         </ResourceDictionary>
     </Window.Resources>
-    <Grid Margin="14">
+    <Grid Margin="12" ClipToBounds="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -24,309 +35,330 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{DynamicResource DesktopPaneHeader}" Margin="0,0,0,8">
-            <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="16,0,0,0">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Browse Image" Command="{Binding BrowseImageCommand}" Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Remove Image" Command="{Binding RemoveImageCommand}"/>
-                </StackPanel>
-                <StackPanel>
-                    <TextBlock Text="{Binding Title}" Style="{StaticResource PageTitleTextBlock}"/>
+        <Border Grid.Row="0" Style="{DynamicResource DesktopPaneHeader}" Margin="0,0,0,8" MaxHeight="126">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel MinWidth="0">
+                    <TextBlock Text="{Binding Title}" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Maintain identity, contact details, status, photo, and the exact app areas this user can see or operate."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
+                               TextTrimming="CharacterEllipsis"
+                               MaxHeight="42"
                                Margin="0,2,0,0"/>
                 </StackPanel>
-            </DockPanel>
+                <WrapPanel Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="12,0,0,0" MaxWidth="260">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Browse Image" Command="{Binding BrowseImageCommand}" IsEnabled="{Binding CanEditProfile}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Remove Image" Command="{Binding RemoveImageCommand}" IsEnabled="{Binding CanEditProfile}" Margin="0,0,0,6"/>
+                </WrapPanel>
+            </Grid>
         </Border>
 
-        <UniformGrid Grid.Row="1" Columns="4" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,2">
+            <Border Style="{StaticResource UserEditorStepCard}">
                 <StackPanel>
                     <TextBlock Text="01 Identity" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Profile fields" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Profile fields" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Username, role, contact details, and staff photo."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0">
+            <Border Style="{StaticResource UserEditorStepCard}">
                 <StackPanel>
                     <TextBlock Text="02 Access" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Permissions" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Permissions" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Checkboxes decide visible and usable workflow areas."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0">
+            <Border Style="{StaticResource UserEditorStepCard}">
                 <StackPanel>
                     <TextBlock Text="03 Security" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Active and password" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Active and password" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Status flags help admins review login readiness."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" Margin="6,0,0,0">
+            <Border Style="{StaticResource UserEditorStepCard}" Margin="0,0,0,8">
                 <StackPanel>
                     <TextBlock Text="04 Handoff" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="Operational impact" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Operational impact" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Text="Summaries explain what changes will mean after save."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-        </UniformGrid>
+        </WrapPanel>
 
-        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-            <Grid MinHeight="520">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="190"/>
-                    <ColumnDefinition Width="12"/>
-                    <ColumnDefinition Width="*" MinWidth="610"/>
-                </Grid.ColumnDefinitions>
-
-                <Border Grid.Column="0" Style="{StaticResource AdminHandoffCard}" Margin="0">
-                    <StackPanel>
-                        <Border Width="132" Height="132" CornerRadius="6" HorizontalAlignment="Center" Background="{DynamicResource TextBoxBackgroundBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1">
-                            <Grid>
-                                <Image Width="132" Height="132"
-                                       Source="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
-                                       Stretch="UniformToFill" ClipToBounds="True">
-                                    <Image.Style>
-                                        <Style TargetType="Image">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Image.Style>
-                                </Image>
-                                <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
-                                           HorizontalAlignment="Center"
-                                           VerticalAlignment="Center"
-                                           FontWeight="Bold"
-                                           FontSize="46"
-                                           Foreground="{Binding EditingUser.InitialsBrush}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Visibility" Value="Visible"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
-                                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                            </Grid>
-                        </Border>
-
-                        <TextBlock Text="{Binding EditingUser.UserName, TargetNullValue='New user'}" Style="{StaticResource SectionHeader}" Margin="0,12,0,2" TextWrapping="Wrap"/>
-                        <TextBlock Text="{Binding EditingUser.Role, TargetNullValue='Set role and contact details'}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-                        <TextBlock Text="{Binding EditingUser.UserID, StringFormat='User #: {0}'}" Style="{StaticResource CaptionTextBlock}" Margin="0,6,0,10"/>
-
-                        <Border Style="{StaticResource DesktopSectionActionStrip}" Padding="10" Margin="0,0,0,8">
-                            <StackPanel>
-                                <TextBlock Text="Access Result" Style="{StaticResource LabelTextBlock}"/>
-                                <TextBlock Text="{Binding PermissionStatusSummary}" FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                            </StackPanel>
-                        </Border>
-
-                        <TextBlock Text="Current Access" Style="{StaticResource LabelTextBlock}" Margin="0,2,0,2"/>
-                        <TextBlock Text="{Binding EditingUser.AccessSummary}" FontSize="11" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-
-                <Grid Grid.Column="2">
+        <Grid Grid.Row="2">
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          CanContentScroll="True"
+                          Focusable="False"
+                          IsEnabled="{Binding CanEditProfile}">
+                <Grid MinWidth="0">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="1.02*" MinWidth="290"/>
-                        <ColumnDefinition Width="10"/>
-                        <ColumnDefinition Width="1.48*" MinWidth="360"/>
+                        <ColumnDefinition Width="160" MinWidth="0"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition Width="*" MinWidth="0"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
+                    <Border Grid.Column="0" Style="{StaticResource AdminHandoffCard}" Margin="0" MaxWidth="180">
+                        <StackPanel>
+                            <Border Width="112" Height="112" CornerRadius="6" HorizontalAlignment="Center" Background="{DynamicResource TextBoxBackgroundBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1">
+                                <Grid>
+                                    <Image Width="112" Height="112"
+                                           Source="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
+                                           Stretch="UniformToFill" ClipToBounds="True">
+                                        <Image.Style>
+                                            <Style TargetType="Image">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Image.Style>
+                                    </Image>
+                                    <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               FontWeight="Bold"
+                                               FontSize="40"
+                                               Foreground="{Binding EditingUser.InitialsBrush}">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
+                            </Border>
 
-                            <Border Grid.Row="0" Style="{DynamicResource DesktopPaneHeader}">
+                            <TextBlock Text="{Binding EditingUser.UserName, TargetNullValue='New user'}" Style="{StaticResource SectionHeader}" Margin="0,10,0,2" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding EditingUser.Role, TargetNullValue='Set role and contact details'}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding EditingUser.UserID, StringFormat='User #: {0}'}" Style="{StaticResource CaptionTextBlock}" Margin="0,6,0,10"/>
+
+                            <Border Style="{StaticResource DesktopSectionActionStrip}" Padding="10" Margin="0,0,0,8">
                                 <StackPanel>
-                                    <TextBlock Text="Profile Fields" Style="{StaticResource SectionHeader}" Margin="0"/>
-                                    <TextBlock Text="Keep identity, contact, and status fields aligned for quick admin edits." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                    <TextBlock Text="Access Result" Style="{StaticResource LabelTextBlock}"/>
+                                    <TextBlock Text="{Binding PermissionStatusSummary}" FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0"/>
                                 </StackPanel>
                             </Border>
 
-                            <Grid Grid.Row="1" Margin="12">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="96"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
+                            <TextBlock Text="Current Access" Style="{StaticResource LabelTextBlock}" Margin="0,2,0,2"/>
+                            <TextBlock Text="{Binding EditingUser.AccessSummary}" FontSize="11" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Grid Grid.Column="2" MinWidth="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1.02*" MinWidth="250"/>
+                            <ColumnDefinition Width="8"/>
+                            <ColumnDefinition Width="1.48*" MinWidth="300"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                            <Grid MinWidth="0">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+
+                                <Border Grid.Row="0" Style="{DynamicResource DesktopPaneHeader}">
+                                    <StackPanel>
+                                        <TextBlock Text="Profile Fields" Style="{StaticResource SectionHeader}" Margin="0"/>
+                                        <TextBlock Text="Keep identity, contact, and status fields aligned for quick admin edits." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
+
+                                <Grid Grid.Row="1" Margin="10" MinWidth="0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="92" MinWidth="78"/>
+                                        <ColumnDefinition Width="*" MinWidth="0"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Username" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8" TextWrapping="Wrap"/>
+                                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding EditingUser.UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8" MinWidth="120"/>
+
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Role" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8" TextWrapping="Wrap"/>
+                                    <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding EditingUser.Role, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8" MinWidth="120"/>
+
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8" TextWrapping="Wrap"/>
+                                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding EditingUser.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8" MinWidth="120"/>
+
+                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8" TextWrapping="Wrap"/>
+                                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding EditingUser.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8" MinWidth="120"/>
+
+                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8" TextWrapping="Wrap"/>
+                                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding EditingUser.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8" MinWidth="120"/>
+
+                                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Address" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Top" Margin="0,3,8,8" TextWrapping="Wrap"/>
+                                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding EditingUser.Address, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8" MinHeight="62" MaxHeight="96" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+
+                                    <Border Grid.Row="6" Grid.ColumnSpan="2" Style="{StaticResource DesktopSectionActionStrip}" Padding="10" Margin="0,2,0,8">
+                                        <CheckBox Content="Full administrator" IsChecked="{Binding EditingUser.IsAdmin, Mode=TwoWay}" FontWeight="SemiBold"/>
+                                    </Border>
+
+                                    <WrapPanel Grid.Row="7" Grid.ColumnSpan="2">
+                                        <CheckBox Content="Active" IsChecked="{Binding EditingUser.IsActive, Mode=TwoWay}" Margin="0,0,16,8"/>
+                                        <CheckBox Content="Password expired" IsChecked="{Binding EditingUser.PasswordExpired, Mode=TwoWay}" Margin="0,0,0,8"/>
+                                    </WrapPanel>
+
+                                    <Border Grid.Row="8" Grid.ColumnSpan="2" Style="{StaticResource AdminHandoffCard}" VerticalAlignment="Top" Margin="0,2,0,0">
+                                        <StackPanel>
+                                            <TextBlock Text="Profile Readiness" Style="{StaticResource SectionHeader}"/>
+                                            <TextBlock Text="{Binding SaveStatusText}"
+                                                       Style="{StaticResource CaptionTextBlock}"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,2,0,0"/>
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
+                            </Grid>
+                        </Border>
+
+                        <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+
+                        <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                            <Grid MinWidth="0">
+                                <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
 
-                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Username" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding EditingUser.UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-
-                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Role" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding EditingUser.Role, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-
-                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding EditingUser.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-
-                                <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding EditingUser.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-
-                                <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-                                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding EditingUser.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-
-                                <TextBlock Grid.Row="5" Grid.Column="0" Text="Address" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Top" Margin="0,3,8,8"/>
-                                <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding EditingUser.Address, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8" Height="72" TextWrapping="Wrap" AcceptsReturn="True"/>
-
-                                <Border Grid.Row="6" Grid.ColumnSpan="2" Style="{StaticResource DesktopSectionActionStrip}" Padding="10" Margin="0,2,0,8">
-                                    <CheckBox Content="Full administrator" IsChecked="{Binding EditingUser.IsAdmin, Mode=TwoWay}" FontWeight="SemiBold"/>
+                                <Border Grid.Row="0" Style="{DynamicResource DesktopPaneHeader}">
+                                    <DockPanel>
+                                        <TextBlock Text="Permission Checklist" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0" TextWrapping="Wrap"/>
+                                        <TextBlock Text="Tick visible and usable areas" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" TextWrapping="Wrap" Margin="8,0,0,0"/>
+                                    </DockPanel>
                                 </Border>
 
-                                <WrapPanel Grid.Row="7" Grid.ColumnSpan="2">
-                                    <CheckBox Content="Active" IsChecked="{Binding EditingUser.IsActive, Mode=TwoWay}" Margin="0,0,16,8"/>
-                                    <CheckBox Content="Password expired" IsChecked="{Binding EditingUser.PasswordExpired, Mode=TwoWay}" Margin="0,0,0,8"/>
-                                </WrapPanel>
-
-                                <Border Grid.Row="8" Grid.ColumnSpan="2" Style="{StaticResource AdminHandoffCard}" VerticalAlignment="Top" Margin="0,2,0,0">
-                                    <StackPanel>
-                                        <TextBlock Text="Profile Readiness" Style="{StaticResource SectionHeader}"/>
-                                        <TextBlock Text="Save after checking identity, role, status, and photo so account rows and permission handoffs stay clear."
-                                                   Style="{StaticResource CaptionTextBlock}"
-                                                   TextWrapping="Wrap"
-                                                   Margin="0,2,0,0"/>
-                                    </StackPanel>
+                                <Border Grid.Row="1" Style="{StaticResource DesktopSectionActionStrip}" Padding="10" Margin="10,10,10,8">
+                                    <WrapPanel>
+                                        <Button Style="{StaticResource GhostButton}" Content="Advisor" Command="{Binding SelectAdvisorPresetCommand}" IsEnabled="{Binding CanEditProfile}" Margin="0,0,6,4"/>
+                                        <Button Style="{StaticResource GhostButton}" Content="Technician" Command="{Binding SelectTechnicianPresetCommand}" IsEnabled="{Binding CanEditProfile}" Margin="0,0,6,4"/>
+                                        <Button Style="{StaticResource GhostButton}" Content="Admin" Command="{Binding SelectAdminPresetCommand}" IsEnabled="{Binding CanEditProfile}" Margin="0,0,6,4"/>
+                                        <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearPermissionsCommand}" IsEnabled="{Binding CanEditProfile}" Margin="0,0,0,4"/>
+                                    </WrapPanel>
                                 </Border>
+
+                                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" CanContentScroll="True">
+                                    <Grid Margin="10,0,10,10" MinWidth="0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="1.05*" MinWidth="0"/>
+                                            <ColumnDefinition Width="8"/>
+                                            <ColumnDefinition Width="*" MinWidth="0"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <StackPanel Grid.Column="0">
+                                            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
+                                                <StackPanel>
+                                                    <TextBlock Text="Operations" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,6"/>
+                                                    <CheckBox Content="Manage items" IsChecked="{Binding CanManageItems, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Rentals / checkout" IsChecked="{Binding CanUseRentals, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Customers" IsChecked="{Binding CanUseCustomers, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Maintenance" IsChecked="{Binding CanUseMaintenance, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Calibration" IsChecked="{Binding CanUseCalibration, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Reservations / holds" IsChecked="{Binding CanUseReservations, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Kits" IsChecked="{Binding CanUseKits, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Categories" IsChecked="{Binding CanUseCategories, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Print labels" IsChecked="{Binding CanPrintLabels, Mode=TwoWay}"/>
+                                                </StackPanel>
+                                            </Border>
+                                            <Border Style="{StaticResource DesktopSummaryCard}">
+                                                <StackPanel>
+                                                    <TextBlock Text="Management" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,6"/>
+                                                    <CheckBox Content="Reports" IsChecked="{Binding CanUseReports, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Activity logs" IsChecked="{Binding CanUseActivityLogs, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Import / export" IsChecked="{Binding CanUseImportExport, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Manage users" IsChecked="{Binding CanManageUsers, Mode=TwoWay}" Margin="0,0,0,5"/>
+                                                    <CheckBox Content="Settings" IsChecked="{Binding CanUseSettings, Mode=TwoWay}"/>
+                                                </StackPanel>
+                                            </Border>
+                                        </StackPanel>
+
+                                        <StackPanel Grid.Column="2">
+                                            <Border Style="{StaticResource AdminHandoffCard}" Margin="0,0,0,8">
+                                                <StackPanel>
+                                                    <TextBlock Text="Access Result" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                    <TextBlock Text="{Binding PermissionStatusSummary}" TextWrapping="Wrap"/>
+                                                    <TextBlock Text="{Binding AdminNextStepSummary}" Style="{StaticResource CaptionTextBlock}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                                                </StackPanel>
+                                            </Border>
+                                            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8">
+                                                <StackPanel>
+                                                    <TextBlock Text="Can See And Use" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                    <TextBlock Text="{Binding AllowedPermissionSummary}" TextWrapping="Wrap"/>
+                                                </StackPanel>
+                                            </Border>
+                                            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8">
+                                                <StackPanel>
+                                                    <TextBlock Text="Hidden Or Blocked" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                    <TextBlock Text="{Binding HiddenPermissionSummary}" TextWrapping="Wrap"/>
+                                                </StackPanel>
+                                            </Border>
+                                            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8">
+                                                <StackPanel>
+                                                    <TextBlock Text="Operational Impact" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                    <TextBlock Text="{Binding WorkflowImpactSummary}" TextWrapping="Wrap"/>
+                                                </StackPanel>
+                                            </Border>
+                                            <Border Style="{StaticResource DesktopNoteCard}">
+                                                <StackPanel>
+                                                    <TextBlock Text="Guarded Actions" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                    <TextBlock Text="{Binding GuardedActionSummary}" TextWrapping="Wrap"/>
+                                                </StackPanel>
+                                            </Border>
+                                        </StackPanel>
+                                    </Grid>
+                                </ScrollViewer>
                             </Grid>
-                        </Grid>
-                    </Border>
-
-                    <GridSplitter Grid.Column="1" Width="10" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
-
-                    <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
-
-                            <Border Grid.Row="0" Style="{DynamicResource DesktopPaneHeader}">
-                                <DockPanel>
-                                    <TextBlock Text="Permission Checklist" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                                    <TextBlock Text="Tick visible and usable areas" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                                </DockPanel>
-                            </Border>
-
-                            <Border Grid.Row="1" Style="{StaticResource DesktopSectionActionStrip}" Padding="10" Margin="10,10,10,8">
-                                <WrapPanel>
-                                    <Button Style="{StaticResource GhostButton}" Content="Advisor" Command="{Binding SelectAdvisorPresetCommand}" Margin="0,0,6,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Technician" Command="{Binding SelectTechnicianPresetCommand}" Margin="0,0,6,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Admin" Command="{Binding SelectAdminPresetCommand}" Margin="0,0,6,4"/>
-                                    <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearPermissionsCommand}" Margin="0,0,0,4"/>
-                                </WrapPanel>
-                            </Border>
-
-                            <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
-                                <Grid Margin="10,0,10,10">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="1.05*"/>
-                                        <ColumnDefinition Width="12"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-
-                                    <StackPanel Grid.Column="0">
-                                        <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
-                                            <StackPanel>
-                                                <TextBlock Text="Operations" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,6"/>
-                                                <CheckBox Content="Manage items" IsChecked="{Binding CanManageItems, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Rentals / checkout" IsChecked="{Binding CanUseRentals, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Customers" IsChecked="{Binding CanUseCustomers, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Maintenance" IsChecked="{Binding CanUseMaintenance, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Calibration" IsChecked="{Binding CanUseCalibration, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Reservations / holds" IsChecked="{Binding CanUseReservations, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Kits" IsChecked="{Binding CanUseKits, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Categories" IsChecked="{Binding CanUseCategories, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Print labels" IsChecked="{Binding CanPrintLabels, Mode=TwoWay}"/>
-                                            </StackPanel>
-                                        </Border>
-                                        <Border Style="{StaticResource DesktopSummaryCard}">
-                                            <StackPanel>
-                                                <TextBlock Text="Management" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,6"/>
-                                                <CheckBox Content="Reports" IsChecked="{Binding CanUseReports, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Activity logs" IsChecked="{Binding CanUseActivityLogs, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Import / export" IsChecked="{Binding CanUseImportExport, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Manage users" IsChecked="{Binding CanManageUsers, Mode=TwoWay}" Margin="0,0,0,5"/>
-                                                <CheckBox Content="Settings" IsChecked="{Binding CanUseSettings, Mode=TwoWay}"/>
-                                            </StackPanel>
-                                        </Border>
-                                    </StackPanel>
-
-                                    <StackPanel Grid.Column="2">
-                                        <Border Style="{StaticResource AdminHandoffCard}" Margin="0,0,0,8">
-                                            <StackPanel>
-                                                <TextBlock Text="Access Result" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
-                                                <TextBlock Text="{Binding PermissionStatusSummary}" TextWrapping="Wrap"/>
-                                                <TextBlock Text="{Binding AdminNextStepSummary}" Style="{StaticResource CaptionTextBlock}" Margin="0,4,0,0" TextWrapping="Wrap"/>
-                                            </StackPanel>
-                                        </Border>
-                                        <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8">
-                                            <StackPanel>
-                                                <TextBlock Text="Can See And Use" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
-                                                <TextBlock Text="{Binding AllowedPermissionSummary}" TextWrapping="Wrap"/>
-                                            </StackPanel>
-                                        </Border>
-                                        <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8">
-                                            <StackPanel>
-                                                <TextBlock Text="Hidden Or Blocked" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
-                                                <TextBlock Text="{Binding HiddenPermissionSummary}" TextWrapping="Wrap"/>
-                                            </StackPanel>
-                                        </Border>
-                                        <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8">
-                                            <StackPanel>
-                                                <TextBlock Text="Operational Impact" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
-                                                <TextBlock Text="{Binding WorkflowImpactSummary}" TextWrapping="Wrap"/>
-                                            </StackPanel>
-                                        </Border>
-                                        <Border Style="{StaticResource DesktopNoteCard}">
-                                            <StackPanel>
-                                                <TextBlock Text="Guarded Actions" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
-                                                <TextBlock Text="{Binding GuardedActionSummary}" TextWrapping="Wrap"/>
-                                            </StackPanel>
-                                        </Border>
-                                    </StackPanel>
-                                </Grid>
-                            </ScrollViewer>
-                        </Grid>
-                    </Border>
+                        </Border>
+                    </Grid>
                 </Grid>
-            </Grid>
-        </ScrollViewer>
+            </ScrollViewer>
 
-        <controls:SaveCancelBar Grid.Row="3" Margin="0,10,0,0"/>
+            <Border MaxWidth="360" MinHeight="112" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center"
+                    Visibility="{Binding IsSaving, Converter={StaticResource BoolToVis}}"
+                    Style="{StaticResource DesktopNoteCard}">
+                <StackPanel>
+                    <TextBlock Text="Saving user profile" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                    <TextBlock Text="{Binding SaveStatusText}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
+        </Grid>
+
+        <controls:SaveCancelBar Grid.Row="3" Margin="0,8,0,0"/>
 
         <Border Grid.Row="4" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
             <DockPanel LastChildFill="True">
-                <TextBlock DockPanel.Dock="Left" Text="User profile ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <TextBlock Text="Save applies profile, photo, status, and permission changes; cancel returns without updating this account."
+                <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0" TextTrimming="CharacterEllipsis"/>
+                <TextBlock Text="{Binding SaveStatusText}"
                            Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
                            VerticalAlignment="Center"/>

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml.cs
@@ -14,7 +14,7 @@ namespace InventoryManagementApp.Views.Windows
         public UsersEditWindow(User user, Func<Task> onSave, Action onCancel, IFileDialogService fileDialogService)
         {
             InitializeComponent();
-            this.UseResponsiveDefaultSize(1120, 880);
+            this.UseResponsiveDefaultSize(920, 700);
             DataContext = new UsersEditViewModel(user, fileDialogService, onSave, onCancel);
             this.DisposeDataContextOnUnload();
         }


### PR DESCRIPTION
## What changed

- Reduced the Users Edit dialog startup/minimum dimensions and aligned code-behind responsive sizing for 1366 x 768 and scaled Windows desktops.
- Added layout rounding, pixel snapping, and root clipping for cleaner high-scale rendering.
- Replaced the fixed four-column workflow strip with wrapping bounded step cards.
- Reworked the header into shrinkable title/help text plus wrapping photo actions.
- Lowered main editor split pressure by reducing avatar/sidebar width, splitter width, and profile/permission pane minimums.
- Removed the fixed body minimum height so the scrollable editor can shrink safely.
- Bounded avatar, profile labels, text inputs, address input, and permission checklist regions to reduce clipping and layout churn.
- Added save readiness state to `UsersEditViewModel`, including username-required save gating and clear no-access-account messaging.
- Added save-in-progress state that disables profile editing, image actions, permission presets, Save, and Cancel while the save task is running.
- Added a saving overlay and footer/profile readiness text so operators can see why controls are paused.
- Made the shared Save/Cancel bar wrap-friendly by replacing fixed-width horizontal actions with bounded wrapping controls.
- Added `UsersEditWindowResponsiveContractTests` and extended `UsersEditViewModelTests` for layout, command gating, save readiness, and busy-state behavior.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-07-users-editor-responsiveness.md`.

## Why this was highest value

The latest merged work improved password entry dialogs, while the Users editor still had a large fixed layout, fixed four-column summary strip, high pane minimums, and no save-in-progress/readiness state. This is a core admin workflow: account edits should remain readable at Windows scaling, avoid duplicate saves, and show clear status while persistence work is running.

## Why this is real progress

This is a complete workflow slice across UI layout, runtime sizing, ViewModel command state, shared footer controls, behavior/source-contract tests, and progress notes. It improves responsiveness, professional data display, validation clarity, and duplicate-action safety without adding new app scope.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, seven focused commits ahead, and limited to Users Edit UI/ViewModel/tests, the shared Save/Cancel bar, and one progress note.
- GitHub connector readback confirmed the responsive shell and ViewModel save-state contracts on the branch.
- GitHub connector status readback found no attached commit statuses for head `0981efb55af59ee86d067cf98fa2c5b2f954d25c` before PR creation.

## Could not check

- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime smoke tests, screenshots, or Windows scaling checks because this scheduled Linux environment cannot clone the repo directly due GitHub HTTP 403 and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

## Follow-up

- Run the full validation runner on a Windows/.NET-capable checkout.
- Smoke test Users Edit at 125%, 150%, and 200% Windows scaling for scrolling, Save/Cancel reachability, disabled duplicate-save behavior, image actions, preset actions, and no-access account messaging.