### PR TITLE
Improve customer editor responsiveness and save readiness

### DIFF
--- a/InventoryManagementApp.Tests/CustomerEditViewModelTests.cs
+++ b/InventoryManagementApp.Tests/CustomerEditViewModelTests.cs
@@ -6,7 +6,7 @@ namespace InventoryManagementApp.Tests;
 public class CustomerEditViewModelTests
 {
     [Fact]
-    public void SaveCommand_WithMissingContact_ShowsValidationAndDoesNotSave()
+    public void SaveCommand_WithMissingContact_IsDisabledAndShowsReadiness()
     {
         var saved = false;
         var customer = new CustomerModel
@@ -16,10 +16,12 @@ public class CustomerEditViewModelTests
         };
         var vm = new CustomerEditViewModel(customer, () => saved = true, () => { });
 
+        Assert.False(vm.SaveCommand.CanExecute(null));
         vm.SaveCommand.Execute(null);
 
         Assert.False(saved);
-        Assert.Contains("Contact is required", vm.StatusMessage);
+        Assert.Contains("primary contact", vm.StatusMessage);
+        Assert.False(vm.HasValidationMessage);
     }
 
     [Fact]
@@ -36,6 +38,7 @@ public class CustomerEditViewModelTests
         };
         var vm = new CustomerEditViewModel(customer, () => saved = true, () => { });
 
+        Assert.True(vm.SaveCommand.CanExecute(null));
         vm.SaveCommand.Execute(null);
 
         Assert.True(saved);
@@ -44,5 +47,82 @@ public class CustomerEditViewModelTests
         Assert.Equal("078472255", customer.Phone);
         Assert.Equal("garett@sdeuropean.co.nz", customer.Email);
         Assert.Equal("1 Norton Road", customer.Address);
+        Assert.False(vm.IsSaving);
+        Assert.Contains("ready", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void SaveCommand_ReevaluatesWhenRequiredFieldsChange()
+    {
+        var customer = new CustomerModel();
+        var vm = new CustomerEditViewModel(customer, () => { }, () => { });
+
+        Assert.False(vm.SaveCommand.CanExecute(null));
+        Assert.Contains("company", vm.SaveReadinessText);
+
+        customer.Company = "Pickerill Automotive And Tyres";
+        Assert.False(vm.SaveCommand.CanExecute(null));
+        Assert.Contains("primary contact", vm.SaveReadinessText);
+
+        customer.Contact = "Service Desk";
+        Assert.False(vm.SaveCommand.CanExecute(null));
+        Assert.Contains("phone or mobile", vm.SaveReadinessText);
+
+        customer.Mobile = "0215550101";
+        Assert.True(vm.SaveCommand.CanExecute(null));
+        Assert.Contains("ready", vm.SaveReadinessText);
+    }
+
+    [Fact]
+    public void SaveCommand_DisablesSaveAndCancelWhileSaveCallbackRuns()
+    {
+        CustomerEditViewModel? vm = null;
+        var wasSavingInsideCallback = false;
+        var couldSaveInsideCallback = true;
+        var couldCancelInsideCallback = true;
+        var customer = new CustomerModel
+        {
+            Company = "Pickerill Automotive And Tyres",
+            Contact = "Service Desk",
+            Phone = "078472255"
+        };
+
+        vm = new CustomerEditViewModel(customer, () =>
+        {
+            wasSavingInsideCallback = vm!.IsSaving;
+            couldSaveInsideCallback = vm.SaveCommand.CanExecute(null);
+            couldCancelInsideCallback = vm.CancelCommand.CanExecute(null);
+        }, () => { });
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(wasSavingInsideCallback);
+        Assert.False(couldSaveInsideCallback);
+        Assert.False(couldCancelInsideCallback);
+        Assert.False(vm.IsSaving);
+        Assert.True(vm.SaveCommand.CanExecute(null));
+        Assert.True(vm.CancelCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void CustomerFieldChangeClearsValidationMessageAndRefreshesStatus()
+    {
+        var customer = new CustomerModel
+        {
+            Company = "Pickerill Automotive And Tyres",
+            Contact = "Service Desk"
+        };
+        var vm = new CustomerEditViewModel(customer, () => { }, () => { });
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasValidationMessage);
+        Assert.Contains("phone or mobile", vm.StatusMessage);
+
+        customer.Phone = "078472255";
+
+        Assert.False(vm.HasValidationMessage);
+        Assert.True(vm.SaveCommand.CanExecute(null));
+        Assert.Contains("ready", vm.StatusMessage);
     }
 }

--- a/InventoryManagementApp.Tests/CustomerEditViewModelTests.cs
+++ b/InventoryManagementApp.Tests/CustomerEditViewModelTests.cs
@@ -105,7 +105,7 @@ public class CustomerEditViewModelTests
     }
 
     [Fact]
