### PR TITLE
[codex] Improve Activity Audit visible row responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
@@ -44,11 +44,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void ActivityLogsPage_BoundsEmptyStateAndHandoffTextInsteadOfForcingPageWidthOrHeight()
+        public void ActivityLogsPage_BoundsEmptyOmittedAndHandoffTextInsteadOfForcingPageWidthOrHeight()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml");
 
-            Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"360\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"3\" MaxWidth=\"360\" Margin=\"12\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" Margin=\"8,0,8,8\" MaxWidth=\"780\" HorizontalAlignment=\"Left\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Binding=\"{Binding HasOmittedActivityRows}\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding ActivityWindowStatusText}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MinHeight=\"130\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MaxHeight=\"260\"", xaml, StringComparison.Ordinal);
             Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\"", xaml, StringComparison.Ordinal);
@@ -93,6 +96,21 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<DataTrigger Binding=\"{Binding IsBusy}\" Value=\"True\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<ProgressBar IsIndeterminate=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ActivityBusyMessage", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsPage_ShowsMatchedVisibleHiddenAndLoadedCounts()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml");
+
+            Assert.Contains("Text=\"MATCHED\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"OMITTED\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("MatchedLogCount", xaml, StringComparison.Ordinal);
+            Assert.Contains("OmittedLogCount", xaml, StringComparison.Ordinal);
+            Assert.Contains("StringFormat='Matched: {0}'", xaml, StringComparison.Ordinal);
+            Assert.Contains("StringFormat='Hidden: {0}'", xaml, StringComparison.Ordinal);
+            Assert.Contains("StringFormat='Loaded: {0}'", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("{Binding FilteredLogCount, StringFormat={}{0} visible}", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -176,6 +194,24 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ActivityLogsPage_PrintPreviewAccountsForMatchedVisibleHiddenAndPrintedRows()
+        {
+            var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("var totalMatchedCount = vm.MatchedLogCount;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var totalVisibleCount = vm.FilteredLogs.Count;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var hiddenFromGridCount = vm.OmittedLogCount;", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("var printOmittedCount = Math.Max(0, totalVisibleCount - printRows.Count);", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("BuildPrintDocument(printRows, totalMatchedCount, totalVisibleCount, hiddenFromGridCount, printOmittedCount, vm.PrintStatusText, vm.ActivitySummary)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Matched Activity Rows", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Visible Grid Rows", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Hidden From Grid", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Print Omitted Rows", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Live Grid Limit", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ActivityLogsViewModel.MaxVisibleActivityRows", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ActivityLogsViewModel_CoalescesFilteringAndKeepsRowsDuringRefreshFailure()
         {
             var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
@@ -184,7 +220,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("CancellationTokenSource? _filterRefreshCts", viewModel, StringComparison.Ordinal);
             Assert.Contains("Interlocked.Exchange(ref _filterRefreshCts, cts)", viewModel, StringComparison.Ordinal);
             Assert.Contains("await Task.Delay(FilterDebounceMilliseconds, cts.Token);", viewModel, StringComparison.Ordinal);
-            Assert.Contains("await Task.Run(() => rows", viewModel, StringComparison.Ordinal);
+            Assert.Contains("await Task.Run(() => BuildFilteredLogWindow(rows", viewModel, StringComparison.Ordinal);
             Assert.Contains("PreserveActivityLogRowsAfterLoadFailure", viewModel, StringComparison.Ordinal);
             Assert.DoesNotContain("ClearActivityLogRowsAfterLoadFailure", viewModel, StringComparison.Ordinal);
         }
@@ -249,14 +285,37 @@ namespace InventoryManagementApp.Tests
         {
             var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
 
-            Assert.Contains("ReplaceFilteredLogs(filtered, previousSelection);", viewModel, StringComparison.Ordinal);
-            Assert.Contains("private void ReplaceFilteredLogs(IReadOnlyList<ActivityLog> filtered, ActivityLog? previousSelection)", viewModel, StringComparison.Ordinal);
-            Assert.Contains("if (!HasSameRows(FilteredLogs, filtered))", viewModel, StringComparison.Ordinal);
+            Assert.Contains("ReplaceFilteredLogs(filterResult.VisibleRows, previousSelection);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private void ReplaceFilteredLogs(IReadOnlyList<ActivityLog> visibleRows, ActivityLog? previousSelection)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (!HasSameRows(FilteredLogs, visibleRows))", viewModel, StringComparison.Ordinal);
             Assert.Contains("SelectedLog = previousSelection != null && FilteredLogs.Contains(previousSelection)", viewModel, StringComparison.Ordinal);
             Assert.Contains("private static bool HasSameRows(IReadOnlyList<ActivityLog> currentRows, IReadOnlyList<ActivityLog> nextRows)", viewModel, StringComparison.Ordinal);
             Assert.Contains("if (!ReferenceEquals(currentRows[i], nextRows[i]))", viewModel, StringComparison.Ordinal);
             Assert.Contains("previousCts?.Dispose();", viewModel, StringComparison.Ordinal);
             Assert.Contains("_searchRows = Array.Empty<ActivityLogSearchRow>();", viewModel, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ActivityLogsViewModel_CapsLiveGridRowsAndReportsHiddenMatches()
+        {
+            var viewModel = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
+
+            Assert.Contains("public const int MaxVisibleActivityRows = 500;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private int _matchedLogCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public int MatchedLogCount => _matchedLogCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public int OmittedLogCount => Math.Max(0, MatchedLogCount - FilteredLogCount);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public bool HasOmittedActivityRows => OmittedLogCount > 0;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("var visibleRows = new List<ActivityLog>(MaxVisibleActivityRows);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (visibleRows.Count < MaxVisibleActivityRows)", viewModel, StringComparison.Ordinal);
+            Assert.Contains("return new FilteredActivityLogResult(visibleRows, matchedCount);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("_matchedLogCount = filterResult.MatchedCount;", viewModel, StringComparison.Ordinal);
+            Assert.Contains("public string ActivityWindowStatusText", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(MatchedLogCount));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(OmittedLogCount));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(HasOmittedActivityRows));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ActivityWindowStatusText));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("private sealed record FilteredActivityLogResult(IReadOnlyList<ActivityLog> VisibleRows, int MatchedCount);", viewModel, StringComparison.Ordinal);
+            Assert.DoesNotContain(".Where(row => row.Matches(selectedUserFilter, selectedActionFilter, search))\n                    .Select(row => row.Log)\n                    .ToList()", viewModel, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-activity-audit-visible-row-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-activity-audit-visible-row-responsiveness.md
@@ -1,0 +1,23 @@
+# Activity Audit Visible Row Responsiveness - 2026-07-07
+
+## Completed
+
+- Bounded the live Activity Audit grid to the first 500 matching audit rows so large activity trails do not push every match into the WPF `ObservableCollection`.
+- Added matched, visible, omitted, and loaded row state to `ActivityLogsViewModel`.
+- Replaced full-list LINQ filtering with a counted visible-window filter loop that stops adding rows after the live-grid cap while still counting all matches.
+- Added Activity Audit window-status text so operators know when filters need to be refined to reach hidden matches.
+- Updated Activity Audit header metrics, pane header, omitted-row banner, and footer counters to distinguish visible, matched, hidden, and loaded rows.
+- Kept busy, empty, selection, keyboard, and row-action guards intact while changing the row-display contract.
+- Updated Activity Audit print-preview accounting to distinguish matched rows, visible grid rows, hidden-from-grid rows, printed rows, and print-omitted rows.
+- Added live-grid and print-preview limit labels to the printed audit packet so large audit trails remain professionally documented.
+- Extended Activity Audit source-contract coverage for capped row filtering, omitted-row display, matched/hidden counters, status text, and print accounting.
+
+## Validation
+
+- GitHub connector readback and compare should be used for this scheduled pass because direct local checkout is blocked in the Linux runner.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime checks, screenshots, scaling checks, and print-preview rendering could not be run because this scheduled environment cannot clone the repository directly and does not provide Windows/.NET/WPF tooling.
+
+## Follow-up
+
+- Run the full validation runner on a Windows/.NET-capable checkout.
+- Smoke test Activity Audit with more than 500 matching rows to confirm the live grid, omitted banner, print preview, and filter status remain responsive and clear.

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -18,6 +18,7 @@ namespace InventoryManagementApp.ViewModels
         const string AllUsersFilter = "All users";
         const string AllActionsFilter = "All actions";
         const int FilterDebounceMilliseconds = 160;
+        public const int MaxVisibleActivityRows = 500;
         const int MaxActivityPrintRows = 250;
 
         private readonly ActivityLogService _service;
@@ -25,6 +26,7 @@ namespace InventoryManagementApp.ViewModels
         private CancellationTokenSource? _filterRefreshCts;
         private bool _suppressFilterRefresh;
         private IReadOnlyList<ActivityLogSearchRow> _searchRows = Array.Empty<ActivityLogSearchRow>();
+        private int _matchedLogCount;
 
         public ObservableCollection<ActivityLog> Logs { get; } = new();
         public ObservableCollection<ActivityLog> FilteredLogs { get; } = new();
@@ -135,14 +137,17 @@ namespace InventoryManagementApp.ViewModels
 
         public string LastLoadedText => LastLoadedAt.HasValue ? LastLoadedAt.Value.ToString("g") : "Not loaded";
         public int TotalLogCount => Logs.Count;
+        public int MatchedLogCount => _matchedLogCount;
         public int FilteredLogCount => FilteredLogs.Count;
+        public int OmittedLogCount => Math.Max(0, MatchedLogCount - FilteredLogCount);
+        public bool HasOmittedActivityRows => OmittedLogCount > 0;
         public bool IsBusy => IsLoading || IsFiltering;
         public bool HasActiveFilters => HasActiveFilter();
         public bool CanChangeActivityFilters => !IsLoading;
         public bool CanRefreshActivityRows => !IsBusy;
         public bool CanUseSelectedLogActions => !IsBusy && SelectedLog != null;
         public bool CanPrintActivityRows => !IsBusy && FilteredLogs.Count > 0;
-        public bool CanShowActivityEmptyState => !IsBusy && FilteredLogs.Count == 0;
+        public bool CanShowActivityEmptyState => !IsBusy && MatchedLogCount == 0;
         public string ActivityBusyMessage => IsLoading
             ? "Refreshing recent audit rows without blocking the rest of the screen."
             : "Applying the current search and filter choices to the loaded audit rows.";
@@ -157,6 +162,12 @@ namespace InventoryManagementApp.ViewModels
             ? "Refresh the audit trail to review recent operations, account changes, imports, rentals, and item events."
             : "Clear or adjust the current search, user, and action filters to review more of the audit trail.";
 
+        public string ActivityWindowStatusText => HasOmittedActivityRows
+            ? $"Showing first {FilteredLogCount} of {MatchedLogCount} matching activity rows to keep the live grid responsive; refine filters to reach {OmittedLogCount} more."
+            : MatchedLogCount == 0
+                ? "No matching activity rows are visible."
+                : "All matching activity rows are visible in the live grid.";
+
         public string PrintStatusText
         {
             get
@@ -167,6 +178,12 @@ namespace InventoryManagementApp.ViewModels
                     return "Print preview will be available after the current filters finish applying.";
                 if (FilteredLogs.Count == 0)
                     return "No activity rows are ready to print.";
+
+                var printRows = Math.Min(FilteredLogs.Count, MaxActivityPrintRows);
+                if (HasOmittedActivityRows && FilteredLogs.Count > MaxActivityPrintRows)
+                    return $"Print preview will include the first {printRows} of {FilteredLogs.Count} visible row(s); {OmittedLogCount} additional matching row(s) are hidden from the live grid.";
+                if (HasOmittedActivityRows)
+                    return $"Print preview ready for {printRows} visible row(s); {OmittedLogCount} additional matching row(s) are hidden from the live grid.";
                 if (FilteredLogs.Count > MaxActivityPrintRows)
                     return $"Print preview will include the first {MaxActivityPrintRows} of {FilteredLogs.Count} visible row(s).";
 
@@ -184,7 +201,7 @@ namespace InventoryManagementApp.ViewModels
                         : $"Refreshing activity rows; {FilteredLogs.Count} previously visible row(s) remain on screen.";
                 if (IsFiltering)
                     return $"Filtering {Logs.Count} loaded activity row(s).";
-                if (FilteredLogs.Count == 0)
+                if (MatchedLogCount == 0)
                     return Logs.Count == 0
                         ? "No activity rows loaded yet. Refresh to review recent operations."
                         : "No matching activity rows. Clear filters or refine the audit search.";
@@ -196,7 +213,12 @@ namespace InventoryManagementApp.ViewModels
                     .Take(3)
                     .Select(group => $"{group.Key}: {group.Count()}");
 
-                return $"{FilteredLogs.Count} visible of {Logs.Count} loaded. Top activity: {string.Join(", ", groups)}.";
+                var matchScope = HasActiveFilter() ? "matching" : "loaded";
+                var omittedText = HasOmittedActivityRows
+                    ? $" {OmittedLogCount} {matchScope} row(s) are hidden from the live grid."
+                    : string.Empty;
+
+                return $"{FilteredLogs.Count} visible of {MatchedLogCount} {matchScope} activity row(s).{omittedText} Top visible activity: {string.Join(", ", groups)}.";
             }
         }
 
@@ -290,7 +312,7 @@ namespace InventoryManagementApp.ViewModels
                 LastLoadedAt = DateTime.Now;
                 RebuildFilterLists();
                 await ApplyFiltersAsync(false);
-                StatusMessage = $"Loaded {Logs.Count} recent activity row(s).";
+                StatusMessage = $"Loaded {Logs.Count} recent activity row(s); {FilteredLogs.Count} are visible in the live grid.";
                 return true;
             }
             catch (Exception ex)
@@ -326,6 +348,7 @@ namespace InventoryManagementApp.ViewModels
             if (Logs.Count == 0)
             {
                 FilteredLogs.Clear();
+                _matchedLogCount = 0;
                 _searchRows = Array.Empty<ActivityLogSearchRow>();
                 SelectedLog = null;
                 LastLoadedAt = null;
@@ -412,18 +435,16 @@ namespace InventoryManagementApp.ViewModels
                 var previousSelection = SelectedLog;
                 var rows = GetSearchRowsSnapshot();
 
-                var filtered = await Task.Run(() => rows
-                    .Where(row => row.Matches(selectedUserFilter, selectedActionFilter, search))
-                    .Select(row => row.Log)
-                    .ToList(), cts.Token);
+                var filterResult = await Task.Run(() => BuildFilteredLogWindow(rows, selectedUserFilter, selectedActionFilter, search, cts.Token), cts.Token);
 
                 cts.Token.ThrowIfCancellationRequested();
-                ReplaceFilteredLogs(filtered, previousSelection);
+                _matchedLogCount = filterResult.MatchedCount;
+                ReplaceFilteredLogs(filterResult.VisibleRows, previousSelection);
 
                 NotifyActivityStateChanged();
                 StatusMessage = HasActiveFilter()
-                    ? $"{FilteredLogs.Count} of {Logs.Count} activity row(s) match the current filters."
-                    : $"{Logs.Count} recent activity row(s) visible.";
+                    ? $"{FilteredLogs.Count} visible of {MatchedLogCount} matching activity row(s)."
+                    : $"{FilteredLogs.Count} visible of {Logs.Count} recent activity row(s).";
             }
             catch (OperationCanceledException)
             {
@@ -439,6 +460,25 @@ namespace InventoryManagementApp.ViewModels
 
                 cts.Dispose();
             }
+        }
+
+        private static FilteredActivityLogResult BuildFilteredLogWindow(IReadOnlyList<ActivityLogSearchRow> rows, string selectedUserFilter, string selectedActionFilter, string search, CancellationToken cancellationToken)
+        {
+            var visibleRows = new List<ActivityLog>(MaxVisibleActivityRows);
+            var matchedCount = 0;
+
+            foreach (var row in rows)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!row.Matches(selectedUserFilter, selectedActionFilter, search))
+                    continue;
+
+                matchedCount++;
+                if (visibleRows.Count < MaxVisibleActivityRows)
+                    visibleRows.Add(row.Log);
+            }
+
+            return new FilteredActivityLogResult(visibleRows, matchedCount);
         }
 
         private IReadOnlyList<ActivityLogSearchRow> GetSearchRowsSnapshot()
@@ -464,12 +504,12 @@ namespace InventoryManagementApp.ViewModels
             return true;
         }
 
-        private void ReplaceFilteredLogs(IReadOnlyList<ActivityLog> filtered, ActivityLog? previousSelection)
+        private void ReplaceFilteredLogs(IReadOnlyList<ActivityLog> visibleRows, ActivityLog? previousSelection)
         {
-            if (!HasSameRows(FilteredLogs, filtered))
+            if (!HasSameRows(FilteredLogs, visibleRows))
             {
                 FilteredLogs.Clear();
-                foreach (var log in filtered)
+                foreach (var log in visibleRows)
                     FilteredLogs.Add(log);
             }
 
@@ -495,7 +535,10 @@ namespace InventoryManagementApp.ViewModels
         private void NotifyActivityStateChanged()
         {
             OnPropertyChanged(nameof(TotalLogCount));
+            OnPropertyChanged(nameof(MatchedLogCount));
             OnPropertyChanged(nameof(FilteredLogCount));
+            OnPropertyChanged(nameof(OmittedLogCount));
+            OnPropertyChanged(nameof(HasOmittedActivityRows));
             OnPropertyChanged(nameof(IsBusy));
             OnPropertyChanged(nameof(HasActiveFilters));
             OnPropertyChanged(nameof(CanChangeActivityFilters));
@@ -506,6 +549,7 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(ActivityBusyMessage));
             OnPropertyChanged(nameof(ActivityEmptyStateTitle));
             OnPropertyChanged(nameof(ActivityEmptyStateMessage));
+            OnPropertyChanged(nameof(ActivityWindowStatusText));
             OnPropertyChanged(nameof(PrintStatusText));
             OnPropertyChanged(nameof(ActivitySummary));
             ClearFiltersCommand.NotifyCanExecuteChanged();
@@ -592,6 +636,8 @@ namespace InventoryManagementApp.ViewModels
         {
             return string.IsNullOrWhiteSpace(text) ? fallback : text.Trim();
         }
+
+        private sealed record FilteredActivityLogResult(IReadOnlyList<ActivityLog> VisibleRows, int MatchedCount);
 
         private sealed class ActivityLogSearchRow
         {

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
@@ -47,7 +47,7 @@
                     <Border Style="{StaticResource ActivityStatCard}">
                         <StackPanel>
                             <TextBlock Text="VISIBLE" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding FilteredLogCount, StringFormat={}{0} rows visible}"
+                            <TextBlock Text="{Binding FilteredLogCount, StringFormat={}{0} rows shown}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
                                        TextWrapping="Wrap"
@@ -56,8 +56,8 @@
                     </Border>
                     <Border Style="{StaticResource ActivityStatCard}">
                         <StackPanel>
-                            <TextBlock Text="LOADED" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding TotalLogCount, StringFormat={}{0} recent rows}"
+                            <TextBlock Text="MATCHED" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding MatchedLogCount, StringFormat={}{0} rows matched}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
                                        TextWrapping="Wrap"
@@ -66,8 +66,8 @@
                     </Border>
                     <Border Style="{StaticResource ActivityStatCard}">
                         <StackPanel>
-                            <TextBlock Text="SELECTED" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedLogActionGroup}"
+                            <TextBlock Text="OMITTED" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding OmittedLogCount, StringFormat={}{0} hidden from grid}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
                                        TextWrapping="Wrap"
