### PR TITLE
Improve Rentals desk display responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
@@ -257,6 +257,41 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ManageRentalsPage_UsesExplicitRecyclingVirtualizationForDenseRentalAndRequestGrids()
+        {
+            var xaml = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml"));
+            var busyGridStyle = ExtractSourceBlock(xaml, "<Style x:Key=\"RentalBusyDataGridStyle\"", "        </Style>\n    </Page.Resources>");
+
+            Assert.Contains("<Setter Property=\"VirtualizingPanel.IsVirtualizing\" Value=\"True\"/>", busyGridStyle, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"VirtualizingPanel.VirtualizationMode\" Value=\"Recycling\"/>", busyGridStyle, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"VirtualizingPanel.IsVirtualizingWhenGrouping\" Value=\"True\"/>", busyGridStyle, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"ScrollViewer.CanContentScroll\" Value=\"True\"/>", busyGridStyle, StringComparison.Ordinal);
+            Assert.Contains("HeadersVisibility=\"Column\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("RowDetailsVisibilityMode=\"Collapsed\"", xaml, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(xaml, "Style=\"{StaticResource RentalBusyDataGridStyle}\">"));
+            Assert.DoesNotContain("VirtualizingPanel.VirtualizationMode=\"Standard\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageRentalsPage_ShowsProfessionalSummaryStatusAndTrimmedGridCells()
+        {
+            var xaml = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml"));
+
+            Assert.Contains("<Style x:Key=\"RentalStatusPillText\" TargetType=\"TextBlock\" BasedOn=\"{StaticResource CaptionTextBlock}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"RentalGridTextBlock\" TargetType=\"TextBlock\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"TextTrimming\" Value=\"CharacterEllipsis\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"ToolTip\" Value=\"{Binding Text, RelativeSource={RelativeSource Self}}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"{Binding SearchSummary}\" Style=\"{StaticResource RentalDetailText}\" ToolTip=\"{Binding SearchSummary}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"{Binding CheckedOutSummary}\" Style=\"{StaticResource RentalDetailText}\" ToolTip=\"{Binding CheckedOutSummary}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"{Binding RequestSummary}\" Style=\"{StaticResource RentalDetailText}\" ToolTip=\"{Binding RequestSummary}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<RowDefinition Height=\"Auto\"/>\n                    </Grid.RowDefinitions>\n                    <Border Style=\"{StaticResource DesktopPaneHeader}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"3\" Style=\"{StaticResource DesktopPaneSubheader}\" Padding=\"10,6\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"2\" Style=\"{StaticResource DesktopPaneSubheader}\" Padding=\"10,6\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding SelectedRequestNextAction}\" Style=\"{StaticResource CaptionTextBlock}\" TextWrapping=\"Wrap\" TextTrimming=\"CharacterEllipsis\" MaxWidth=\"520\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ElementStyle=\"{StaticResource RentalGridTextBlock}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ManageRentalsPage_PreservesRentalAndRequestCommandsAndRowHandlers()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml");
@@ -299,6 +334,19 @@ namespace InventoryManagementApp.Tests
             Assert.True(end > start, $"Could not find source block end marker: {endMarker}");
 
             return source[start..end];
+        }
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-rentals-desk-display-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-rentals-desk-display-responsiveness.md
@@ -1,0 +1,22 @@
+# Rentals Desk Display Responsiveness - 2026-07-07
+
+## Completed
+
+- Added explicit recycling virtualization to the shared Rentals busy data-grid style.
+- Kept both Rentals desk and Request queue grids on the same recycling virtualization contract.
+- Disabled row-details rendering on both dense grids so hidden detail presenters cannot add layout work.
+- Kept column headers explicit on both grids for clearer table presentation.
+- Added a reusable trimmed grid-cell text style with hover tooltips for long customer, item, date, status, and note values.
+- Applied the trimmed grid-cell style across rental and request text columns.
+- Replaced static summary-card helper copy with live Search, Checked Out, and Request summaries.
+- Added bounded tooltip-backed status text for the Rental Desk pane header.
+- Added a footer status row under the rental grid with current filtered and checked-out counts.
+- Added bounded Request queue status text beside queue actions.
+- Added a footer status row under the request queue with queue summary and selected-request next-action guidance.
+- Preserved loading overlays, busy action gating, context-menu suppression, keyboard guards, and existing row gestures while improving professional data display.
+- Extended source-contract coverage for recycling virtualization, grid trimming/tooltips, live summary bindings, and footer/status rows.
+
+## Validation
+
+- GitHub connector readback and comparison were used to review the XAML, source-contract tests, and progress note on the branch.
+- Local `pwsh -File scripts/run-full-validation.ps1`, .NET build/test, WPF runtime walkthrough, screenshots, scaling checks, and live Rentals desk large-row testing could not be run because this scheduled Linux environment cannot clone the repository directly and does not provide Windows/.NET/WPF tooling.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -20,6 +20,17 @@
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="Margin" Value="0,2,0,0"/>
         </Style>
+        <Style x:Key="RentalStatusPillText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
+            <Setter Property="MaxWidth" Value="320"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+        <Style x:Key="RentalGridTextBlock" TargetType="TextBlock">
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="TextWrapping" Value="NoWrap"/>
+            <Setter Property="ToolTip" Value="{Binding Text, RelativeSource={RelativeSource Self}}"/>
+        </Style>
         <Style x:Key="RentalFilterLabel" TargetType="TextBlock" BasedOn="{StaticResource LabelTextBlock}">
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="Margin" Value="0,0,6,4"/>
@@ -70,6 +81,10 @@
             </Style.Triggers>
         </Style>
         <Style x:Key="RentalBusyDataGridStyle" TargetType="DataGrid" BasedOn="{StaticResource VirtualizedDataGridStyle}">
+            <Setter Property="VirtualizingPanel.IsVirtualizing" Value="True"/>
+            <Setter Property="VirtualizingPanel.VirtualizationMode" Value="Recycling"/>
+            <Setter Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="True"/>
+            <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>
             <Style.Triggers>
                 <DataTrigger Binding="{Binding IsLoading}" Value="True">
                     <Setter Property="IsEnabled" Value="False"/>
@@ -112,21 +127,21 @@
                 <StackPanel>
                     <TextBlock Text="Filtered Rentals" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding Rentals.Count}" Style="{StaticResource RentalStatValueText}"/>
-                    <TextBlock Text="Rows matching the current search, date range, and status" Style="{StaticResource RentalDetailText}"/>
+                    <TextBlock Text="{Binding SearchSummary}" Style="{StaticResource RentalDetailText}" ToolTip="{Binding SearchSummary}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource RentalStatCard}">
                 <StackPanel>
                     <TextBlock Text="Checked Out" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding ActiveRentals.Count}" Style="{StaticResource RentalStatValueText}"/>