-    public void CustomerFieldChangeClearsValidationMessageAndRefreshesStatus()
+    public void CustomerFieldChangeRefreshesReadinessAndCommandState()
     {
         var customer = new CustomerModel
         {
@@ -114,9 +114,7 @@ public class CustomerEditViewModelTests
         };
         var vm = new CustomerEditViewModel(customer, () => { }, () => { });
 
-        vm.SaveCommand.Execute(null);
-
-        Assert.True(vm.HasValidationMessage);
+        Assert.False(vm.SaveCommand.CanExecute(null));
         Assert.Contains("phone or mobile", vm.StatusMessage);
 
         customer.Phone = "078472255";

--- a/InventoryManagementApp.Tests/CustomerEditWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerEditWindowResponsiveContractTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomerEditWindowResponsiveContractTests
+    {
+        [Fact]
+        public void CustomerEditWindow_UsesCompactBoundedResponsiveShell()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CustomerEditWindow.xaml");
+            var code = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CustomerEditWindow.xaml.cs");
+
+            Assert.Contains("Width=\"700\" Height=\"560\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinWidth=\"560\" MinHeight=\"440\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("UseLayoutRounding=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SnapsToDevicePixels=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Grid Margin=\"12\" ClipToBounds=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("this.UseResponsiveDefaultSize(760, 620);", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("Width=\"720\" Height=\"580\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinWidth=\"600\" MinHeight=\"500\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("this.UseResponsiveDefaultSize(900, 760);", code, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerEditWindow_WrapsStepsAndDetailSections()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CustomerEditWindow.xaml");
+
+            Assert.Contains("<Style x:Key=\"CustomerEditorStepCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"215\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"CustomerEditorSectionCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"248\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"360\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,2\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<Grid Margin=\"12\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"1.1*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerEditWindow_BoundsHeaderFieldsAndScrollableBody()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CustomerEditWindow.xaml");
+
+            Assert.Contains("MaxHeight=\"116\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextTrimming=\"CharacterEllipsis\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxHeight=\"42\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxWidth=\"170\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ScrollViewer Grid.Row=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding CanEditCustomer}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"88\" MinWidth=\"74\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ColumnDefinition Width=\"78\" MinWidth=\"68\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight=\"72\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MaxHeight=\"128\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"104\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ColumnDefinition Width=\"82\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("MinHeight=\"96\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerEditWindow_ShowsReadinessAndSavingOverlay()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "CustomerEditWindow.xaml");
+
+            Assert.Contains("Text=\"{Binding SaveReadinessText}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding StatusMessage}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Visibility=\"{Binding IsSaving, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Saving customer profile\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Directory fields are paused until the customer update finishes.", xaml, StringComparison.Ordinal);
+            Assert.Contains("<controls:SaveCancelBar Grid.Row=\"3\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Text=\"Customer profile ready\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerEditViewModel_GatesSaveAndReportsReadiness()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CustomerEditViewModel.cs");
+
+            Assert.Contains("using System.ComponentModel;", source, StringComparison.Ordinal);
+            Assert.Contains("private bool _isSaving;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsSaving", source, StringComparison.Ordinal);
+            Assert.Contains("public bool CanEditCustomer => !IsSaving;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool CanSaveCustomer => !IsSaving && HasRequiredCustomerDetails();", source, StringComparison.Ordinal);
+            Assert.Contains("public bool HasValidationMessage", source, StringComparison.Ordinal);
+            Assert.Contains("public string SaveReadinessText", source, StringComparison.Ordinal);
+            Assert.Contains("Customer.PropertyChanged += Customer_PropertyChanged;", source, StringComparison.Ordinal);
+            Assert.Contains("SaveCommand = new RelayCommand(Save, () => CanSaveCustomer);", source, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand = new RelayCommand(onCancel, () => CanEditCustomer);", source, StringComparison.Ordinal);
+            Assert.Contains("IsSaving = true;", source, StringComparison.Ordinal);
+            Assert.Contains("IsSaving = false;", source, StringComparison.Ordinal);
+            Assert.Contains("SaveCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-customer-editor-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-customer-editor-responsiveness.md
@@ -1,0 +1,29 @@
+# Customer Editor Responsiveness
+
+Date: 2026-07-07
+
+## Completed
+
+- Reduced the Customer Edit dialog startup and minimum dimensions for safer 1366 x 768 and scaled Windows desktop use.
+- Aligned code-behind responsive startup sizing with the smaller XAML shell.
+- Added layout rounding, device-pixel snapping, and root clipping for cleaner high-scale rendering.
+- Bounded the header height, long helper copy, and directory-record chip so text cannot force actions or content off-screen.
+- Replaced fixed two-column editor pressure with wrapping customer detail cards for account identity, communication, and service address sections.
+- Lowered label-column and address-field fixed-size pressure while keeping the body scrollable and horizontally constrained.
+- Added live save-readiness text for missing company, missing contact, missing phone/mobile, ready, and saving states.
+- Disabled customer field editing, Save, and Cancel while save work is active so duplicate saves cannot queue.
+- Added a visible saving overlay that explains why customer fields are paused.
+- Kept final save validation and trimming in the view model while surfacing readiness before operators click Save.
+- Added behavior tests for readiness transitions, required-field command gating, trimming, and save-time command disabling.
+- Added source-contract coverage for the responsive shell, wrapping sections, bounded fields/body, saving overlay, and ViewModel command/readiness contracts.
+
+## Validation
+
+- GitHub connector read/write succeeded for Customer Edit XAML/code-behind, Customer Edit ViewModel, behavior tests, responsive source-contract tests, and this progress note.
+- Source readback was used to confirm the customer domain model raises property-change notifications used by the ViewModel readiness updates.
+- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, or Windows scaling checks in this scheduled Linux environment because direct checkout remains blocked by GitHub HTTP 403 and Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full validation runner on a Windows/.NET-capable checkout.
+- Smoke test Customer Edit at 125%, 150%, and 200% Windows scaling for wrapping sections, field editing, disabled Save until required data exists, Save/Cancel reachability, and the duplicate-save guard.

--- a/InventoryManagementApp/ViewModels/CustomerEditViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerEditViewModel.cs
@@ -1,5 +1,6 @@
 // ViewModels/CustomerEditViewModel.cs
 using System;
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -12,6 +13,23 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand SaveCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
+        private readonly Action _onSave;
+
+        private bool _isSaving;
+        public bool IsSaving
+        {
+            get => _isSaving;
+            private set
+            {
+                if (SetProperty(ref _isSaving, value))
+                    NotifySaveStateChanged();
+            }
+        }
+
+        public bool CanEditCustomer => !IsSaving;
+
+        public bool CanSaveCustomer => !IsSaving && HasRequiredCustomerDetails();
+
         private string _validationMessage = string.Empty;
         public string ValidationMessage
         {
@@ -19,25 +37,83 @@ namespace InventoryManagementApp.ViewModels
             private set
             {
                 if (SetProperty(ref _validationMessage, value))
+                {
+                    OnPropertyChanged(nameof(HasValidationMessage));
                     OnPropertyChanged(nameof(StatusMessage));
+                }
             }
         }
 
-        public string StatusMessage => string.IsNullOrWhiteSpace(ValidationMessage)
-            ? "Save updates customer lookup, rental handoffs, and printed customer sheets; cancel returns without applying profile edits."
-            : ValidationMessage;
+        public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+        public string SaveReadinessText
+        {
+            get
+            {
+                if (IsSaving)
+                    return "Saving customer profile - directory actions are paused until the update finishes.";
+
+                var company = (Customer.Company ?? string.Empty).Trim();
+                var contact = (Customer.Contact ?? string.Empty).Trim();
+                var phone = (Customer.Phone ?? string.Empty).Trim();
+                var mobile = (Customer.Mobile ?? string.Empty).Trim();
+
+                if (string.IsNullOrWhiteSpace(company))
+                    return "Enter a company name before saving this customer profile.";
+
+                if (string.IsNullOrWhiteSpace(contact))
+                    return "Enter a primary contact before saving this customer profile.";
+
+                if (string.IsNullOrWhiteSpace(phone) && string.IsNullOrWhiteSpace(mobile))
+                    return "Enter a phone or mobile number before saving this customer profile.";
+
+                return "Customer profile ready - save applies account, contact, phone, email, and service address updates.";
+            }
+        }
+
+        public string StatusMessage => HasValidationMessage
+            ? ValidationMessage
+            : SaveReadinessText;
 
         public CustomerEditViewModel(CustomerModel customer, Action onSave, Action onCancel)
         {
             Customer = customer;
-            SaveCommand = new RelayCommand(() =>
-            {
-                if (!ValidateForSave())
-                    return;
+            _onSave = onSave;
+            Customer.PropertyChanged += Customer_PropertyChanged;
+            SaveCommand = new RelayCommand(Save, () => CanSaveCustomer);
+            CancelCommand = new RelayCommand(onCancel, () => CanEditCustomer);
+        }
 
-                onSave();
-            });
-            CancelCommand = new RelayCommand(onCancel);
+        void Customer_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(Customer.Company)
+                || e.PropertyName == nameof(Customer.Contact)
+                || e.PropertyName == nameof(Customer.Phone)
+                || e.PropertyName == nameof(Customer.Mobile)
+                || e.PropertyName == nameof(Customer.Email)
+                || e.PropertyName == nameof(Customer.Address))
+            {
+                if (HasValidationMessage)
+                    ValidationMessage = string.Empty;
+
+                NotifySaveStateChanged();
+            }
+        }
+
+        void Save()
+        {
+            if (!ValidateForSave())
+                return;
+
+            IsSaving = true;
+            try
+            {
+                _onSave();
+            }
+            finally
+            {
+                IsSaving = false;
+            }
         }
 
         bool ValidateForSave()
@@ -73,6 +149,29 @@ namespace InventoryManagementApp.ViewModels
             Customer.Address = (Customer.Address ?? string.Empty).Trim();
             ValidationMessage = string.Empty;
             return true;
+        }
+
+        bool HasRequiredCustomerDetails()
+        {
+            var company = (Customer.Company ?? string.Empty).Trim();
+            var contact = (Customer.Contact ?? string.Empty).Trim();
+            var phone = (Customer.Phone ?? string.Empty).Trim();
+            var mobile = (Customer.Mobile ?? string.Empty).Trim();
+
+            return !string.IsNullOrWhiteSpace(company)
+                && !string.IsNullOrWhiteSpace(contact)
+                && (!string.IsNullOrWhiteSpace(phone) || !string.IsNullOrWhiteSpace(mobile));
+        }
+
+        void NotifySaveStateChanged()
+        {
+            OnPropertyChanged(nameof(IsSaving));
+            OnPropertyChanged(nameof(CanEditCustomer));
+            OnPropertyChanged(nameof(CanSaveCustomer));
+            OnPropertyChanged(nameof(SaveReadinessText));
+            OnPropertyChanged(nameof(StatusMessage));
+            SaveCommand.NotifyCanExecuteChanged();
+            CancelCommand.NotifyCanExecuteChanged();
         }
     }
 }

--- a/InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml
@@ -3,9 +3,27 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
-        Title="Customer" Width="720" Height="580" MinWidth="600" MinHeight="500" WindowStartupLocation="CenterOwner"
-        Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="12">
+        Title="Customer"
+        Width="700" Height="560"
+        MinWidth="560" MinHeight="440"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}"
+        UseLayoutRounding="True"
+        SnapsToDevicePixels="True">
+    <Window.Resources>
+        <Style x:Key="CustomerEditorStepCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
+            <Setter Property="MinWidth" Value="150"/>
+            <Setter Property="MaxWidth" Value="215"/>
+            <Setter Property="MinHeight" Value="78"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+        <Style x:Key="CustomerEditorSectionCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+            <Setter Property="MinWidth" Value="248"/>
+            <Setter Property="MaxWidth" Value="360"/>
+            <Setter Property="Margin" Value="0,0,10,10"/>
+        </Style>
+    </Window.Resources>
+    <Grid Margin="12" ClipToBounds="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -14,7 +32,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8">
+        <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,8" MaxHeight="116">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" MinWidth="0"/>
@@ -25,104 +43,161 @@
                     <TextBlock Text="Keep account, contact, and delivery details ready for rentals, reservations, service handoffs, and printed customer sheets."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