@@ -147,6 +147,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
@@ -157,7 +158,7 @@
                                 <TextBlock Text="01 Activity Directory" Style="{StaticResource SectionHeader}" Margin="0"/>
                                 <TextBlock Text="Scan the current audit trail by user, event family, destination, and follow-up path." Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
-                            <TextBlock Text="{Binding FilteredLogCount, StringFormat={}{0} visible}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding ActivityWindowStatusText}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
                         </DockPanel>
                     </Border>
 
@@ -168,8 +169,22 @@
                         </DockPanel>
                     </Border>
 
+                    <Border Grid.Row="2" Margin="8,0,8,8" MaxWidth="780" HorizontalAlignment="Left">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource AdminHandoffCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasOmittedActivityRows}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock Text="{Binding ActivityWindowStatusText}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                    </Border>
+
                     <DataGrid x:Name="ActivityGrid"
-                              Grid.Row="2"
+                              Grid.Row="3"
                               ItemsSource="{Binding FilteredLogs}"
                               SelectedItem="{Binding SelectedLog, Mode=TwoWay}"
                               IsReadOnly="True"
@@ -223,7 +238,7 @@
                         </DataGrid.Columns>
                     </DataGrid>
 
-                    <Border Grid.Row="2" MaxWidth="360" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Border Grid.Row="3" MaxWidth="360" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -240,7 +255,7 @@
                         </StackPanel>
                     </Border>
 
