### PR TITLE
Improve Settings keyboard focus responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
@@ -200,6 +200,40 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("var nested = FindVisualChild<T>(child);", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void SettingsPage_CodeBehindAddsCtrlFFocusForActiveTabEditableFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml.cs");
+
+            Assert.Contains("PreviewKeyDown += SettingsPage_PreviewKeyDown;", source, StringComparison.Ordinal);
+            Assert.Contains("private void SettingsPage_PreviewKeyDown(object sender, KeyEventArgs e)", source, StringComparison.Ordinal);
+            Assert.Contains("e.Key != Key.F || (Keyboard.Modifiers & ModifierKeys.Control) != ModifierKeys.Control", source, StringComparison.Ordinal);
+            Assert.Contains("var target = FindFirstEditableTextBoxInActiveTab() ?? FindFirstEditableTextBox(this);", source, StringComparison.Ordinal);
+            Assert.Contains("target.Focus();", source, StringComparison.Ordinal);
+            Assert.Contains("target.SelectAll();", source, StringComparison.Ordinal);
+            Assert.Contains("e.Handled = true;", source, StringComparison.Ordinal);
+            Assert.Contains("private TextBox? FindFirstEditableTextBoxInActiveTab()", source, StringComparison.Ordinal);
+            Assert.Contains("tabControl?.SelectedContent is DependencyObject selectedContent", source, StringComparison.Ordinal);
+            Assert.Contains("tabControl?.SelectedItem is TabItem { Content: DependencyObject selectedTabContent }", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SettingsPage_CodeBehindFiltersFocusTargetsWithoutRecursiveTraversal()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml.cs");
+
+            Assert.Contains("private static TextBox? FindFirstEditableTextBox(DependencyObject parent)", source, StringComparison.Ordinal);
+            Assert.Contains("var pending = new Stack<DependencyObject>();", source, StringComparison.Ordinal);
+            Assert.Contains("if (current is TextBox textBox && IsUsableFocusTarget(textBox))", source, StringComparison.Ordinal);
+            Assert.Contains("private static bool IsUsableFocusTarget(TextBox textBox)", source, StringComparison.Ordinal);
+            Assert.Contains("textBox.IsVisible", source, StringComparison.Ordinal);
+            Assert.Contains("textBox.IsEnabled", source, StringComparison.Ordinal);
+            Assert.Contains("!textBox.IsReadOnly", source, StringComparison.Ordinal);
+            Assert.Contains("textBox.Focusable", source, StringComparison.Ordinal);
+            Assert.Contains("pending.Push(VisualTreeHelper.GetChild(current, i));", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("FindFirstEditableTextBox(child)", source, StringComparison.Ordinal);
+        }
+
         private static int CountOccurrences(string text, string value)
         {
             var count = 0;

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-settings-keyboard-focus-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-settings-keyboard-focus-responsiveness.md
@@ -1,0 +1,20 @@
+# Settings Keyboard Focus Responsiveness - 2026-07-07
+
+## Completed
+
+- Added a page-level Ctrl+F shortcut on the Settings workbench so operators can jump to the first editable field in the currently selected settings tab.
+- Scoped the shortcut to the active tab first, with a page-level fallback if the selected tab content is not yet available.
+- Selected the target field text after focus so operators can quickly replace long configuration values like connection strings, sender addresses, backup folders, and template text.
+- Skipped hidden, disabled, read-only, and non-focusable text boxes so the shortcut does not land on stale, protected, or unavailable fields.
+- Reused iterative visual-tree traversal rather than recursive lookup to avoid deep visual-tree stack pressure in a large tabbed WPF page.
+- Preserved the existing first-paint initialization, protected-field sync, theme-tab retry, and settings workflow command bindings.
+- Extended Settings source-contract coverage for shortcut registration, active-tab targeting, select-all behavior, focus-target filtering, and non-recursive traversal.
+
+## Why it matters
+
+Settings is a dense administrative workflow with many tabs and long configuration fields. Fast keyboard focus makes the screen feel more responsive during setup and reduces pointer-heavy navigation when operators need to adjust database, email, branding, messaging, or backup values at scaled desktop sizes.
+
+## Validation
+
+- Source-contract coverage was updated in `InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs`.
+- Local WPF runtime testing, screenshots, Windows scaling checks, and `pwsh -File scripts/run-full-validation.ps1` still require a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
@@ -30,6 +30,7 @@ namespace InventoryManagementApp.Views.Pages
             Loaded += SettingsPage_Loaded;
             Unloaded += SettingsPage_Unloaded;
             DataContextChanged += SettingsPage_DataContextChanged;
+            PreviewKeyDown += SettingsPage_PreviewKeyDown;
         }
 
         private void SettingsPage_Loaded(object sender, RoutedEventArgs e)
@@ -56,6 +57,71 @@ namespace InventoryManagementApp.Views.Pages
             AttachViewModel(e.NewValue as SettingsViewModel);
             QueueSensitiveFieldSync(_settingsViewModel);
             StartSettingsInitialization();
+        }
+
+        private void SettingsPage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.F || (Keyboard.Modifiers & ModifierKeys.Control) != ModifierKeys.Control)
+            {
+                return;
+            }
+
+            var target = FindFirstEditableTextBoxInActiveTab() ?? FindFirstEditableTextBox(this);
+            if (target == null)
+            {
+                return;
+            }
+
+            target.Focus();
+            target.SelectAll();
+            e.Handled = true;
+        }
+
+        private TextBox? FindFirstEditableTextBoxInActiveTab()
+        {
+            var tabControl = FindVisualChild<TabControl>(this);
+            if (tabControl?.SelectedContent is DependencyObject selectedContent)
+            {
+                return FindFirstEditableTextBox(selectedContent);
+            }
+
+            if (tabControl?.SelectedItem is TabItem { Content: DependencyObject selectedTabContent })
+            {
+                return FindFirstEditableTextBox(selectedTabContent);
+            }
+
+            return null;
+        }
+
+        private static TextBox? FindFirstEditableTextBox(DependencyObject parent)
+        {
+            var pending = new Stack<DependencyObject>();
+            pending.Push(parent);
+
+            while (pending.Count > 0)
+            {
+                var current = pending.Pop();
+                if (current is TextBox textBox && IsUsableFocusTarget(textBox))
+                {
+                    return textBox;
+                }
+
+                var childCount = GetVisualChildrenCount(current);
+                for (var i = childCount - 1; i >= 0; i--)
+                {
+                    pending.Push(VisualTreeHelper.GetChild(current, i));
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsUsableFocusTarget(TextBox textBox)
+        {
+            return textBox.IsVisible
+                && textBox.IsEnabled
+                && !textBox.IsReadOnly
+                && textBox.Focusable;
         }
 
         private void AddThemeDesignerTab()


### PR DESCRIPTION
## What changed

- Added a page-level Ctrl+F shortcut on the Settings workbench.
- Targeted the first editable text field in the currently selected Settings tab before falling back to the page.
- Selected the focused field text so long settings values can be replaced quickly.
- Skipped hidden, disabled, read-only, and non-focusable text boxes.
- Used iterative visual-tree traversal for the focus search instead of recursive lookup.
- Preserved the existing Settings first-paint initialization, protected-field sync, theme-tab retry, and workflow command bindings.
- Added source-contract coverage for shortcut registration, active-tab lookup, focus/select behavior, focus-target filtering, and non-recursive traversal.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-07-settings-keyboard-focus-responsiveness.md`.

## Why this was highest value

Recent Settings work hardened layout and lifecycle behavior, but the Settings desk is still a dense multi-tab admin workflow with long configuration fields. Keyboard access to the active tab's editable field improves perceived responsiveness and setup speed without repeating the broader layout work already completed.

## Why this is real progress

This is a focused workflow-level slice across Settings keyboard behavior, safe visual traversal, source-contract coverage, and progress notes. It improves operator speed and scaled-desktop usability while keeping the change small enough to be safe in the connector-only scheduled environment.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, three focused commits ahead, and limited to Settings code-behind, Settings responsive contracts, and one progress note.
- GitHub connector readback confirmed the Ctrl+F handler, active-tab editable field lookup, focus/select behavior, target filtering, and contract assertions on the branch.
- GitHub connector status/workflow readback found no attached commit statuses or workflow runs for head `31efb352ac7c8d8bf8e18a1b9879c35cf8ad5c33` before PR creation.

## Could not check

- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime smoke tests, screenshots, or Windows scaling checks because this scheduled Linux environment cannot clone the repo directly due GitHub HTTP 403 and does not provide Windows/.NET/WPF tooling.

## Follow-up

- Run the full validation runner on a Windows/.NET-capable checkout.
- Smoke test Settings Ctrl+F across Database, General, Email, Branding, Messaging, and Backups tabs at 125%, 150%, and 200% Windows scaling.