+                               TextTrimming="CharacterEllipsis"
+                               MaxHeight="42"
                                Margin="0,2,0,0"/>
                 </StackPanel>
-                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="10,0,0,0" MaxWidth="190" VerticalAlignment="Center">
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="10,0,0,0" MaxWidth="170" VerticalAlignment="Center">
                     <StackPanel>
                         <TextBlock Text="Directory Record" Style="{StaticResource LabelTextBlock}"/>
-                        <TextBlock Text="{Binding Customer.Company, TargetNullValue='New customer'}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
+                        <TextBlock Text="{Binding Customer.Company, TargetNullValue='New customer'}" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="44"/>
                     </StackPanel>
                 </Border>
             </Grid>
         </Border>
 
-        <WrapPanel Grid.Row="1" Margin="0,0,0,8">
-            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="155" MaxWidth="225" Margin="0,0,8,8">
+        <WrapPanel Grid.Row="1" Margin="0,0,0,2">
+            <Border Style="{StaticResource CustomerEditorStepCard}">
                 <StackPanel>
                     <TextBlock Text="01 Account" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Company and contact" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
-                    <TextBlock Text="Primary identity used by customer lookup and rental handoffs."
+                    <TextBlock Text="Primary identity used by lookup and rental handoffs."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="155" MaxWidth="225" Margin="0,0,8,8">
+            <Border Style="{StaticResource CustomerEditorStepCard}">
                 <StackPanel>
                     <TextBlock Text="02 Communication" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Email and phones" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
