### PR TITLE
Improve Users directory visible row responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
@@ -89,7 +89,78 @@ namespace InventoryManagementApp.Tests
             Assert.True(vm.CanPrintUsers);
             Assert.Equal(2, vm.VisibleUserCount);
             Assert.Equal(2, vm.TotalUserCount);
+            Assert.Equal(2, vm.MatchedUserCount);
+            Assert.Equal(0, vm.OmittedUserCount);
             Assert.Equal(new[] { "alpha", "bravo" }, vm.Users.Select(user => user.UserName).ToArray());
+        }
+
+        [Fact]
+        public async Task LoadUsersAsync_BoundsVisibleRowsAndTracksFullMatchCounts()
+        {
+            var service = new StubUserService();
+            for (var i = 1; i <= UserManagementViewModel.MaxVisibleUserRows + 25; i++)
+            {
+                service.Users.Add(new UserModel
+                {
+                    UserID = i,
+                    UserName = $"user{i:000}",
+                    Role = "Workshop Staff",
+                    IsActive = true
+                });
+            }
+
+            var vm = new UserManagementViewModel(service, new StubFileDialogService(), new StubDialogService());
+            await vm.LoadUsersAsync();
+
+            Assert.Equal(UserManagementViewModel.MaxVisibleUserRows + 25, vm.TotalUserCount);
+            Assert.Equal(UserManagementViewModel.MaxVisibleUserRows + 25, vm.MatchedUserCount);
+            Assert.Equal(UserManagementViewModel.MaxVisibleUserRows, vm.VisibleUserCount);
+            Assert.Equal(25, vm.OmittedUserCount);
+            Assert.True(vm.IsUserWindowLimited);
+            Assert.Equal("user001", vm.Users.First().UserName);
+            Assert.Equal("user500", vm.Users.Last().UserName);
+            Assert.DoesNotContain(vm.Users, user => user.UserName == "user501");
+            Assert.Contains("showing first 500 of 525", vm.UserDirectoryStatusText);
+            Assert.Contains("refine search", vm.UserWindowStatusText);
+
+            vm.UserSearchText = "user52";
+            vm.SearchUsersCommand.Execute(null);
+
+            Assert.Equal(6, vm.MatchedUserCount);
+            Assert.Equal(6, vm.VisibleUserCount);
+            Assert.Equal(0, vm.OmittedUserCount);
+            Assert.False(vm.IsUserWindowLimited);
+            Assert.Equal(new[] { "user520", "user521", "user522", "user523", "user524", "user525" }, vm.Users.Select(user => user.UserName).ToArray());
+            Assert.Contains("6 matches", vm.UserFilterStatusText);
+        }
+
+        [Fact]
+        public async Task DeleteUserFromRowCommand_ReplenishesVisibleWindowAfterVisibleDelete()
+        {
+            var service = new StubUserService();
+            for (var i = 1; i <= UserManagementViewModel.MaxVisibleUserRows + 1; i++)
+            {
+                service.Users.Add(new UserModel
+                {
+                    UserID = i,
+                    UserName = $"user{i:000}",
+                    Role = "Workshop Staff",
+                    IsActive = true
+                });
+            }
+
+            var vm = new UserManagementViewModel(service, new StubFileDialogService(), new StubDialogService());
+            await vm.LoadUsersAsync();
+            var deletedUser = vm.Users.First();
+
+            await vm.DeleteUserFromRowCommand.ExecuteAsync(deletedUser);
+
+            Assert.Equal(UserManagementViewModel.MaxVisibleUserRows, vm.TotalUserCount);
+            Assert.Equal(UserManagementViewModel.MaxVisibleUserRows, vm.MatchedUserCount);
+            Assert.Equal(UserManagementViewModel.MaxVisibleUserRows, vm.VisibleUserCount);
+            Assert.Equal(0, vm.OmittedUserCount);
+            Assert.DoesNotContain(vm.Users, user => user.UserID == deletedUser.UserID);
+            Assert.Contains(vm.Users, user => user.UserName == "user501");
         }
 
         [Fact]