-                    <Border Grid.Row="2" MaxWidth="380" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Border Grid.Row="3" MaxWidth="380" MinHeight="118" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -258,7 +273,7 @@
                         </StackPanel>
                     </Border>
 
-                    <Border Grid.Row="3" Style="{StaticResource DesktopPaneSubheader}" BorderThickness="0,1,0,0">
+                    <Border Grid.Row="4" Style="{StaticResource DesktopPaneSubheader}" BorderThickness="0,1,0,0">
                         <DockPanel LastChildFill="True">
                             <TextBlock Text="{Binding PrintStatusText}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Left" TextWrapping="Wrap" Margin="0,0,10,0"/>
                             <Button Style="{StaticResource GhostButton}" Content="Clear Filters" Command="{Binding ClearFiltersCommand}" HorizontalAlignment="Right"/>
@@ -342,6 +357,8 @@
             <DockPanel LastChildFill="True">
                 <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
                     <TextBlock Text="{Binding FilteredLogCount, StringFormat='Visible: {0}'}" FontSize="11" Margin="0,0,12,0"/>
+                    <TextBlock Text="{Binding MatchedLogCount, StringFormat='Matched: {0}'}" FontSize="11" Margin="0,0,12,0"/>
+                    <TextBlock Text="{Binding OmittedLogCount, StringFormat='Hidden: {0}'}" FontSize="11" Margin="0,0,12,0"/>
                     <TextBlock Text="{Binding TotalLogCount, StringFormat='Loaded: {0}'}" FontSize="11" Margin="0,0,12,0"/>
                     <TextBlock Text="{Binding LastLoadedText, StringFormat='Last refresh: {0}'}" FontSize="11"/>
                 </WrapPanel>

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -295,13 +295,16 @@ namespace InventoryManagementApp.Views.Pages
                     return;
                 }
 