-                    <TextBlock Text="Follow-up details stay together for advisors and printouts."
+                    <TextBlock Text="Follow-up details stay together for advisors."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
-            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="155" MaxWidth="225" Margin="0,0,8,8">
+            <Border Style="{StaticResource CustomerEditorStepCard}">
                 <StackPanel>
                     <TextBlock Text="03 Address" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="Delivery notes" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
-                    <TextBlock Text="Service address supports delivery, pickup, and customer sheets."
+                    <TextBlock Text="Service address supports pickup and printed sheets."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
         </WrapPanel>
 
-        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" MinWidth="0">
-            <Grid MinWidth="0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
+        <Grid Grid.Row="2" MinWidth="0">
+            <Border Style="{StaticResource Card}" Padding="0" MinWidth="0">
+                <Grid MinWidth="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-                <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
-                    <DockPanel LastChildFill="True">
-                        <TextBlock DockPanel.Dock="Left" Text="Customer Directory Details" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
-                        <TextBlock Text="Aligned fields keep quick edits steady across customer records." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" HorizontalAlignment="Right" Margin="12,0,0,0"/>
-                    </DockPanel>
-                </Border>
+                    <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" MinWidth="0"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0" MinWidth="0">
+                                <TextBlock Text="Customer Directory Details" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
+                                <TextBlock Text="Aligned fields keep quick edits steady across customer records." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="36"/>
+                            </StackPanel>
+                            <TextBlock Grid.Column="1" Text="{Binding SaveReadinessText}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxWidth="260" MaxHeight="48" Margin="12,0,0,0" VerticalAlignment="Center"/>
+                        </Grid>
+                    </Border>
 
