### PR TITLE
Preserve Dashboard action bindings during refresh

### DIFF
--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -152,24 +152,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void DashboardPage_DisablesVisibleCommandButtonsWhileRowsRefresh()
+        public void DashboardPage_DisablesRootWhileRowsRefreshWithoutOverwritingActionBindings()
         {
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
 
-            Assert.Contains("using System.Collections.Generic;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("using System.Windows.Media;", codeBehind, StringComparison.Ordinal);
             Assert.Contains("SetDashboardInteractiveActionsEnabled(false);", codeBehind, StringComparison.Ordinal);
             Assert.Contains("SetDashboardInteractiveActionsEnabled(true);", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("private void SetDashboardInteractiveActionsEnabled(bool isEnabled)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("EnumerateVisualDescendants(DashboardRoot)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("ReferenceEquals(element, DashboardLoadRetryButton)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("case Button button:", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("button.IsEnabled = isEnabled;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("case MenuItem menuItem:", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("menuItem.IsEnabled = isEnabled;", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("VisualTreeHelper.GetChildrenCount(current)", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("pending.Push(child);", codeBehind, StringComparison.Ordinal);
-            Assert.DoesNotContain("foreach (var descendant in EnumerateVisualDescendants(child))", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("private void SetDashboardInteractiveActionsEnabled(bool isEnabled)\n        {\n            DashboardRoot.IsEnabled = isEnabled;\n        }", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("DashboardLoadRetryButton.IsEnabled = DashboardLoadRetryButton.Visibility == Visibility.Visible;", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("EnumerateVisualDescendants", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("VisualTreeHelper.GetChildrenCount", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("case Button button:", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("case MenuItem menuItem:", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("button.IsEnabled = isEnabled;", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("menuItem.IsEnabled = isEnabled;", codeBehind, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-dashboard-refresh-binding-preservation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-dashboard-refresh-binding-preservation.md
@@ -1,0 +1,30 @@
+# Dashboard Refresh Binding Preservation
+
+Completed on 2026-07-07.
+
+## What changed
+
+- Replaced Dashboard refresh-time visual-tree traversal with root-level `DashboardRoot.IsEnabled` toggling.
+- Preserved row-action `IsEnabled` bindings for selected rentals, checked-out items, incomplete items, common items, and activity rows after refresh completes.
+- Avoided setting local `IsEnabled` values on each Dashboard button, which could make selection-gated actions appear available after a refresh.
+- Avoided setting local `IsEnabled` values on Dashboard context-menu items, preserving command and selection readiness instead of flattening all menu states.
+- Removed repeated Dashboard visual-tree scans during load start and load completion.
+- Kept the retry button state managed by the load-status path rather than the general Dashboard action-disable path.
+- Preserved the existing loading, cancellation, retry, keyboard, context-menu, double-click, and row-retargeting guards.
+- Reduced refresh overhead on the high-traffic Dashboard screen by changing action gating from per-control mutation to one root state change.
+- Simplified unload cleanup so it restores the root interaction state without walking child controls.
+- Updated Dashboard responsive source-contract coverage to verify root-level disabling and the absence of visual-tree control mutation.
+
+## Why it matters
+
+The Dashboard is the app's first operational screen and has several selection-gated row actions. The previous refresh guard disabled every child button/menu item and then re-enabled them all, which risked overwriting WPF bindings such as `HasSelectedRental` and making row actions look available when no row was selected. Root-level disabling keeps the screen non-interactive while rows refresh, then lets existing bindings recover naturally.
+
+## Validation
+
+- Updated `InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs` to cover the new root-level refresh-disable contract and to prevent reintroducing visual-tree scans or local per-control `IsEnabled` writes.
+- Used GitHub connector readback/compare for the branch because this scheduled Linux environment cannot clone the repository directly or run Windows/.NET/WPF validation.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on a Windows/.NET-capable checkout.
+- Smoke test Dashboard refresh, retry, row selection, context menus, keyboard shortcuts, and print shortcuts at 1366 x 768 and higher Windows scaling.

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Threading;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -137,40 +135,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void SetDashboardInteractiveActionsEnabled(bool isEnabled)
         {
-            foreach (var element in EnumerateVisualDescendants(DashboardRoot))
-            {
-                if (ReferenceEquals(element, DashboardLoadRetryButton))
-                    continue;
-
-                switch (element)
-                {
-                    case Button button:
-                        button.IsEnabled = isEnabled;
-                        break;
-                    case MenuItem menuItem:
-                        menuItem.IsEnabled = isEnabled;
-                        break;
-                }
-            }
-        }
-
-        private static IEnumerable<DependencyObject> EnumerateVisualDescendants(DependencyObject parent)
-        {
-            var pending = new Stack<DependencyObject>();
-            pending.Push(parent);
-
-            while (pending.Count > 0)
-            {
-                var current = pending.Pop();
-                var childCount = VisualTreeHelper.GetChildrenCount(current);
-
-                for (var index = childCount - 1; index >= 0; index--)
-                {
-                    var child = VisualTreeHelper.GetChild(current, index);
-                    pending.Push(child);
-                    yield return child;
-                }
-            }
+            DashboardRoot.IsEnabled = isEnabled;
         }
 
         private void DashboardPage_Unloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## What changed

- Replaced Dashboard refresh-time visual-tree traversal with root-level `DashboardRoot.IsEnabled` toggling.
- Preserved row-action `IsEnabled` bindings for selected rentals, checked-out items, incomplete items, common items, and activity rows after refresh completes.
- Avoided setting local `IsEnabled` values on Dashboard buttons and context-menu items, which could make selection-gated row actions appear enabled after a refresh.
- Removed repeated visual-tree scans during Dashboard load start, completion, and unload cleanup.
- Kept retry-button state managed by the load-status path while preserving existing cancellation, retry, keyboard, context-menu, double-click, and row-retargeting guards.
- Updated Dashboard source-contract coverage and recorded progress notes.

## Why this was highest value

The Dashboard is the app's first operational screen and recent work made its row actions selection-aware. The refresh guard still disabled and re-enabled child controls directly, which could overwrite those selection bindings and add unnecessary refresh overhead. Root-level disabling keeps the screen non-interactive while loading without flattening bound action readiness.

## Why this is real progress

This is a workflow-level refresh responsiveness fix: loading, retry, row selection, row actions, context menus, keyboard shortcuts, and cleanup now share a safer interaction boundary with less UI-tree work.

## Validation

- GitHub connector compare/readback confirmed the branch is current with `master` and limited to Dashboard code-behind, Dashboard source-contract tests, and a progress note.
- Source-contract coverage was updated in `InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs`.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- WPF runtime smoke tests, screenshots, scaling checks, and live Dashboard refresh/selection checks

This scheduled Linux environment cannot clone the repo directly (`CONNECT tunnel failed, response 403`) and does not provide Windows/.NET/WPF tooling.

## Follow-up

- Run full validation on a Windows/.NET-capable checkout.
- Smoke test Dashboard refresh, retry, row selection, context menus, keyboard shortcuts, and print shortcuts at 1366 x 768 and higher Windows scaling.