-                var totalFilteredCount = vm.FilteredLogs.Count;
+                var totalMatchedCount = vm.MatchedLogCount;
+                var totalVisibleCount = vm.FilteredLogs.Count;
+                var hiddenFromGridCount = vm.OmittedLogCount;
                 var printRows = vm.FilteredLogs.Take(MaxActivityPrintRows).ToList();
-                var document = BuildPrintDocument(printRows, totalFilteredCount, vm.PrintStatusText, vm.ActivitySummary);
+                var printOmittedCount = Math.Max(0, totalVisibleCount - printRows.Count);
+                var document = BuildPrintDocument(printRows, totalMatchedCount, totalVisibleCount, hiddenFromGridCount, printOmittedCount, vm.PrintStatusText, vm.ActivitySummary);
                 new PrintPreviewWindow().ShowPreview(
                     document,
                     "Activity Logs",
-                    "Review the filtered audit trail, destination routing, and operator handoff before printing. Large result sets print the first 250 rows so preview stays responsive.");
+                    "Review the filtered audit trail, destination routing, hidden grid matches, and operator handoff before printing. Large result sets print the first 250 visible rows so preview stays responsive.");
             });
         }
 
@@ -387,10 +390,9 @@ namespace InventoryManagementApp.Views.Pages
                    $"Action: {SafeText(log.Action, "No activity detail was recorded.")}";
         }
 
