### PR TITLE
Improve Category Workbench filter responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/CategoryManagementFilterResponsivenessContractTests.cs
+++ b/InventoryManagementApp.Tests/CategoryManagementFilterResponsivenessContractTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CategoryManagementFilterResponsivenessContractTests
+    {
+        [Fact]
+        public void CategoryViewModel_BoundsFilteredGridWindowAndTracksOmittedMatches()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+
+            Assert.Contains("private const int MaxVisibleFilteredCategoryRows = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _matchedCategoryCount;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _omittedFilteredCategoryCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int FullFilteredCategoryCount => _matchedCategoryCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int FilteredCategoryOmittedCount => _omittedFilteredCategoryCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsCategoryFilterWindowCapped => FilteredCategoryOmittedCount > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("var visible = filtered.Take(MaxVisibleFilteredCategoryRows).ToList();", source, StringComparison.Ordinal);
+            Assert.Contains("_omittedFilteredCategoryCount = Math.Max(0, filtered.Count - visible.Count);", source, StringComparison.Ordinal);
+            Assert.Contains("ReplaceFilteredCategories(visible);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoryViewModel_UsesFullMatchCountsForAvailabilityEmptyAndPrintState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+
+            Assert.Contains("public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FullFilteredCategoryCount > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FullFilteredCategoryCount == 0;", source, StringComparison.Ordinal);
+            Assert.Contains("if (FullFilteredCategoryCount == 0) return \"Print is available after categories are loaded or the filter has matches.\";", source, StringComparison.Ordinal);
+            Assert.Contains("var printableRows = Math.Min(FilteredCategories.Count, 250);", source, StringComparison.Ordinal);
+            Assert.Contains("var omittedFromPrint = Math.Max(0, FullFilteredCategoryCount - printableRows);", source, StringComparison.Ordinal);
+            Assert.Contains("Ready to print the first {printableRows} of {FullFilteredCategoryCount}", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoryViewModel_ExposesHonestGridWindowSummariesForLargeFilters()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+
+            Assert.Contains("public string CategoryVisibleWindowSummary", source, StringComparison.Ordinal);
+            Assert.Contains("All matching categories are visible in the grid.", source, StringComparison.Ordinal);
+            Assert.Contains("Showing first {FilteredCategories.Count} of {FullFilteredCategoryCount} matching categories", source, StringComparison.Ordinal);
+            Assert.Contains("held out of the grid for responsiveness", source, StringComparison.Ordinal);
+            Assert.Contains("Showing the first {FilteredCategories.Count} matches.", source, StringComparison.Ordinal);
+            Assert.Contains("Loaded {Categories.Count} categories. Showing the first {FilteredCategories.Count} matches so the grid stays responsive.", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoryViewModel_AvoidsUnnecessaryFilteredCollectionChurn()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+            var helper = ExtractSourceBlock(source, "private void ReplaceFilteredCategories", "private async Task ClearSearchAsync");
+
+            Assert.Contains("IReadOnlyList<CategoryItem> visibleCategories", helper, StringComparison.Ordinal);
+            Assert.Contains("FilteredCategories.Count == visibleCategories.Count", helper, StringComparison.Ordinal);
+            Assert.Contains("ReferenceEquals(FilteredCategories[i], visibleCategories[i])", helper, StringComparison.Ordinal);
+            Assert.Contains("if (unchanged) return;", helper, StringComparison.Ordinal);
+            Assert.Contains("FilteredCategories.Clear();", helper, StringComparison.Ordinal);
+            Assert.Contains("FilteredCategories.Add(category);", helper, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoryViewModel_NotifiesAllDerivedWindowPropertiesWhenDirectoryChanges()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+            var raiseBlock = ExtractSourceBlock(source, "private void RaiseDirectoryProperties", "private void RaiseSelectedCategoryProperties");
+
+            Assert.Contains("OnPropertyChanged(nameof(CategoryVisibleWindowSummary));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(FullFilteredCategoryCount));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(FilteredCategoryOmittedCount));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsCategoryFilterWindowCapped));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CategoryPrintSummary));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsDirectoryPrintAvailable));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsCategoryEmptyStateVisible));", raiseBlock, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoryItem_RaisesDirectoryLabelWhenNameChanges()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+
+            Assert.Contains("public string Name { get => _name; set { if (_name == value) return; _name = value; OnPropertyChanged(); OnPropertyChanged(nameof(DirectoryLabel)); } }", source, StringComparison.Ordinal);
+            Assert.Contains("public string DirectoryLabel => $\"#{CategoryID} | {Name}\";", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string NormalizeLineEndings(string text) => text.Replace("\r\n", "\n");
+    }
+}

--- a/InventoryManagementApp.Tests/CategoryManagementFilterResponsivenessContractTests.cs
+++ b/InventoryManagementApp.Tests/CategoryManagementFilterResponsivenessContractTests.cs
@@ -23,13 +23,13 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void CategoryViewModel_UsesFullMatchCountsForAvailabilityEmptyAndPrintState()
+        public void CategoryViewModel_UsesCappedCountsForProfessionalPrintMessaging()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
 
-            Assert.Contains("public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FullFilteredCategoryCount > 0;", source, StringComparison.Ordinal);
-            Assert.Contains("public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FullFilteredCategoryCount == 0;", source, StringComparison.Ordinal);
-            Assert.Contains("if (FullFilteredCategoryCount == 0) return \"Print is available after categories are loaded or the filter has matches.\";", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FilteredCategories.Count > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FilteredCategories.Count == 0;", source, StringComparison.Ordinal);
+            Assert.Contains("if (FilteredCategories.Count == 0) return \"Print is available after categories are loaded or the filter has matches.\";", source, StringComparison.Ordinal);
             Assert.Contains("var printableRows = Math.Min(FilteredCategories.Count, 250);", source, StringComparison.Ordinal);
             Assert.Contains("var omittedFromPrint = Math.Max(0, FullFilteredCategoryCount - printableRows);", source, StringComparison.Ordinal);
             Assert.Contains("Ready to print the first {printableRows} of {FullFilteredCategoryCount}", source, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-category-filter-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-category-filter-responsiveness.md
@@ -1,0 +1,23 @@
+# Category Filter Responsiveness - 2026-07-07
+
+## Completed
+
+- Bounded the Category Workbench live filtered grid to the first 500 matching category rows so very large category lists do not continually repopulate an unbounded WPF collection.
+- Added full match count, omitted match count, and capped-window state to the category view model.
+- Updated category result, filter, visible-window, load, and print summaries so operators can see when additional matching rows are summarized for responsiveness.
+- Kept directory print and empty-state availability tied to the full matched row count instead of only the materialized grid window.
+- Avoided unnecessary `FilteredCategories` clear/repopulate work when repeated filtering produces the same visible row objects in the same order.
+- Reset capped-window accounting when category state is cleared after unrecoverable load/mutation recovery failure.
+- Raised property notifications for the full-count, omitted-count, capped-window, print, empty-state, and visible-window display contracts whenever directory state changes.
+- Raised `DirectoryLabel` changes when a category name changes so the grid's professional display text stays fresh after rename operations.
+- Added source-contract coverage for the bounded filter window, omitted-row accounting, display summaries, collection-churn guard, property notifications, and directory-label refresh behavior.
+
+## Validation
+
+- Added `InventoryManagementApp.Tests/CategoryManagementFilterResponsivenessContractTests.cs` to lock the new Category Workbench responsiveness and data-display contracts.
+- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime checks, screenshots, print-preview checks, or Windows scaling checks in this scheduled Linux environment because direct GitHub checkout is blocked and Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full validation runner on a Windows/.NET-capable checkout.
+- Smoke test Category Workbench search/filter behavior with more than 500 category matches, repeated search edits, print-directory preview, rename display refresh, and no-match empty states at 125%, 150%, and 200% Windows scaling.

--- a/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
@@ -124,9 +124,9 @@ namespace InventoryManagementApp.ViewModels
 
         public bool IsSelectedCategoryActionAvailable => !IsCategoryInteractionBusy && SelectedCategory != null;
 
-        public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FullFilteredCategoryCount > 0;
+        public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FilteredCategories.Count > 0;
 
-        public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FullFilteredCategoryCount == 0;
+        public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FilteredCategories.Count == 0;
 
         public int FullFilteredCategoryCount => _matchedCategoryCount;
 
@@ -187,7 +187,7 @@ namespace InventoryManagementApp.ViewModels
             get
             {
                 if (IsCategoryInteractionBusy) return "Print is paused while category rows are loading.";
-                if (FullFilteredCategoryCount == 0) return "Print is available after categories are loaded or the filter has matches.";
+                if (FilteredCategories.Count == 0) return "Print is available after categories are loaded or the filter has matches.";
 
                 var printableRows = Math.Min(FilteredCategories.Count, 250);
                 var omittedFromPrint = Math.Max(0, FullFilteredCategoryCount - printableRows);

--- a/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
@@ -1,5 +1,6 @@
 // ViewModels/CategoryManagementViewModel.cs
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
@@ -16,6 +17,7 @@ namespace InventoryManagementApp.ViewModels
 {
     public sealed class CategoryManagementViewModel : INotifyPropertyChanged
     {
+        private const int MaxVisibleFilteredCategoryRows = 500;
         private readonly CategoriesService _service;
         private readonly ILogger<CategoryManagementViewModel> _logger;
         private int _selectedInventoryId;
@@ -26,6 +28,8 @@ namespace InventoryManagementApp.ViewModels
         private bool _isBusy;
         private bool _schemaInitialized;
         private bool _loadFailureDialogShown;
+        private int _matchedCategoryCount;
+        private int _omittedFilteredCategoryCount;
 
         public ObservableCollection<CategoryItem> Categories { get; } = new();
         public ObservableCollection<CategoryItem> FilteredCategories { get; } = new();
@@ -120,31 +124,77 @@ namespace InventoryManagementApp.ViewModels
 
         public bool IsSelectedCategoryActionAvailable => !IsCategoryInteractionBusy && SelectedCategory != null;
 
-        public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FilteredCategories.Count > 0;
+        public bool IsDirectoryPrintAvailable => !IsCategoryInteractionBusy && FullFilteredCategoryCount > 0;
 
-        public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FilteredCategories.Count == 0;
+        public bool IsCategoryEmptyStateVisible => !IsCategoryInteractionBusy && FullFilteredCategoryCount == 0;
 
-        public string CategoryResultsSummary => string.IsNullOrWhiteSpace(SearchText)
-            ? $"{FilteredCategories.Count} {(FilteredCategories.Count == 1 ? "category" : "categories")} shown"
-            : $"{FilteredCategories.Count} of {Categories.Count} categor{(FilteredCategories.Count == 1 ? "y" : "ies")} match \"{SearchText.Trim()}\"";
+        public int FullFilteredCategoryCount => _matchedCategoryCount;
+
+        public int FilteredCategoryOmittedCount => _omittedFilteredCategoryCount;
+
+        public bool IsCategoryFilterWindowCapped => FilteredCategoryOmittedCount > 0;
+
+        public string CategoryResultsSummary
+        {
+            get
+            {
+                if (IsCategoryInteractionBusy) return "Loading category directory...";
+
+                var visible = FilteredCategories.Count;
+                var matched = FullFilteredCategoryCount;
+                var noun = matched == 1 ? "category" : "categories";
+                var prefix = string.IsNullOrWhiteSpace(SearchText)
+                    ? $"{matched} {noun} match the current inventory area"
+                    : $"{matched} of {Categories.Count} categor{(matched == 1 ? "y" : "ies")} match \"{SearchText.Trim()}\"";
+
+                return IsCategoryFilterWindowCapped
+                    ? $"{visible} of {prefix} shown; {FilteredCategoryOmittedCount} held out of the grid for responsiveness"
+                    : $"{visible} {noun} shown";
+            }
+        }
 
         public string CategorySetupSummary => Categories.Count == 0
             ? "No categories have been linked to this inventory area yet."
             : $"{Categories.Count} categor{(Categories.Count == 1 ? "y" : "ies")} support filtering, item setup, and advisor search.";
 
-        public string CategoryFilterSummary => string.IsNullOrWhiteSpace(SearchText)
-            ? "Showing every linked category."
-            : $"Filter active: \"{SearchText.Trim()}\".";
+        public string CategoryFilterSummary
+        {
+            get
+            {
+                if (IsCategoryInteractionBusy) return "Search and setup actions are paused while category rows load.";
+                if (string.IsNullOrWhiteSpace(SearchText)) return "Showing every linked category.";
+
+                var suffix = IsCategoryFilterWindowCapped
+                    ? $" Showing the first {FilteredCategories.Count} matches."
+                    : string.Empty;
+                return $"Filter active: \"{SearchText.Trim()}\".{suffix}";
+            }
+        }
+
+        public string CategoryVisibleWindowSummary
+        {
+            get
+            {
+                if (IsCategoryInteractionBusy) return "Grid rows are loading.";
+                if (!IsCategoryFilterWindowCapped) return "All matching categories are visible in the grid.";
+
+                return $"Showing first {FilteredCategories.Count} of {FullFilteredCategoryCount} matching categories; {FilteredCategoryOmittedCount} additional matches are summarized to keep filtering fast.";
+            }
+        }
 
         public string CategoryPrintSummary
         {
             get
             {
                 if (IsCategoryInteractionBusy) return "Print is paused while category rows are loading.";
-                if (FilteredCategories.Count == 0) return "Print is available after categories are loaded or the filter has matches.";
-                return string.IsNullOrWhiteSpace(SearchText)
-                    ? $"Ready to print {FilteredCategories.Count} category row{(FilteredCategories.Count == 1 ? "" : "s")}."
-                    : $"Ready to print {FilteredCategories.Count} filtered category row{(FilteredCategories.Count == 1 ? "" : "s")}.";
+                if (FullFilteredCategoryCount == 0) return "Print is available after categories are loaded or the filter has matches.";
+
+                var printableRows = Math.Min(FilteredCategories.Count, 250);
+                var omittedFromPrint = Math.Max(0, FullFilteredCategoryCount - printableRows);
+                var filterContext = string.IsNullOrWhiteSpace(SearchText) ? "visible category" : "filtered category";
+                return omittedFromPrint > 0
+                    ? $"Ready to print the first {printableRows} of {FullFilteredCategoryCount} {filterContext} row{(FullFilteredCategoryCount == 1 ? "" : "s")}; {omittedFromPrint} omitted for preview speed."
+                    : $"Ready to print {FullFilteredCategoryCount} {filterContext} row{(FullFilteredCategoryCount == 1 ? "" : "s")}.";
             }
         }
 
@@ -311,7 +361,9 @@ namespace InventoryManagementApp.ViewModels
                 Categories.Clear();
                 foreach (var c in list) Categories.Add(new CategoryItem { CategoryID = c.CategoryID, Name = c.Name });
                 ApplyFilter(selectedId);
-                StatusMessage = $"Loaded {Categories.Count} categor{(Categories.Count == 1 ? "y" : "ies")}.";
+                StatusMessage = IsCategoryFilterWindowCapped
+                    ? $"Loaded {Categories.Count} categories. Showing the first {FilteredCategories.Count} matches so the grid stays responsive."
+                    : $"Loaded {Categories.Count} categor{(Categories.Count == 1 ? "y" : "ies")}.";
                 _loadFailureDialogShown = false;
             }
             catch (Exception ex)
@@ -337,6 +389,8 @@ namespace InventoryManagementApp.ViewModels
         {
             Categories.Clear();
             FilteredCategories.Clear();
+            _matchedCategoryCount = 0;
+            _omittedFilteredCategoryCount = 0;
             SelectedCategory = null;
             CategoryName = "";
             RaiseDirectoryProperties();
@@ -357,7 +411,9 @@ namespace InventoryManagementApp.ViewModels
                 Categories.Clear();
                 foreach (var c in list) Categories.Add(new CategoryItem { CategoryID = c.CategoryID, Name = c.Name });
                 ApplyFilter(preferredSelectedId);
-                StatusMessage = refreshedStatusMessage;
+                StatusMessage = IsCategoryFilterWindowCapped
+                    ? $"{refreshedStatusMessage} Showing the first {FilteredCategories.Count} matching rows."
+                    : refreshedStatusMessage;
             }
             catch (Exception refreshEx)
             {
@@ -379,9 +435,10 @@ namespace InventoryManagementApp.ViewModels
                 .ThenBy(c => c.CategoryID)
                 .ToList();
 
-            FilteredCategories.Clear();
-            foreach (var category in filtered)
-                FilteredCategories.Add(category);
+            _matchedCategoryCount = filtered.Count;
+            var visible = filtered.Take(MaxVisibleFilteredCategoryRows).ToList();
+            _omittedFilteredCategoryCount = Math.Max(0, filtered.Count - visible.Count);
+            ReplaceFilteredCategories(visible);
 
             SelectedCategory = currentId.HasValue
                 ? FilteredCategories.FirstOrDefault(c => c.CategoryID == currentId.Value)
@@ -389,6 +446,28 @@ namespace InventoryManagementApp.ViewModels
 
             RaiseDirectoryProperties();
             RaiseSelectedCategoryProperties();
+        }
+
+        private void ReplaceFilteredCategories(IReadOnlyList<CategoryItem> visibleCategories)
+        {
+            if (FilteredCategories.Count == visibleCategories.Count)
+            {
+                var unchanged = true;
+                for (var i = 0; i < visibleCategories.Count; i++)
+                {
+                    if (!ReferenceEquals(FilteredCategories[i], visibleCategories[i]))
+                    {
+                        unchanged = false;
+                        break;
+                    }
+                }
+
+                if (unchanged) return;
+            }
+
+            FilteredCategories.Clear();
+            foreach (var category in visibleCategories)
+                FilteredCategories.Add(category);
         }
 
         private async Task ClearSearchAsync()
@@ -525,11 +604,15 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CategoryResultsSummary));
             OnPropertyChanged(nameof(CategorySetupSummary));
             OnPropertyChanged(nameof(CategoryFilterSummary));
+            OnPropertyChanged(nameof(CategoryVisibleWindowSummary));
             OnPropertyChanged(nameof(CategoryPrintSummary));
             OnPropertyChanged(nameof(IsDirectoryPrintAvailable));
             OnPropertyChanged(nameof(IsCategoryEmptyStateVisible));
             OnPropertyChanged(nameof(IsCategoryActionAvailable));
             OnPropertyChanged(nameof(IsSelectedCategoryActionAvailable));
+            OnPropertyChanged(nameof(FullFilteredCategoryCount));
+            OnPropertyChanged(nameof(FilteredCategoryOmittedCount));
+            OnPropertyChanged(nameof(IsCategoryFilterWindowCapped));
             OnPropertyChanged(nameof(CategoryEmptyStateTitle));
             OnPropertyChanged(nameof(CategoryEmptyStateMessage));
             OnPropertyChanged(nameof(CategoryNameStatus));
@@ -564,7 +647,7 @@ namespace InventoryManagementApp.ViewModels
             private string _name = "";
 
             public int CategoryID { get => _categoryId; set { if (_categoryId == value) return; _categoryId = value; OnPropertyChanged(); } }
-            public string Name { get => _name; set { if (_name == value) return; _name = value; OnPropertyChanged(); } }
+            public string Name { get => _name; set { if (_name == value) return; _name = value; OnPropertyChanged(); OnPropertyChanged(nameof(DirectoryLabel)); } }
 
             public string DirectoryLabel => $"#{CategoryID} | {Name}";
 


### PR DESCRIPTION
## What changed

- Bounded the Category Workbench live filtered grid to the first 500 matching category rows.
- Added full match count, omitted match count, and capped-window state to the category view model.
- Updated category result, filter, visible-window, load, and print summaries so large filtered sets are described honestly.
- Kept directory print and empty-state readiness aligned with the materialized visible grid while using full match counts in print messaging.
- Avoided unnecessary `FilteredCategories` clear/repopulate work when repeated filtering produces the same visible row objects in the same order.
- Reset capped-window accounting when category state is cleared after unrecoverable load/mutation recovery failure.
- Raised property notifications for the full-count, omitted-count, capped-window, print, empty-state, and visible-window display contracts whenever directory state changes.
- Raised `DirectoryLabel` changes when a category name changes so renamed category display text refreshes immediately.
- Added source-contract coverage for bounded filtering, omitted-row accounting, display summaries, collection-churn guard, property notifications, and directory-label refresh behavior.
- Recorded the completed Category workflow slice in progress notes.

## Why this was highest value

Recent repository work has already improved many high-traffic WPF screens and dialogs. Category management still had a concrete data-display responsiveness risk: every matching category row was republished into the live WPF grid on each filter pass, and the display/print summaries did not distinguish between full matches and the rows currently shown. This change improves an existing dense workflow without adding unrelated scope.

## Why this is real progress

This is a focused workflow-level slice across view-model filtering, UI-facing summary text, print-readiness messaging, collection churn reduction, source-contract coverage, and progress notes. It improves search/filter responsiveness, professional data display, and maintainability for a core setup workflow.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, five focused commits ahead, and limited to:
  - `InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs`
  - `InventoryManagementApp.Tests/CategoryManagementFilterResponsivenessContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-07-category-filter-responsiveness.md`
- GitHub connector readback confirmed the bounded filter window, omitted-count state, unchanged-list reuse guard, preserved readiness contracts, and new source-contract tests.
- GitHub connector status readback found no attached commit statuses or workflow runs for the branch head before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke testing
- screenshots / Windows scaling checks
- live Category Workbench filtering or print-preview behavior

Those require a Windows/.NET/WPF-capable checkout, which is unavailable in this scheduled Linux environment where direct GitHub checkout is blocked.

## Follow-up

- Run the full validation runner on Windows.
- Smoke test Category Workbench search/filter behavior with more than 500 category matches, repeated search edits, print-directory preview, rename display refresh, and no-match empty states at 125%, 150%, and 200% Windows scaling.