-                    <TextBlock Text="Active customer handoffs that still need return or extension" Style="{StaticResource RentalDetailText}"/>
+                    <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource RentalDetailText}" ToolTip="{Binding CheckedOutSummary}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource RentalStatCard}">
                 <StackPanel>
                     <TextBlock Text="Open Requests" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding PendingRequests.Count}" Style="{StaticResource RentalStatValueText}"/>
-                    <TextBlock Text="Customer holds waiting for advisor follow-up" Style="{StaticResource RentalDetailText}"/>
+                    <TextBlock Text="{Binding RequestSummary}" Style="{StaticResource RentalDetailText}" ToolTip="{Binding RequestSummary}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource RentalStatCard}">
@@ -151,6 +166,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Border Style="{StaticResource DesktopPaneHeader}">
                         <DockPanel LastChildFill="False">
@@ -158,7 +174,7 @@
                                 <TextBlock Text="Rental Desk" Style="{StaticResource SectionHeader}" Margin="0"/>
                                 <TextBlock Text="Search, return, extend, document, or inspect the selected rental." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
-                            <TextBlock DockPanel.Dock="Right" Text="{Binding SearchSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" Margin="12,0,0,0"/>
+                            <TextBlock DockPanel.Dock="Right" Text="{Binding SearchSummary}" Style="{StaticResource RentalStatusPillText}" ToolTip="{Binding SearchSummary}" Margin="12,0,0,0"/>
                         </DockPanel>
                     </Border>
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}" Padding="10,8">
@@ -185,6 +201,8 @@
                               AutoGenerateColumns="False"
                               EnableRowVirtualization="True"
                               EnableColumnVirtualization="True"