@@ -119,16 +190,20 @@ namespace InventoryManagementApp.Tests
             vm.SearchUsersCommand.Execute(null);
             var userById = Assert.Single(vm.Users);
             Assert.Equal("scheduler", userById.UserName);
+            Assert.Equal(1, vm.MatchedUserCount);
+            Assert.Equal(0, vm.OmittedUserCount);
 
             vm.UserSearchText = "failed login";
             vm.SearchUsersCommand.Execute(null);
             var userByLockout = Assert.Single(vm.Users);
             Assert.Equal("locked", userByLockout.UserName);
+            Assert.Equal(1, vm.MatchedUserCount);
 
             vm.UserSearchText = "Reservations";
             vm.SearchUsersCommand.Execute(null);
             var userByAccess = Assert.Single(vm.Users);
             Assert.Equal("scheduler", userByAccess.UserName);
+            Assert.Equal(1, vm.MatchedUserCount);
         }
 
         [Fact]
@@ -194,6 +269,8 @@ namespace InventoryManagementApp.Tests
 
             Assert.Empty(vm.Users);
             Assert.Null(vm.SelectedUser);
+            Assert.Equal(0, vm.MatchedUserCount);
+            Assert.Equal(0, vm.OmittedUserCount);
             Assert.False(vm.UpdateUserCommand.CanExecute(null));
             Assert.False(vm.EditUserCommand.CanExecute(null));
             Assert.Equal("Error", dialog.LastTitle);

--- a/InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs
@@ -72,6 +72,7 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("UserDirectoryStatusText", xaml, StringComparison.Ordinal);
             Assert.Contains("UserFilterStatusText", xaml, StringComparison.Ordinal);
+            Assert.Contains("UserWindowStatusText", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedAccessStatusText", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedSecurityStatusText", xaml, StringComparison.Ordinal);
             Assert.Contains("UserEmptyStateTitle", xaml, StringComparison.Ordinal);
