### PR TITLE
Improve Reservation Workbench visible row responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
@@ -19,6 +19,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.85*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding ReservationPrintStatus}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"ROWS\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"{Binding ReservationVisibleWindowSummary}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"380\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"540\"/>", xaml, StringComparison.Ordinal);
@@ -46,6 +48,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("x:Name=\"ReservationGrid\"", xaml, StringComparison.Ordinal);
             Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.VirtualizationMode=\"Recycling\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("RowDetailsVisibilityMode=\"Collapsed\"", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectionMode=\"Single\"", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
@@ -141,17 +145,50 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ReservationViewModel_BoundsLiveRowsAndReportsFullCounts()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");
+
+            Assert.Contains("private const int MaxVisibleReservationRows = 500;", source, StringComparison.Ordinal);
+            Assert.Contains("private int _matchedReservationCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int VisibleReservationCount => FilteredReservations.Count;", source, StringComparison.Ordinal);
+            Assert.Contains("public int MatchingReservationCount => _matchedReservationCount;", source, StringComparison.Ordinal);
+            Assert.Contains("public int OmittedReservationCount => Math.Max(0, MatchingReservationCount - VisibleReservationCount);", source, StringComparison.Ordinal);
+            Assert.Contains("public bool HasOmittedReservationRows => OmittedReservationCount > 0;", source, StringComparison.Ordinal);
+            Assert.Contains("public string ReservationVisibleWindowSummary", source, StringComparison.Ordinal);
+            Assert.Contains("new System.Collections.Generic.List<Reservation>(MaxVisibleReservationRows)", source, StringComparison.Ordinal);
+            Assert.Contains("if (visibleRows.Count < MaxVisibleReservationRows)", source, StringComparison.Ordinal);
+            Assert.Contains("_matchedReservationCount = matchedCount;", source, StringComparison.Ordinal);
+            Assert.Contains("ApplyFilteredReservationWindow(visibleRows);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("FilteredReservations.Clear();\n\n            var filtered = Reservations.AsEnumerable();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservationViewModel_AvoidsUnchangedWindowRepopulationAndResetsFailureCounts()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");
+
+            Assert.Contains("private void ApplyFilteredReservationWindow(System.Collections.Generic.IReadOnlyList<Reservation> visibleRows)", source, StringComparison.Ordinal);
+            Assert.Contains("FilteredReservations.Select((row, index) => ReferenceEquals(row, visibleRows[index])).All(match => match)", source, StringComparison.Ordinal);
+            Assert.Contains("_matchedReservationCount = 0;", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(VisibleReservationCount));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(MatchingReservationCount));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(OmittedReservationCount));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ReservationVisibleWindowSummary));", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ReservationPrintPreview_IsBoundedAndUsesProportionalColumns()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");
 
             Assert.Contains("private const int MaxReservationPrintRows = 250;", source, StringComparison.Ordinal);
             Assert.Contains("FilteredReservations.Take(MaxReservationPrintRows).ToList();", source, StringComparison.Ordinal);
-            Assert.Contains("Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows}", source, StringComparison.Ordinal);
-            Assert.Contains("Large reservation preview limited to the first", source, StringComparison.Ordinal);
+            Assert.Contains("Matched: {matchedRows} | Visible grid: {visibleRows} | Hidden from grid: {hiddenFromGridRows} | Printed: {printRows.Count} | Print omitted: {omittedRows}", source, StringComparison.Ordinal);
+            Assert.Contains("The live grid shows up to {MaxVisibleReservationRows} rows", source, StringComparison.Ordinal);
             Assert.Contains("new GridLength(0.85, GridUnitType.Star)", source, StringComparison.Ordinal);
             Assert.Contains("new GridLength(1.65, GridUnitType.Star)", source, StringComparison.Ordinal);