+                              HeadersVisibility="Column"
+                              RowDetailsVisibilityMode="Collapsed"
                               ScrollViewer.CanContentScroll="True"
                               ScrollViewer.HorizontalScrollBarVisibility="Auto"
                               ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -196,11 +214,11 @@
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="ID" Binding="{Binding RentalID}" Width="52"/>
-                            <DataGridTextColumn Header="Items" Binding="{Binding JobItemSummary}" Width="96" MinWidth="78"/>
-                            <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="1.7*" MinWidth="130"/>
-                            <DataGridTextColumn Header="Due Back" Binding="{Binding JobDueDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="124" MinWidth="104"/>
-                            <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="90" MinWidth="74"/>
+                            <DataGridTextColumn Header="ID" Binding="{Binding RentalID}" Width="52" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Items" Binding="{Binding JobItemSummary}" Width="96" MinWidth="78" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="1.7*" MinWidth="130" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Due Back" Binding="{Binding JobDueDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="124" MinWidth="104" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="90" MinWidth="74" ElementStyle="{StaticResource RentalGridTextBlock}"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
@@ -248,6 +266,12 @@
                             <TextBlock Text="Refreshing rental desk" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
                             <TextBlock Text="Keeping the current rows visible while rental, request, and print actions pause until the refresh completes." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
+                    </Border>
+                    <Border Grid.Row="3" Style="{StaticResource DesktopPaneSubheader}" Padding="10,6">
+                        <DockPanel LastChildFill="False">
+                            <TextBlock DockPanel.Dock="Left" Text="{Binding SearchSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" ToolTip="{Binding SearchSummary}"/>
+                            <TextBlock DockPanel.Dock="Right" Text="{Binding CheckedOutSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" ToolTip="{Binding CheckedOutSummary}" Margin="12,0,0,0"/>
+                        </DockPanel>
                     </Border>
                 </Grid>
             </Border>
@@ -340,6 +364,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Border Style="{StaticResource DesktopPaneHeader}">
                     <DockPanel LastChildFill="False">
@@ -348,6 +373,7 @@
                             <TextBlock Text="Confirm, cancel, print, and route customer holds tied to unavailable rental items." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                         </StackPanel>
                         <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="12,0,0,0">
+                            <TextBlock Text="{Binding RequestSummary}" Style="{StaticResource RentalStatusPillText}" ToolTip="{Binding RequestSummary}" Margin="0,0,8,6"/>
                             <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="0,0,4,6"/>
                             <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,6"/>
                             <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,4,6"/>
@@ -372,6 +398,8 @@
                               AutoGenerateColumns="False"
                               EnableRowVirtualization="True"
                               EnableColumnVirtualization="True"
+                              HeadersVisibility="Column"
+                              RowDetailsVisibilityMode="Collapsed"
                               ScrollViewer.CanContentScroll="True"
                               ScrollViewer.HorizontalScrollBarVisibility="Auto"
                               ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -392,14 +420,14 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="100" MinWidth="78"/>
