### PR TITLE
Improve Kit Workbench filter responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/KitManagementFilterResponsivenessContractTests.cs
+++ b/InventoryManagementApp.Tests/KitManagementFilterResponsivenessContractTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class KitManagementFilterResponsivenessContractTests
+    {
+        [Fact]
+        public void KitViewModel_BoundsFilteredGridWindowAndTracksOmittedMatches()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+
+            Assert.Contains("private const int MaxVisibleFilteredKitRows = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _matchedKitCount;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _omittedFilteredKitCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int FullFilteredKitCount => _matchedKitCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int FilteredKitOmittedCount => _omittedFilteredKitCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsKitFilterWindowCapped => FilteredKitOmittedCount > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("var visible = matched.Take(MaxVisibleFilteredKitRows).ToList();", source, StringComparison.Ordinal);
+            Assert.Contains("_omittedFilteredKitCount = Math.Max(0, matched.Count - visible.Count);", source, StringComparison.Ordinal);
+            Assert.Contains("ReplaceFilteredKits(visible);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitViewModel_ExposesHonestVisibleWindowAndFilterSummaries()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+
+            Assert.Contains("public string KitVisibleWindowSummary", source, StringComparison.Ordinal);
+            Assert.Contains("All matching kit rows are visible in the grid.", source, StringComparison.Ordinal);
+            Assert.Contains("Showing first {FilteredKits.Count} of {FullFilteredKitCount} matching kit rows", source, StringComparison.Ordinal);
+            Assert.Contains("held out of the grid for responsiveness", source, StringComparison.Ordinal);
+            Assert.Contains("Showing the first {FilteredKits.Count} matches so the grid stays responsive.", source, StringComparison.Ordinal);
+            Assert.Contains("{matched} matching kit", source, StringComparison.Ordinal);
+            Assert.Contains("first {FilteredKits.Count} shown", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitViewModel_UsesFullMatchCountForPrintMessagingAndPreviewAccounting()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+
+            Assert.Contains("var printableRows = Math.Min(FilteredKits.Count, MaxDirectoryPrintRows);", source, StringComparison.Ordinal);
+            Assert.Contains("var omittedFromPrint = Math.Max(0, FullFilteredKitCount - printableRows);", source, StringComparison.Ordinal);
+            Assert.Contains("Ready to print the first {printableRows} of {FullFilteredKitCount} matching kit rows", source, StringComparison.Ordinal);
+            Assert.Contains("var omittedCount = Math.Max(0, FullFilteredKitCount - printedKits.Count);", source, StringComparison.Ordinal);
+            Assert.Contains("Matched {FullFilteredKitCount} | Grid window {visibleKits.Count} | Printed {printedKits.Count} | Omitted {omittedCount}", source, StringComparison.Ordinal);
+            Assert.Contains("Large filtered directories print the first 250 matching rows to keep preview responsive.", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitViewModel_AvoidsUnnecessaryFilteredCollectionChurn()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+            var helper = ExtractSourceBlock(source, "private void ReplaceFilteredKits", "private void RefreshKitItemSummaries");
+
+            Assert.Contains("IReadOnlyList<Kit> visibleKits", helper, StringComparison.Ordinal);
+            Assert.Contains("FilteredKits.Count == visibleKits.Count", helper, StringComparison.Ordinal);
+            Assert.Contains("ReferenceEquals(FilteredKits[i], visibleKits[i])", helper, StringComparison.Ordinal);
+            Assert.Contains("if (unchanged) return;", helper, StringComparison.Ordinal);
+            Assert.Contains("FilteredKits.Clear();", helper, StringComparison.Ordinal);
+            Assert.Contains("FilteredKits.Add(kit);", helper, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitViewModel_ResetsAndNotifiesCappedDirectoryState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+            var failureBlock = ExtractSourceBlock(source, "private void ClearKitStateAfterLoadFailure", "private async Task LoadKitItemsAsync");
+            var raiseBlock = ExtractSourceBlock(source, "private void RaiseDirectoryStateChanged", "private void RaiseKitItemStateChanged");
+
+            Assert.Contains("_matchedKitCount = 0;", failureBlock, StringComparison.Ordinal);
+            Assert.Contains("_omittedFilteredKitCount = 0;", failureBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(FullFilteredKitCount));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(FilteredKitOmittedCount));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsKitFilterWindowCapped));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(KitVisibleWindowSummary));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(KitResultsSummary));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(KitFilterSummary));", raiseBlock, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(KitPrintSummary));", raiseBlock, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker after {startMarker}: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string NormalizeLineEndings(string text) => text.Replace("\r\n", "\n");
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-kit-filter-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-kit-filter-responsiveness.md
@@ -1,0 +1,25 @@
+# Kit Filter Responsiveness - 2026-07-07
+
+## Completed
+
+- Bounded the Kit Workbench live filtered grid to the first 500 matching kit rows so large kit catalogs do not repeatedly republish an unbounded WPF collection during search and status-filter changes.
+- Added full match count, omitted match count, and capped-window state to the kit view model.
+- Updated kit result, filter, visible-window, and print summaries so operators can see when additional matching kit rows are summarized for responsiveness.
+- Kept directory print and empty-state availability tied to the materialized visible grid while using full match counts in print messaging.
+- Made kit directory print-preview accounting report matched rows, visible grid window size, printed rows, and omitted rows.
+- Avoided unnecessary `FilteredKits` clear/repopulate work when repeated filtering produces the same visible row objects in the same order.
+- Preserved selected-kit restoration inside the bounded visible window and falls back to the first visible match when the prior selection is outside the current window.
+- Reset capped-window accounting when kit state is cleared after an unrecoverable load failure.
+- Raised property notifications for full-count, omitted-count, capped-window, visible-window, result, filter, print, empty-state, and print-readiness display contracts whenever directory state changes.
+- Added source-contract coverage for bounded filtering, omitted-row accounting, professional display summaries, print accounting, collection-churn avoidance, failure reset, and property notifications.
+
+## Validation
+
+- Added `InventoryManagementApp.Tests/KitManagementFilterResponsivenessContractTests.cs` to lock the new Kit Workbench responsiveness and data-display contracts.
+- GitHub connector readback should be used to confirm the branch contains the bounded filter window, omitted-count state, unchanged-list reuse guard, print accounting, and progress note.
+- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime checks, screenshots, print-preview checks, or Windows scaling checks in this scheduled Linux environment because direct GitHub checkout is blocked and Windows/.NET/WPF tooling is unavailable.
+
+## Follow-up
+
+- Run the full validation runner on a Windows/.NET-capable checkout.
+- Smoke test Kit Workbench search/filter behavior with more than 500 matching kits, repeated search edits, print-directory preview, selected-kit restoration, no-match empty states, and active/inactive filters at 125%, 150%, and 200% Windows scaling.