@@ -80,6 +81,42 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("CanUseUserActions", xaml, StringComparison.Ordinal);
             Assert.Contains("CanUseSelectedUserActions", xaml, StringComparison.Ordinal);
             Assert.Contains("CanPrintUsers", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersPage_ViewModelCapsLiveDirectoryRowsAndReportsOmittedMatches()
+        {
+            var code = ReadRepoFile("InventoryManagementApp", "ViewModels", "UserManagementViewModel.cs");
+
+            Assert.Contains("public const int MaxVisibleUserRows = 500;", code, StringComparison.Ordinal);
+            Assert.Contains("public int MatchedUserCount => _matchedUserCount;", code, StringComparison.Ordinal);
+            Assert.Contains("public int OmittedUserCount => Math.Max(0, MatchedUserCount - VisibleUserCount);", code, StringComparison.Ordinal);
+            Assert.Contains("public bool IsUserWindowLimited => OmittedUserCount > 0;", code, StringComparison.Ordinal);
+            Assert.Contains("var visibleUsers = matchedUsers.Take(MaxVisibleUserRows).ToList();", code, StringComparison.Ordinal);
+            Assert.Contains("if (!AreSameVisibleRows(visibleUsers))", code, StringComparison.Ordinal);
+            Assert.Contains("Users.ReplaceRange(visibleUsers);", code, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(MatchedUserCount));", code, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(OmittedUserCount));", code, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(UserWindowStatusText));", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("Users.ReplaceRange(FilterUsers(_allUsers));", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("Users.ReplaceRange(_allUsers);", code, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UsersPage_PrintPreviewAccountsForMatchedVisibleHiddenAndPrintedRows()
+        {
+            var code = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs");
+
+            Assert.Contains("var totalMatchedCount = ViewModel.MatchedUserCount;", code, StringComparison.Ordinal);
+            Assert.Contains("var hiddenFromGridCount = ViewModel.OmittedUserCount;", code, StringComparison.Ordinal);
+            Assert.Contains("Matched users: {totalMatchedCount}; visible rows: {totalVisibleCount}; printed rows: {printRows.Count}; hidden from grid: {hiddenFromGridCount}; print omitted rows: {printOmittedCount}", code, StringComparison.Ordinal);
+            Assert.Contains("BuildPrintDocument(printRows, totalMatchedCount, totalVisibleCount, hiddenFromGridCount, summary)", code, StringComparison.Ordinal);
+            Assert.Contains("Matched Accounts", code, StringComparison.Ordinal);
+            Assert.Contains("Visible Grid Rows", code, StringComparison.Ordinal);
+            Assert.Contains("Hidden From Grid", code, StringComparison.Ordinal);
+            Assert.Contains("Live Grid Limit", code, StringComparison.Ordinal);
+            Assert.Contains("UserManagementViewModel.MaxVisibleUserRows", code, StringComparison.Ordinal);
+            Assert.Contains("Print Limit", code, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-users-directory-visible-window.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-users-directory-visible-window.md
@@ -1,0 +1,17 @@
+# Users Directory Visible Window Responsiveness - 2026-07-07
+
+## Completed
+
+- Bounded the live Users Workbench account grid to the first 500 matching accounts so large admin directories do not push every match into the WPF `ObservableCollection`.
+- Added full matched, visible, omitted, total, and window-limited state to `UserManagementViewModel`.
+- Updated Users status, filter, summary, and footer text so operators can tell whether all matches are visible or whether search should be refined.
+- Preserved deterministic account ordering while reducing unnecessary collection churn when the visible row window has not changed.
+- Refilled the visible row window after deleting a visible user so the grid stays dense and honest when hidden matches remain.
+- Updated Users print-preview accounting to distinguish matched accounts, visible grid rows, hidden-from-grid rows, printed rows, and print-omitted rows.
+- Added behavior coverage for large directories, search recovery, omitted-row state, and delete-window refill behavior.
+- Added source-contract coverage for the live-grid cap, omitted-row messaging, unchanged-window reuse, and print accounting.
+
+## Validation
+
+- GitHub connector readback/compare was used in the scheduled Linux environment.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime checks, screenshots, scaling checks, and print-preview rendering could not be run because direct checkout remains blocked and Windows/.NET/WPF tooling is unavailable in this environment.

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -24,6 +24,8 @@ namespace InventoryManagementApp.ViewModels
 {
     public class UserManagementViewModel : ObservableObject
     {
+        public const int MaxVisibleUserRows = 500;
+
         private readonly IUserService _userService;
         private readonly IFileDialogService _fileDialogService;
         private readonly IDialogService _dialogService;
@@ -32,6 +34,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly IServiceProvider? _serviceProvider;
 
         private List<UserModel> _allUsers = new();
+        private int _matchedUserCount;
         private bool _hasLoadedUsers;
 
         public ObservableCollection<UserModel> Users { get; } = new();
@@ -76,8 +79,11 @@ namespace InventoryManagementApp.ViewModels
         }
 
         public int TotalUserCount => _allUsers.Count;
+        public int MatchedUserCount => _matchedUserCount;
         public int VisibleUserCount => Users.Count;
+        public int OmittedUserCount => Math.Max(0, MatchedUserCount - VisibleUserCount);
         public bool HasUserFilter => !string.IsNullOrWhiteSpace(UserSearchText);
+        public bool IsUserWindowLimited => OmittedUserCount > 0;
         public bool CanUseUserActions => !IsLoadingUsers;
         public bool CanUseSelectedUserActions => !IsLoadingUsers && SelectedUser != null;
         public bool CanPrintUsers => !IsLoadingUsers && Users.Count > 0;
@@ -91,12 +97,15 @@ namespace InventoryManagementApp.ViewModels
                         ? $"Refreshing account directory - keeping {Users.Count} current rows visible"
                         : "Loading account directory";
 
-                if (Users.Count == 0)
+                if (MatchedUserCount == 0)
                     return HasUserFilter
                         ? $"No users match \"{UserSearchText.Trim()}\""
                         : "No user accounts are available";
 
-                return $"Admin desk ready - {Users.Count} visible of {_allUsers.Count} accounts";
+                if (IsUserWindowLimited)
+                    return $"Admin desk ready - showing first {VisibleUserCount} of {MatchedUserCount} matching accounts ({OmittedUserCount} hidden from the live grid)";
+
+                return $"Admin desk ready - {VisibleUserCount} visible of {TotalUserCount} accounts";
             }
         }
 
@@ -107,11 +116,21 @@ namespace InventoryManagementApp.ViewModels
                 if (IsLoadingUsers)
                     return "Search pauses until account rows finish loading";
 
-                return HasUserFilter
-                    ? $"Filter: {UserSearchText.Trim()}"
+                if (HasUserFilter)
+                    return IsUserWindowLimited
+                        ? $"Filter: {UserSearchText.Trim()} - {MatchedUserCount} matches, first {VisibleUserCount} shown"
+                        : $"Filter: {UserSearchText.Trim()} - {MatchedUserCount} matches";
+
+                return IsUserWindowLimited
+                    ? $"All accounts - first {VisibleUserCount} of {MatchedUserCount} shown"
                     : "All accounts";
             }
         }
