### PR TITLE
Improve Reports visible row responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
@@ -15,9 +15,11 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"240\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding ReportLineWindowSummary}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"390\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"540\"/>", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("ReportLineCount, StringFormat={}{0} action row(s)", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -89,7 +91,7 @@ namespace InventoryManagementApp.Tests
             var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReportsViewModel.cs");
 
             Assert.Contains("public bool CanUseReportRows => !IsBusy && ReportLines.Count > 0;", viewModel, StringComparison.Ordinal);
-            Assert.Contains("public bool CanPrintCurrentReport => !IsBusy && LastRunAt.HasValue", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool CanPrintCurrentReport => !IsBusy && LastRunAt.HasValue && ReportLineCount > 0 && ReportLines.Count > 0", viewModel, StringComparison.Ordinal);
             Assert.Contains("OnPropertyChanged(nameof(CanPrintCurrentReport));", viewModel, StringComparison.Ordinal);
             Assert.Contains("OnPropertyChanged(nameof(CanUseReportRows));", viewModel, StringComparison.Ordinal);
             Assert.Contains("IsEnabled=\"{Binding CanUseReportRows}\"", xaml, StringComparison.Ordinal);
@@ -104,12 +106,53 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ReportsViewModel_CapsVisibleReportRowsAndTracksFullCounts()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReportsViewModel.cs");
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
+
+            Assert.Contains("internal const int MaxVisibleReportRows = 500;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private int _totalReportLineCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private int _omittedReportLineCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public int ReportLineCount => _totalReportLineCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public int VisibleReportLineCount => ReportLines.Count;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public int OmittedReportLineCount => _omittedReportLineCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool HasOmittedReportRows => _omittedReportLineCount > 0;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string ReportLineWindowSummary => HasOmittedReportRows", viewModel, StringComparison.Ordinal);
+            Assert.Contains("SetReportLineCounts(detailLines.Count, Math.Max(0, detailLines.Count - MaxVisibleReportRows));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("var visibleLines = detailLines.Take(MaxVisibleReportRows).ToList();", viewModel, StringComparison.Ordinal);
+            Assert.Contains("for (var i = 0; i < visibleLines.Count; i++)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("BuildSummary(detailLines)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("showing first {VisibleReportLineCount} so the results grid stays responsive", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding ReportLineWindowSummary}\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("for (var i = 0; i < detailLines.Count; i++)", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReportsViewModel_ResetsAndNotifiesBoundedReportCountState()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReportsViewModel.cs");
+
+            Assert.Contains("SetReportLineCounts(0, 0);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private void SetReportLineCounts(int totalLineCount, int omittedLineCount)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_totalReportLineCount = Math.Max(0, totalLineCount);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_omittedReportLineCount = Math.Max(0, omittedLineCount);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private void NotifyReportOutputChanged()", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ReportLineCount));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(VisibleReportLineCount));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(OmittedReportLineCount));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(HasOmittedReportRows));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ReportLineWindowSummary));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("NotifyReportOutputChanged();", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ReportsPage_BoundsPrintPreviewRowsAndReportsOmittedRows()
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
 
             Assert.Contains("private const int MaxReportPrintRows = 250;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("var totalLineCount = vm.ReportLines.Count;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var totalLineCount = vm.ReportLineCount;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("var printRows = vm.ReportLines.Take(MaxReportPrintRows).ToList();", codeBehind, StringComparison.Ordinal);
             Assert.Contains("BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, printRows, totalLineCount)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("Large reports print the first 250 rows so preview stays responsive.", codeBehind, StringComparison.Ordinal);
@@ -119,6 +162,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("AddKeyValueRow(group, \"Omitted Action Rows\"", codeBehind, StringComparison.Ordinal);
             Assert.Contains("AddKeyValueRow(group, \"Large Report Limit\"", codeBehind, StringComparison.Ordinal);
             Assert.Contains("Review each destination, source-page route, next action, and omitted-row count", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("var totalLineCount = vm.ReportLines.Count;", codeBehind, StringComparison.Ordinal);
             Assert.DoesNotContain("BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, vm.ReportLines.ToList())", codeBehind, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-reports-visible-row-window.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-reports-visible-row-window.md
@@ -1,0 +1,24 @@
+# Reports Visible Row Window Responsiveness - 2026-07-07
+
+## Completed
+
+- Bounded the Reports Workbench live results grid to the first 500 generated action rows so very large reports do not republish every parsed paragraph into the WPF grid.
+- Added full generated-row, visible-row, omitted-row, and omitted-state tracking to `ReportsViewModel`.
+- Kept report summaries based on the full generated output while limiting the live `ObservableCollection` to the responsive visible window.
+- Added a reusable row-window summary for the header metrics and report-results pane so operators can see when only the first rows are displayed.
+- Updated completed-run status text for large reports to explain that the grid is intentionally capped for responsiveness.
+- Reset full/visible/omitted row state after report selection changes, clear actions, and generation failures.
+- Notified row-count, omitted-count, visible-window, print-readiness, row-action readiness, and operator-path bindings together after report output changes.
+- Kept source-page, copy, context-menu, double-click, and print actions tied to visible rows while preserving full count context.
+- Updated print-preview handoff accounting to use the full generated row count rather than the capped visible grid count.
+- Added source-contract coverage for the bounded live grid, full-count state, UI row-window display, reset/notification behavior, and print-preview accounting.
+
+## Validation
+
+- Source changes were inspected through GitHub connector readback in the scheduled Linux environment.
+- Full Windows/.NET validation, WPF runtime smoke testing, screenshots, scaling checks, and live large-report behavior remain blocked in this environment because direct checkout and Windows desktop tooling are unavailable.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test Reports Workbench with a report producing more than 500 action rows and verify grid responsiveness, visible/total counts, source handoff, copy handoff, print preview counts, and clear/selection changes at 125%, 150%, and 200% Windows scaling.

--- a/InventoryManagementApp/ViewModels/ReportsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReportsViewModel.cs
@@ -13,7 +13,11 @@ namespace InventoryManagementApp.ViewModels
 {
     public class ReportsViewModel : ObservableObject
     {
+        internal const int MaxVisibleReportRows = 500;
+
         private readonly ReportService _reportService;
+        private int _totalReportLineCount;
+        private int _omittedReportLineCount;
 
         public ObservableCollection<string> ReportTypes { get; }
         public ObservableCollection<ReportLine> ReportLines { get; } = new();
@@ -110,8 +114,14 @@ namespace InventoryManagementApp.ViewModels
         }
 
         public string LastRunText => LastRunAt.HasValue ? LastRunAt.Value.ToString("g") : "Not run";
-        public int ReportLineCount => ReportLines.Count;
-        public bool CanPrintCurrentReport => !IsBusy && LastRunAt.HasValue && ReportLines.Count > 0 && !string.Equals(ReportStatus, "Report failed.", StringComparison.Ordinal);
+        public int ReportLineCount => _totalReportLineCount;
+        public int VisibleReportLineCount => ReportLines.Count;
+        public int OmittedReportLineCount => _omittedReportLineCount;
+        public bool HasOmittedReportRows => _omittedReportLineCount > 0;
+        public string ReportLineWindowSummary => HasOmittedReportRows
+            ? $"Showing first {VisibleReportLineCount} of {ReportLineCount} action row(s)"
+            : $"{ReportLineCount} action row(s)";
+        public bool CanPrintCurrentReport => !IsBusy && LastRunAt.HasValue && ReportLineCount > 0 && ReportLines.Count > 0 && !string.Equals(ReportStatus, "Report failed.", StringComparison.Ordinal);
         public bool CanUseReportRows => !IsBusy && ReportLines.Count > 0;
         public string ReportOperatorPath => string.IsNullOrWhiteSpace(SelectedReport)
             ? "Choose a report, run it, then open the source page from any row that needs follow-up."
@@ -205,10 +215,8 @@ namespace InventoryManagementApp.ViewModels
                 ReportSummary = ex.Message;
                 ReportStatus = "Report failed.";
                 LastRunAt = null;
-                OnPropertyChanged(nameof(ReportLineCount));
-                OnPropertyChanged(nameof(CanPrintCurrentReport));
-                OnPropertyChanged(nameof(CanUseReportRows));
-                OnPropertyChanged(nameof(ReportOperatorPath));
+                SetReportLineCounts(0, 0);
+                NotifyReportOutputChanged();
                 ClearReportCommand.NotifyCanExecuteChanged();
             }
             finally
@@ -232,29 +240,27 @@ namespace InventoryManagementApp.ViewModels
             ReportSubtitle = BuildSubtitle(SelectedReport);
 
             var detailLines = lines.Skip(1).ToList();
-            for (var i = 0; i < detailLines.Count; i++)
+            SetReportLineCounts(detailLines.Count, Math.Max(0, detailLines.Count - MaxVisibleReportRows));
+
+            var visibleLines = detailLines.Take(MaxVisibleReportRows).ToList();
+            for (var i = 0; i < visibleLines.Count; i++)
             {
-                var category = ClassifyLine(detailLines[i]);
+                var category = ClassifyLine(visibleLines[i]);
                 ReportLines.Add(new ReportLine(
                     i + 1,
                     category,
-                    detailLines[i],
-                    BuildActionHint(detailLines[i]),
+                    visibleLines[i],
+                    BuildActionHint(visibleLines[i]),
                     BuildDestinationKey(SelectedReport, category),
                     BuildDestinationName(SelectedReport, category)));
             }
 
             LastRunAt = DateTime.Now;
             ReportSummary = BuildSummary(detailLines);
-            ReportStatus = ReportLines.Count == 0
-                ? $"{SelectedReport} completed with no rows to action."
-                : $"{SelectedReport} completed with {ReportLines.Count} line(s). Select a row or open the source page.";
+            ReportStatus = BuildCompletedStatus();
             if (ReportLines.Count > 0)
                 SelectedReportLine = ReportLines[0];
-            OnPropertyChanged(nameof(ReportLineCount));
-            OnPropertyChanged(nameof(CanPrintCurrentReport));
-            OnPropertyChanged(nameof(CanUseReportRows));
-            OnPropertyChanged(nameof(ReportOperatorPath));
+            NotifyReportOutputChanged();
             ClearReportCommand.NotifyCanExecuteChanged();
         }
 
@@ -262,6 +268,7 @@ namespace InventoryManagementApp.ViewModels
         {
             ReportLines.Clear();
             SelectedReportLine = null;
+            SetReportLineCounts(0, 0);
             ReportTitle = string.IsNullOrWhiteSpace(reportName) ? "Reports" : reportName;
             ReportSubtitle = string.IsNullOrWhiteSpace(reportName)
                 ? "Run operational reports for inventory, rentals, maintenance, reservations, and usage."
@@ -270,10 +277,7 @@ namespace InventoryManagementApp.ViewModels
                 ? "No report has been run yet."
                 : $"Run {reportName} to refresh report rows.";
             LastRunAt = null;
-            OnPropertyChanged(nameof(ReportLineCount));
-            OnPropertyChanged(nameof(CanPrintCurrentReport));
-            OnPropertyChanged(nameof(CanUseReportRows));
-            OnPropertyChanged(nameof(ReportOperatorPath));
+            NotifyReportOutputChanged();
             ClearReportCommand.NotifyCanExecuteChanged();
         }
 
@@ -281,16 +285,43 @@ namespace InventoryManagementApp.ViewModels
         {
             ReportLines.Clear();
             SelectedReportLine = null;
+            SetReportLineCounts(0, 0);
             ReportTitle = "Reports";
             ReportSubtitle = "Run operational reports for inventory, rentals, maintenance, reservations, and usage.";
             ReportSummary = "No report has been run yet.";
             ReportStatus = "Report cleared.";
             LastRunAt = null;
+            NotifyReportOutputChanged();
+            ClearReportCommand.NotifyCanExecuteChanged();
+        }
+
+        private void SetReportLineCounts(int totalLineCount, int omittedLineCount)
+        {
+            _totalReportLineCount = Math.Max(0, totalLineCount);
+            _omittedReportLineCount = Math.Max(0, omittedLineCount);
+        }
+
+        private string BuildCompletedStatus()
+        {
+            if (ReportLineCount == 0)
+                return $"{SelectedReport} completed with no rows to action.";
+
+            if (HasOmittedReportRows)
+                return $"{SelectedReport} completed with {ReportLineCount} line(s); showing first {VisibleReportLineCount} so the results grid stays responsive.";
+
+            return $"{SelectedReport} completed with {ReportLineCount} line(s). Select a row or open the source page.";
+        }
+
+        private void NotifyReportOutputChanged()
+        {
             OnPropertyChanged(nameof(ReportLineCount));
+            OnPropertyChanged(nameof(VisibleReportLineCount));
+            OnPropertyChanged(nameof(OmittedReportLineCount));
+            OnPropertyChanged(nameof(HasOmittedReportRows));
+            OnPropertyChanged(nameof(ReportLineWindowSummary));
             OnPropertyChanged(nameof(CanPrintCurrentReport));
             OnPropertyChanged(nameof(CanUseReportRows));
             OnPropertyChanged(nameof(ReportOperatorPath));
-            ClearReportCommand.NotifyCanExecuteChanged();
         }
 
         private static string BuildSubtitle(string reportName)

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml
@@ -57,7 +57,7 @@
                     <Border Style="{StaticResource ReportsStatCard}">
                         <StackPanel>
                             <TextBlock Text="ROWS" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding ReportLineCount, StringFormat={}{0} action row(s)}"
+                            <TextBlock Text="{Binding ReportLineWindowSummary}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
                                        TextWrapping="Wrap"
@@ -142,7 +142,7 @@
                                 <TextBlock Text="01 Report Results" Style="{StaticResource SectionHeader}" Margin="0"/>
                                 <TextBlock Text="Review generated report lines, priority wording, destination, and next action before opening the source workflow." Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
-                            <TextBlock Text="{Binding ReportLineCount, StringFormat={}{0} row(s)}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding ReportLineWindowSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
                         </DockPanel>
                     </Border>
 

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -88,7 +88,7 @@ namespace InventoryManagementApp.Views.Pages
                     return;
                 }
 
-                var totalLineCount = vm.ReportLines.Count;
+                var totalLineCount = vm.ReportLineCount;
                 var printRows = vm.ReportLines.Take(MaxReportPrintRows).ToList();
                 var document = BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, printRows, totalLineCount);
                 new PrintPreviewWindow().ShowPreview(


### PR DESCRIPTION
## What changed

- Bounded the Reports Workbench live results grid to the first 500 generated action rows.
- Added full generated-row, visible-row, omitted-row, and omitted-state tracking to `ReportsViewModel`.
- Kept report summaries based on the full generated output while limiting the live `ObservableCollection` to the responsive visible window.
- Added a reusable row-window summary for the header metrics and report-results pane so operators can see when only the first rows are displayed.
- Updated completed-run status text for large reports to explain that the grid is intentionally capped for responsiveness.
- Reset full/visible/omitted row state after report selection changes, clear actions, and generation failures.
- Notified row-count, omitted-count, visible-window, print-readiness, row-action readiness, and operator-path bindings together after report output changes.
- Kept source-page, copy, context-menu, double-click, and print actions tied to visible rows while preserving full count context.
- Updated print-preview handoff accounting to use the full generated row count rather than the capped visible grid count.
- Added source-contract coverage and a progress note for the completed workflow slice.

## Why this was highest value

Recent work has steadily improved dense WPF workflows where large row sets can slow screen loading, searching, filtering, printing, and tab switching. Reports already capped print preview output, but the generated report parser still pushed every generated action row into the live WPF grid. That was a concrete remaining responsiveness and data-display risk in an existing core workflow.

## Why this is real progress

This is a vertical slice across view-model report loading, UI-facing row summaries, print-preview accounting, source-contract coverage, and progress notes. It improves loading/rendering responsiveness for large reports while keeping report summaries and print handoffs honest about full generated row counts.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, five focused commits ahead, and limited to:
  - `InventoryManagementApp/ViewModels/ReportsViewModel.cs`
  - `InventoryManagementApp/Views/Pages/ReportsPage.xaml`
  - `InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs`
  - `InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-07-reports-visible-row-window.md`
- GitHub connector readback confirmed the bounded visible row window, full/visible/omitted row state, UI row-window bindings, full-count print handoff, source-contract assertions, and progress note.
- GitHub connector workflow readback found no attached workflow runs for branch head `a9cb103ca1c514b572dbf50ae8524c5552866fcf` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke testing
- screenshots / Windows scaling checks
- live Reports Workbench large-report behavior or print-preview rendering

Those require a Windows/.NET/WPF-capable checkout, which is unavailable in this scheduled Linux environment where direct GitHub checkout is blocked.

## Follow-up

- Run the full validation runner on Windows.
- Smoke test Reports Workbench with more than 500 generated action rows, source handoff, copy handoff, clear/selection changes, and print preview counts at 125%, 150%, and 200% Windows scaling.