--- a/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
@@ -19,11 +20,14 @@ namespace InventoryManagementApp.ViewModels
         private const int MaxDirectoryPrintRows = 250;
         private const int MaxSelectedKitHandoffRows = 100;
         private const int MaxSelectedKitPrintRows = 250;
+        private const int MaxVisibleFilteredKitRows = 500;
         private readonly KitService _kitService;
         private readonly IDialogService _dialogService;
         private bool _isLoadingKits;
         private bool _isLoadingKitItems;
         private int _kitItemLoadVersion;
+        private int _matchedKitCount;
+        private int _omittedFilteredKitCount;
 
         public ObservableCollection<Kit> Kits { get; }
         public ObservableCollection<Kit> FilteredKits { get; }
@@ -65,6 +69,24 @@ namespace InventoryManagementApp.ViewModels
 
         public bool IsKitDirectoryPrintAvailable => !IsKitInteractionBusy && FilteredKits.Count > 0;
 
+        public int FullFilteredKitCount => _matchedKitCount;
+
+        public int FilteredKitOmittedCount => _omittedFilteredKitCount;
+
+        public bool IsKitFilterWindowCapped => FilteredKitOmittedCount > 0;
+
+        public string KitVisibleWindowSummary
+        {
+            get
+            {
+                if (IsLoadingKits) return "Kit rows are loading; the visible grid window will refresh shortly.";
+                if (FilteredKits.Count == 0) return "No kit rows match the current search and status filter.";
+                if (!IsKitFilterWindowCapped) return "All matching kit rows are visible in the grid.";
+
+                return $"Showing first {FilteredKits.Count} of {FullFilteredKitCount} matching kit rows; {FilteredKitOmittedCount} held out of the grid for responsiveness.";
+            }
+        }
+
         public string KitResultsSummary
         {
             get
@@ -72,7 +94,9 @@ namespace InventoryManagementApp.ViewModels
                 if (IsLoadingKits) return "Loading kit directory...";
                 var active = Kits.Count(k => k.IsActive);
                 var inactive = Kits.Count - active;
-                return $"{FilteredKits.Count} kit{(FilteredKits.Count == 1 ? string.Empty : "s")} shown | {active} active | {inactive} inactive";
+                var matched = FullFilteredKitCount;
+                var window = IsKitFilterWindowCapped ? $" first {FilteredKits.Count} shown" : $" {FilteredKits.Count} shown";
+                return $"{matched} matching kit{(matched == 1 ? string.Empty : "s")} |{window} | {active} active | {inactive} inactive";
             }
         }
 
