### PR TITLE
Improve Rental History export responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs
@@ -12,6 +12,7 @@ namespace InventoryManagementApp.Tests
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
 
             Assert.Contains("Width=\"1040\" Height=\"660\" MinWidth=\"760\" MinHeight=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"RentalHistoryRoot\" Margin=\"10\" MinWidth=\"0\" ClipToBounds=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
             Assert.Contains("x:Key=\"RentalHistoryMetricCard\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"MinWidth\" Value=\"190\"/>", xaml, StringComparison.Ordinal);
@@ -47,6 +48,7 @@ namespace InventoryManagementApp.Tests
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
 
             Assert.Contains("x:Name=\"RentalHistoryDataGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsEnabled=\"{Binding IsHistoryActionReady}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
@@ -58,13 +60,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RentalHistoryWindow_BoundsEmptyFilteringAndOmittedRowStates()
+        public void RentalHistoryWindow_BoundsEmptyBusyAndOmittedRowStates()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
 
             Assert.Contains("Style=\"{StaticResource Card}\" Padding=\"0\" MinWidth=\"0\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Grid MinWidth=\"0\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<RowDefinition Height=\"Auto\"/>\n                    <RowDefinition Height=\"*\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Search and CSV export run off the UI path; row actions pause while work is active.", xaml, StringComparison.Ordinal);
             Assert.Contains("MaxWidth=\"520\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border Grid.Row=\"2\" Margin=\"8,0,8,8\" MaxWidth=\"780\" HorizontalAlignment=\"Left\">", xaml, StringComparison.Ordinal);
             Assert.Contains("Binding=\"{Binding HasOmittedHistoryRows}\" Value=\"True\"", xaml, StringComparison.Ordinal);
@@ -72,9 +75,12 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Binding=\"{Binding IsEmptyStateVisible}\" Value=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding EmptyStateTitle}\" Style=\"{StaticResource SectionHeader}\" TextAlignment=\"Center\" TextWrapping=\"Wrap\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding EmptyStateMessage}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Border MaxWidth=\"300\" Margin=\"12\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Top\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("Binding=\"{Binding IsFiltering}\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border MaxWidth=\"340\" Margin=\"12\" HorizontalAlignment=\"Center\" VerticalAlignment=\"Top\" IsHitTestVisible=\"True\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Binding=\"{Binding IsHistoryBusy}\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Working on rental history", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding HistoryBusyStatus}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Binding=\"{Binding HasNoResults}\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Binding=\"{Binding IsFiltering}\" Value=\"True\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Width=\"360\" HorizontalAlignment=\"Center\"", xaml, StringComparison.Ordinal);
         }
 
@@ -98,6 +104,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("HistoryRow_PreviewMouseRightButtonDown", xaml, StringComparison.Ordinal);
             Assert.Contains("Open Details", xaml, StringComparison.Ordinal);
             Assert.Contains("Export Current View", xaml, StringComparison.Ordinal);
+            Assert.Contains("ToolTip=\"{Binding ExportSummary}\"", xaml, StringComparison.Ordinal);
 
             Assert.Contains("PreviewKeyDown += RentalHistoryWindow_PreviewKeyDown;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F", codeBehind, StringComparison.Ordinal);