-                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                    <Grid Margin="12" MinWidth="0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1.1*" MinWidth="0"/>
-                            <ColumnDefinition Width="8"/>
-                            <ColumnDefinition Width="*" MinWidth="0"/>
-                        </Grid.ColumnDefinitions>
+                    <ScrollViewer Grid.Row="1"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  CanContentScroll="True"
+                                  IsEnabled="{Binding CanEditCustomer}">
+                        <StackPanel Margin="12" MinWidth="0">
+                            <WrapPanel>
+                                <Border Style="{StaticResource CustomerEditorSectionCard}">
+                                    <Grid MinWidth="0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="88" MinWidth="74"/>
+                                            <ColumnDefinition Width="*" MinWidth="0"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
 
-                        <Grid Grid.Column="0" MinWidth="0">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Account Identity" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" Margin="0,0,0,4"/>
+                                        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Company and contact appear in customer lookup, printouts, and selected-customer handoffs."
+                                                   Style="{StaticResource CaptionTextBlock}"
+                                                   TextWrapping="Wrap"
+                                                   Margin="0,0,0,10"/>
 
-                            <Border Grid.Row="0" Style="{StaticResource DesktopSectionActionStrip}" Padding="10" Margin="0,0,0,8" MinWidth="0">
-                                <StackPanel>
-                                    <TextBlock Text="Account Identity" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                                    <TextBlock Text="The company and primary contact appear in customer lookup, printouts, and selected-customer handoffs."
-                                               Style="{StaticResource CaptionTextBlock}"
-                                               TextWrapping="Wrap"
-                                               Margin="0,2,0,0"/>
-                                </StackPanel>
-                            </Border>
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Company" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,10" TextWrapping="Wrap"/>
+                                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Customer.Company, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10" MinWidth="120"/>
 
