### PR TITLE
Improve Manage Items grid display responsiveness

### DIFF
--- a/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
@@ -15,6 +15,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"230\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("DirectoryStatValueText", xaml, StringComparison.Ordinal);
+            Assert.Contains("Virtualized directory rows currently in memory", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Grid Grid.Row=\"1\" Margin=\"0,0,0,5\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"1.25*\"/>", xaml, StringComparison.Ordinal);
         }
@@ -55,11 +56,39 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("x:Name=\"ItemDirectoryGrid\"", xaml, StringComparison.Ordinal);
             Assert.Contains("EnableRowVirtualization=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("EnableColumnVirtualization=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.IsVirtualizing=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.VirtualizationMode=\"Recycling\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.ScrollUnit=\"Item\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.CacheLength=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VirtualizingPanel.CacheLengthUnit=\"Page\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("RowDetailsVisibilityMode=\"Collapsed\"", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectionMode=\"Extended\"", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectionUnit=\"FullRow\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ScrollViewer.CanContentScroll=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ScrollViewer.HorizontalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ScrollViewer.VerticalScrollBarVisibility=\"Auto\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ManageItemsPage_KeepsGridProfessionalAndOperatorAdjustable()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml");
+
+            Assert.Contains("HeadersVisibility=\"Column\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("GridLinesVisibility=\"Horizontal\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanUserResizeColumns=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanUserReorderColumns=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CanUserSortColumns=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ClipboardCopyMode=\"IncludeHeader\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("DirectoryGridTextBlockStyle", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"TextTrimming\" Value=\"CharacterEllipsis\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"ToolTip\" Value=\"{Binding Text, RelativeSource={RelativeSource Self}}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Part Number\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Quantity\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Unit Price\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ToolTip=\"{Binding AvailabilityDetail}\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Header=\"Part #\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Header=\"Qty\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -70,6 +99,10 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"320\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Loaded rows: {0}", xaml, StringComparison.Ordinal);
+            Assert.Contains("Page size: {0}", xaml, StringComparison.Ordinal);
+            Assert.Contains("Pending inline edits: {0}", xaml, StringComparison.Ordinal);
+            Assert.Contains("Missing images in loaded rows: {0}", xaml, StringComparison.Ordinal);
             Assert.Contains("More rows available: {0}", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"300\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-07-07-manage-items-grid-display-responsiveness.md
+++ b/InventoryManagementApp/ProgressNotes/2026-07-07-manage-items-grid-display-responsiveness.md
@@ -1,0 +1,26 @@
+# Manage Items Grid Display Responsiveness - 2026-07-07
+
+## Completed
+
+- Made the Manage Items directory grid explicitly use WPF item virtualization with recycling row containers.
+- Added a bounded one-page virtualization cache so large item directories can scroll without keeping excessive row visuals alive.
+- Kept content scrolling enabled and paired it with item-based virtualization for steadier grid movement.
+- Collapsed row details so hidden row-detail templates cannot add per-row layout pressure.
+- Kept column headers visible and horizontal grid lines enabled for a more readable dense desktop table.
+- Preserved operator column resizing, reordering, sorting, and header-inclusive copy behavior.
+- Added a shared trimmed cell text style with tooltips so long item numbers, names, brands, locations, activity summaries, and notes stay readable without widening rows or clipping abruptly.
+- Replaced shorthand item-grid headers with professional labels for Part Number, Quantity, and Unit Price.
+- Added availability-detail tooltips on status cells so operators can inspect context without opening the handoff pane.
+- Updated the loaded-row summary copy to make clear that rows are virtualized and currently in memory.
+- Expanded the footer status strip with loaded row count, page size, pending edit count, missing-image count, current sort, and whether more rows are available.
+- Extended Manage Items source-contract coverage for the grid display, virtualization, trimmed-cell, header, and footer-status contracts.
+
+## Validation
+
+- Source-contract coverage was updated in `InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs`.
+- GitHub connector readback should be used to confirm the changed XAML and tests on the PR branch.
+- Local Windows/WPF validation, screenshots, scaling checks, and `pwsh -File scripts/run-full-validation.ps1` could not be run in this scheduled Linux environment because direct checkout and Windows/.NET/WPF tooling are unavailable.
+
+## Follow-up
+
+- Run full Windows/.NET validation and smoke test Manage Items with a large item directory at 1366 x 768 and common Windows scaling levels.

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -70,6 +70,12 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
+        <Style x:Key="DirectoryGridTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="TextWrapping" Value="NoWrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="ToolTip" Value="{Binding Text, RelativeSource={RelativeSource Self}}"/>
+        </Style>
     </Page.Resources>
 
     <Grid Margin="4">
@@ -102,7 +108,7 @@
                 <StackPanel>
                     <TextBlock Text="Loaded Rows" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding Items.Count}" Style="{StaticResource DirectoryStatValueText}"/>
-                    <TextBlock Text="Incremental directory rows currently in memory" Style="{StaticResource DirectoryDetailText}"/>
+                    <TextBlock Text="Virtualized directory rows currently in memory" Style="{StaticResource DirectoryDetailText}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource DirectoryStatCard}">
@@ -202,6 +208,18 @@
                               AutoGenerateColumns="False"
                               EnableRowVirtualization="True"
                               EnableColumnVirtualization="True"
+                              VirtualizingPanel.IsVirtualizing="True"
+                              VirtualizingPanel.VirtualizationMode="Recycling"
+                              VirtualizingPanel.ScrollUnit="Item"
+                              VirtualizingPanel.CacheLength="1"
+                              VirtualizingPanel.CacheLengthUnit="Page"
+                              RowDetailsVisibilityMode="Collapsed"
+                              HeadersVisibility="Column"
+                              GridLinesVisibility="Horizontal"
+                              CanUserResizeColumns="True"
+                              CanUserReorderColumns="True"
+                              CanUserSortColumns="True"
+                              ClipboardCopyMode="IncludeHeader"
                               ScrollViewer.CanContentScroll="True"
                               ScrollViewer.HorizontalScrollBarVisibility="Auto"
                               ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -228,22 +246,22 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Number" Visibility="{Binding Data.ShowItemNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding ItemNumber, Mode=OneWay}" Width="110"/>
-                            <DataGridTextColumn Header="Part #" Visibility="{Binding Data.ShowPartNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding PartNumber, Mode=OneWay}" Width="110"/>
-                            <DataGridTextColumn Header="Name" Visibility="{Binding Data.ShowName, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Name, Mode=OneWay}" Width="210"/>
-                            <DataGridTextColumn Header="Brand" Visibility="{Binding Data.ShowBrand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Brand, Mode=OneWay}" Width="120"/>
+                            <DataGridTextColumn Header="Number" Visibility="{Binding Data.ShowItemNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding ItemNumber, Mode=OneWay}" ElementStyle="{StaticResource DirectoryGridTextBlockStyle}" Width="110"/>
+                            <DataGridTextColumn Header="Part Number" Visibility="{Binding Data.ShowPartNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding PartNumber, Mode=OneWay}" ElementStyle="{StaticResource DirectoryGridTextBlockStyle}" Width="120"/>
+                            <DataGridTextColumn Header="Name" Visibility="{Binding Data.ShowName, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Name, Mode=OneWay}" ElementStyle="{StaticResource DirectoryGridTextBlockStyle}" Width="210"/>
+                            <DataGridTextColumn Header="Brand" Visibility="{Binding Data.ShowBrand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Brand, Mode=OneWay}" ElementStyle="{StaticResource DirectoryGridTextBlockStyle}" Width="120"/>
                             <DataGridTemplateColumn Header="Status" Width="125">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <TextBlock Style="{StaticResource AvailabilityTextBlock}" Text="{Binding AvailabilityStatus}" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Style="{StaticResource AvailabilityTextBlock}" Text="{Binding AvailabilityStatus}" TextTrimming="CharacterEllipsis" ToolTip="{Binding AvailabilityDetail}"/>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Qty" Visibility="{Binding Data.ShowQuantityOnHand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="70"/>
-                            <DataGridTextColumn Header="Location" Visibility="{Binding Data.ShowLocation, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="130"/>
-                            <DataGridTextColumn Header="Price" Visibility="{Binding Data.ShowPrice, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="84"/>
-                            <DataGridTextColumn Header="Activity" Binding="{Binding ActivitySummary, Mode=OneWay}" Width="150"/>
-                            <DataGridTextColumn Header="Notes" Visibility="{Binding Data.ShowNotes, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Notes, Mode=OneWay}" Width="*"/>
+                            <DataGridTextColumn Header="Quantity" Visibility="{Binding Data.ShowQuantityOnHand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ElementStyle="{StaticResource DirectoryGridTextBlockStyle}" Width="80"/>
+                            <DataGridTextColumn Header="Location" Visibility="{Binding Data.ShowLocation, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ElementStyle="{StaticResource DirectoryGridTextBlockStyle}" Width="130"/>
+                            <DataGridTextColumn Header="Unit Price" Visibility="{Binding Data.ShowPrice, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ElementStyle="{StaticResource DirectoryGridTextBlockStyle}" Width="90"/>
+                            <DataGridTextColumn Header="Activity" Binding="{Binding ActivitySummary, Mode=OneWay}" ElementStyle="{StaticResource DirectoryGridTextBlockStyle}" Width="150"/>
+                            <DataGridTextColumn Header="Notes" Visibility="{Binding Data.ShowNotes, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Notes, Mode=OneWay}" ElementStyle="{StaticResource DirectoryGridTextBlockStyle}" Width="*"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
@@ -384,7 +402,10 @@
 
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Padding="6,3" Margin="0,5,0,0">
             <WrapPanel>
+                <TextBlock Text="{Binding Items.Count, StringFormat='Loaded rows: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Text="{Binding PageSize, StringFormat='Page size: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
                 <TextBlock Text="{Binding PendingEdits.Count, StringFormat='Pending inline edits: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Text="{Binding MissingImageCount, StringFormat='Missing images in loaded rows: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
                 <TextBlock Text="{Binding SelectedSortOption.DisplayName, StringFormat='Sort: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
                 <TextBlock Text="{Binding Items.HasMoreItems, StringFormat='More rows available: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
             </WrapPanel>


### PR DESCRIPTION
## What changed

- Made the Manage Items item directory grid explicitly use WPF virtualization with recycling row containers.
- Added item-based virtualized scrolling plus a bounded one-page cache for steadier large-directory scrolling.
- Collapsed row details so hidden per-row detail templates cannot add layout pressure.
- Kept column headers visible, added horizontal grid lines, and preserved operator column resizing, reordering, and sorting.
- Kept clipboard copy useful by including column headers.
- Added a shared trimmed cell text style with tooltips for long item numbers, names, brands, locations, activity summaries, and notes.
- Added availability-detail tooltips on status cells.
- Replaced shorthand data-grid headers with professional labels for Part Number, Quantity, and Unit Price.
- Clarified the loaded-row summary card so it says loaded rows are virtualized rows currently in memory.
- Expanded the footer status strip with loaded row count, page size, pending edit count, missing-image count, sort state, and more-row availability.
- Extended Manage Items source-contract coverage for grid virtualization, professional display settings, trimmed cells, headers, tooltips, and footer status.
- Recorded progress in `InventoryManagementApp/ProgressNotes/2026-07-07-manage-items-grid-display-responsiveness.md`.

## Why this was highest value

Recent hourly runs have improved many high-traffic grids and workbenches, and current repo evidence showed Manage Items had startup, loading, layout, and keyboard improvements but still lacked explicit recycling virtualization and professional large-row display details in the grid itself. Manage Items is a core inventory workflow, so improving scroll/render pressure, dense table readability, and footer state is directly aligned with the current loading-speed and data-display focus.

## Why this is real progress

This is a focused Manage Items data-display workflow slice across the grid render contract, column/cell readability, operator-adjustable table behavior, status/footer visibility, source-contract coverage, and progress notes. It improves more than ten practical table and workflow details without adding unrelated features or changing persistence behavior.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, ahead by three focused commits, and limited to:
  - `InventoryManagementApp/Views/Pages/ManageItemsPage.xaml`
  - `InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs`
  - `InventoryManagementApp/ProgressNotes/2026-07-07-manage-items-grid-display-responsiveness.md`
- Connector readback confirmed the new virtualization settings, recycling mode, row-details suppression, grid display settings, trimmed-cell style, professional headers, status tooltip, footer counters, source-contract additions, and progress note.
- Connector status readback found no attached commit statuses on branch head `023e92296807074c65cfc6c978fa8f801b6f03a5`.

Could not run `pwsh -File scripts/run-full-validation.ps1`, .NET restore/build/test, WPF runtime checks, screenshots, Windows scaling checks, or live grid responsiveness testing because direct checkout is blocked in this scheduled Linux environment and Windows/.NET/WPF tooling is unavailable here.

## Follow-up

- Run the full Windows/.NET validation runner.
- Smoke test Manage Items with a large directory at 1366 x 768 and common Windows scaling levels, including sorting, column resizing/reordering, copy-to-clipboard, long text cells, and more-row loading.