@@ -108,19 +115,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RentalHistoryWindow_BlocksStaleRowActionsWhileFiltering()
+        public void RentalHistoryWindow_BlocksStaleRowActionsWhileBusy()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml");
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "RentalHistoryWindow.xaml.cs");
 
             Assert.Contains("IsEnabled=\"{Binding IsHistoryActionReady}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("if (vm.IsFiltering && IsRentalHistoryActionShortcut(e))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!vm.IsHistoryActionReady && IsRentalHistoryActionShortcut(e))", codeBehind, StringComparison.Ordinal);
             Assert.Contains("private static bool IsRentalHistoryActionShortcut(KeyEventArgs e)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("return e.Key is Key.D or Key.E;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("return Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("if (vm.IsFiltering)\n            {\n                e.Handled = true;\n                return;\n            }", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("DataContext is RentalHistoryViewModel { IsFiltering: true }", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("e.Handled = true;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("if (!vm.IsHistoryActionReady)\n            {\n                e.Handled = true;\n                return;\n            }", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DataContext is RentalHistoryViewModel { IsHistoryActionReady: false }", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (vm.IsFiltering && IsRentalHistoryActionShortcut(e))", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("DataContext is RentalHistoryViewModel { IsFiltering: true }", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -142,22 +150,59 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RentalHistoryViewModel_DisablesActionsAndEmptyStateDuringFiltering()
+        public void RentalHistoryViewModel_DisablesActionsAndEmptyStateDuringBusyWork()
         {
             var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
 
-            Assert.Contains("public bool IsEmptyStateVisible => HasNoResults && !IsFiltering;", viewModel, StringComparison.Ordinal);
-            Assert.Contains("public bool CanOpenDetails => SelectedEntry != null && !IsFiltering;", viewModel, StringComparison.Ordinal);
-            Assert.Contains("public bool CanExportHistory => History.Count > 0 && !IsFiltering;", viewModel, StringComparison.Ordinal);
-            Assert.Contains("public bool CanClearSearch => !IsFiltering && (HasActiveSearch || !string.IsNullOrWhiteSpace(SearchText));", viewModel, StringComparison.Ordinal);
-            Assert.Contains("public bool IsHistoryActionReady => !IsFiltering;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool IsHistoryBusy => IsFiltering || IsExportingCsv;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool IsEmptyStateVisible => HasNoResults && !IsHistoryBusy;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanOpenDetails => SelectedEntry != null && !IsHistoryBusy;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanExportHistory => History.Count > 0 && !IsHistoryBusy;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanClearSearch => !IsHistoryBusy && (HasActiveSearch || !string.IsNullOrWhiteSpace(SearchText));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool IsHistoryActionReady => !IsHistoryBusy;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string HistoryBusyStatus => IsExportingCsv", viewModel, StringComparison.Ordinal);
+            Assert.Contains("SearchCommand = new AsyncRelayCommand(ExecuteSearchAsync, () => !IsHistoryBusy);", viewModel, StringComparison.Ordinal);
             Assert.Contains("ClearSearchCommand = new RelayCommand(ClearSearch, () => CanClearSearch);", viewModel, StringComparison.Ordinal);
             Assert.Contains("OpenDetailsCommand = new RelayCommand(OpenDetails, () => CanOpenDetails);", viewModel, StringComparison.Ordinal);
-            Assert.Contains("ExportCsvCommand = new RelayCommand(ExportCsv, () => CanExportHistory);", viewModel, StringComparison.Ordinal);
-            Assert.Contains("OpenDetailsCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
-            Assert.Contains("ClearSearchCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
-            Assert.Contains("OnPropertyChanged(nameof(IsHistoryActionReady));", viewModel, StringComparison.Ordinal);
             Assert.Contains("if (!CanOpenDetails || SelectedEntry == null)", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryViewModel_ExportsCsvAsynchronouslyWithBusyStateAndSnapshotRows()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
+
+            Assert.Contains("private bool _isExportingCsv;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool IsExportingCsv", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public IAsyncRelayCommand ExportCsvCommand { get; }", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ExportCsvCommand = new AsyncRelayCommand(ExportCsvAsync, () => CanExportHistory);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("async Task ExportCsvAsync()", viewModel, StringComparison.Ordinal);
+            Assert.Contains("var visibleRows = History.ToList();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("var filteredView = SearchStatus;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("IsExportingCsv = true;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("var csv = await Task.Run(() => BuildCsv(visibleRows, filteredView));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("await File.WriteAllTextAsync(path, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("finally\n            {\n                IsExportingCsv = false;\n            }", viewModel, StringComparison.Ordinal);
+            Assert.Contains("static string BuildCsv(IReadOnlyList<RentalModel> rows, string filteredView)", viewModel, StringComparison.Ordinal);
+            Assert.DoesNotContain("void ExportCsv()", viewModel, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var r in History)", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryViewModel_NotifiesCommandsAndStatusForBusyTransitions()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "RentalHistoryViewModel.cs");
+
+            Assert.Contains("void NotifyBusyStateChanged()", viewModel, StringComparison.Ordinal);
+            Assert.Contains("SearchCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ClearSearchCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OpenDetailsCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ExportCsvCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsHistoryBusy));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(HistoryBusyStatus));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsHistoryActionReady));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ExportSummary));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("SearchCommand.NotifyCanExecuteChanged();\n            ClearSearchCommand.NotifyCanExecuteChanged();\n            OpenDetailsCommand.NotifyCanExecuteChanged();\n            ExportCsvCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-rental-history-export-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-rental-history-export-responsiveness.md
@@ -1,0 +1,27 @@
+# Rental History Export Responsiveness
+
+Date: 2026-07-06
+
+## Completed
+
+- Converted Rental History CSV export from a synchronous command into an async command so large visible histories do not block the dialog while the CSV is prepared and written.
+- Added `IsExportingCsv` and shared `IsHistoryBusy` state so search, details, clear search, export, context menu, grid actions, double-click, right-click retargeting, and action shortcuts pause consistently during export or filtering.
+- Snapshotted the visible rows and current filter status before export so the CSV represents the operator's current view while avoiding enumeration of the live UI collection during file generation.
+- Moved CSV body construction onto a background task and used asynchronous file writing for the final output.
+- Added export-specific status and summary text so operators see that a CSV is being prepared and why actions are temporarily unavailable.
+- Added a bounded Rental History busy overlay shared by filtering and export, with hit testing enabled to prevent stale row interaction while work is active.
+- Bound the rental-history grid enabled state to action readiness so selection and row gestures do not compete with filtering/export work.
+- Updated toolbar and footer export tooltips to reuse the export summary, including omitted-row guidance and busy-state guidance.
+- Tightened the window root with `ClipToBounds` and `MinWidth=0` to reduce scaled desktop overflow risk.
+- Updated keyboard and mouse guards to use the shared busy state instead of filtering-only checks.
+- Extended source-contract coverage for async export command wiring, busy-state notifications, background CSV construction, async file writing, row snapshotting, disabled grid actions, export tooltips, root bounds, and the shared busy overlay.
+
+## Validation
+
+- Source-contract tests were updated in `InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs` to guard the new responsiveness contracts.
+- GitHub connector readback should be used to confirm the branch contents because this scheduled Linux environment cannot clone the repository directly or run WPF/.NET validation.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test Rental History CSV export with no filter, an active filter, omitted rows, a canceled save dialog, and a file write failure at 1366 x 768 and higher Windows scaling.

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -53,6 +53,9 @@ namespace InventoryManagementApp.ViewModels.Rental
         {
             get
             {
+                if (IsExportingCsv)
+                    return $"Exporting {History.Count} visible rental record(s) to CSV...";
+
                 if (IsFiltering)
                     return "Searching rental history...";
 
@@ -72,22 +75,37 @@ namespace InventoryManagementApp.ViewModels.Rental
         public bool HasOmittedHistoryRows => OmittedHistoryCount > 0;
         public bool HasActiveSearch => !string.IsNullOrWhiteSpace(AppliedSearchText);
         public bool HasNoResults => History.Count == 0;
-        public bool IsEmptyStateVisible => HasNoResults && !IsFiltering;
-        public bool CanOpenDetails => SelectedEntry != null && !IsFiltering;
-        public bool CanExportHistory => History.Count > 0 && !IsFiltering;
-        public bool CanClearSearch => !IsFiltering && (HasActiveSearch || !string.IsNullOrWhiteSpace(SearchText));
-        public bool IsHistoryActionReady => !IsFiltering;
+        public bool IsHistoryBusy => IsFiltering || IsExportingCsv;
+        public bool IsEmptyStateVisible => HasNoResults && !IsHistoryBusy;
+        public bool CanOpenDetails => SelectedEntry != null && !IsHistoryBusy;
+        public bool CanExportHistory => History.Count > 0 && !IsHistoryBusy;
+        public bool CanClearSearch => !IsHistoryBusy && (HasActiveSearch || !string.IsNullOrWhiteSpace(SearchText));
+        public bool IsHistoryActionReady => !IsHistoryBusy;
+        public string HistoryBusyStatus => IsExportingCsv
+            ? $"Preparing a CSV export for {History.Count} visible rental record(s). The dialog remains responsive while the file is written."
+            : "Searching rental history off the UI path...";
         public string EmptyStateTitle => HasActiveSearch ? "No matching rental records" : "No rental history records";
         public string EmptyStateMessage => HasActiveSearch
             ? "Clear the search or try a rental number, item number, customer, location, status, or date."
             : "Previous rental activity for this item will appear here once records exist.";
-        public string ExportSummary => CanExportHistory
-            ? HasOmittedHistoryRows
-                ? $"Export {History.Count} visible record(s); {OmittedHistoryCount} row(s) are omitted from the current grid for responsiveness."
-                : $"Export {History.Count} visible record(s) to CSV."
-            : IsFiltering
-                ? "Wait for search to finish before exporting."
-                : "No visible rental records to export.";
+        public string ExportSummary
+        {
+            get
+            {
+                if (IsExportingCsv)
+                    return $"Exporting {History.Count} visible record(s); actions are paused until the CSV is ready.";
+
+                if (IsFiltering)
+                    return "Wait for search to finish before exporting.";
+
+                if (History.Count == 0)
+                    return "No visible rental records to export.";
+
+                return HasOmittedHistoryRows
+                    ? $"Export {History.Count} visible record(s); {OmittedHistoryCount} row(s) are omitted from the current grid for responsiveness."
+                    : $"Export {History.Count} visible record(s) to CSV.";
+            }
+        }
         public string SelectedEntrySummary => SelectedEntry == null
             ? "Select a rental row to see holder, dates, and status. Double-click any row for details."
             : $"Rental #{SelectedEntry.RentalID} | {SelectedEntry.ItemNumber} | {SelectedEntry.CustomerName} | {SelectedEntry.Status}";
@@ -132,19 +150,18 @@ namespace InventoryManagementApp.ViewModels.Rental
             private set
             {
                 if (SetProperty(ref _isFiltering, value))
-                {
-                    SearchCommand.NotifyCanExecuteChanged();
-                    ClearSearchCommand.NotifyCanExecuteChanged();
-                    OpenDetailsCommand.NotifyCanExecuteChanged();
-                    ExportCsvCommand.NotifyCanExecuteChanged();
-                    OnPropertyChanged(nameof(SearchStatus));
-                    OnPropertyChanged(nameof(IsEmptyStateVisible));
-                    OnPropertyChanged(nameof(CanOpenDetails));
-                    OnPropertyChanged(nameof(CanExportHistory));
-                    OnPropertyChanged(nameof(CanClearSearch));
-                    OnPropertyChanged(nameof(IsHistoryActionReady));
-                    OnPropertyChanged(nameof(ExportSummary));
-                }
+                    NotifyBusyStateChanged();
+            }
+        }
+
+        private bool _isExportingCsv;
+        public bool IsExportingCsv
+        {
+            get => _isExportingCsv;
+            private set
+            {
+                if (SetProperty(ref _isExportingCsv, value))
+                    NotifyBusyStateChanged();
             }
         }
 
@@ -170,7 +187,7 @@ namespace InventoryManagementApp.ViewModels.Rental
         public IAsyncRelayCommand SearchCommand { get; }
         public IRelayCommand ClearSearchCommand { get; }
         public IRelayCommand OpenDetailsCommand { get; }
-        public IRelayCommand ExportCsvCommand { get; }
+        public IAsyncRelayCommand ExportCsvCommand { get; }
         public IRelayCommand CloseCommand { get; }
 
         public RentalHistoryViewModel(ItemModel? item, IEnumerable<RentalModel>? history, IDialogService dialogService, ILogger<RentalHistoryViewModel>? logger = null)
@@ -189,10 +206,10 @@ namespace InventoryManagementApp.ViewModels.Rental
             _logger = logger ?? NullLogger<RentalHistoryViewModel>.Instance;
             _dialogService = dialogService;
 
-            SearchCommand = new AsyncRelayCommand(ExecuteSearchAsync, () => !IsFiltering);
+            SearchCommand = new AsyncRelayCommand(ExecuteSearchAsync, () => !IsHistoryBusy);
             ClearSearchCommand = new RelayCommand(ClearSearch, () => CanClearSearch);
             OpenDetailsCommand = new RelayCommand(OpenDetails, () => CanOpenDetails);
-            ExportCsvCommand = new RelayCommand(ExportCsv, () => CanExportHistory);
+            ExportCsvCommand = new AsyncRelayCommand(ExportCsvAsync, () => CanExportHistory);
             CloseCommand = new RelayCommand(CloseWindow);
         }
 
@@ -244,7 +261,7 @@ namespace InventoryManagementApp.ViewModels.Rental
             ThrowIfDisposed();
 
             _searchCts?.Cancel();
-            if (IsFiltering)
+            if (IsHistoryBusy)
                 return;
 
             SearchText = string.Empty;
@@ -282,6 +299,23 @@ namespace InventoryManagementApp.ViewModels.Rental
                 : History.FirstOrDefault();
         }
 
+        void NotifyBusyStateChanged()
+        {
+            SearchCommand.NotifyCanExecuteChanged();
+            ClearSearchCommand.NotifyCanExecuteChanged();
+            OpenDetailsCommand.NotifyCanExecuteChanged();
+            ExportCsvCommand.NotifyCanExecuteChanged();
+            OnPropertyChanged(nameof(SearchStatus));
+            OnPropertyChanged(nameof(IsHistoryBusy));
+            OnPropertyChanged(nameof(HistoryBusyStatus));
+            OnPropertyChanged(nameof(IsEmptyStateVisible));
+            OnPropertyChanged(nameof(CanOpenDetails));
+            OnPropertyChanged(nameof(CanExportHistory));
+            OnPropertyChanged(nameof(CanClearSearch));
+            OnPropertyChanged(nameof(IsHistoryActionReady));
+            OnPropertyChanged(nameof(ExportSummary));
+        }
+
         void NotifyHistoryViewChanged()
         {
             OnPropertyChanged(nameof(ResultsSummary));
@@ -291,6 +325,8 @@ namespace InventoryManagementApp.ViewModels.Rental
             OnPropertyChanged(nameof(OmittedHistoryCount));
             OnPropertyChanged(nameof(HasOmittedHistoryRows));
             OnPropertyChanged(nameof(HasNoResults));
+            OnPropertyChanged(nameof(IsHistoryBusy));
+            OnPropertyChanged(nameof(HistoryBusyStatus));
             OnPropertyChanged(nameof(IsEmptyStateVisible));
             OnPropertyChanged(nameof(CanOpenDetails));
             OnPropertyChanged(nameof(CanExportHistory));
@@ -299,6 +335,7 @@ namespace InventoryManagementApp.ViewModels.Rental
             OnPropertyChanged(nameof(EmptyStateTitle));
             OnPropertyChanged(nameof(EmptyStateMessage));
             OnPropertyChanged(nameof(ExportSummary));
+            SearchCommand.NotifyCanExecuteChanged();
             ClearSearchCommand.NotifyCanExecuteChanged();
             OpenDetailsCommand.NotifyCanExecuteChanged();
             ExportCsvCommand.NotifyCanExecuteChanged();
@@ -326,8 +363,10 @@ namespace InventoryManagementApp.ViewModels.Rental
             _dialogService.ShowInfo(details, "Rental History Details");
         }
 
-        void ExportCsv()
+        async Task ExportCsvAsync()
         {
+            ThrowIfDisposed();
+
             if (!CanExportHistory)
                 return;
 
@@ -353,9 +392,32 @@ namespace InventoryManagementApp.ViewModels.Rental
 
             path ??= Path.Combine(Environment.CurrentDirectory, BuildExportFileName());
 
+            var visibleRows = History.ToList();
+            var filteredView = SearchStatus;
+            IsExportingCsv = true;
+
+            try
+            {
+                var csv = await Task.Run(() => BuildCsv(visibleRows, filteredView));
+                await File.WriteAllTextAsync(path, csv, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+                _dialogService.ShowInfo($"Exported {visibleRows.Count} rental record(s) to {path}.", "Rental History Export");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to export rental history to {Path}", path);
+                _dialogService.ShowInfo($"Failed to export rental history: {ex.Message}", "Error");
+            }
+            finally
+            {
+                IsExportingCsv = false;
+            }
+        }
+
+        static string BuildCsv(IReadOnlyList<RentalModel> rows, string filteredView)
+        {
             var sb = new StringBuilder();
             sb.AppendLine("RentalID,ItemNumber,ItemLocation,CustomerName,RentalDate,DueDate,ReturnDate,Status,FilteredView");
-            foreach (var r in History)
+            foreach (var r in rows)
             {
                 sb.AppendLine(string.Join(',',
                     r.RentalID.ToString(CultureInfo.InvariantCulture),
@@ -366,19 +428,10 @@ namespace InventoryManagementApp.ViewModels.Rental
                     r.DueDate.ToString("o", CultureInfo.InvariantCulture),
                     r.ReturnDate?.ToString("o", CultureInfo.InvariantCulture) ?? string.Empty,
                     Escape(r.Status),
-                    Escape(SearchStatus)));
+                    Escape(filteredView)));
             }
 
-            try
-            {
-                File.WriteAllText(path, sb.ToString(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
-                _dialogService.ShowInfo($"Exported {History.Count} rental record(s) to {path}.", "Rental History Export");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to export rental history to {Path}", path);
-                _dialogService.ShowInfo($"Failed to export rental history: {ex.Message}", "Error");
-            }
+            return sb.ToString();
         }
 
         string BuildExportFileName()

--- a/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
@@ -25,7 +25,7 @@
         </Style>
     </Window.Resources>
 
-    <Grid Margin="10">
+    <Grid x:Name="RentalHistoryRoot" Margin="10" MinWidth="0" ClipToBounds="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -90,7 +90,7 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="Rental Records" Style="{StaticResource SectionHeader}" Margin="0" TextWrapping="Wrap"/>
-                        <TextBlock Grid.Column="1" Text="Search runs off the UI path and matches rental #, item, customer, location, status, and rental dates."
+                        <TextBlock Grid.Column="1" Text="Search and CSV export run off the UI path; row actions pause while work is active."
                                    Style="{StaticResource CaptionTextBlock}"
                                    HorizontalAlignment="Right"
                                    TextWrapping="Wrap"
@@ -111,7 +111,7 @@
                                          SearchLabel=""
                                          Margin="0,0,10,6"/>
                         <TextBlock Text="{Binding SearchStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="360" Margin="0,0,10,6"/>
-                        <Button Style="{StaticResource PrimaryButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" ToolTip="Export the visible history rows (Ctrl+E)" Margin="0,0,0,6"/>
+                        <Button Style="{StaticResource PrimaryButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" ToolTip="{Binding ExportSummary}" Margin="0,0,0,6"/>
                     </WrapPanel>
                 </Border>
 
@@ -133,6 +133,7 @@
                     <DataGrid x:Name="RentalHistoryDataGrid"
                               ItemsSource="{Binding History}"
                               SelectedItem="{Binding SelectedEntry}"
+                              IsEnabled="{Binding IsHistoryActionReady}"
                               IsReadOnly="True"
                               AutoGenerateColumns="False"
                               EnableRowVirtualization="True"
@@ -188,18 +189,21 @@
                                        Margin="0,4,0,0"/>
                         </StackPanel>
                     </Border>
-                    <Border MaxWidth="300" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Top">
+                    <Border MaxWidth="340" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Top" IsHitTestVisible="True">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource AdminHandoffCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsFiltering}" Value="True">
+                                    <DataTrigger Binding="{Binding IsHistoryBusy}" Value="True">
                                         <Setter Property="Visibility" Value="Visible"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
-                        <TextBlock Text="{Binding SearchStatus}" Style="{StaticResource CaptionTextBlock}" TextAlignment="Center" TextWrapping="Wrap"/>
+                        <StackPanel>
+                            <TextBlock Text="Working on rental history" Style="{StaticResource SectionHeader}" TextAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding HistoryBusyStatus}" Style="{StaticResource CaptionTextBlock}" TextAlignment="Center" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                        </StackPanel>
                     </Border>
                 </Grid>
             </Grid>
@@ -214,7 +218,7 @@
                 <TextBlock Grid.Column="0" Text="{Binding SearchStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,12,4"/>
                 <WrapPanel Grid.Column="1" HorizontalAlignment="Right">
                     <Button Style="{StaticResource PrimaryButton}" MinWidth="86" Content="Details" Command="{Binding OpenDetailsCommand}" ToolTip="Open selected rental details (Ctrl+D)" Margin="0,0,6,4"/>
-                    <Button Style="{StaticResource GhostButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" ToolTip="Export the visible history rows (Ctrl+E)" Margin="0,0,6,4"/>
+                    <Button Style="{StaticResource GhostButton}" MinWidth="104" Content="Export CSV" Command="{Binding ExportCsvCommand}" ToolTip="{Binding ExportSummary}" Margin="0,0,6,4"/>
                     <Button Style="{StaticResource GhostButton}" MinWidth="86" Content="Close" Command="{Binding CloseCommand}" ToolTip="Close rental history (Esc)" Margin="0,0,0,4"/>
                 </WrapPanel>
             </Grid>

--- a/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml.cs
@@ -32,7 +32,7 @@ namespace InventoryManagementApp.Views.Windows
             if (DataContext is not RentalHistoryViewModel vm)
                 return;
 
-            if (vm.IsFiltering && IsRentalHistoryActionShortcut(e))
+            if (!vm.IsHistoryActionReady && IsRentalHistoryActionShortcut(e))
             {
                 e.Handled = true;
                 return;
@@ -75,7 +75,7 @@ namespace InventoryManagementApp.Views.Windows
             if (DataContext is not RentalHistoryViewModel vm)
                 return;
 
-            if (vm.IsFiltering)
+            if (!vm.IsHistoryActionReady)
             {
                 e.Handled = true;
                 return;
@@ -90,7 +90,7 @@ namespace InventoryManagementApp.Views.Windows
 
         private void HistoryRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is RentalHistoryViewModel { IsFiltering: true })
+            if (DataContext is RentalHistoryViewModel { IsHistoryActionReady: false })
             {
                 e.Handled = true;
                 return;


### PR DESCRIPTION
## What changed

- Converted Rental History CSV export to an async command with explicit `IsExportingCsv` state.
- Added shared `IsHistoryBusy` readiness so search, details, clear search, export, grid selection, context menu, double-click, right-click retargeting, and shortcuts pause consistently while filtering or exporting.
- Snapshotted visible rows and the current filter/status before CSV generation, then built the CSV off the UI path and wrote the file asynchronously.
- Added export-specific status/summary text, export tooltips, and a bounded busy overlay shared by search and export.
- Tightened the Rental History root bounds and disabled the grid while history work is active.
- Extended Rental History source-contract coverage for async export, busy notifications, row snapshotting, action guards, root bounds, tooltips, and busy overlay behavior.
- Added a progress note for the completed workflow slice.

## Why this was highest value

Recent repo work has focused on loading speed, UI responsiveness, data display, and print/export safety. Rental History already had responsive search and grid virtualization, but export still performed synchronous CSV work from the UI-facing command path and only guarded stale actions while filtering. This completes that workflow more end to end.

## Why this is real progress

This is a full vertical slice across view model behavior, dialog display, keyboard/mouse interaction guards, source-contract coverage, and progress documentation. It improves a data-heavy workflow operators reach from item/rental workflows without adding unrelated features.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, five focused files ahead, and contains the intended source changes.
- Source-contract tests were updated in `InventoryManagementApp.Tests/RentalHistoryWindowResponsiveContractTests.cs`.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- WPF runtime smoke testing
- screenshots / Windows scaling checks
- live CSV export behavior

Those require a Windows/.NET/WPF-capable checkout, which is unavailable in this scheduled Linux environment where direct clone is blocked.

## Follow-up

- Run the full validation script on Windows.
- Smoke test Rental History CSV export with no filter, an active filter, omitted rows, a canceled save dialog, and file write failure at 1366 x 768 and higher Windows scaling.