-                            <Grid Grid.Row="1" MinWidth="0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="104"/>
-                                    <ColumnDefinition Width="*" MinWidth="0"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Contact" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0" TextWrapping="Wrap"/>
+                                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Customer.Contact, UpdateSourceTrigger=PropertyChanged}" MinWidth="120"/>
+                                    </Grid>
+                                </Border>
 
-                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Company" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,10"/>
-                                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Customer.Company, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10"/>
+                                <Border Style="{StaticResource CustomerEditorSectionCard}">
+                                    <Grid MinWidth="0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="78" MinWidth="68"/>
+                                            <ColumnDefinition Width="*" MinWidth="0"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
 
-                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Contact" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Customer.Contact, UpdateSourceTrigger=PropertyChanged}"/>
-                            </Grid>
+                                        <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Communication" Style="{StaticResource SectionHeader}" TextWrapping="Wrap" Margin="0,0,0,4"/>
+                                        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="At least one phone number keeps rental and reservation follow-up reachable."
+                                                   Style="{StaticResource CaptionTextBlock}"
+                                                   TextWrapping="Wrap"
+                                                   Margin="0,0,0,10"/>
 
-                            <Border Grid.Row="2" Style="{StaticResource AdminHandoffCard}" Margin="0,10,0,0" MinWidth="0">
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,10" TextWrapping="Wrap"/>
+                                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Customer.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10" MinWidth="120"/>
+
+                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,10" TextWrapping="Wrap"/>
+                                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Customer.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10" MinWidth="120"/>
+
+                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0" TextWrapping="Wrap"/>
+                                        <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Customer.Mobile, UpdateSourceTrigger=PropertyChanged}" MinWidth="120"/>
+                                    </Grid>
+                                </Border>
+
+                                <Border Style="{StaticResource CustomerEditorSectionCard}">
+                                    <Grid MinWidth="0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Text="Service Address" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                                        <TextBlock Grid.Row="1" Text="Keep this concise enough for directory rows, handoff sheets, and delivery notes."
+                                                   Style="{StaticResource CaptionTextBlock}"
+                                                   TextWrapping="Wrap"
+                                                   Margin="0,2,0,8"/>
+                                        <TextBox Grid.Row="2"
+                                                 Text="{Binding Customer.Address, UpdateSourceTrigger=PropertyChanged}"
+                                                 AcceptsReturn="True"
+                                                 TextWrapping="Wrap"
+                                                 MinHeight="72"
+                                                 MaxHeight="128"
+                                                 VerticalScrollBarVisibility="Auto"
+                                                 HorizontalScrollBarVisibility="Disabled"/>
+                                    </Grid>
+                                </Border>
+                            </WrapPanel>
+
+                            <Border Style="{StaticResource AdminHandoffCard}" Margin="0,0,0,2" MinWidth="0">
                                 <StackPanel>
                                     <TextBlock Text="Customer Operations Handoff" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
                                     <TextBlock Text="Save after confirming the account name, best contact path, and service address so directory rows and printed customer sheets remain trustworthy."
