### PR TITLE
Improve maintenance and calibration visible row responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/OperationalServiceRegisterVisibleWindowContractTests.cs
+++ b/InventoryManagementApp.Tests/OperationalServiceRegisterVisibleWindowContractTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class OperationalServiceRegisterVisibleWindowContractTests
+    {
+        [Fact]
+        public void MaintenanceViewModel_BoundsLiveRowsAndKeepsFullMatchState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MaintenanceManagementViewModel.cs");
+
+            Assert.Contains("private const int MaxMaintenanceVisibleRows = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _maintenanceMatchCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int MaintenanceMatchCount => _maintenanceMatchCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int MaintenanceVisibleCount => FilteredMaintenanceRecords.Count;", source, StringComparison.Ordinal);
+            Assert.Contains("public int MaintenanceOmittedCount => Math.Max(0, MaintenanceMatchCount - MaintenanceVisibleCount);", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsMaintenanceWindowCapped => MaintenanceOmittedCount > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("public string MaintenanceVisibleWindowSummary", source, StringComparison.Ordinal);
+            Assert.Contains("Showing first {MaintenanceVisibleCount} of {MaintenanceMatchCount} matching maintenance rows", source, StringComparison.Ordinal);
+            Assert.Contains("? $\"{MaintenanceVisibleCount} of {MaintenanceMatchCount} maintenance records shown\"", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenanceViewModel_AppliesCappedWindowWithoutUnchangedGridChurn()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MaintenanceManagementViewModel.cs");
+            var applyFilter = ExtractSourceBlock(source, "private void ApplyFilter", "private void OpenMaintenanceDetails");
+            var sameWindow = ExtractSourceBlock(source, "private static bool IsSameVisibleWindow", "private static FlowDocument CreateMaintenanceDocument");
+
+            Assert.Contains("var visibleList = filteredList.Take(MaxMaintenanceVisibleRows).ToList();", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("_maintenanceMatchCount = filteredList.Count;", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("if (!IsSameVisibleWindow(FilteredMaintenanceRecords, visibleList))", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("FilteredMaintenanceRecords.Clear();", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("foreach (var record in visibleList)", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("ReferenceEquals(currentRows[i], nextRows[i])", sameWindow, StringComparison.Ordinal);
+            Assert.Contains("System.Collections.Generic.IReadOnlyList<MaintenanceRecord>", sameWindow, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var record in filteredList)\n            {\n                FilteredMaintenanceRecords.Add(record);", applyFilter, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenancePrintPreview_ReportsMatchedVisiblePrintedAndHiddenRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MaintenanceManagementViewModel.cs");
+            var printList = ExtractSourceBlock(source, "private void PrintMaintenanceList()", "private void PrintSelectedMaintenance()");
+
+            Assert.Contains("var matchedRows = MaintenanceMatchCount;", printList, StringComparison.Ordinal);
+            Assert.Contains("var visibleRows = MaintenanceVisibleCount;", printList, StringComparison.Ordinal);
+            Assert.Contains("var omittedRows = Math.Max(0, matchedRows - printRows.Count);", printList, StringComparison.Ordinal);
+            Assert.Contains("var hiddenRows = Math.Max(0, matchedRows - visibleRows);", printList, StringComparison.Ordinal);
+            Assert.Contains("Matched: {matchedRows} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows}", printList, StringComparison.Ordinal);
+            Assert.Contains("additional matching maintenance rows are outside the live grid window", printList, StringComparison.Ordinal);
+            Assert.Contains("live-grid limits", printList, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MaintenanceViewModel_NotifiesVisibleWindowPropertiesAndResetsAfterFailure()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MaintenanceManagementViewModel.cs");
+            var clearState = ExtractSourceBlock(source, "private void ClearMaintenanceStateAfterLoadFailure", "private async Task RefreshMaintenanceAfterMutationFailureAsync");
+            var notifications = ExtractSourceBlock(source, "private void NotifyMaintenanceListStateChanged", "private void OnSelectedRecordSummariesChanged");
+
+            Assert.Contains("_maintenanceMatchCount = 0;", clearState, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(MaintenanceMatchCount));", notifications, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(MaintenanceVisibleCount));", notifications, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(MaintenanceOmittedCount));", notifications, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsMaintenanceWindowCapped));", notifications, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(MaintenanceVisibleWindowSummary));", notifications, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationViewModel_BoundsLiveRowsAndKeepsFullMatchState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");
+
+            Assert.Contains("private const int MaxCalibrationVisibleRows = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _calibrationMatchCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int CalibrationMatchCount => _calibrationMatchCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int CalibrationVisibleCount => FilteredCalibrationRecords.Count;", source, StringComparison.Ordinal);
+            Assert.Contains("public int CalibrationOmittedCount => Math.Max(0, CalibrationMatchCount - CalibrationVisibleCount);", source, StringComparison.Ordinal);
+            Assert.Contains("public bool IsCalibrationWindowCapped => CalibrationOmittedCount > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("public string CalibrationVisibleWindowSummary", source, StringComparison.Ordinal);
+            Assert.Contains("Showing first {CalibrationVisibleCount} of {CalibrationMatchCount} matching calibration rows", source, StringComparison.Ordinal);
+            Assert.Contains("? $\"{CalibrationVisibleCount} of {CalibrationMatchCount} calibration records shown\"", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationViewModel_AppliesCappedWindowWithoutUnchangedGridChurn()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");
+            var applyFilter = ExtractSourceBlock(source, "private void ApplyFilter", "private void OpenCalibrationDetails");
+            var sameWindow = ExtractSourceBlock(source, "private static bool IsSameVisibleWindow", "private static FlowDocument CreateCalibrationDocument");
+
+            Assert.Contains("var visibleList = filteredList.Take(MaxCalibrationVisibleRows).ToList();", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("_calibrationMatchCount = filteredList.Count;", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("if (!IsSameVisibleWindow(FilteredCalibrationRecords, visibleList))", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("FilteredCalibrationRecords.Clear();", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("foreach (var record in visibleList)", applyFilter, StringComparison.Ordinal);
+            Assert.Contains("ReferenceEquals(currentRows[i], nextRows[i])", sameWindow, StringComparison.Ordinal);
+            Assert.Contains("System.Collections.Generic.IReadOnlyList<CalibrationRecord>", sameWindow, StringComparison.Ordinal);
+            Assert.DoesNotContain("foreach (var record in filteredList)\n            {\n                FilteredCalibrationRecords.Add(record);", applyFilter, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationPrintPreview_ReportsMatchedVisiblePrintedAndHiddenRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");
+            var printList = ExtractSourceBlock(source, "private void PrintCalibrationList()", "private void PrintSelectedCalibration()");
+
+            Assert.Contains("var matchedRows = CalibrationMatchCount;", printList, StringComparison.Ordinal);
+            Assert.Contains("var visibleRows = CalibrationVisibleCount;", printList, StringComparison.Ordinal);
+            Assert.Contains("var omittedRows = Math.Max(0, matchedRows - printRows.Count);", printList, StringComparison.Ordinal);
+            Assert.Contains("var hiddenRows = Math.Max(0, matchedRows - visibleRows);", printList, StringComparison.Ordinal);
+            Assert.Contains("Matched: {matchedRows} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows}", printList, StringComparison.Ordinal);
+            Assert.Contains("additional matching calibration rows are outside the live grid window", printList, StringComparison.Ordinal);
+            Assert.Contains("live-grid limits", printList, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationViewModel_NotifiesVisibleWindowPropertiesAndResetsAfterFailure()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");
+            var clearState = ExtractSourceBlock(source, "private void ClearCalibrationStateAfterLoadFailure", "private async Task RefreshCalibrationAfterMutationFailureAsync");
+            var notifications = ExtractSourceBlock(source, "private void NotifyCalibrationListStateChanged", "private void OnSelectedRecordSummariesChanged");
+
+            Assert.Contains("_calibrationMatchCount = 0;", clearState, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CalibrationMatchCount));", notifications, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CalibrationVisibleCount));", notifications, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CalibrationOmittedCount));", notifications, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(IsCalibrationWindowCapped));", notifications, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CalibrationVisibleWindowSummary));", notifications, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string ExtractSourceBlock(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find source block start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string NormalizeLineEndings(string text)
+            => text.Replace("\r\n", "\n");
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-maintenance-calibration-visible-window.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-maintenance-calibration-visible-window.md
@@ -1,0 +1,22 @@
+# Maintenance and Calibration Visible Row Windows - 2026-07-07
+
+## Completed
+- Bounded the Maintenance Workbench live filtered grid to the first 500 matching maintenance rows.
+- Bounded the Calibration Workbench live filtered grid to the first 500 matching calibration rows.
+- Added full match, visible row, omitted row, and capped-window state to both operational service-register view models.
+- Updated Maintenance and Calibration result summaries so operators can distinguish rows shown from total matching rows.
+- Updated Maintenance and Calibration visible-window summaries for large search/filter result sets.
+- Kept print readiness tied to the live visible grid while keeping print copy honest about total matched rows.
+- Updated Maintenance and Calibration print-preview accounting to report matched, visible, printed, omitted, and hidden-from-grid rows.
+- Added large-preview guidance that explains when additional matching rows are outside the live grid window.
+- Avoided unnecessary `FilteredMaintenanceRecords` and `FilteredCalibrationRecords` clear/repopulate work when repeated filter passes produce the same visible row objects in the same order.
+- Reset capped-window match state after unrecoverable load or recovery failures.
+- Added source-contract coverage for capped row windows, count state, unchanged-window guards, print accounting, and property notifications.
+
+## Validation
+- GitHub connector readback should be used to confirm the branch contains the intended view-model updates, new source-contract tests, and this progress note.
+- Local Windows/.NET/WPF validation, screenshots, scaling checks, live large-row filtering, and print-preview rendering still require a Windows-capable checkout.
+
+## Follow-up
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test Maintenance and Calibration with more than 500 matching rows, repeated search/filter changes, selected-row actions, context menus, clear-search flow, print preview counts, and 125%, 150%, and 200% Windows scaling.

--- a/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
@@ -15,17 +15,52 @@ namespace InventoryManagementApp.ViewModels
 {
     public class CalibrationManagementViewModel : ObservableObject
     {
+        private const int MaxCalibrationVisibleRows = 500;
         private const int MaxCalibrationPrintRows = 250;
 
         private readonly CalibrationService _calibrationService;
         private readonly IDialogService _dialogService;
+        private int _calibrationMatchCount;
 
         public ObservableCollection<CalibrationRecord> CalibrationRecords { get; }
         public ObservableCollection<CalibrationRecord> FilteredCalibrationRecords { get; }
 
+        public int CalibrationMatchCount => _calibrationMatchCount;
+
+        public int CalibrationVisibleCount => FilteredCalibrationRecords.Count;
+
+        public int CalibrationOmittedCount => Math.Max(0, CalibrationMatchCount - CalibrationVisibleCount);
+
+        public bool IsCalibrationWindowCapped => CalibrationOmittedCount > 0;
+
+        public string CalibrationVisibleWindowSummary
+        {
+            get
+            {
+                if (IsLoading)
+                {
+                    return "Calibration row window is updating";
+                }
+
+                if (CalibrationMatchCount == 0)
+                {
+                    return "No calibration rows visible";
+                }
+
+                if (IsCalibrationWindowCapped)
+                {
+                    return $"Showing first {CalibrationVisibleCount} of {CalibrationMatchCount} matching calibration rows; refine search or due-state filters to view the rest";
+                }
+
+                return $"Showing all {CalibrationVisibleCount} matching calibration row{(CalibrationVisibleCount == 1 ? string.Empty : "s")}";
+            }
+        }
+
         public string CalibrationResultsSummary => IsLoading
             ? "Loading calibration records..."
-            : $"{FilteredCalibrationRecords.Count} of {CalibrationRecords.Count} calibration record{(CalibrationRecords.Count == 1 ? string.Empty : "s")} shown";
+            : IsCalibrationWindowCapped
+                ? $"{CalibrationVisibleCount} of {CalibrationMatchCount} calibration records shown"
+                : $"{CalibrationVisibleCount} calibration record{(CalibrationVisibleCount == 1 ? string.Empty : "s")} shown";
 
         public string CalibrationBacklogSummary
         {
@@ -71,13 +106,20 @@ namespace InventoryManagementApp.ViewModels
                         : "No certificate rows ready to print";
                 }
 
-                var visible = FilteredCalibrationRecords.Count;
+                var visible = CalibrationVisibleCount;
+                var matched = CalibrationMatchCount;
                 var printed = Math.Min(visible, MaxCalibrationPrintRows);
-                var omitted = Math.Max(0, visible - printed);
+                var omitted = Math.Max(0, matched - printed);
                 var filterContext = IsFilterActive ? "filtered" : "all rows";
-                return omitted == 0
-                    ? $"Ready to print {printed} {filterContext} certificate row{(printed == 1 ? string.Empty : "s")}."
-                    : $"Ready to print first {printed} of {visible} {filterContext} certificate rows; {omitted} omitted from preview.";
+
+                if (omitted == 0)
+                {
+                    return $"Ready to print {printed} {filterContext} certificate row{(printed == 1 ? string.Empty : "s")}.";
+                }
+
+                return IsCalibrationWindowCapped
+                    ? $"Ready to print first {printed} of {visible} shown {filterContext} certificate rows; {matched} matched."
+                    : $"Ready to print first {printed} of {matched} {filterContext} certificate rows; {omitted} omitted from preview.";
             }
         }
 
@@ -363,6 +405,7 @@ namespace InventoryManagementApp.ViewModels
 
         private void ClearCalibrationStateAfterLoadFailure()
         {
+            _calibrationMatchCount = 0;
             CalibrationRecords.Clear();
             FilteredCalibrationRecords.Clear();
             SelectedRecord = null;
@@ -407,7 +450,6 @@ namespace InventoryManagementApp.ViewModels
         private void ApplyFilter(int? preferredCalibrationId = null)
         {
             preferredCalibrationId ??= SelectedRecord?.CalibrationID;
-            FilteredCalibrationRecords.Clear();
 
             var filtered = CalibrationRecords.AsEnumerable();
 
@@ -437,10 +479,16 @@ namespace InventoryManagementApp.ViewModels
                 .ThenBy(r => r.NextCalibrationDue)
                 .ThenBy(r => Searchable(r.ItemNumber))
                 .ToList();
+            var visibleList = filteredList.Take(MaxCalibrationVisibleRows).ToList();
+            _calibrationMatchCount = filteredList.Count;
 
-            foreach (var record in filteredList)
+            if (!IsSameVisibleWindow(FilteredCalibrationRecords, visibleList))
             {
-                FilteredCalibrationRecords.Add(record);
+                FilteredCalibrationRecords.Clear();
+                foreach (var record in visibleList)
+                {
+                    FilteredCalibrationRecords.Add(record);
+                }
             }
 
             SelectedRecord = FilteredCalibrationRecords.FirstOrDefault(r => r.CalibrationID == preferredCalibrationId)
@@ -513,11 +561,13 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
-                var visibleRows = FilteredCalibrationRecords.Count;
+                var matchedRows = CalibrationMatchCount;
+                var visibleRows = CalibrationVisibleCount;
                 var printRows = FilteredCalibrationRecords.Take(MaxCalibrationPrintRows).ToList();
-                var omittedRows = Math.Max(0, visibleRows - printRows.Count);
+                var omittedRows = Math.Max(0, matchedRows - printRows.Count);
+                var hiddenRows = Math.Max(0, matchedRows - visibleRows);
                 var doc = CreateCalibrationDocument("Calibration Due Report", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows} | {CalibrationBacklogSummary}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | Matched: {matchedRows} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows} | {CalibrationBacklogSummary}"))
                 {
                     FontSize = 10,
                     Margin = new Thickness(0, 0, 0, 8)
@@ -525,7 +575,7 @@ namespace InventoryManagementApp.ViewModels
 
                 if (omittedRows > 0)
                 {
-                    doc.Blocks.Add(new Paragraph(new Run($"Large calibration preview limited to the first {MaxCalibrationPrintRows} visible rows to keep print preview responsive. Clear filters or print smaller certificate packets for full handoff review."))
+                    doc.Blocks.Add(new Paragraph(new Run($"Large calibration preview limited to the first {MaxCalibrationPrintRows} visible rows to keep print preview responsive. {hiddenRows} additional matching calibration rows are outside the live grid window. Refine filters or print smaller certificate packets for full handoff review."))
                     {
                         FontSize = 10,
                         FontStyle = FontStyles.Italic,
@@ -551,7 +601,7 @@ namespace InventoryManagementApp.ViewModels
                 }
 
                 doc.Blocks.Add(table);
-                doc.Blocks.Add(new Paragraph(new Run("Review overdue rows, due-soon certificates, missing certificate numbers, calibration standard, and omitted-row counts before releasing items to the shelf."))
+                doc.Blocks.Add(new Paragraph(new Run("Review overdue rows, due-soon certificates, missing certificate numbers, calibration standard, live-grid limits, and omitted-row counts before releasing items to the shelf."))
                 {
                     FontSize = 10,
                     FontStyle = FontStyles.Italic,
@@ -621,6 +671,7 @@ namespace InventoryManagementApp.ViewModels
             OnSelectedRecordSummariesChanged();
             OnPropertyChanged(nameof(CalibrationBacklogSummary));
             OnPropertyChanged(nameof(CalibrationResultsSummary));
+            OnPropertyChanged(nameof(CalibrationVisibleWindowSummary));
         }
 
         private void NotifyCalibrationListStateChanged()
@@ -632,6 +683,11 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CalibrationEmptyMessage));
             OnPropertyChanged(nameof(CanPrintCalibrationList));
             OnPropertyChanged(nameof(CalibrationPrintStatus));
+            OnPropertyChanged(nameof(CalibrationMatchCount));
+            OnPropertyChanged(nameof(CalibrationVisibleCount));
+            OnPropertyChanged(nameof(CalibrationOmittedCount));
+            OnPropertyChanged(nameof(IsCalibrationWindowCapped));
+            OnPropertyChanged(nameof(CalibrationVisibleWindowSummary));
             PrintCalibrationListCommand.NotifyCanExecuteChanged();
         }
 
@@ -647,6 +703,24 @@ namespace InventoryManagementApp.ViewModels
         private static bool IsCurrent(CalibrationRecord record) => !record.IsOverdue && !record.IsDueSoon;
 
         private static string Searchable(string? value) => value?.ToLowerInvariant() ?? string.Empty;
+
+        private static bool IsSameVisibleWindow(ObservableCollection<CalibrationRecord> currentRows, System.Collections.Generic.IReadOnlyList<CalibrationRecord> nextRows)
+        {
+            if (currentRows.Count != nextRows.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < nextRows.Count; i++)
+            {
+                if (!ReferenceEquals(currentRows[i], nextRows[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
 
         private static FlowDocument CreateCalibrationDocument(string title, double fontSize = 16)
         {

--- a/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
@@ -15,17 +15,52 @@ namespace InventoryManagementApp.ViewModels
 {
     public class MaintenanceManagementViewModel : ObservableObject
     {
+        private const int MaxMaintenanceVisibleRows = 500;
         private const int MaxMaintenancePrintRows = 250;
 
         private readonly MaintenanceService _maintenanceService;
         private readonly IDialogService _dialogService;
+        private int _maintenanceMatchCount;
 
         public ObservableCollection<MaintenanceRecord> MaintenanceRecords { get; }
         public ObservableCollection<MaintenanceRecord> FilteredMaintenanceRecords { get; }
 
+        public int MaintenanceMatchCount => _maintenanceMatchCount;
+
+        public int MaintenanceVisibleCount => FilteredMaintenanceRecords.Count;
+
+        public int MaintenanceOmittedCount => Math.Max(0, MaintenanceMatchCount - MaintenanceVisibleCount);
+
+        public bool IsMaintenanceWindowCapped => MaintenanceOmittedCount > 0;
+
+        public string MaintenanceVisibleWindowSummary
+        {
+            get
+            {
+                if (IsLoading)
+                {
+                    return "Maintenance row window is updating";
+                }
+
+                if (MaintenanceMatchCount == 0)
+                {
+                    return "No maintenance rows visible";
+                }
+
+                if (IsMaintenanceWindowCapped)
+                {
+                    return $"Showing first {MaintenanceVisibleCount} of {MaintenanceMatchCount} matching maintenance rows; refine search or filters to view the rest";
+                }
+
+                return $"Showing all {MaintenanceVisibleCount} matching maintenance row{(MaintenanceVisibleCount == 1 ? string.Empty : "s")}";
+            }
+        }
+
         public string MaintenanceResultsSummary => IsLoading
             ? "Loading maintenance records..."
-            : $"{FilteredMaintenanceRecords.Count} of {MaintenanceRecords.Count} maintenance record{(MaintenanceRecords.Count == 1 ? string.Empty : "s")} shown";
+            : IsMaintenanceWindowCapped
+                ? $"{MaintenanceVisibleCount} of {MaintenanceMatchCount} maintenance records shown"
+                : $"{MaintenanceVisibleCount} maintenance record{(MaintenanceVisibleCount == 1 ? string.Empty : "s")} shown";
 
         public string MaintenanceBacklogSummary
         {
@@ -72,13 +107,20 @@ namespace InventoryManagementApp.ViewModels
                         : "No maintenance rows ready to print";
                 }
 
-                var visible = FilteredMaintenanceRecords.Count;
+                var visible = MaintenanceVisibleCount;
+                var matched = MaintenanceMatchCount;
                 var printed = Math.Min(visible, MaxMaintenancePrintRows);
-                var omitted = Math.Max(0, visible - printed);
+                var omitted = Math.Max(0, matched - printed);
                 var filterContext = IsFilterActive ? "filtered" : "all rows";
-                return omitted == 0
-                    ? $"Ready to print {printed} {filterContext} row{(printed == 1 ? string.Empty : "s")}."
-                    : $"Ready to print first {printed} of {visible} {filterContext} rows; {omitted} omitted from preview.";
+
+                if (omitted == 0)
+                {
+                    return $"Ready to print {printed} {filterContext} row{(printed == 1 ? string.Empty : "s")}.";
+                }
+
+                return IsMaintenanceWindowCapped
+                    ? $"Ready to print first {printed} of {visible} shown {filterContext} rows; {matched} matched."
+                    : $"Ready to print first {printed} of {matched} {filterContext} rows; {omitted} omitted from preview.";
             }
         }
 
@@ -406,6 +448,7 @@ namespace InventoryManagementApp.ViewModels
 
         private void ClearMaintenanceStateAfterLoadFailure()
         {
+            _maintenanceMatchCount = 0;
             MaintenanceRecords.Clear();
             FilteredMaintenanceRecords.Clear();
             SelectedRecord = null;
@@ -450,7 +493,6 @@ namespace InventoryManagementApp.ViewModels
         private void ApplyFilter(int? preferredMaintenanceId = null)
         {
             preferredMaintenanceId ??= SelectedRecord?.MaintenanceID;
-            FilteredMaintenanceRecords.Clear();
 
             var filtered = MaintenanceRecords.AsEnumerable();
 
@@ -480,10 +522,16 @@ namespace InventoryManagementApp.ViewModels
                 .ThenBy(r => r.ScheduledDate)
                 .ThenBy(r => Searchable(r.ItemNumber))
                 .ToList();
+            var visibleList = filteredList.Take(MaxMaintenanceVisibleRows).ToList();
+            _maintenanceMatchCount = filteredList.Count;
 
-            foreach (var record in filteredList)
+            if (!IsSameVisibleWindow(FilteredMaintenanceRecords, visibleList))
             {
-                FilteredMaintenanceRecords.Add(record);
+                FilteredMaintenanceRecords.Clear();
+                foreach (var record in visibleList)
+                {
+                    FilteredMaintenanceRecords.Add(record);
+                }
             }
 
             SelectedRecord = FilteredMaintenanceRecords.FirstOrDefault(r => r.MaintenanceID == preferredMaintenanceId)
@@ -554,11 +602,13 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
-                var visibleRows = FilteredMaintenanceRecords.Count;
+                var matchedRows = MaintenanceMatchCount;
+                var visibleRows = MaintenanceVisibleCount;
                 var printRows = FilteredMaintenanceRecords.Take(MaxMaintenancePrintRows).ToList();
-                var omittedRows = Math.Max(0, visibleRows - printRows.Count);
+                var omittedRows = Math.Max(0, matchedRows - printRows.Count);
+                var hiddenRows = Math.Max(0, matchedRows - visibleRows);
                 var doc = CreateMaintenanceDocument("Maintenance Schedule", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows} | {MaintenanceBacklogSummary}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | Matched: {matchedRows} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows} | {MaintenanceBacklogSummary}"))
                 {
                     FontSize = 10,
                     Margin = new Thickness(0, 0, 0, 8)
@@ -566,7 +616,7 @@ namespace InventoryManagementApp.ViewModels
 
                 if (omittedRows > 0)
                 {
-                    doc.Blocks.Add(new Paragraph(new Run($"Large schedule preview limited to the first {MaxMaintenancePrintRows} visible rows to keep print preview responsive. Clear filters or export smaller packets for full handoff review."))
+                    doc.Blocks.Add(new Paragraph(new Run($"Large schedule preview limited to the first {MaxMaintenancePrintRows} visible rows to keep print preview responsive. {hiddenRows} additional matching maintenance rows are outside the live grid window. Refine filters or print smaller packets for full handoff review."))
                     {
                         FontSize = 10,
                         FontStyle = FontStyles.Italic,
@@ -592,7 +642,7 @@ namespace InventoryManagementApp.ViewModels
                 }
 
                 doc.Blocks.Add(table);
-                doc.Blocks.Add(new Paragraph(new Run("Review overdue rows, technician assignment, completed dates, and omitted-row counts before handing this schedule to the bench."))
+                doc.Blocks.Add(new Paragraph(new Run("Review overdue rows, technician assignment, completed dates, live-grid limits, and omitted-row counts before handing this schedule to the bench."))
                 {
                     FontSize = 10,
                     FontStyle = FontStyles.Italic,
@@ -664,6 +714,7 @@ namespace InventoryManagementApp.ViewModels
             OnSelectedRecordSummariesChanged();
             OnPropertyChanged(nameof(MaintenanceBacklogSummary));
             OnPropertyChanged(nameof(MaintenanceResultsSummary));
+            OnPropertyChanged(nameof(MaintenanceVisibleWindowSummary));
         }
 
         private void NotifyMaintenanceListStateChanged()
@@ -675,6 +726,11 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(MaintenanceEmptyMessage));
             OnPropertyChanged(nameof(CanPrintMaintenanceList));
             OnPropertyChanged(nameof(MaintenancePrintStatus));
+            OnPropertyChanged(nameof(MaintenanceMatchCount));
+            OnPropertyChanged(nameof(MaintenanceVisibleCount));
+            OnPropertyChanged(nameof(MaintenanceOmittedCount));
+            OnPropertyChanged(nameof(IsMaintenanceWindowCapped));
+            OnPropertyChanged(nameof(MaintenanceVisibleWindowSummary));
             PrintMaintenanceListCommand.NotifyCanExecuteChanged();
         }
 
@@ -697,6 +753,24 @@ namespace InventoryManagementApp.ViewModels
             IsScheduled(record) && record.ScheduledDate >= DateTime.Now && record.ScheduledDate <= DateTime.Now.AddDays(30);
 
         private static string Searchable(string? value) => value?.ToLowerInvariant() ?? string.Empty;
+
+        private static bool IsSameVisibleWindow(ObservableCollection<MaintenanceRecord> currentRows, System.Collections.Generic.IReadOnlyList<MaintenanceRecord> nextRows)
+        {
+            if (currentRows.Count != nextRows.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < nextRows.Count; i++)
+            {
+                if (!ReferenceEquals(currentRows[i], nextRows[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
 
         private static FlowDocument CreateMaintenanceDocument(string title, double fontSize = 16)
         {


### PR DESCRIPTION
## What changed

- Bounded the Maintenance Workbench live filtered grid to the first 500 matching maintenance rows.
- Bounded the Calibration Workbench live filtered grid to the first 500 matching calibration rows.
- Added full match, visible row, omitted row, and capped-window state to both operational service-register view models.
- Updated Maintenance and Calibration result summaries so operators can distinguish rows shown from total matching rows.
- Added visible-window summary state for large maintenance/calibration search and due-state result sets.
- Kept print readiness tied to materialized visible rows while preserving full match context in print copy.
- Updated Maintenance and Calibration print-preview accounting to report matched, visible, printed, omitted, and hidden-from-grid rows.
- Added large-preview guidance explaining when additional matching rows are outside the live grid window.
- Avoided unnecessary `FilteredMaintenanceRecords` and `FilteredCalibrationRecords` clear/repopulate work when repeated filter passes produce the same visible row objects in the same order.
- Reset capped-window match state after unrecoverable load/recovery failures.
- Added source-contract coverage for capped windows, count state, unchanged-window guards, print accounting, and notifications.
- Recorded the completed workflow slice in progress notes.

## Why this was highest value

Recent merged work capped Customer, Category, Kit, and Reports row windows. Maintenance and Calibration still had the same concrete risk: every matching operational service row was republished into live WPF grids on each search/filter pass. These are dense existing workbenches with print-preview handoffs, so bounding their live grids directly improves loading, filtering, tab switching, and professional large-result display without adding unrelated scope.

## Why this is real progress

This is a workflow-level slice across two related operational screens: view-model filtering, row-window state, collection churn reduction, print-preview accounting, source-contract tests, and progress notes. It completes the same responsiveness pattern for maintenance and calibration service registers rather than making a tiny isolated tweak.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, four commits ahead, zero behind, and limited to:
  - `InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs`
  - `InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs`
  - `InventoryManagementApp.Tests/OperationalServiceRegisterVisibleWindowContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-07-maintenance-calibration-visible-window.md`
- GitHub connector readback confirmed the 500-row visible windows, full/visible/omitted count state, unchanged-window guards, full-match print accounting, source-contract tests, and progress note.
- GitHub connector status readback found no attached commit statuses for branch head `4c7c2147388da0f2767e194d70926a446ceab0e3` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke testing
- screenshots / Windows scaling checks
- live Maintenance and Calibration large-row filtering or print-preview rendering

Those require a Windows/.NET/WPF-capable checkout, which is unavailable in this scheduled Linux environment where direct GitHub checkout is blocked.

## Follow-up

- Run the full validation runner on Windows.
- Smoke test Maintenance and Calibration with more than 500 matching rows, repeated search/filter changes, selected-row actions, context menus, clear-search flow, print preview counts, and 125%, 150%, and 200% Windows scaling.