-            Assert.Contains("Review pending, confirmed, upcoming", source, StringComparison.Ordinal);
+            Assert.Contains("hidden-from-grid counts, and print-omitted counts", source, StringComparison.Ordinal);
             Assert.DoesNotContain("table.Columns.Add(new TableColumn { Width = new GridLength(80) });", source, StringComparison.Ordinal);
             Assert.DoesNotContain("table.Columns.Add(new TableColumn { Width = new GridLength(165) });", source, StringComparison.Ordinal);
             Assert.DoesNotContain("foreach (var reservation in FilteredReservations)", source, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-reservation-visible-row-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-reservation-visible-row-responsiveness.md
@@ -1,0 +1,25 @@
+# Reservation Workbench Visible Row Responsiveness
+
+Date: 2026-07-07
+
+## Completed
+
+- Bounded the Reservations Workbench live WPF grid to the first 500 matching reservation rows.
+- Added matched, visible, omitted, total, and capped-window display state to `ReservationManagementViewModel`.
+- Updated reservation summary, row-window, footer, and print status copy so operators can distinguish full matching holds from the rows currently materialized in the live grid.
+- Kept action availability, selection handoff, and empty states tied to visible rows while preserving full match context for display and print guidance.
+- Reduced unnecessary filtered-collection churn by skipping `FilteredReservations` clear/repopulate work when the same visible reservation window is already displayed.
+- Reset capped-window count state after unrecoverable reservation load/recovery failures.
+- Updated Reservation Directory print-preview accounting to report matched rows, visible grid rows, hidden-from-grid rows, printed rows, and print-omitted rows.
+- Enabled recycling virtualization and collapsed row details on the reservation grid for denser large-result rendering.
+- Extended reservation source-contract coverage for visible-row caps, full-count display state, unchanged-window reuse, count notifications, grid virtualization, UI row summaries, and print accounting.
+
+## Validation
+
+- GitHub connector compare/readback should confirm the branch is current with `master` and contains the reservation visible-window, XAML display, source-contract, and progress-note changes.
+- Full Windows validation, WPF runtime smoke testing, screenshots, scaling checks, and print-preview rendering still need to run in a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repo directly and does not provide the required Windows/WPF runtime.
+
+## Follow-up
+
+- Run `pwsh -File scripts/run-full-validation.ps1` on Windows.
+- Smoke test Reservations with more than 500 matching holds, repeated search/filter changes, selected-row actions, context menus, clear-search flow, print-directory preview counts, and 125%, 150%, and 200% Windows scaling.

--- a/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
@@ -15,10 +15,12 @@ namespace InventoryManagementApp.ViewModels
 {
     public class ReservationManagementViewModel : ObservableObject
     {
+        private const int MaxVisibleReservationRows = 500;
         private const int MaxReservationPrintRows = 250;
 
         private readonly ReservationService _reservationService;
         private readonly IDialogService _dialogService;
+        private int _matchedReservationCount;
 
         public ObservableCollection<Reservation> Reservations { get; }
         public ObservableCollection<Reservation> FilteredReservations { get; }
@@ -33,11 +35,45 @@ namespace InventoryManagementApp.ViewModels
                 }
 
                 var activeCount = Reservations.Count(r => r.IsActive);
-                var shown = $"{FilteredReservations.Count} of {Reservations.Count} reservation{(Reservations.Count == 1 ? string.Empty : "s")} shown";
+                var matchLabel = MatchingReservationCount == 1 ? "reservation" : "reservations";
+                var shown = HasOmittedReservationRows
+                    ? $"{VisibleReservationCount} of {MatchingReservationCount} matching {matchLabel} shown"
+                    : $"{VisibleReservationCount} of {TotalReservationCount} reservation{(TotalReservationCount == 1 ? string.Empty : "s")} shown";
                 var active = $"{activeCount} active";
+                var omitted = HasOmittedReservationRows
+                    ? $" | {OmittedReservationCount} hidden from live grid"
+                    : string.Empty;
+
                 return string.IsNullOrWhiteSpace(SearchText)
-                    ? $"{shown} | {active} | filter: {SelectedFilter}"
-                    : $"{shown} for \"{SearchText.Trim()}\" | {active} | filter: {SelectedFilter}";
+                    ? $"{shown} | {active} | filter: {SelectedFilter}{omitted}"
+                    : $"{shown} for \"{SearchText.Trim()}\" | {active} | filter: {SelectedFilter}{omitted}";
+            }
+        }
+
+        public int VisibleReservationCount => FilteredReservations.Count;
+        public int TotalReservationCount => Reservations.Count;
+        public int MatchingReservationCount => _matchedReservationCount;
+        public int OmittedReservationCount => Math.Max(0, MatchingReservationCount - VisibleReservationCount);
+        public bool HasOmittedReservationRows => OmittedReservationCount > 0;
+        public string ReservationVisibleWindowSummary
+        {
+            get
+            {
+                if (IsLoading)
+                {
+                    return "Rows loading...";
+                }
+
+                if (VisibleReservationCount == 0)
+                {
+                    return IsFilterActive
+                        ? "No matching rows"
+                        : "No active rows";
+                }
+
+                return HasOmittedReservationRows
+                    ? $"Showing first {VisibleReservationCount} of {MatchingReservationCount}; {OmittedReservationCount} hidden for responsiveness."
+                    : $"Showing all {VisibleReservationCount} matching row{(VisibleReservationCount == 1 ? string.Empty : "s")}.";
             }
         }
 