-        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<ActivityLog> logs, int totalFilteredCount, string summary, string activitySummary)
+        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<ActivityLog> logs, int totalMatchedCount, int totalVisibleCount, int hiddenFromGridCount, int printOmittedCount, string summary, string activitySummary)
         {
             var printedRowCount = logs.Count;
-            var omittedRowCount = Math.Max(0, totalFilteredCount - printedRowCount);
             var document = new FlowDocument
             {
                 FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
@@ -409,7 +411,7 @@ namespace InventoryManagementApp.Views.Pages
                 FontSize = 10,
                 Margin = new Thickness(0, 0, 0, 4)
             });
-            document.Blocks.Add(BuildSummarySection(summary, activitySummary, totalFilteredCount, printedRowCount, omittedRowCount));
+            document.Blocks.Add(BuildSummarySection(summary, activitySummary, totalMatchedCount, totalVisibleCount, printedRowCount, hiddenFromGridCount, printOmittedCount));
 
             var table = new Table { CellSpacing = 0 };
             table.Columns.Add(new TableColumn { Width = new GridLength(0.16, GridUnitType.Star) });
@@ -451,7 +453,7 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             document.Blocks.Add(table);
-            document.Blocks.Add(new Paragraph(new Run("Review destination, next action, and any omitted rows before filing the audit handoff."))
+            document.Blocks.Add(new Paragraph(new Run("Review destination, next action, hidden grid matches, and any omitted print rows before filing the audit handoff."))
             {
                 FontSize = 9,
                 FontStyle = FontStyles.Italic,
@@ -460,7 +462,7 @@ namespace InventoryManagementApp.Views.Pages
             return document;
         }
 
-        private static Block BuildSummarySection(string summary, string activitySummary, int totalFilteredCount, int printedRowCount, int omittedRowCount)
+        private static Block BuildSummarySection(string summary, string activitySummary, int totalMatchedCount, int totalVisibleCount, int printedRowCount, int hiddenFromGridCount, int printOmittedCount)
         {
             var group = new Section
             {
@@ -470,8 +472,14 @@ namespace InventoryManagementApp.Views.Pages
                 Margin = new Thickness(0, 0, 0, 10)
             };
 
-            AddSummaryLine(group, "Print Packet", $"{printedRowCount} of {totalFilteredCount} filtered activity row(s)");
-            AddSummaryLine(group, "Omitted Rows", omittedRowCount == 0 ? "None" : $"{omittedRowCount} row(s) not printed; narrow filters or print again after refining the audit search.");
+            AddSummaryLine(group, "Print Packet", $"{printedRowCount} printed row(s) from {totalVisibleCount} visible activity row(s)");
+            AddSummaryLine(group, "Matched Activity Rows", totalMatchedCount.ToString());
+            AddSummaryLine(group, "Visible Grid Rows", totalVisibleCount.ToString());
+            AddSummaryLine(group, "Hidden From Grid", hiddenFromGridCount == 0 ? "None" : $"{hiddenFromGridCount} matching row(s) hidden from the live grid; refine filters to review or print them");
+            AddSummaryLine(group, "Printed Rows", printedRowCount.ToString());
+            AddSummaryLine(group, "Print Omitted Rows", printOmittedCount == 0 ? "None" : $"{printOmittedCount} visible row(s) not printed; narrow filters or print again after refining the audit search");
+            AddSummaryLine(group, "Live Grid Limit", $"First {ActivityLogsViewModel.MaxVisibleActivityRows} matching activity row(s)");
+            AddSummaryLine(group, "Print Limit", $"First {MaxActivityPrintRows} visible row(s)");
             AddSummaryLine(group, "Filter Status", ValueOrNotRecorded(summary));
             AddSummaryLine(group, "Activity Mix", ValueOrNotRecorded(activitySummary));
             return group;


### PR DESCRIPTION
## What changed

- Bounded the Activity Audit live grid to the first 500 matching audit rows while still counting every match.
- Added matched, visible, omitted, and loaded row state to `ActivityLogsViewModel`.
- Replaced full-list filter materialization with a counted visible-window filter loop.
- Updated Activity Audit header cards, pane header, omitted-row banner, footer counters, and status text so operators can see visible, matched, hidden, and loaded rows clearly.
- Updated print-preview accounting to distinguish matched rows, visible grid rows, hidden-from-grid rows, printed rows, print-omitted rows, live-grid limit, and print limit.
- Extended Activity Audit source-contract coverage for capped filtering, omitted-row display, matched/hidden counters, row-window status, and print accounting.
- Added a progress note for the completed workflow slice.

## Why this was highest value

Recent repo history shows the highest-value active performance work is bounding dense operational grids while keeping professional count and print reporting. Activity Audit already had responsive layout and virtualization, but it still materialized every matching audit row into the live filtered collection. This completes the next natural performance slice for a high-traffic audit/history workflow.

## Why this is real progress

This is a vertical workflow improvement across filtering logic, display state, XAML, print preview, source-contract coverage, and project progress notes. It reduces live-grid churn for large audit trails and makes omitted rows visible rather than silently hidden.

## Validation

- GitHub connector readback confirmed the changed files on the branch contain the row-window cap, matched/visible/hidden/loaded UI bindings, omitted-row banner, print accounting, source-contract coverage, and progress note.
- GitHub connector compare confirmed the branch is current with `master`, ahead by 5 commits, and scoped to the intended five files.

## Could not check here

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke test
- screenshots/scaling checks
- print-preview rendering

Those require a Windows/.NET/WPF-capable checkout; direct clone remains blocked in this scheduled Linux environment.

## Follow-up

- Run full validation on Windows.
- Smoke test Activity Audit with more than 500 matching rows to verify the live grid, omitted banner, status text, and print preview stay responsive and clear.