+
+        public string UserWindowStatusText =>
+            IsUserWindowLimited
+                ? $"Showing first {VisibleUserCount} accounts to keep the grid responsive; refine search to reach {OmittedUserCount} more matches."
+                : "All matching accounts are visible in the live grid.";
 
         public string SelectedAccessStatusText =>
             IsLoadingUsers
@@ -212,13 +231,43 @@ namespace InventoryManagementApp.ViewModels
             _hasLoadedUsers = true;
 
             AssignInitialsBrushes(_allUsers);
-            Users.ReplaceRange(FilterUsers(_allUsers));
+            ApplyFilteredUserRows();
+        }
+
+        private void ApplyFilteredUserRows()
+        {
+            var matchedUsers = FilterUsers(_allUsers).ToList();
+            var visibleUsers = matchedUsers.Take(MaxVisibleUserRows).ToList();
+            _matchedUserCount = matchedUsers.Count;
+
+            if (!AreSameVisibleRows(visibleUsers))
+                Users.ReplaceRange(visibleUsers);
+
+            if (SelectedUser != null && !Users.Any(user => user.UserID == SelectedUser.UserID))
+                SelectedUser = null;
+
             NotifyUserDirectoryStateChanged();
+            NotifyUserCommandStatesChanged();
+        }
+
+        private bool AreSameVisibleRows(IReadOnlyList<UserModel> visibleUsers)
+        {
+            if (Users.Count != visibleUsers.Count)
+                return false;
+
+            for (var i = 0; i < visibleUsers.Count; i++)
+            {
+                if (!ReferenceEquals(Users[i], visibleUsers[i]))
+                    return false;
+            }
+
+            return true;
         }
 
         private void ClearUsersAfterLoadFailure()
         {
             _allUsers.Clear();
+            _matchedUserCount = 0;
             _hasLoadedUsers = false;
             Users.Clear();
             SelectedUser = null;
@@ -344,11 +393,9 @@ namespace InventoryManagementApp.ViewModels
                 await _userService.UpdateUserAsync(SelectedUser);
                 var idxAll = _allUsers.IndexOf(SelectedUser);
                 if (idxAll >= 0) _allUsers[idxAll] = SelectedUser;
-                var idx = Users.IndexOf(SelectedUser);
-                if (idx >= 0) Users[idx] = SelectedUser;
+                ApplyFilteredUserRows();
                 if (_userContext?.CurrentUser?.UserID == SelectedUser.UserID)
                     _userContext.CurrentUser = SelectedUser;
-                NotifyUserDirectoryStateChanged();
             }
             catch (UnauthorizedAccessException)
             {
@@ -370,11 +417,9 @@ namespace InventoryManagementApp.ViewModels
                 await _userService.UpdateUserAsync(SelectedUser);
                 var idxAll = _allUsers.IndexOf(SelectedUser);
                 if (idxAll >= 0) _allUsers[idxAll] = SelectedUser;
-                var idx = Users.IndexOf(SelectedUser);
-                if (idx >= 0) Users[idx] = SelectedUser;
+                ApplyFilteredUserRows();
                 if (_userContext?.CurrentUser?.UserID == SelectedUser.UserID)
                     _userContext.CurrentUser = SelectedUser;
-                NotifyUserDirectoryStateChanged();
             }
             catch (UnauthorizedAccessException)
             {
@@ -495,8 +540,7 @@ namespace InventoryManagementApp.ViewModels
         void SearchUsers()
         {
             if (!CanUseUserActions) return;
-            Users.ReplaceRange(FilterUsers(_allUsers));
-            NotifyUserDirectoryStateChanged();
+            ApplyFilteredUserRows();
         }
 
         private IEnumerable<UserModel> FilterUsers(IEnumerable<UserModel> users)
@@ -523,8 +567,7 @@ namespace InventoryManagementApp.ViewModels
         {
             if (!CanUseUserActions) return;
             UserSearchText = string.Empty;
-            Users.ReplaceRange(_allUsers);
-            NotifyUserDirectoryStateChanged();
+            ApplyFilteredUserRows();
         }
 
         public async Task EditUserAsync(UserModel? user)
@@ -575,13 +618,12 @@ namespace InventoryManagementApp.ViewModels
                     try
                     {
                         await _userService.UpdateUserAsync(clone);
-                        var idx = Users.IndexOf(user);
-                        if (idx >= 0) Users[idx] = clone;
                         var idxAll = _allUsers.IndexOf(user);
                         if (idxAll >= 0) _allUsers[idxAll] = clone;
                         AssignInitialsBrushes(_allUsers);
-                        NotifyUserDirectoryStateChanged();
-                        if (ReferenceEquals(SelectedUser, user)) SelectedUser = clone;
+                        ApplyFilteredUserRows();
+                        if (Users.Any(visibleUser => visibleUser.UserID == clone.UserID))
+                            SelectedUser = clone;
                         if (_userContext?.CurrentUser?.UserID == clone.UserID)
                             _userContext.CurrentUser = clone;
                         if (win != null)
@@ -665,11 +707,9 @@ namespace InventoryManagementApp.ViewModels
                 var deleted = await _userService.TryDeleteUserAsync(user.UserID);
                 if (deleted)
                 {
-                    _allUsers.Remove(user);
-                    Users.Remove(user);
+                    _allUsers.RemoveAll(existing => existing.UserID == user.UserID);
                     if (ReferenceEquals(SelectedUser, user)) SelectedUser = null;
-                    NotifyUserDirectoryStateChanged();
-                    NotifyUserCommandStatesChanged();
+                    ApplyFilteredUserRows();
                 }
                 else
                 {
@@ -692,13 +732,17 @@ namespace InventoryManagementApp.ViewModels
         private void NotifyUserDirectoryStateChanged()
         {
             OnPropertyChanged(nameof(TotalUserCount));
+            OnPropertyChanged(nameof(MatchedUserCount));
             OnPropertyChanged(nameof(VisibleUserCount));
+            OnPropertyChanged(nameof(OmittedUserCount));
             OnPropertyChanged(nameof(HasUserFilter));
+            OnPropertyChanged(nameof(IsUserWindowLimited));
             OnPropertyChanged(nameof(CanUseUserActions));
             OnPropertyChanged(nameof(CanUseSelectedUserActions));
             OnPropertyChanged(nameof(CanPrintUsers));
             OnPropertyChanged(nameof(UserDirectoryStatusText));
             OnPropertyChanged(nameof(UserFilterStatusText));
+            OnPropertyChanged(nameof(UserWindowStatusText));
             OnPropertyChanged(nameof(UserEmptyStateTitle));
             OnPropertyChanged(nameof(UserEmptyStateMessage));
             OnPropertyChanged(nameof(SelectedAccessStatusText));

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -62,7 +62,7 @@
                 <StackPanel>
                     <TextBlock Text="Visible Users" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding VisibleUserCount}" Style="{StaticResource UserStatValueText}"/>
-                    <TextBlock Text="{Binding UserDirectoryStatusText}" Style="{StaticResource UserDetailText}"/>
+                    <TextBlock Text="{Binding UserWindowStatusText}" Style="{StaticResource UserDetailText}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource UserStatCard}">
@@ -375,7 +375,7 @@
                            FontSize="11"
                            VerticalAlignment="Center"/>
                 <TextBlock DockPanel.Dock="Right"
-                           Text="Select a row, then edit access, reset password, copy handoff, upload photo, or print the filtered directory."
+                           Text="{Binding UserWindowStatusText}"
                            Style="{StaticResource CaptionTextBlock}"
                            VerticalAlignment="Center"
                            TextWrapping="Wrap"/>

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
@@ -138,11 +138,14 @@ namespace InventoryManagementApp.Views.Pages
                     return;
                 }
 
+                var totalMatchedCount = ViewModel.MatchedUserCount;
                 var totalVisibleCount = ViewModel.Users.Count;
+                var hiddenFromGridCount = ViewModel.OmittedUserCount;
                 var printRows = ViewModel.Users.Take(MaxUsersPrintRows).ToList();
-                var summary = $"Visible users: {totalVisibleCount}; printed rows: {printRows.Count}; omitted rows: {Math.Max(0, totalVisibleCount - printRows.Count)}";
-                var document = BuildPrintDocument(printRows, totalVisibleCount, summary);
-                ShowPrintPreview(document, "User Directory", "Review the current account directory, access coverage, lockout state, active state, contact handoff details, and any omitted rows before filing an admin packet.");
+                var printOmittedCount = Math.Max(0, totalVisibleCount - printRows.Count);
+                var summary = $"Matched users: {totalMatchedCount}; visible rows: {totalVisibleCount}; printed rows: {printRows.Count}; hidden from grid: {hiddenFromGridCount}; print omitted rows: {printOmittedCount}";
+                var document = BuildPrintDocument(printRows, totalMatchedCount, totalVisibleCount, hiddenFromGridCount, summary);
+                ShowPrintPreview(document, "User Directory", "Review the current account directory, access coverage, lockout state, active state, contact handoff details, hidden grid matches, and any omitted print rows before filing an admin packet.");
             });
         }
 