@@ -69,13 +105,12 @@ namespace InventoryManagementApp.ViewModels
                         : "No hold rows ready to print";
                 }
 
-                var visible = FilteredReservations.Count;
-                var printed = Math.Min(visible, MaxReservationPrintRows);
-                var omitted = Math.Max(0, visible - printed);
+                var printed = Math.Min(VisibleReservationCount, MaxReservationPrintRows);
+                var omitted = Math.Max(0, MatchingReservationCount - printed);
                 var filterContext = IsFilterActive ? "filtered" : "active";
                 return omitted == 0
                     ? $"Ready to print {printed} {filterContext} hold row{(printed == 1 ? string.Empty : "s")}."
-                    : $"Ready to print first {printed} of {visible} {filterContext} hold rows; {omitted} omitted from preview.";
+                    : $"Ready to print first {printed} of {MatchingReservationCount} {filterContext} hold rows; {omitted} omitted from preview.";
             }
         }
 
@@ -463,7 +498,6 @@ namespace InventoryManagementApp.ViewModels
         private void ApplyFilter(int? preferredReservationId = null)
         {
             preferredReservationId ??= SelectedReservation?.ReservationID;
-            FilteredReservations.Clear();
 
             var filtered = Reservations.AsEnumerable();
 
@@ -490,13 +524,35 @@ namespace InventoryManagementApp.ViewModels
                 _ => filtered
             };
 
-            foreach (var reservation in filtered.OrderBy(r => r.StartDate).ThenBy(r => r.CustomerName))
+            var visibleRows = new System.Collections.Generic.List<Reservation>(MaxVisibleReservationRows);
+            var matchedCount = 0;
+            foreach (var reservation in filtered.OrderBy(r => r.StartDate).ThenBy(r => r.CustomerName).ThenBy(r => r.ReservationID))
+            {
+                matchedCount++;
+                if (visibleRows.Count < MaxVisibleReservationRows)
+                {
+                    visibleRows.Add(reservation);
+                }
+            }
+
+            _matchedReservationCount = matchedCount;
+            ApplyFilteredReservationWindow(visibleRows);
+            SelectBestReservationAfterRefresh(preferredReservationId);
+            NotifyReservationListStateChanged();
+        }
+
+        private void ApplyFilteredReservationWindow(System.Collections.Generic.IReadOnlyList<Reservation> visibleRows)
+        {
+            if (FilteredReservations.Count == visibleRows.Count && FilteredReservations.Select((row, index) => ReferenceEquals(row, visibleRows[index])).All(match => match))
+            {
+                return;
+            }
+
+            FilteredReservations.Clear();
+            foreach (var reservation in visibleRows)
             {
                 FilteredReservations.Add(reservation);
             }
-
-            SelectBestReservationAfterRefresh(preferredReservationId);
-            NotifyReservationListStateChanged();
         }
 
         private void ClearReservationSearch()