@@ -131,63 +206,30 @@
                                                Margin="0,2,0,0"/>
                                 </StackPanel>
                             </Border>
-                        </Grid>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
 
-                        <Grid Grid.Column="2" MinWidth="0">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
-
-                            <Border Grid.Row="0" Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,8" MinWidth="0">
-                                <Grid MinWidth="0">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="82"/>
-                                        <ColumnDefinition Width="*" MinWidth="0"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-
-                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,10"/>
-                                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Customer.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10"/>
-
-                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Phone" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,10"/>
-                                    <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Customer.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10"/>
-
-                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Mobile" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Customer.Mobile, UpdateSourceTrigger=PropertyChanged}"/>
-                                </Grid>
-                            </Border>
-
-                            <Border Grid.Row="1" Style="{StaticResource DesktopNoteCard}" MinWidth="0">
-                                <Grid MinWidth="0">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="*"/>
-                                    </Grid.RowDefinitions>
-                                    <TextBlock Grid.Row="0" Text="Service Address" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                                    <TextBlock Grid.Row="1" Text="Keep this concise enough for directory rows, handoff sheets, and delivery notes."
-                                               Style="{StaticResource CaptionTextBlock}"
-                                               TextWrapping="Wrap"
-                                               Margin="0,2,0,8"/>
-                                    <TextBox Grid.Row="2"
-                                             Text="{Binding Customer.Address, UpdateSourceTrigger=PropertyChanged}"
-                                             AcceptsReturn="True"
-                                             TextWrapping="Wrap"
-                                             MinHeight="96"
-                                             VerticalScrollBarVisibility="Auto"
-                                             HorizontalScrollBarVisibility="Disabled"/>
-                                </Grid>
-                            </Border>
-                        </Grid>
-                    </Grid>
-                </ScrollViewer>
-            </Grid>
-        </Border>
+            <Border Background="#CCFFFFFF"
+                    BorderBrush="{DynamicResource BorderBrushAlt}"
+                    BorderThickness="1"
+                    CornerRadius="6"
+                    Padding="18"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    MaxWidth="320"
+                    Visibility="{Binding IsSaving, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Text="Saving customer profile" Style="{StaticResource SectionHeader}" TextAlignment="Center" TextWrapping="Wrap"/>
+                    <TextBlock Text="Directory fields are paused until the customer update finishes."
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextAlignment="Center"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+            </Border>
+        </Grid>
 
         <controls:SaveCancelBar Grid.Row="3" Margin="0,8,0,0"/>
 