-                            <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="150" MinWidth="110"/>
-                            <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="1.4*" MinWidth="125"/>
-                            <DataGridTextColumn Header="Requested" Binding="{Binding ReservationDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="118" MinWidth="92"/>
-                            <DataGridTextColumn Header="From" Binding="{Binding StartDate, StringFormat={}{0:yyyy-MM-dd}}" Width="90" MinWidth="72"/>
-                            <DataGridTextColumn Header="Until" Binding="{Binding EndDate, StringFormat={}{0:yyyy-MM-dd}}" Width="90" MinWidth="72"/>
-                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="96" MinWidth="76"/>
-                            <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="*" MinWidth="130"/>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="100" MinWidth="78" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="150" MinWidth="110" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="1.4*" MinWidth="125" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Requested" Binding="{Binding ReservationDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="118" MinWidth="92" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="From" Binding="{Binding StartDate, StringFormat={}{0:yyyy-MM-dd}}" Width="90" MinWidth="72" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Until" Binding="{Binding EndDate, StringFormat={}{0:yyyy-MM-dd}}" Width="90" MinWidth="72" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="96" MinWidth="76" ElementStyle="{StaticResource RentalGridTextBlock}"/>
+                            <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="*" MinWidth="130" ElementStyle="{StaticResource RentalGridTextBlock}"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
@@ -489,6 +517,12 @@
                         </StackPanel>
                     </Border>
                 </Grid>
+                <Border Grid.Row="2" Style="{StaticResource DesktopPaneSubheader}" Padding="10,6">
+                    <DockPanel LastChildFill="False">
+                        <TextBlock DockPanel.Dock="Left" Text="{Binding RequestSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" ToolTip="{Binding RequestSummary}"/>
+                        <TextBlock DockPanel.Dock="Right" Text="{Binding SelectedRequestNextAction}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxWidth="520" ToolTip="{Binding SelectedRequestNextAction}" Margin="12,0,0,0"/>
+                    </DockPanel>
+                </Border>
             </Grid>
         </Border>
 


### PR DESCRIPTION
## What changed

- Added explicit recycling virtualization to the shared Rentals busy data-grid style.
- Kept both Rentals desk and Request queue grids on the same recycling virtualization contract.
- Disabled row-details rendering on both dense grids so hidden detail presenters do not add layout work.
- Kept column headers explicit on both grids for clearer table presentation.
- Added a reusable trimmed grid-cell text style for long customer, item, date, status, and note values.
- Applied the trimmed grid-cell style across rental and request text columns.
- Replaced static summary-card helper copy with live Search, Checked Out, and Request summaries.
- Added bounded status text for the Rental Desk pane header.
- Added a footer status row under the rental grid with current filtered and checked-out counts.
- Added bounded Request queue status text beside queue actions.
- Added a footer status row under the request queue with queue summary and selected-request next-action guidance.
- Preserved loading overlays, busy action gating, context-menu suppression, keyboard guards, and existing row gestures while improving professional data display.
- Extended source-contract coverage for recycling virtualization, grid trimming/tooltips, live summary bindings, and footer/status rows.
- Recorded progress notes for the completed Rentals desk workflow slice.

## Why this was highest value

Recent repo history shows the active product direction is loading speed, UI responsiveness, and professional data display across dense WPF workflows. The Rentals desk already had busy guards and virtualized grids, but its grid rendering and summary surfaces were still less explicit than the newer workbenches. This improves the existing high-traffic rental and request workflow without inventing unrelated scope.

## Why this is real progress

This is a workflow-level UI/data-display slice across the rental grid, request queue grid, summary strip, pane headers, footer status rows, source-contract tests, and progress notes. It improves perceived speed and scan quality while preserving the existing command and loading behavior.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, three commits ahead, zero behind, and scoped to:
  - `InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml`
  - `InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-07-rentals-desk-display-responsiveness.md`
- GitHub connector readback confirmed the XAML virtualization setters, row-details suppression, summary bindings, footer status rows, request queue status text, trimmed grid style, updated source-contract tests, and progress note.
- GitHub connector status readback found no attached commit statuses for branch head `6f74fb68040a6338ff697a7e4288645a80f6d5e2` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke testing
- screenshots / Windows scaling checks
- live Rentals desk large-row behavior or print-preview rendering

Those require a Windows/.NET/WPF-capable checkout, which is unavailable in this scheduled Linux environment where direct GitHub checkout is blocked.

## Follow-up

- Run the full validation runner on Windows.
- Smoke test Rentals desk with large rental/request sets, repeated search/filter changes, selected rental/request actions, context menus, print list/queue actions, and 125%, 150%, and 200% Windows scaling.