@@ -510,6 +566,7 @@ namespace InventoryManagementApp.ViewModels
         {
             Reservations.Clear();
             FilteredReservations.Clear();
+            _matchedReservationCount = 0;
             SelectedReservation = null;
             NotifyCommandStatesAndSummaries();
             NotifyReservationListStateChanged();
@@ -579,11 +636,13 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
-                var visibleRows = FilteredReservations.Count;
+                var matchedRows = MatchingReservationCount;
+                var visibleRows = VisibleReservationCount;
+                var hiddenFromGridRows = OmittedReservationCount;
                 var printRows = FilteredReservations.Take(MaxReservationPrintRows).ToList();
-                var omittedRows = Math.Max(0, visibleRows - printRows.Count);
+                var omittedRows = Math.Max(0, matchedRows - printRows.Count);
                 var doc = CreateReservationDocument("Reservation Directory", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | Visible: {visibleRows} | Printed: {printRows.Count} | Omitted: {omittedRows} | {ReservationResultsSummary}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | Matched: {matchedRows} | Visible grid: {visibleRows} | Hidden from grid: {hiddenFromGridRows} | Printed: {printRows.Count} | Print omitted: {omittedRows} | {ReservationResultsSummary}"))
                 {
                     FontSize = 10,
                     Margin = new Thickness(0, 0, 0, 8)
@@ -591,7 +650,7 @@ namespace InventoryManagementApp.ViewModels
 
                 if (omittedRows > 0)
                 {
-                    doc.Blocks.Add(new Paragraph(new Run($"Large reservation preview limited to the first {MaxReservationPrintRows} visible rows to keep print preview responsive. Narrow the status filter or search before printing a full shelf-pick packet."))
+                    doc.Blocks.Add(new Paragraph(new Run($"Large reservation preview limited to the first {MaxReservationPrintRows} visible rows to keep print preview responsive. The live grid shows up to {MaxVisibleReservationRows} rows; narrow the status filter or search before printing a full shelf-pick packet."))
                     {
                         FontSize = 10,
                         FontStyle = FontStyles.Italic,
@@ -627,7 +686,7 @@ namespace InventoryManagementApp.ViewModels
                 }
 
                 doc.Blocks.Add(table);
-                doc.Blocks.Add(new Paragraph(new Run("Review pending, confirmed, upcoming, fulfilled, cancelled, linked Rental ID, and omitted-row counts before shelf pickup or customer handoff."))
+                doc.Blocks.Add(new Paragraph(new Run("Review pending, confirmed, upcoming, fulfilled, cancelled, linked Rental ID, hidden-from-grid counts, and print-omitted counts before shelf pickup or customer handoff."))
                 {
                     FontSize = 10,
                     FontStyle = FontStyles.Italic,
@@ -675,11 +734,18 @@ namespace InventoryManagementApp.ViewModels
             ShowUpcomingReservationsCommand.NotifyCanExecuteChanged();
             NotifySelectionSummariesChanged();
             OnPropertyChanged(nameof(ReservationResultsSummary));
+            OnPropertyChanged(nameof(ReservationVisibleWindowSummary));
         }
 
         private void NotifyReservationListStateChanged()
         {
             OnPropertyChanged(nameof(ReservationResultsSummary));
+            OnPropertyChanged(nameof(VisibleReservationCount));
+            OnPropertyChanged(nameof(TotalReservationCount));
+            OnPropertyChanged(nameof(MatchingReservationCount));
+            OnPropertyChanged(nameof(OmittedReservationCount));
+            OnPropertyChanged(nameof(HasOmittedReservationRows));
+            OnPropertyChanged(nameof(ReservationVisibleWindowSummary));
             OnPropertyChanged(nameof(IsFilterActive));
             OnPropertyChanged(nameof(ReservationEmptyTitle));
             OnPropertyChanged(nameof(ReservationEmptyMessage));

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml
@@ -66,6 +66,12 @@
                     </Border>
                     <Border Style="{StaticResource ReservationStatCard}">
                         <StackPanel>
+                            <TextBlock Text="ROWS" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding ReservationVisibleWindowSummary}" Style="{StaticResource ReservationStatValueText}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource ReservationStatCard}">
+                        <StackPanel>
                             <TextBlock Text="SELECTED" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="{Binding SelectedReservation.ReservationID, StringFormat=Hold #{0}, TargetNullValue='No hold selected', FallbackValue='No hold selected'}" Style="{StaticResource ReservationStatValueText}"/>
                         </StackPanel>
@@ -153,7 +159,10 @@
                     <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
                         <DockPanel LastChildFill="True">
                             <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,10,0"/>
-                            <TextBlock Text="{Binding ReservationPrintStatus}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                            <StackPanel DockPanel.Dock="Right" MaxWidth="380">
+                                <TextBlock Text="{Binding ReservationPrintStatus}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                                <TextBlock Text="{Binding ReservationVisibleWindowSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" TextAlignment="Right" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                            </StackPanel>
                         </DockPanel>
                     </Border>
 
@@ -167,6 +176,8 @@
                               SelectionUnit="FullRow"
                               EnableRowVirtualization="True"
                               EnableColumnVirtualization="True"
+                              VirtualizingPanel.VirtualizationMode="Recycling"
+                              RowDetailsVisibilityMode="Collapsed"
                               ScrollViewer.CanContentScroll="True"
                               ScrollViewer.HorizontalScrollBarVisibility="Auto"
                               ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -375,6 +386,7 @@
                 </WrapPanel>
                 <StackPanel Margin="2,0,10,0">
                     <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding ReservationVisibleWindowSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                     <TextBlock Text="{Binding ReservationPrintStatus}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
                 </StackPanel>
             </DockPanel>


### PR DESCRIPTION
## What changed

- Bounded the Reservations Workbench live WPF grid to the first 500 matching reservation rows.
- Added matched, visible, omitted, total, and capped-window display state to `ReservationManagementViewModel`.
- Updated reservation summary, row-window, footer, and print status copy so operators can distinguish full matching holds from the rows currently materialized in the live grid.
- Kept action availability, selection handoff, and empty states tied to visible rows while preserving full match context for display and print guidance.
- Reduced unnecessary filtered-collection churn by skipping `FilteredReservations` clear/repopulate work when the same visible reservation window is already displayed.
- Reset capped-window count state after unrecoverable reservation load/recovery failures.
- Updated Reservation Directory print-preview accounting to report matched rows, visible grid rows, hidden-from-grid rows, printed rows, and print-omitted rows.
- Enabled recycling virtualization and collapsed row details on the reservation grid for denser large-result rendering.
- Extended reservation source-contract coverage for visible-row caps, full-count display state, unchanged-window reuse, count notifications, grid virtualization, UI row summaries, and print accounting.
- Recorded the completed workflow slice in progress notes.

## Why this was highest value

Recent repo history shows the active performance direction is bounding dense WPF grids while keeping professional, honest count and print reporting. Reservations still had an unbounded filtered live collection and print accounting based on that collection. This completes the next obvious reservation workflow slice without adding unrelated scope.

## Why this is real progress

This is a workflow-level change across filtering logic, row-window state, collection churn reduction, XAML display, grid virtualization, print-preview accounting, source-contract coverage, and progress notes. It improves screen loading, filtering, grid rendering, and print-preview clarity for large reservation queues.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, four commits ahead, zero behind, and scoped to:
  - `InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs`
  - `InventoryManagementApp/Views/Pages/ReservationPage.xaml`
  - `InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-07-reservation-visible-row-responsiveness.md`
- GitHub connector readback confirmed the 500-row visible window, matched/visible/hidden count state, unchanged-window reuse guard, XAML row-window summaries, recycling virtualization, print-preview accounting, source-contract tests, and progress note.
- GitHub connector status readback found no attached commit statuses for branch head `33420e719bef415e10c88e82ea13d27e14f5c2b2` before PR creation.

## Could not check

- `pwsh -File scripts/run-full-validation.ps1`
- .NET restore/build/test
- WPF runtime smoke testing
- screenshots / Windows scaling checks
- live Reservations large-row filtering or print-preview rendering

Those require a Windows/.NET/WPF-capable checkout, which is unavailable in this scheduled Linux environment where direct GitHub checkout is blocked.

## Follow-up

- Run the full validation runner on Windows.
- Smoke test Reservations with more than 500 matching holds, repeated search/filter changes, selected-row actions, context menus, clear-search flow, print-directory preview counts, and 125%, 150%, and 200% Windows scaling.