@@ -164,7 +167,7 @@ namespace InventoryManagementApp.Views.Pages
                    "Next steps: edit profile details, tick the app sections this user can access, upload a current photo, reset the password if the user is blocked, or review activity logs for recent account actions.";
         }
 
-        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<UserModel> users, int totalVisibleCount, string summary)
+        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<UserModel> users, int totalMatchedCount, int totalVisibleCount, int hiddenFromGridCount, string summary)
         {
             var document = new FlowDocument
             {
@@ -185,7 +188,7 @@ namespace InventoryManagementApp.Views.Pages
                 Margin = new Thickness(0, 0, 0, 8)
             });
 
-            document.Blocks.Add(BuildSummarySection(summary, totalVisibleCount, users.Count, Math.Max(0, totalVisibleCount - users.Count)));
+            document.Blocks.Add(BuildSummarySection(summary, totalMatchedCount, totalVisibleCount, users.Count, hiddenFromGridCount, Math.Max(0, totalVisibleCount - users.Count)));
 
             if (users.Count == 0)
             {
@@ -235,7 +238,7 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             document.Blocks.Add(table);
-            document.Blocks.Add(new Paragraph(new Run("Review access coverage, lockout state, disabled accounts, contact handoff details, and any omitted rows before changing permissions or filing this directory packet."))
+            document.Blocks.Add(new Paragraph(new Run("Review access coverage, lockout state, disabled accounts, contact handoff details, hidden grid matches, and any omitted print rows before changing permissions or filing this directory packet."))
             {
                 FontSize = 10,
                 FontStyle = FontStyles.Italic,
@@ -245,7 +248,7 @@ namespace InventoryManagementApp.Views.Pages
             return document;
         }
 
-        private static Table BuildSummarySection(string summary, int totalVisibleCount, int printedRowCount, int omittedRowCount)
+        private static Table BuildSummarySection(string summary, int totalMatchedCount, int totalVisibleCount, int printedRowCount, int hiddenFromGridCount, int printOmittedRowCount)
         {
             var table = new Table { CellSpacing = 0, Margin = new Thickness(0, 0, 0, 10) };
             table.Columns.Add(new TableColumn { Width = new GridLength(0.25, GridUnitType.Star) });
@@ -254,10 +257,13 @@ namespace InventoryManagementApp.Views.Pages
             var group = new TableRowGroup();
             table.RowGroups.Add(group);
             AddSummaryLine(group, "Print Packet", summary);
-            AddSummaryLine(group, "Total Visible Rows", totalVisibleCount.ToString());
+            AddSummaryLine(group, "Matched Accounts", totalMatchedCount.ToString());
+            AddSummaryLine(group, "Visible Grid Rows", totalVisibleCount.ToString());
             AddSummaryLine(group, "Printed Rows", printedRowCount.ToString());
-            AddSummaryLine(group, "Omitted Rows", omittedRowCount == 0 ? "None" : $"{omittedRowCount} rows omitted to keep preview responsive");
-            AddSummaryLine(group, "Large Directory Limit", $"First {MaxUsersPrintRows} visible rows");
+            AddSummaryLine(group, "Hidden From Grid", hiddenFromGridCount == 0 ? "None" : $"{hiddenFromGridCount} matching accounts hidden from the live grid; refine search to print them");
+            AddSummaryLine(group, "Print Omitted Rows", printOmittedRowCount == 0 ? "None" : $"{printOmittedRowCount} visible rows omitted to keep preview responsive");
+            AddSummaryLine(group, "Live Grid Limit", $"First {UserManagementViewModel.MaxVisibleUserRows} matching accounts");
+            AddSummaryLine(group, "Print Limit", $"First {MaxUsersPrintRows} visible rows");
 
             return table;
         }


### PR DESCRIPTION
## What changed

- Bounded the Users Workbench live account grid to the first 500 matching users while preserving full matched, visible, omitted, and total counts.
- Added visible-window state and operator-facing messaging so large directories clearly show when additional matches are hidden from the live grid.
- Reduced filtered collection churn by reusing the existing visible window when the row references have not changed.
- Refilled the visible window after deleting a visible account so the grid stays dense when hidden matches remain.
- Updated Users directory print preview accounting to distinguish matched accounts, visible grid rows, hidden-from-grid rows, printed rows, and print-omitted rows.
- Added behavior coverage for large directories, search recovery, omitted-row state, and delete-window refill behavior.
- Added source-contract coverage for the 500-row cap, omitted-row UI messaging, unchanged-window reuse, and print accounting.
- Recorded the completed workflow in `InventoryManagementApp/ProgressNotes/2026-07-07-users-directory-visible-window.md`.

## Why this was highest value

Recent repository work has focused on loading speed, UI responsiveness, and professional data display across large grids. Users already had loading/action guards and print caps, but the live admin grid could still bind every matching account into the WPF collection. This finishes that performance pattern for the Users directory without inventing a new feature.

## Why this is real progress

This is an end-to-end workflow slice: view-model row-window state, user-visible status text, print-preview accounting, mutation behavior, behavior tests, source-contract tests, and progress notes all move together.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master`, focused to six files, and contains the intended Users visible-window, print-accounting, tests, and progress note changes.
- Could not run `pwsh -File scripts/run-full-validation.ps1`, local .NET build/test, WPF runtime checks, screenshots, scaling checks, or print-preview rendering because direct checkout is blocked in this scheduled Linux environment and Windows/.NET/WPF tooling is unavailable.

## Follow-up

- Run the full Windows/.NET validation runner and WPF smoke checks from a Windows-capable checkout.
- Continue applying row-window and honest count patterns only to screens that still have evidence of unbounded live grids or sluggish data display.