@@ -83,9 +107,13 @@ namespace InventoryManagementApp.ViewModels
                 if (IsLoadingKits) return "Filter and search are paused while kit rows load.";
 
                 var status = SelectedFilter == "All" ? "all kits" : SelectedFilter.ToLowerInvariant() + " kits";
-                return string.IsNullOrWhiteSpace(SearchText)
+                var prefix = string.IsNullOrWhiteSpace(SearchText)
                     ? $"Showing {status}."
                     : $"Showing {status} matching \"{SearchText.Trim()}\".";
+
+                return IsKitFilterWindowCapped
+                    ? $"{prefix} Showing the first {FilteredKits.Count} matches so the grid stays responsive."
+                    : prefix;
             }
         }
 
@@ -96,11 +124,14 @@ namespace InventoryManagementApp.ViewModels
                 if (IsLoadingKits) return "Print is paused while kit rows are loading.";
                 if (FilteredKits.Count == 0) return "Print is available after kits are loaded or the filter has matches.";
 
-                var visible = FilteredKits.Count;
-                var printed = Math.Min(visible, MaxDirectoryPrintRows);
-                var omitted = visible - printed;
-                var suffix = omitted > 0 ? $" First {printed} will print; {omitted} omitted for preview speed." : string.Empty;
-                return $"Ready to print {visible} visible kit row{(visible == 1 ? string.Empty : "s")}.{suffix}";
+                var printableRows = Math.Min(FilteredKits.Count, MaxDirectoryPrintRows);
+                var omittedFromPrint = Math.Max(0, FullFilteredKitCount - printableRows);
+                if (omittedFromPrint > 0)
+                {
+                    return $"Ready to print the first {printableRows} of {FullFilteredKitCount} matching kit rows; {omittedFromPrint} omitted for preview speed.";
+                }
+
+                return $"Ready to print {FullFilteredKitCount} visible kit row{(FullFilteredKitCount == 1 ? string.Empty : "s")}.";
             }
         }
 
