### PR TITLE
[codex] Improve import/export data operation readiness

### DIFF
--- a/InventoryManagementApp.Tests/ImportExportDataOperationReadinessContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportDataOperationReadinessContractTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ImportExportDataOperationReadinessContractTests
+    {
+        [Fact]
+        public void ImportExportViewModel_WrapsImageMappingInSharedReadinessCommand()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("private readonly IAsyncRelayCommand _openImageImportMappingWindowCommand;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_openImageImportMappingWindowCommand = openImageImportMappingWindowCommand ?? new AsyncRelayCommand(ct => Task.CompletedTask);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OpenImageImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImageImportMappingAsync(ct), () => CanOpenImageImportMapping);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("async Task OpenImageImportMappingAsync(CancellationToken cancellationToken)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (!CanOpenImageImportMapping)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("await _openImageImportMappingWindowCommand.ExecuteAsync(null);", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ExposesImageMappingReadinessWithPermissionAndBusyState()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("public bool CanOpenImageImportMapping => CanImportImages && !IsDataOperationBusy;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string ActiveDataOperationName => ValueOrDefault(_currentDataOperation, \"Data operation\");", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Image mapping is paused while {ActiveDataOperationName.ToLowerInvariant()} is running", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Image import requires the {User.PermissionLabels[User.PermissionImportExport]} permission", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Image import is available for matching photos", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ReportsBusyBackupAndRestoreStateInSharedSummary()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("public string BackupSummary => IsDataOperationBusy", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Backup and restore are paused while {ActiveDataOperationName.ToLowerInvariant()} is running.", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Finish or cancel the current data operation before starting another import, export, backup, restore, image mapping, copy, or print handoff.", viewModel, StringComparison.Ordinal);
+            Assert.Contains("Ready for the next import, export, backup, restore, image mapping, copy, or print handoff.", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_NotifiesImageMappingReadinessOnUserAndBusyTransitions()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("OnPropertyChanged(nameof(CanOpenImageImportMapping));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ActiveDataOperationName));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ImageImportSummary));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(BackupSummary));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OpenImageImportMappingWindowCommand.NotifyCanExecuteChanged();", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ImportExportPage_UsesWrappedImageMappingCommandEverywhere()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
+
+            Assert.True(CountOccurrences(xaml, "Command=\"{Binding OpenImageImportMappingWindowCommand}\"") >= 2);
+            Assert.Contains("Visibility=\"{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Click=\"OpenImageImportMapping", xaml, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            var count = 0;
+            var startIndex = 0;
+            while (true)
+            {
+                var index = text.IndexOf(value, startIndex, StringComparison.Ordinal);
+                if (index < 0)
+                    return count;
+
+                count++;
+                startIndex = index + value.Length;
+            }
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return NormalizeLineEndings(File.ReadAllText(candidate));
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+
+        private static string NormalizeLineEndings(string text) =>
+            text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-07-06-import-export-data-operation-readiness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-06-import-export-data-operation-readiness.md
@@ -1,0 +1,27 @@
+# Import / Export Data Operation Readiness
+
+Date: 2026-07-06
+
+## Completed
+
+- Routed the image-mapping entry point through the same shared Import / Export data-operation readiness model used by imports, exports, backup, restore, copy, print, and log clearing.
+- Preserved the existing injected image-mapping command while wrapping it with `CanOpenImageImportMapping` so every existing XAML image-mapping button automatically disables during active data work.
+- Added permission-aware image-mapping readiness so the command remains unavailable without import/export access and while another data operation is active.
+- Expanded the data-operation summary to explicitly include image mapping, making the footer/busy messaging honest about all blocked workflow lanes.
+- Added a reusable active-operation display name so busy status, image-mapping messaging, and backup/restore messaging all describe the current operation consistently.
+- Updated image import guidance to say when mapping is paused by an active import/export/backup/restore operation.
+- Updated backup/restore guidance to say when recovery actions are paused by an active operation.
+- Notified image-mapping command state and summary text when user permissions change.
+- Notified image-mapping command state, image guidance, backup guidance, and active-operation naming on busy-state transitions.
+- Added a guarded unavailable-command path that records a log entry and user-facing message when the wrapped image mapping command cannot execute from the current data desk state.
+- Added source-contract coverage for wrapped image-mapping command construction, permission/busy readiness, shared summaries, notification paths, and the existing XAML command bindings.
+
+## Validation
+
+- GitHub connector readback/diff validation was used for the changed files because direct checkout and raw GitHub downloads are blocked in this scheduled Linux environment.
+- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, or print-preview checks here because the container has no Windows/.NET/WPF toolchain and direct clone remains blocked by GitHub HTTP 403.
+
+## Follow-up
+
+- Run the full validation runner on a Windows/.NET-capable checkout.
+- Smoke test starting an import/export/backup operation and confirm image mapping, backup/restore guidance, run-log copy/print, and footer status all remain synchronized while busy.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -32,6 +32,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly ILogger<ImportExportViewModel> _logger;
         private readonly IUserContext _userContext;
         private readonly RentalConfigurationService? _rentalConfigService;
+        private readonly IAsyncRelayCommand _openImageImportMappingWindowCommand;
         private int _activeDataOperationCount;
         private int _omittedImportExportLogCount;
         private string? _currentDataOperation;
@@ -52,13 +53,15 @@ namespace InventoryManagementApp.ViewModels
         public bool HasOmittedImportExportLogs => _omittedImportExportLogCount > 0;
         public bool IsDataOperationBusy => _activeDataOperationCount > 0;
         public bool IsDataOperationReady => !IsDataOperationBusy;
+        public bool CanOpenImageImportMapping => CanImportImages && !IsDataOperationBusy;
         public bool CanReviewSelectedLog => !IsDataOperationBusy && !string.IsNullOrWhiteSpace(SelectedImportExportLog);
         public bool CanPrintImportExportLogs => !IsDataOperationBusy && HasLogEntries;
+        public string ActiveDataOperationName => ValueOrDefault(_currentDataOperation, "Data operation");
         public string DataOperationStatus => IsDataOperationBusy
-            ? $"{ValueOrDefault(_currentDataOperation, "Data operation")} running"
+            ? $"{ActiveDataOperationName} running"
             : "Data desk ready";
         public string DataOperationSummary => IsDataOperationBusy
-            ? "Finish or cancel the current data operation before starting another import, export, backup, restore, copy, or print handoff."
+            ? "Finish or cancel the current data operation before starting another import, export, backup, restore, image mapping, copy, or print handoff."
             : "Ready for the next import, export, backup, restore, image mapping, copy, or print handoff.";
         public string LogSummary
         {
@@ -85,12 +88,22 @@ namespace InventoryManagementApp.ViewModels
         public string CustomerDataSummary =>
             "Import customers from mapped CSV, JSON, or XML. Export the customer directory to CSV, JSON, or XML for advisor handoff or cleanup.";
 
-        public string ImageImportSummary => CanImportImages
-            ? $"Image import is available for matching photos to {LabelProvider.Instance.ItemLabelPlural}."
-            : $"Image import requires the {User.PermissionLabels[User.PermissionImportExport]} permission. Ask an admin to grant it before mapping photos to {LabelProvider.Instance.ItemLabelPlural}.";
+        public string ImageImportSummary
+        {
+            get
+            {
+                if (IsDataOperationBusy)
+                    return $"Image mapping is paused while {ActiveDataOperationName.ToLowerInvariant()} is running so heavy data workflows do not overlap.";
 
-        public string BackupSummary =>
-            "Create or restore a full recovery package containing the database and app assets.";
+                return CanImportImages
+                    ? $"Image import is available for matching photos to {LabelProvider.Instance.ItemLabelPlural}."
+                    : $"Image import requires the {User.PermissionLabels[User.PermissionImportExport]} permission. Ask an admin to grant it before mapping photos to {LabelProvider.Instance.ItemLabelPlural}.";
+            }
+        }
+
+        public string BackupSummary => IsDataOperationBusy
+            ? $"Backup and restore are paused while {ActiveDataOperationName.ToLowerInvariant()} is running."
+            : "Create or restore a full recovery package containing the database and app assets.";
 
         private string? _selectedImportExportLog;
         public string? SelectedImportExportLog
@@ -149,13 +162,15 @@ namespace InventoryManagementApp.ViewModels
             _databaseService = databaseService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
-            OpenImageImportMappingWindowCommand = openImageImportMappingWindowCommand ?? new AsyncRelayCommand(ct => Task.CompletedTask);
+            _openImageImportMappingWindowCommand = openImageImportMappingWindowCommand ?? new AsyncRelayCommand(ct => Task.CompletedTask);
             _userContext = userContext ?? new DummyUserContext();
             _userContext.UserChanged += (_, _) =>
             {
                 OnPropertyChanged(nameof(CanImportImages));
                 OnPropertyChanged(nameof(IsCurrentUserAdmin));
+                OnPropertyChanged(nameof(CanOpenImageImportMapping));
                 OnPropertyChanged(nameof(ImageImportSummary));
+                OpenImageImportMappingWindowCommand.NotifyCanExecuteChanged();
             };
             _rentalConfigService = rentalConfigService;
             ImportExportLogs.CollectionChanged += (_, _) =>
@@ -197,6 +212,7 @@ namespace InventoryManagementApp.ViewModels
             ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct), CanStartDataOperation);
             BackupDatabaseCommand = new AsyncRelayCommand(ct => BackupDatabaseAsync(ct), CanStartDataOperation);
             RestoreBackupCommand = new AsyncRelayCommand(ct => RestoreBackupAsync(ct), CanStartDataOperation);
+            OpenImageImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImageImportMappingAsync(ct), () => CanOpenImageImportMapping);
             ClearImportExportLogsCommand = new RelayCommand(ClearImportExportLogs, () => HasLogEntries && !IsDataOperationBusy);
         }
 
@@ -248,10 +264,14 @@ namespace InventoryManagementApp.ViewModels
         {
             OnPropertyChanged(nameof(IsDataOperationBusy));
             OnPropertyChanged(nameof(IsDataOperationReady));
+            OnPropertyChanged(nameof(CanOpenImageImportMapping));
             OnPropertyChanged(nameof(CanReviewSelectedLog));
             OnPropertyChanged(nameof(CanPrintImportExportLogs));
+            OnPropertyChanged(nameof(ActiveDataOperationName));
             OnPropertyChanged(nameof(DataOperationStatus));
             OnPropertyChanged(nameof(DataOperationSummary));
+            OnPropertyChanged(nameof(ImageImportSummary));
+            OnPropertyChanged(nameof(BackupSummary));
             ImportItemsCommand.NotifyCanExecuteChanged();
             CancelImportItemsCommand.NotifyCanExecuteChanged();
             ExportItemsCommand.NotifyCanExecuteChanged();
@@ -259,6 +279,7 @@ namespace InventoryManagementApp.ViewModels
             ExportCustomersCommand.NotifyCanExecuteChanged();
             BackupDatabaseCommand.NotifyCanExecuteChanged();
             RestoreBackupCommand.NotifyCanExecuteChanged();
+            OpenImageImportMappingWindowCommand.NotifyCanExecuteChanged();
             ClearImportExportLogsCommand.NotifyCanExecuteChanged();
         }
 
@@ -296,6 +317,23 @@ namespace InventoryManagementApp.ViewModels
         {
             AddLog(message);
             await _dialogService.ShowInfoAsync(message, title);
+        }
+
+        async Task OpenImageImportMappingAsync(CancellationToken cancellationToken)
+        {
+            if (!CanOpenImageImportMapping)
+                return;
+
+            if (!_openImageImportMappingWindowCommand.CanExecute(null))
+            {
+                const string message = "Image mapping is not available from the current data desk state.";
+                AddLog(message);
+                await _dialogService.ShowInfoAsync(message, "Image Mapping");
+                return;
+            }
+
+            AddLog("Opening image mapping workspace...");
+            await _openImageImportMappingWindowCommand.ExecuteAsync(null);
         }
 
         async Task ImportItemsAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## What changed

- Routed Import / Export image mapping through the shared data-operation readiness model already used by import, export, backup, restore, copy, print, and log clearing actions.
- Preserved the injected image-mapping command while wrapping it with `CanOpenImageImportMapping`, so existing XAML buttons disable automatically while another data operation is active or when the user lacks import/export access.
- Expanded busy/ready summaries so image mapping, backup, and restore guidance honestly reflect the currently running operation.
- Added source-contract coverage for image-mapping command wrapping, permission and busy readiness, summary notifications, and the existing XAML command bindings.
- Added a progress note for the completed workflow slice.

## Why this was highest value

Recent scheduled work has already bounded the Import / Export run log and guarded copy/print/log actions. The remaining gap in the same workflow was that image mapping still entered through an injected command without the shared busy/readiness contract, making overlapping heavy data work easier to start from the UI.

## Why this is real progress

This is a complete vertical slice for the Import / Export data desk: view-model readiness state, command gating, user-facing status text, notification paths, source-contract tests, and progress notes. It improves UI responsiveness and workflow safety without introducing a new screen or unrelated subsystem.

## Validation

- Connector compare confirmed the branch is current with `master`, ahead by three commits, and scoped to:
  - `InventoryManagementApp/ViewModels/ImportExportViewModel.cs`
  - `InventoryManagementApp.Tests/ImportExportDataOperationReadinessContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-06-import-export-data-operation-readiness.md`
- Connector readback verified the updated view-model readiness properties, wrapped image-mapping command, notification paths, new source-contract tests, and progress note.

## Could not check

- Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET tests, WPF runtime checks, screenshots, or print-preview checks in this scheduled Linux environment because direct checkout/raw GitHub downloads are blocked by HTTP 403 and Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run the full validation runner on a Windows/.NET-capable checkout.
- Smoke test starting an import/export/backup operation and confirm image mapping, backup/restore guidance, run-log copy/print, and footer status all remain synchronized while busy.