@@ -197,10 +239,12 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="Customer profile ready" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Grid.Column="0" Text="Customer profile" FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0"/>
                 <TextBlock Grid.Column="1" Text="{Binding StatusMessage}"
                            Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
+                           TextTrimming="CharacterEllipsis"
+                           MaxHeight="44"
                            VerticalAlignment="Center"/>
             </Grid>
         </Border>

--- a/InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml.cs
@@ -12,7 +12,7 @@ namespace InventoryManagementApp.Views.Windows
         public CustomerEditWindow(CustomerModel customer, Action onSave, Action onCancel)
         {
             InitializeComponent();
-            this.UseResponsiveDefaultSize(900, 760);
+            this.UseResponsiveDefaultSize(760, 620);
             DataContext = new CustomerEditViewModel(customer, onSave, onCancel);
             this.DisposeDataContextOnUnload();
         }


### PR DESCRIPTION
## What changed

- Reduced the Customer Edit dialog startup/minimum dimensions for safer 1366 x 768 and scaled Windows desktop use.
- Aligned the code-behind responsive default sizing with the smaller XAML shell.
- Added layout rounding, device-pixel snapping, and root clipping for cleaner high-scale rendering.
- Bounded the header height, helper copy, and directory-record chip so long text cannot push content off-screen.
- Replaced the fixed two-column editor body with wrapping customer detail cards for account identity, communication, and service address.
- Lowered label-column and address-field fixed-size pressure while preserving a vertically scrollable, horizontally constrained body.
- Added live save-readiness text for missing company, missing contact, missing phone/mobile, ready, and saving states.
- Disabled customer fields, Save, and Cancel while save work is active to avoid duplicate save dispatch.
- Added a visible saving overlay that explains why customer fields are paused.
- Preserved final save validation and trimming while surfacing readiness before the operator clicks Save.
- Extended Customer Edit behavior tests for required-field command gating, readiness transitions, trimming, and save-time command disabling.
- Added Customer Edit responsive source-contract coverage and a progress note.

## Why this was highest value

Recent merged work tightened Users Edit, Change Password, Dashboard, Import/Export, Rentals, Kit Management, and Activity Logs. Customer Edit remained a core high-traffic directory workflow with older fixed layout pressure, a larger runtime default than its XAML shell, no dedicated responsive contract tests, and Save appearing available until validation ran. This improves an existing workflow without inventing new app scope.

## Why this is real progress

This is a complete workflow slice across UI layout, runtime sizing, ViewModel readiness/command state, behavior tests, source-contract coverage, and progress notes. It improves loading/display responsiveness at Windows scaling, makes required data visible before save, and prevents duplicate save/cancel actions while persistence work is active.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, seven commits ahead, zero behind, and limited to Customer Edit UI/ViewModel/tests plus one progress note.
- GitHub connector readback confirmed the revised ViewModel readiness/save-state contracts and the new responsive source-contract tests.
- Source readback confirmed the customer domain model raises property-change notifications used by the new readiness updates.
- GitHub connector status/workflow readback found no attached commit statuses or workflow runs for head `39317c689f996eb90491ea3ad115bb647b8da2ab` before PR creation.

## Could not check

- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime smoke tests, screenshots, or Windows scaling checks because this scheduled Linux environment cannot clone the repo directly due GitHub HTTP 403 and does not provide `dotnet`, `pwsh`, `gh`, or a WPF runtime.

## Follow-up

- Run the full validation runner on a Windows/.NET-capable checkout.
- Smoke test Customer Edit at 125%, 150%, and 200% Windows scaling for wrapping sections, disabled Save until required data exists, Save/Cancel reachability, field editing, and duplicate-save behavior.