@@ -360,6 +391,8 @@ namespace InventoryManagementApp.ViewModels
         private void ClearKitStateAfterLoadFailure()
         {
             Kits.Clear();
+            _matchedKitCount = 0;
+            _omittedFilteredKitCount = 0;
             FilteredKits.Clear();
             SelectedKit = null;
             SelectedKitItem = null;
@@ -702,18 +735,18 @@ namespace InventoryManagementApp.ViewModels
             {
                 var visibleKits = FilteredKits.ToList();
                 var printedKits = visibleKits.Take(MaxDirectoryPrintRows).ToList();
-                var omittedCount = visibleKits.Count - printedKits.Count;
+                var omittedCount = Math.Max(0, FullFilteredKitCount - printedKits.Count);
                 var filterContext = string.IsNullOrWhiteSpace(SearchText)
                     ? $"Status filter: {SelectedFilter}"
                     : $"Status filter: {SelectedFilter} | Search: {SearchText.Trim()}";
 
                 var doc = CreateKitDocument("Kit Directory", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Visible {visibleKits.Count} | Printed {printedKits.Count} | Omitted {omittedCount} | {filterContext}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Matched {FullFilteredKitCount} | Grid window {visibleKits.Count} | Printed {printedKits.Count} | Omitted {omittedCount} | {filterContext}"))
                 {
                     FontSize = 10,
                     Margin = new Thickness(0, 0, 0, 8)
                 });
-                doc.Blocks.Add(new Paragraph(new Run("Review active status, category, and descriptions before staging grouped item sets. Large filtered directories print the first 250 visible rows to keep preview responsive."))
+                doc.Blocks.Add(new Paragraph(new Run("Review active status, category, and descriptions before staging grouped item sets. Large filtered directories print the first 250 matching rows to keep preview responsive."))
                 {
                     FontSize = 10,
                     Margin = new Thickness(0, 0, 0, 10)
@@ -861,8 +894,6 @@ namespace InventoryManagementApp.ViewModels
 
         private void ApplyFilter(int? preferredKitId = null)
         {
-            FilteredKits.Clear();
-
             var filtered = Kits.AsEnumerable();
 
             if (!string.IsNullOrWhiteSpace(SearchText))
@@ -882,10 +913,15 @@ namespace InventoryManagementApp.ViewModels
                 _ => filtered
             };
 
-            foreach (var kit in filtered.OrderByDescending(k => k.IsActive).ThenBy(k => k.Name).ThenBy(k => k.KitNumber))
-            {
-                FilteredKits.Add(kit);
-            }
+            var matched = filtered
+                .OrderByDescending(k => k.IsActive)
+                .ThenBy(k => k.Name)
+                .ThenBy(k => k.KitNumber)
+                .ToList();
+            _matchedKitCount = matched.Count;
+            var visible = matched.Take(MaxVisibleFilteredKitRows).ToList();
+            _omittedFilteredKitCount = Math.Max(0, matched.Count - visible.Count);
+            ReplaceFilteredKits(visible);
 
             var selectedKit = preferredKitId.HasValue
                 ? FilteredKits.FirstOrDefault(k => k.KitID == preferredKitId.Value)
@@ -894,6 +930,30 @@ namespace InventoryManagementApp.ViewModels
 
             RaiseDirectoryStateChanged();
             RaiseCommandStates();
+        }
+
+        private void ReplaceFilteredKits(IReadOnlyList<Kit> visibleKits)
+        {
+            var unchanged = FilteredKits.Count == visibleKits.Count;
+            if (unchanged)
+            {
+                for (var i = 0; i < visibleKits.Count; i++)
+                {
+                    if (!ReferenceEquals(FilteredKits[i], visibleKits[i]))
+                    {
+                        unchanged = false;
+                        break;
+                    }
+                }
+            }
+
+            if (unchanged) return;
+
+            FilteredKits.Clear();
+            foreach (var kit in visibleKits)
+            {
+                FilteredKits.Add(kit);
+            }
         }
 
         private void RefreshKitItemSummaries()
@@ -914,6 +974,10 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(IsKitInteractionBusy));
             OnPropertyChanged(nameof(IsKitDirectoryEmptyVisible));
             OnPropertyChanged(nameof(IsKitDirectoryPrintAvailable));
+            OnPropertyChanged(nameof(FullFilteredKitCount));
+            OnPropertyChanged(nameof(FilteredKitOmittedCount));
+            OnPropertyChanged(nameof(IsKitFilterWindowCapped));
+            OnPropertyChanged(nameof(KitVisibleWindowSummary));
             OnPropertyChanged(nameof(KitResultsSummary));
             OnPropertyChanged(nameof(KitFilterSummary));
             OnPropertyChanged(nameof(KitPrintSummary));


### PR DESCRIPTION
## What changed

- Bounded the Kit Workbench live filtered grid to the first 500 matching kit rows.
- Added full match count, omitted match count, and capped-window state to `KitManagementViewModel`.
- Updated kit result, filter, visible-window, and print summaries so large filtered sets are described honestly.
- Kept print availability tied to materialized visible rows while using full match counts in print messaging.
- Updated directory print-preview accounting to show matched rows, visible grid window size, printed rows, and omitted rows.
- Avoided unnecessary `FilteredKits` clear/repopulate work when repeated filtering produces the same visible row objects in the same order.
- Preserved selected-kit restoration inside the bounded visible window and falls back to the first visible match when the prior selection is outside the current window.
- Reset capped-window accounting when kit state is cleared after an unrecoverable load failure.
- Raised property notifications for full-count, omitted-count, capped-window, visible-window, result, filter, print, empty-state, and print-readiness display contracts whenever directory state changes.
- Added source-contract coverage for bounded filtering, omitted-row accounting, professional display summaries, print accounting, collection-churn avoidance, failure reset, and notifications.
- Recorded the completed Kit workflow slice in progress notes.

## Why this was highest value

Recent repository work has steadily improved dense WPF workflows where large row sets could slow screen loading, searching, filtering, printing, and tab switching. Kit Management already had strong layout and busy-state guards, but its filter path still republished every matching kit into the live WPF grid on each search/status change. This was a concrete responsiveness risk in an existing workflow, closely aligned with the current app direction and not a speculative new feature.

## Why this is real progress

This is a focused workflow-level slice across view-model filtering, collection churn reduction, professional display summaries, print-preview accounting, source-contract coverage, and progress documentation. It improves loading/search/filter responsiveness and data display clarity for a core kit-staging workflow.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, three focused commits ahead, and limited to:
  - `InventoryManagementApp/ViewModels/KitManagementViewModel.cs`
  - `InventoryManagementApp.Tests/KitManagementFilterResponsivenessContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-07-kit-filter-responsiveness.md`
- GitHub connector readback confirmed the bounded filter window, omitted-count state, unchanged-list reuse guard, print accounting, derived property notifications, new source-contract tests, and progress note.
- GitHub connector status/workflow readback found no attached commit statuses or workflow runs for the branch head before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke testing
- screenshots / Windows scaling checks
- live Kit Workbench filtering or print-preview behavior

Those require a Windows/.NET/WPF-capable checkout, which is unavailable in this scheduled Linux environment where direct GitHub checkout is blocked.

## Follow-up

- Run the full validation runner on Windows.
- Smoke test Kit Workbench search/filter behavior with more than 500 matching kits, repeated search edits, print-directory preview, selected-kit restoration, no-match empty states, and active/inactive filters at 125%, 150%, and 200% Windows scaling.