### PR TITLE
Unify page headers and refresh item images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,5 +381,7 @@ Thumbs.db
 !.qa-screenshots/.gitignore
 .qa-screenshots-targeted/*
 !.qa-screenshots-targeted/.gitignore
+.qa-screenshots-*/
+.qa-run/
 .qa-print-pdfs/*
 !.qa-print-pdfs/.gitignore

--- a/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogsPageResponsiveContractTests.cs
@@ -11,9 +11,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"230\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"ActivityStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
         }
 
@@ -107,9 +106,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Text=\"OMITTED\"", xaml, StringComparison.Ordinal);
             Assert.Contains("MatchedLogCount", xaml, StringComparison.Ordinal);
             Assert.Contains("OmittedLogCount", xaml, StringComparison.Ordinal);
-            Assert.Contains("StringFormat='Matched: {0}'", xaml, StringComparison.Ordinal);
-            Assert.Contains("StringFormat='Hidden: {0}'", xaml, StringComparison.Ordinal);
-            Assert.Contains("StringFormat='Loaded: {0}'", xaml, StringComparison.Ordinal);
+            Assert.Contains("StringFormat={}{0} rows matched", xaml, StringComparison.Ordinal);
+            Assert.Contains("StringFormat={}{0} hidden from grid", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("{Binding FilteredLogCount, StringFormat={}{0} visible}", xaml, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CalibrationPageResponsiveContractTests.cs
@@ -11,10 +11,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Style x:Key=\"CalibrationMetricCard\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"CalibrationMetricCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding CalibrationPrintStatus}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CategoriesPageResponsiveContractTests.cs
@@ -11,9 +11,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"CategoryStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("CategoryStatValueText", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("PRINT", xaml, StringComparison.Ordinal);
@@ -75,7 +74,6 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
 
-            Assert.Contains("Content=\"Print Directory\" Click=\"PrintCategories_Click\" IsEnabled=\"{Binding IsDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Header=\"Print Current Directory\" Click=\"PrintCategories_Click\" IsEnabled=\"{Binding IsDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("CategoryPrintSummary", xaml, StringComparison.Ordinal);
         }
@@ -86,7 +84,7 @@ namespace InventoryManagementApp.Tests
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
 
             Assert.Contains("Content=\"Open\" Click=\"OpenCategoryDetail_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Content=\"Copy Handoff\" Click=\"CopyCategory_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Copy\" Click=\"CopyCategory_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Content=\"Print Sheet\" Click=\"PrintSelectedCategory_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Header=\"Open Category Detail\" Click=\"OpenCategoryDetail_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Header=\"Copy Setup Handoff\" Click=\"CopyCategory_Click\" IsEnabled=\"{Binding IsSelectedCategoryActionAvailable}\"", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomersPageResponsiveContractTests.cs
@@ -11,15 +11,15 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"160\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"250\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"CustomerStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("CustomerStatValueText", xaml, StringComparison.Ordinal);
             Assert.Contains("CustomerDirectoryVisibleCount", xaml, StringComparison.Ordinal);
             Assert.Contains("CustomerDirectoryMatchCount", xaml, StringComparison.Ordinal);
             Assert.Contains("CustomerVisibleWindowSummary", xaml, StringComparison.Ordinal);
             Assert.Contains("CustomerPrintSummary", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Grid Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"1.35*\"/>", xaml, StringComparison.Ordinal);
         }
 
@@ -84,13 +84,13 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml");
 
-            Assert.Contains("Content=\"Add\" Command=\"{Binding AddCustomerCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Add Customer\" Command=\"{Binding AddCustomerCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryActionAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Content=\"Details\" Command=\"{Binding OpenCustomerDetailsCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Content=\"Edit\" Command=\"{Binding EditCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Content=\"Copy Contact\" Command=\"{Binding CopySelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Content=\"Print Sheet\" Command=\"{Binding PrintSelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Content=\"Directory\" Command=\"{Binding PrintCustomerDirectoryCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Content=\"Delete\" Command=\"{Binding DeleteCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Copy\" Command=\"{Binding CopySelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Print\" Command=\"{Binding PrintSelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Print Directory\" Command=\"{Binding PrintCustomerDirectoryCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Delete Customer\" Command=\"{Binding DeleteCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("IsEnabled=\"{Binding IsCustomerDirectoryActionAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("IsEnabled=\"{Binding IsCustomerDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
         }
@@ -106,8 +106,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Header=\"Print Customer Sheet\" Command=\"{Binding PrintSelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Header=\"Print Customer Directory\" Command=\"{Binding PrintCustomerDirectoryCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryPrintAvailable}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Header=\"Delete Customer\" Command=\"{Binding DeleteCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Content=\"Copy Contact\" Command=\"{Binding CopySelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Content=\"Clear Search\" Command=\"{Binding ClearCustomerSearchCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Copy\" Command=\"{Binding CopySelectedCustomerCommand}\" IsEnabled=\"{Binding IsSelectedCustomerActionAvailable}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Clear\" Command=\"{Binding ClearCustomerSearchCommand}\" IsEnabled=\"{Binding IsCustomerDirectoryActionAvailable}\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardPageResponsiveContractTests.cs
@@ -11,12 +11,12 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Row=\"2\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
             Assert.Contains("DashboardMetricCard", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"230\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("BasedOn=\"{StaticResource PageHeaderStatCard}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("DashboardMetricValueText", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Columns=\"4\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<WrapPanel Grid.Row=\"2\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -67,7 +67,9 @@ namespace InventoryManagementApp.Tests
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");
 
             Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" MinWidth=\"210\" MaxWidth=\"320\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Border Style=\"{StaticResource DesktopSummaryCard}\" MinWidth=\"92\" MaxWidth=\"160\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Style=\"{StaticResource PageHeaderStatCard}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"New Item\" Command=\"{Binding NewItemCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Print Snapshot\" Command=\"{Binding PrintDashboardSnapshotCommand}\"", xaml, StringComparison.Ordinal);
             Assert.True(CountOccurrences(xaml, "<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">") >= 3);
             Assert.DoesNotContain("<StackPanel Orientation=\"Horizontal\" DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
         }
@@ -79,6 +81,7 @@ namespace InventoryManagementApp.Tests
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
 
             Assert.Contains("x:Name=\"DashboardRoot\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Grid x:Name=\"DashboardRoot\" Margin=\"4\">", xaml, StringComparison.Ordinal);
             Assert.Contains("x:Name=\"DashboardLoadStatusBanner\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Grid.Row=\"1\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Visibility=\"Collapsed\"", xaml, StringComparison.Ordinal);
@@ -247,9 +250,9 @@ namespace InventoryManagementApp.Tests
             var codeBehind = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs");
 
             Assert.Contains("NewItemCommand", xaml, StringComparison.Ordinal);
-            Assert.Contains("OpenItemsCommand", xaml, StringComparison.Ordinal);
-            Assert.Contains("OpenRentalsCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("PrintDashboardSnapshotCommand", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Command=\"{Binding OpenItemsCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Command=\"{Binding OpenRentalsCommand}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("PrintCheckedOutItemsCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("Content=\"Print Mine\" Command=\"{Binding PrintMyCheckedOutItemsCommand}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Header=\"Print My Checked-Out Items\"", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ImportExportPageResponsiveContractTests.cs
@@ -11,9 +11,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"230\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"DataOperationStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("DataOperationStatValueText", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
@@ -76,10 +75,10 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"340\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
             Assert.Contains("HorizontalScrollBarVisibility=\"Disabled\" MaxHeight=\"260\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<TextBlock Text=\"{Binding LogSummary}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Text=\"{Binding DataOperationStatus}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding DataOperationSummary}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<ProgressBar Width=\"120\" Height=\"14\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Visibility=\"{Binding IsDataOperationBusy, Converter={StaticResource BoolToVis}}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsDataOperationBusy", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Text=\"{Binding DataOperationStatus}\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<ProgressBar Width=\"120\" Height=\"14\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Text=\"Data desk ready\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Text=\"Item import running\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"360\"", xaml, StringComparison.Ordinal);
@@ -92,8 +91,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml");
 
-            Assert.True(CountOccurrences(xaml, "IsEnabled=\"{Binding CanReviewSelectedLog}\"") >= 6);
-            Assert.True(CountOccurrences(xaml, "IsEnabled=\"{Binding CanPrintImportExportLogs}\"") >= 5);
+            Assert.True(CountOccurrences(xaml, "IsEnabled=\"{Binding CanReviewSelectedLog}\"") >= 5);
+            Assert.True(CountOccurrences(xaml, "IsEnabled=\"{Binding CanPrintImportExportLogs}\"") >= 4);
             Assert.Contains("<ContextMenu DataContext=\"{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<MenuItem Header=\"Open Log Detail\" Click=\"OpenSelectedLog_Click\" IsEnabled=\"{Binding CanReviewSelectedLog}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<MenuItem Header=\"Copy Selected Log\" Click=\"CopySelectedLog_Click\" IsEnabled=\"{Binding CanReviewSelectedLog}\"/>", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ItemSearchPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemSearchPageResponsiveContractTests.cs
@@ -12,15 +12,22 @@ namespace InventoryManagementApp.Tests
             var xaml = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml"));
 
             Assert.Contains("<DockPanel LastChildFill=\"True\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<WrapPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<ComboBox Width=\"150\" MinWidth=\"120\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\" Orientation=\"Horizontal\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<WrapPanel VerticalAlignment=\"Center\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"0\" Style=\"{StaticResource PageHeaderBand}\" Background=\"{DynamicResource PageHeaderSearchBrush}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Search Tools\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ComboBox Height=\"27\" MinHeight=\"27\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Print Results\" Click=\"PrintSearchResults_Click\" Style=\"{StaticResource GhostButton}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Style=\"{StaticResource PageHeaderStatsPanel}\" MinWidth=\"0\">", xaml, StringComparison.Ordinal);
+            Assert.Equal(3, CountOccurrences(xaml, "<Border Style=\"{StaticResource PageHeaderStatCard}\">"));
             Assert.DoesNotContain("Text=\"Find item\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Text=\"{Binding SearchText, UpdateSourceTrigger=PropertyChanged}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"320\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"180\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("Source=\"{Binding IsAsync=True, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"No search results yet\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Binding SearchResults.Count", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Nothing is checked out\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Binding CheckedOutItems.Count", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -42,7 +49,7 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml"));
 
-            Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\" MinWidth=\"180\" MaxWidth=\"420\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\" HorizontalAlignment=\"Left\" MinWidth=\"180\" MaxWidth=\"520\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\" MinWidth=\"170\" MaxWidth=\"360\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\" MinWidth=\"180\" MaxWidth=\"360\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"MinWidth\" Value=\"145\"/>", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -508,6 +508,25 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task EditItemCommand_ReplacesVisibleRowSoUpdatedImageAppearsImmediately()
+        {
+            var original = new ItemModel { ItemID = 1, ItemNumber = "T-1", ImagePath = "Assets/ItemImages/old.jpg" };
+            var updated = new ItemModel { ItemID = 1, ItemNumber = "T-1", ImagePath = "Assets/ItemImages/new.jpg" };
+            var dialog = new RecordingDialogService { EditItemDialogResult = updated };
+            var itemService = new RecordingItemService2();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, new DummyRentalService(), new DummySettingsService(), NullLogger<ItemsViewModel>.Instance);
+            vm.Items.Add(original);
+            vm.SelectedItem = original;
+
+            await vm.EditItemCommand.ExecuteAsync(null);
+
+            Assert.Same(updated, vm.Items[0]);
+            Assert.Same(updated, vm.SelectedItem);
+            Assert.Equal("Assets/ItemImages/new.jpg", vm.Items[0].ImagePath);
+        }
+
+        [Fact]
         public async Task EditItemCommand_HandlesCancellation()
         {
             var item = new ItemModel { ItemID = 1 };

--- a/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/KitManagementPageResponsiveContractTests.cs
@@ -11,9 +11,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"KitStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("KitStatValueText", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("{Binding KitFilterSummary}", xaml, StringComparison.Ordinal);
@@ -68,7 +67,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("{Binding KitEmptyStateTitle}", xaml, StringComparison.Ordinal);
             Assert.Contains("{Binding KitItemsEmptyStateMessage}", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer Grid.Row=\"1\" VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\" Padding=\"12\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Copy\" Command=\"{Binding CopySelectedKitCommand}\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"320\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Width=\"320\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/MainWindowResponsiveContractTests.cs
@@ -103,18 +103,15 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void MainWindow_PageHeaderWrapsWorkflowActionsInBoundedArea()
+        public void MainWindow_UsesOneShellHeaderAndLeavesPageActionsToPageContent()
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "MainWindow.xaml");
 
-            Assert.Contains("MinHeight=\"44\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<ColumnDefinition Width=\"*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<ColumnDefinition Width=\"Auto\" MinWidth=\"0\" MaxWidth=\"420\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<StackPanel VerticalAlignment=\"Center\" MinWidth=\"0\" Margin=\"0,0,12,0\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<WrapPanel Grid.Column=\"1\" Orientation=\"Horizontal\" HorizontalAlignment=\"Right\" VerticalAlignment=\"Center\" MaxWidth=\"420\">", xaml, StringComparison.Ordinal);
-            Assert.Equal(2, CountOccurrences(xaml, "MinWidth=\"96\"\n                            MaxWidth=\"180\""));
-            Assert.Contains("Margin=\"0,0,4,4\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Margin=\"0,0,0,4\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<RowDefinition x:Name=\"ShellHeaderRow\" Height=\"Auto\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<RowDefinition x:Name=\"ShellMenuRow\" Height=\"Auto\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Frame Grid.Row=\"2\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("x:Name=\"PageHeaderBand\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("CurrentWorkflowPrimaryCommand", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -193,9 +190,9 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("GlobalSearchCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("SwitchUserCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("CurrentPage", xaml, StringComparison.Ordinal);
-            Assert.Contains("CurrentWorkflowPrimaryCommand", xaml, StringComparison.Ordinal);
-            Assert.Contains("CurrentWorkflowSecondaryCommand", xaml, StringComparison.Ordinal);
-            Assert.Contains("CurrentWorkflowGuide", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("CurrentWorkflowPrimaryCommand", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("CurrentWorkflowSecondaryCommand", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("CurrentWorkflowGuide", xaml, StringComparison.Ordinal);
             Assert.Contains("CurrentUserRole", xaml, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenancePageResponsiveContractTests.cs
@@ -11,9 +11,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"MaintenanceStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding MaintenancePrintStatus}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageResponsiveContractTests.cs
@@ -11,12 +11,13 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,5\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"230\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"0\" Style=\"{StaticResource PageHeaderBand}\" Background=\"{DynamicResource PageHeaderManageItemsBrush}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Style=\"{StaticResource PageHeaderStatsPanel}\" Margin=\"12,0,0,0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"DirectoryStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("DirectoryStatValueText", xaml, StringComparison.Ordinal);
             Assert.Contains("Virtualized directory rows currently in memory", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Grid Grid.Row=\"1\" Margin=\"0,0,0,5\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,5\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"1.25*\"/>", xaml, StringComparison.Ordinal);
         }
 
@@ -26,7 +27,8 @@ namespace InventoryManagementApp.Tests
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml");
 
             Assert.Contains("<StackPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\" MinWidth=\"220\" MaxWidth=\"460\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\" HorizontalAlignment=\"Right\" Margin=\"12,0,0,0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"New\" Command=\"{Binding NewItemCommand}\" Margin=\"0,0,4,4\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Mobile Capture\" Command=\"{Binding OpenMobileCaptureCommand}\" Margin=\"0,0,4,4\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\" HorizontalAlignment=\"Right\" Margin=\"12,0,0,0\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<pages:SearchBar Width=\"240\"", xaml, StringComparison.Ordinal);
@@ -101,11 +103,11 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Border Grid.Row=\"2\" MaxWidth=\"320\" MinHeight=\"120\" Margin=\"12\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<ScrollViewer VerticalScrollBarVisibility=\"Auto\" HorizontalScrollBarVisibility=\"Disabled\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<WrapPanel>", xaml, StringComparison.Ordinal);
-            Assert.Contains("Loaded rows: {0}", xaml, StringComparison.Ordinal);
-            Assert.Contains("Page size: {0}", xaml, StringComparison.Ordinal);
-            Assert.Contains("Pending inline edits: {0}", xaml, StringComparison.Ordinal);
-            Assert.Contains("Missing images in loaded rows: {0}", xaml, StringComparison.Ordinal);
-            Assert.Contains("More rows available: {0}", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Loaded Rows\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Page Size\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Pending Edits\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Missing Images\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Loaded rows: {0}", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Border Grid.Row=\"2\" Width=\"300\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("VerticalScrollBarVisibility=\"Hidden\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<DockPanel LastChildFill=\"False\">\n                <TextBlock DockPanel.Dock=\"Left\" Text=\"{Binding PendingEdits.Count", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
@@ -69,12 +69,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void ActionButtons_AppearAtTop()
+        public void CreationActionsAppearAtTopAndSelectedItemActionsStayWithTheDetailPane()
         {
             var xaml = ReadXaml();
+            var newIndex = xaml.IndexOf("Content=\"New\"");
             var editIndex = xaml.IndexOf("Content=\"Edit\"");
             var dataGridIndex = xaml.IndexOf("<DataGrid");
-            Assert.True(editIndex >= 0 && dataGridIndex >= 0 && editIndex < dataGridIndex);
+            Assert.True(newIndex >= 0 && dataGridIndex >= 0 && newIndex < dataGridIndex);
+            Assert.True(editIndex > dataGridIndex, "Selected-item actions should remain in the detail pane instead of being duplicated above the grid.");
         }
 
         [Fact]
@@ -116,12 +118,13 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadXaml();
 
-            Assert.Contains("<Setter Property=\"MinHeight\" Value=\"54\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"DirectoryStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("Style=\"{StaticResource DirectoryStatValueText}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.7*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"0.95*\" MinWidth=\"300\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<pages:SearchBar Width=\"240\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Padding=\"6,3\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"New\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Mobile Capture\"", xaml, StringComparison.Ordinal);
         }
 
         private static string ReadXaml()

--- a/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageResponsiveContractTests.cs
@@ -11,11 +11,12 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = NormalizeNewlines(ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml"));
 
-            Assert.Contains("<WrapPanel x:Name=\"RentalStatsStrip\" Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Border Grid.Row=\"0\" Style=\"{StaticResource PageHeaderBand}\" Background=\"{DynamicResource PageHeaderRentalsBrush}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel x:Name=\"RentalStatsStrip\" Style=\"{StaticResource PageHeaderStatsPanel}\" Margin=\"12,0,0,0\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"RentalStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("RentalStatValueText", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Grid x:Name=\"RentalStatsStrip\" Grid.Row=\"1\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("x:Name=\"RentalStatsRow\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"1.25*\"/>", xaml, StringComparison.Ordinal);
         }
 
@@ -281,9 +282,9 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("<Style x:Key=\"RentalGridTextBlock\" TargetType=\"TextBlock\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"TextTrimming\" Value=\"CharacterEllipsis\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<Setter Property=\"ToolTip\" Value=\"{Binding Text, RelativeSource={RelativeSource Self}}\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<TextBlock Text=\"{Binding SearchSummary}\" Style=\"{StaticResource RentalDetailText}\" ToolTip=\"{Binding SearchSummary}\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<TextBlock Text=\"{Binding CheckedOutSummary}\" Style=\"{StaticResource RentalDetailText}\" ToolTip=\"{Binding CheckedOutSummary}\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<TextBlock Text=\"{Binding RequestSummary}\" Style=\"{StaticResource RentalDetailText}\" ToolTip=\"{Binding RequestSummary}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"{Binding SearchSummary}\" Style=\"{StaticResource RentalDetailText}\" TextWrapping=\"NoWrap\" TextTrimming=\"CharacterEllipsis\" ToolTip=\"{Binding SearchSummary}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"{Binding CheckedOutSummary}\" Style=\"{StaticResource RentalDetailText}\" TextWrapping=\"NoWrap\" TextTrimming=\"CharacterEllipsis\" ToolTip=\"{Binding CheckedOutSummary}\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<TextBlock Text=\"{Binding RequestSummary}\" Style=\"{StaticResource RentalDetailText}\" TextWrapping=\"NoWrap\" TextTrimming=\"CharacterEllipsis\" ToolTip=\"{Binding RequestSummary}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<RowDefinition Height=\"Auto\"/>\n                    </Grid.RowDefinitions>\n                    <Border Style=\"{StaticResource DesktopPaneHeader}\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border Grid.Row=\"3\" Style=\"{StaticResource DesktopPaneSubheader}\" Padding=\"10,6\">", xaml, StringComparison.Ordinal);
             Assert.Contains("<Border Grid.Row=\"2\" Style=\"{StaticResource DesktopPaneSubheader}\" Padding=\"10,6\">", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ManageRentalsPageTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsPageTests.cs
@@ -26,7 +26,7 @@ namespace InventoryManagementApp.Tests
     public class ManageRentalsPageTests
     {
         [Fact]
-        public void ActionButtons_AreInToolbar_WithCorrectBindings()
+        public void SelectedRentalActionsStayInDetailPaneAndContextMenuWithCorrectBindings()
         {
             Exception? threadEx = null;
             var thread = new Thread(() =>
@@ -48,7 +48,7 @@ namespace InventoryManagementApp.Tests
                     page.DataContext = vm;
 
                     var grid = Assert.IsType<Grid>(page.Content);
-                    Assert.Equal(5, grid.RowDefinitions.Count);
+                    Assert.Equal(4, grid.RowDefinitions.Count);
 
                     var xamlPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml"));
                     var xaml = File.ReadAllText(xamlPath);
@@ -56,15 +56,16 @@ namespace InventoryManagementApp.Tests
                     Assert.Contains("Content=\"Extend\" Command=\"{Binding ExtendCommand}\"", xaml);
                     Assert.Contains("Content=\"History\" Command=\"{Binding OpenHistoryCommand}\"", xaml);
                     Assert.Contains("Content=\"Print Rental\" Command=\"{Binding PrintRentalCommand}\"", xaml);
-                    Assert.Contains("Content=\"Delete\" Command=\"{Binding DeleteRentalCommand}\"", xaml);
-                    Assert.Contains("x:Name=\"RentalStatsRow\"", xaml);
+                    Assert.Contains("Header=\"Delete Rental\" Command=\"{Binding DeleteRentalCommand}\"", xaml);
+                    Assert.DoesNotContain("Content=\"Delete\" Command=\"{Binding DeleteRentalCommand}\"", xaml);
+                    Assert.DoesNotContain("x:Name=\"RentalStatsRow\"", xaml);
                     Assert.Contains("x:Name=\"RentalStatsStrip\"", xaml);
                     Assert.Contains("x:Name=\"RequestDetailColumn\"", xaml);
                     Assert.Contains("x:Name=\"RequestDetailPanel\"", xaml);
                     Assert.Contains("x:Key=\"RentalFilterDatePicker\"", xaml, StringComparison.Ordinal);
                     Assert.Contains("<Setter Property=\"Width\" Value=\"158\"/>", xaml, StringComparison.Ordinal);
                     Assert.Contains("<Setter Property=\"Height\" Value=\"34\"/>", xaml, StringComparison.Ordinal);
-                    Assert.Contains("<Setter Property=\"MinHeight\" Value=\"48\"/>", xaml, StringComparison.Ordinal);
+                    Assert.Contains("<Style x:Key=\"RentalStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
                     Assert.Contains("Style=\"{StaticResource RentalFilterDatePicker}\"", xaml, StringComparison.Ordinal);
                     Assert.DoesNotContain("Width=\"132\"", xaml, StringComparison.Ordinal);
 

--- a/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
+++ b/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
@@ -163,6 +163,45 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void Convert_FileChangedAtSamePath_ReloadsImageInsteadOfServingStaleCache()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(tempDir);
+                try
+                {
+                    ClearImageCaches();
+                    var path = Path.Combine(tempDir, "item.png");
+                    var pngBytes = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAAC0lEQVQI12NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=");
+                    File.WriteAllBytes(path, pngBytes);
+                    var converter = new NullToDefaultImageConverter();
+                    var first = Assert.IsType<BitmapImage>(converter.Convert(path, typeof(BitmapImage), "item", CultureInfo.InvariantCulture));
+
+                    File.WriteAllBytes(path, pngBytes);
+                    File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddSeconds(2));
+                    var second = Assert.IsType<BitmapImage>(converter.Convert(path, typeof(BitmapImage), "item", CultureInfo.InvariantCulture));
+
+                    Assert.NotSame(first, second);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    try { Directory.Delete(tempDir, true); } catch { }
+                    WpfTestHelper.ShutdownApplication();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
         public void Convert_ItemWithoutImagePath_FallsBackToItemNumberImage()
         {
             Exception? threadEx = null;

--- a/InventoryManagementApp.Tests/PageHeaderBandConsistencyTests.cs
+++ b/InventoryManagementApp.Tests/PageHeaderBandConsistencyTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class PageHeaderBandConsistencyTests
+    {
+        [Fact]
+        public void MainPages_UseSharedFixedHeaderBandAndConfiguredBrush()
+        {
+            var pages = new Dictionary<string, string>
+            {
+                ["DashboardPage.xaml"] = "PageHeaderDashboardBrush",
+                ["ItemSearchPage.xaml"] = "PageHeaderSearchBrush",
+                ["ManageItemsPage.xaml"] = "PageHeaderManageItemsBrush",
+                ["ManageRentalsPage.xaml"] = "PageHeaderRentalsBrush",
+                ["CustomersPage.xaml"] = "PageHeaderCustomersBrush",
+                ["ReservationPage.xaml"] = "PageHeaderReservationsBrush",
+                ["MaintenancePage.xaml"] = "PageHeaderMaintenanceBrush",
+                ["CalibrationPage.xaml"] = "PageHeaderCalibrationBrush",
+                ["KitManagementPage.xaml"] = "PageHeaderKitsBrush",
+                ["CategoriesPage.xaml"] = "PageHeaderCategoriesBrush",
+                ["ReportsPage.xaml"] = "PageHeaderReportsBrush",
+                ["ActivityLogsPage.xaml"] = "PageHeaderActivityLogsBrush",
+                ["ImportExportPage.xaml"] = "PageHeaderImportExportBrush",
+                ["UsersPage.xaml"] = "PageHeaderUsersBrush",
+                ["SettingsPage.xaml"] = "PageHeaderSettingsBrush"
+            };
+
+            foreach (var (page, brush) in pages)
+            {
+                var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", page);
+
+                Assert.Contains("Style=\"{StaticResource PageHeaderBand}\"", xaml, StringComparison.Ordinal);
+                Assert.Contains($"Background=\"{{DynamicResource {brush}}}\"", xaml, StringComparison.Ordinal);
+
+                var document = XDocument.Parse(xaml);
+                var header = document.Descendants()
+                    .Single(element => element.Name.LocalName == "Border"
+                        && element.Attribute("Style")?.Value == "{StaticResource PageHeaderBand}");
+                Assert.DoesNotContain(header.Descendants(), element => element.Name.LocalName == "Button");
+
+                Assert.Contains(header.Descendants(), element => element.Name.LocalName == "WrapPanel"
+                    && element.Attribute("Style")?.Value == "{StaticResource PageHeaderStatsPanel}");
+                Assert.DoesNotContain(header.Descendants(), element => element.Name.LocalName == "WrapPanel"
+                    && element.Attribute("Style")?.Value == "{StaticResource PageHeaderStatsPanel}"
+                    && element.Attribute("HorizontalAlignment")?.Value == "Left");
+            }
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                directory = Directory.GetParent(directory)?.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportsPageResponsiveContractTests.cs
@@ -11,9 +11,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"240\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"ReportsStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"{Binding ReportLineWindowSummary}\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationPageResponsiveContractTests.cs
@@ -12,9 +12,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"150\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"235\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"ReservationStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("ReservationStatValueText", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.85*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/Resources/ThemeFullCustomizationOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeFullCustomizationOverrideTests.cs
@@ -28,6 +28,17 @@ namespace InventoryManagementApp.Tests.Resources
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FullCustomizationOverrides.xaml");
 
             Assert.Contains("x:Key=\"ToolbarCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"PageHeaderBand\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"Height\" Value=\"90\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"MinHeight\" Value=\"90\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"PageHeaderStatCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"Width\" Value=\"160\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Setter Property=\"Height\" Value=\"66\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"PageHeaderStatValueText\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"PageHeaderStatCaptionText\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"PageHeaderStatsPanel\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("x:Key=\"PageHeaderActionsPanel\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("x:Key=\"PageHeaderActionButton\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"DataGridColumnHeader\"", xaml, StringComparison.Ordinal);
             Assert.Contains("x:Key=\"DesktopSummaryCard\"", xaml, StringComparison.Ordinal);
             Assert.Contains("x:Key=\"DesktopInsetCard\"", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/SettingsPageResponsiveContractTests.cs
@@ -13,9 +13,8 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("<ColumnDefinition Width=\"1.15*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
             Assert.Contains("<ColumnDefinition Width=\"1.85*\" MinWidth=\"0\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<WrapPanel Grid.Column=\"2\" HorizontalAlignment=\"Right\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"160\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"260\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Grid.Column=\"2\" Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"SettingsStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<UniformGrid Grid.Column=\"2\" Columns=\"4\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"2*\" MinWidth=\"360\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"3*\" MinWidth=\"520\"/>", xaml, StringComparison.Ordinal);
@@ -28,8 +27,9 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("SettingsPrimaryActionButton", xaml, StringComparison.Ordinal);
             Assert.Contains("SettingsActionButton", xaml, StringComparison.Ordinal);
-            Assert.True(CountOccurrences(xaml, "<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">") >= 5);
-            Assert.Contains("<WrapPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
+            Assert.True(CountOccurrences(xaml, "<WrapPanel DockPanel.Dock=\"Right\" VerticalAlignment=\"Center\">") >= 4);
+            Assert.DoesNotContain("<WrapPanel DockPanel.Dock=\"Left\" VerticalAlignment=\"Center\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Text=\"Admin Actions\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Orientation=\"Horizontal\" DockPanel.Dock=\"Left\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Orientation=\"Horizontal\" VerticalAlignment=\"Center\"", xaml, StringComparison.Ordinal);
         }

--- a/InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs
+++ b/InventoryManagementApp.Tests/UsersPageResponsiveContractTests.cs
@@ -11,10 +11,10 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
 
-            Assert.Contains("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MinWidth\" Value=\"160\"/>", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"MaxWidth\" Value=\"250\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("<WrapPanel Style=\"{StaticResource PageHeaderStatsPanel}\">", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Style x:Key=\"UserStatCard\" TargetType=\"Border\" BasedOn=\"{StaticResource PageHeaderStatCard}\"/>", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<Grid Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<WrapPanel Grid.Row=\"1\" Margin=\"0,0,0,6\">", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("<ColumnDefinition Width=\"1.35*\"/>", xaml, StringComparison.Ordinal);
         }
 
@@ -124,8 +124,8 @@ namespace InventoryManagementApp.Tests
         {
             var xaml = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
 
-            Assert.Contains("Content=\"Add User\" Command=\"{Binding AddUserCommand}\" IsEnabled=\"{Binding CanUseUserActions}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Content=\"Edit Access\" Command=\"{Binding EditUserCommand}\" IsEnabled=\"{Binding CanUseSelectedUserActions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"Add\" Command=\"{Binding AddUserCommand}\" IsEnabled=\"{Binding CanUseUserActions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Header=\"Edit User Access\" Command=\"{Binding EditUserCommand}\" IsEnabled=\"{Binding CanUseSelectedUserActions}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Content=\"Reset Password\" Click=\"ResetSelectedUser_Click\" IsEnabled=\"{Binding CanUseSelectedUserActions}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Content=\"Copy Handoff\" Click=\"CopySelectedUser_Click\" IsEnabled=\"{Binding CanUseSelectedUserActions}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Content=\"Print Directory\" Click=\"PrintUsers_Click\" IsEnabled=\"{Binding CanPrintUsers}\"", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ViewModels/CategoriesPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/CategoriesPageXamlTests.cs
@@ -11,13 +11,13 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml");
 
-            Assert.Contains("Category Workbench", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Categories\"", xaml, StringComparison.Ordinal);
             Assert.Contains("CategoryResultsSummary", xaml, StringComparison.Ordinal);
             Assert.Contains("CategoryFilterSummary", xaml, StringComparison.Ordinal);
             Assert.Contains("CategorySetupSummary", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedCategoryTitle", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedCategoryNextAction", xaml, StringComparison.Ordinal);
-            Assert.Contains("SelectedCategoryChecklist", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("SelectedCategoryChecklist", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedCategoryHandoff", xaml, StringComparison.Ordinal);
             Assert.Contains("AddCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("SaveCommand", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -13,7 +13,7 @@ namespace InventoryManagementApp.Tests.ViewModels
 
             AssertContainsAll(
                 xaml,
-                "Data Operations Workbench",
+                "Text=\"Import / Export\"",
                 "DataOperationStatCard",
                 "Data Control Lanes",
                 "Session Handoff",
@@ -21,7 +21,6 @@ namespace InventoryManagementApp.Tests.ViewModels
                 "CustomerDataSummary",
                 "BackupSummary",
                 "ImageImportSummary",
-                "DataOperationStatus",
                 "DataOperationSummary");
         }
 

--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -11,7 +11,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml");
 
-            Assert.Contains("Reports Workbench", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Reports\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ReportsStatCard", xaml, StringComparison.Ordinal);
             Assert.Contains("ReportLineCount", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedLineDestination", xaml, StringComparison.Ordinal);
@@ -56,10 +56,11 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml");
 
-            Assert.Contains("Activity Audit Workbench", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Activity Logs\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ActivityStatCard", xaml, StringComparison.Ordinal);
             Assert.Contains("FilteredLogCount", xaml, StringComparison.Ordinal);
-            Assert.Contains("TotalLogCount", xaml, StringComparison.Ordinal);
+            Assert.Contains("MatchedLogCount", xaml, StringComparison.Ordinal);
+            Assert.Contains("OmittedLogCount", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedLogActionGroup", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedLogDestinationName", xaml, StringComparison.Ordinal);
             Assert.Contains("SearchText", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ViewModels/KitManagementPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/KitManagementPageXamlTests.cs
@@ -11,7 +11,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml");
 
-            Assert.Contains("Kit Workbench", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Kits\"", xaml, StringComparison.Ordinal);
             Assert.Contains("KitResultsSummary", xaml, StringComparison.Ordinal);
             Assert.Contains("KitItemsSummary", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedKitSummary", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ViewModels/MainWindowShellXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainWindowShellXamlTests.cs
@@ -7,16 +7,15 @@ namespace InventoryManagementApp.Tests.ViewModels
     public class MainWindowShellXamlTests
     {
         [Fact]
-        public void MainWindow_KeepsWorkflowGuidanceInThePageHeaderOnly()
+        public void MainWindow_LeavesWorkflowGuidanceToTheActivePage()
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "MainWindow.xaml");
 
             Assert.DoesNotContain("DesktopStatusFooter", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Workflow status", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("ShellWorkflowTicker", xaml, StringComparison.Ordinal);
-            Assert.Contains("CurrentWorkflowGuide", xaml, StringComparison.Ordinal);
-            Assert.Contains("TextTrimming=\"CharacterEllipsis\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("HorizontalAlignment=\"Stretch\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("CurrentWorkflowGuide", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("x:Name=\"PageHeaderBand\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("RepeatBehavior=\"Forever\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Storyboard.TargetProperty=\"(TextBlock.RenderTransform).(TranslateTransform.X)\"", xaml, StringComparison.Ordinal);
         }
@@ -38,15 +37,15 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("MinHeight=\"520\"", xaml, StringComparison.Ordinal);
             Assert.Contains("x:Name=\"ShellHeader\"", xaml, StringComparison.Ordinal);
             Assert.Contains("x:Name=\"ShellMenu\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("x:Name=\"PageHeaderBand\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("x:Name=\"WorkflowGuideText\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("x:Name=\"PageHeaderBand\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("x:Name=\"WorkflowGuideText\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("x:Name=\"ShellStatusFooter\"", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("x:Name=\"ShellFooterRow\"", xaml, StringComparison.Ordinal);
 
             Assert.Contains("CompactShellHeightThreshold = 820", codeBehind, StringComparison.Ordinal);
             Assert.Contains("SystemParameters.WorkArea.Height < CompactShellHeightThreshold", codeBehind, StringComparison.Ordinal);
             Assert.DoesNotContain("ShellStatusFooter.Visibility", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("WorkflowGuideText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible", codeBehind, StringComparison.Ordinal);
+            Assert.DoesNotContain("WorkflowGuideText.Visibility", codeBehind, StringComparison.Ordinal);
             Assert.Contains("MainFrame.Margin = new Thickness(4)", codeBehind, StringComparison.Ordinal);
         }
 
@@ -80,20 +79,21 @@ namespace InventoryManagementApp.Tests.ViewModels
 
             Assert.DoesNotContain("CurrentNavSectionTitle", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Primary: ", xaml, StringComparison.Ordinal);
-            Assert.Contains("CurrentWorkflowPrimaryActionText", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("CurrentWorkflowPrimaryActionText", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("Next: ", xaml, StringComparison.Ordinal);
-            Assert.Contains("CurrentWorkflowSecondaryActionText", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("CurrentWorkflowSecondaryActionText", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
-        public void MainWindow_UsesPageSpecificHeaderBandBrushes()
+        public void MainWindow_DoesNotRenderASecondPageSpecificHeaderBand()
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "MainWindow.xaml");
 
-            Assert.Contains("CurrentPageHeaderKey", xaml, StringComparison.Ordinal);
-            Assert.Contains("PageHeaderDashboardBrush", xaml, StringComparison.Ordinal);
-            Assert.Contains("PageHeaderRentalsBrush", xaml, StringComparison.Ordinal);
-            Assert.Contains("PageHeaderSettingsBrush", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("CurrentPageHeaderKey", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("PageHeaderDashboardBrush", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("PageHeaderRentalsBrush", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("PageHeaderSettingsBrush", xaml, StringComparison.Ordinal);
+            Assert.Contains("<Frame Grid.Row=\"2\"", xaml, StringComparison.Ordinal);
         }
 
         static string ReadRepositoryFile(params string[] relativePathParts)

--- a/InventoryManagementApp.Tests/ViewModels/ReservationPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ReservationPageXamlTests.cs
@@ -11,12 +11,12 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml");
 
-            Assert.Contains("Reservations Workbench", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Reservations\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ReservationResultsSummary", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedReservationSummary", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedReservationTitle", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedReservationNextAction", xaml, StringComparison.Ordinal);
-            Assert.Contains("SelectedReservationShelfChecklist", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("SelectedReservationShelfChecklist", xaml, StringComparison.Ordinal);
             Assert.Contains("AddReservationCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("ConfirmReservationCommand", xaml, StringComparison.Ordinal);
             Assert.Contains("FulfillReservationCommand", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
@@ -11,7 +11,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml");
 
-            Assert.Contains("Admin Settings Workbench", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Settings\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Workstation Defaults", xaml, StringComparison.Ordinal);
             Assert.Contains("Item Detail Visibility", xaml, StringComparison.Ordinal);
             Assert.Contains("Email Reminder Channel", xaml, StringComparison.Ordinal);
@@ -20,7 +20,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("Display contract", xaml, StringComparison.Ordinal);
             Assert.Contains("Sender directory", xaml, StringComparison.Ordinal);
             Assert.Contains("Messaging handoff", xaml, StringComparison.Ordinal);
-            Assert.Contains("Settings desk ready", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Settings desk ready", xaml, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp.Tests/ViewModels/SettingsThemeCustomizationXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/SettingsThemeCustomizationXamlTests.cs
@@ -11,7 +11,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml");
 
-            Assert.Contains("Admin Settings Workbench", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Settings\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Text=\"Theme\"", xaml, StringComparison.Ordinal);
             Assert.Contains("SelectedItem=\"{Binding Theme}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("ItemsSource=\"{Binding ThemeOptions}\"", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/ViewModels/UsersPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/UsersPageXamlTests.cs
@@ -11,7 +11,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml");
 
-            Assert.Contains("Users Workbench", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Users\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Visible Users", xaml, StringComparison.Ordinal);
             Assert.Contains("Directory Filter", xaml, StringComparison.Ordinal);
             Assert.Contains("Selected Access", xaml, StringComparison.Ordinal);
@@ -36,7 +36,8 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("DesktopPaneSubheader", xaml, StringComparison.Ordinal);
             Assert.Contains("DesktopNoteCard", xaml, StringComparison.Ordinal);
             Assert.Contains("Access And Security Handoff", xaml, StringComparison.Ordinal);
-            Assert.Contains("Admin Next Step", xaml, StringComparison.Ordinal);
+            Assert.Contains("Allowed App Areas", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Admin Next Step", xaml, StringComparison.Ordinal);
             Assert.Contains("UserEmptyStateTitle", xaml, StringComparison.Ordinal);
             Assert.Contains("No users match this filter", viewModel, StringComparison.Ordinal);
             Assert.Contains("UserRow_MouseDoubleClick", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/Views/DashboardPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/Views/DashboardPageXamlTests.cs
@@ -64,12 +64,11 @@ namespace InventoryManagementApp.Tests.Views
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml");
 
-            Assert.Contains("Padding=\"10,6\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("BasedOn=\"{StaticResource PageHeaderStatCard}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Style=\"{StaticResource PageTitleTextBlock}\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("MinWidth=\"92\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("FontSize=\"18\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("Padding=\"9,5\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("<Setter Property=\"FontSize\" Value=\"15\"/>", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource PageHeaderStatCard}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource PageHeaderStatValueText}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Content=\"New Item\" Command=\"{Binding NewItemCommand}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Padding=\"6,3\"", xaml, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -34,12 +34,10 @@
         <Grid.RowDefinitions>
             <RowDefinition x:Name="ShellHeaderRow" Height="Auto"/>
             <RowDefinition x:Name="ShellMenuRow" Height="Auto"/>
-            <RowDefinition x:Name="ShellPageHeaderRow" Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="0"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.RowSpan="4"
+        <Border Grid.RowSpan="3"
                 Background="{DynamicResource ThemeAppBackgroundOverlayBrush}"
                 IsHitTestVisible="False"/>
 
@@ -157,94 +155,7 @@
             </ScrollViewer>
         </Border>
 
-        <Border x:Name="PageHeaderBand"
-                Grid.Row="2"
-                BorderBrush="{DynamicResource BorderBrushBase}"
-                BorderThickness="0,0,0,1"
-                Effect="{DynamicResource ThemeSurfaceShadow}"
-                MinHeight="44"
-                Padding="8,6">
-            <Border.Style>
-                <Style TargetType="Border">
-                    <Setter Property="Background" Value="{DynamicResource ThemeShellHeaderBrush}"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Dashboard">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderDashboardBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Search">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderSearchBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="ManageItems">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderManageItemsBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Rentals">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderRentalsBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Customers">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderCustomersBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Reservations">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderReservationsBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Maintenance">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderMaintenanceBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Calibration">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderCalibrationBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Kits">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderKitsBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Categories">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderCategoriesBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Reports">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderReportsBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="ActivityLogs">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderActivityLogsBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="ImportExport">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderImportExportBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Users">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderUsersBrush}"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CurrentPageHeaderKey}" Value="Settings">
-                            <Setter Property="Background" Value="{DynamicResource PageHeaderSettingsBrush}"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Border.Style>
-            <Grid ClipToBounds="True">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" MinWidth="0"/>
-                    <ColumnDefinition Width="Auto" MinWidth="0" MaxWidth="420"/>
-                </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center" MinWidth="0" Margin="0,0,12,0">
-                    <TextBlock Text="{Binding CurrentPageTitle}" Style="{StaticResource PageTitleTextBlock}" TextTrimming="CharacterEllipsis"/>
-                    <TextBlock x:Name="WorkflowGuideText" Text="{Binding CurrentWorkflowGuide}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-                </StackPanel>
-                <WrapPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" MaxWidth="420">
-                    <Button Style="{StaticResource GhostButton}"
-                            Content="{Binding CurrentWorkflowPrimaryActionText}"
-                            Command="{Binding CurrentWorkflowPrimaryCommand}"
-                            Visibility="{Binding HasCurrentWorkflowPrimaryAction, Converter={StaticResource BoolToVis}}"
-                            MinWidth="96"
-                            MaxWidth="180"
-                            Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}"
-                            Content="{Binding CurrentWorkflowSecondaryActionText}"
-                            Command="{Binding CurrentWorkflowSecondaryCommand}"
-                            Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}"
-                            MinWidth="96"
-                            MaxWidth="180"
-                            Margin="0,0,0,4"/>
-                </WrapPanel>
-            </Grid>
-        </Border>
-
-        <Frame Grid.Row="3"
+        <Frame Grid.Row="2"
                Name="MainFrame"
                NavigationUIVisibility="Hidden"
                JournalOwnership="OwnsJournal"

--- a/InventoryManagementApp/MainWindow.xaml.cs
+++ b/InventoryManagementApp/MainWindow.xaml.cs
@@ -87,7 +87,6 @@ namespace InventoryManagementApp
         {
             ShellHeader.Padding = compact ? new Thickness(6, 3, 6, 3) : new Thickness(8, 5, 8, 5);
             ShellMenu.Padding = compact ? new Thickness(4, 1, 4, 1) : new Thickness(4, 3, 4, 3);
-            PageHeaderBand.Padding = compact ? new Thickness(8, 3, 8, 3) : new Thickness(8, 6, 8, 6);
 
             ShellTitleButton.MaxWidth = compact ? 190 : 250;
             ShellTitleButton.MinWidth = 0;
@@ -96,7 +95,6 @@ namespace InventoryManagementApp
             ShellUserButton.MaxWidth = compact ? 176 : 196;
 
             ShellSubtitle.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
-            WorkflowGuideText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
 
             if (compact)
             {

--- a/InventoryManagementApp/Resources/Theme.FullCustomizationOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.FullCustomizationOverrides.xaml
@@ -21,6 +21,50 @@
         <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
 
+    <!--
+        Every primary page uses this fixed header contract so switching pages never
+        shifts the content baseline. Pages supply their own PageHeader*Brush.
+    -->
+    <Style x:Key="PageHeaderBand" TargetType="Border" BasedOn="{StaticResource ToolbarCard}">
+        <Setter Property="Height" Value="90"/>
+        <Setter Property="MinHeight" Value="90"/>
+        <Setter Property="Padding" Value="10,6"/>
+        <Setter Property="Margin" Value="0,0,0,6"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="ClipToBounds" Value="True"/>
+    </Style>
+
+    <!-- Shared contents for page header bands. Keep cards and actions visually stable across views. -->
+    <Style x:Key="PageHeaderStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
+        <Setter Property="Width" Value="160"/>
+        <Setter Property="Height" Value="66"/>
+        <Setter Property="MinWidth" Value="160"/>
+        <Setter Property="MinHeight" Value="66"/>
+        <Setter Property="Padding" Value="10,6"/>
+        <Setter Property="Margin" Value="0,0,8,0"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="ClipToBounds" Value="True"/>
+    </Style>
+
+    <Style x:Key="PageHeaderStatValueText" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="15"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="TextWrapping" Value="NoWrap"/>
+        <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        <Setter Property="Margin" Value="0,2,0,0"/>
+    </Style>
+
+    <Style x:Key="PageHeaderStatCaptionText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
+        <Setter Property="TextWrapping" Value="NoWrap"/>
+        <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        <Setter Property="Margin" Value="0,1,0,0"/>
+    </Style>
+
+    <Style x:Key="PageHeaderStatsPanel" TargetType="WrapPanel">
+        <Setter Property="HorizontalAlignment" Value="Right"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+
     <Style TargetType="DataGridColumnHeader">
         <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>

--- a/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -117,25 +117,43 @@ namespace InventoryManagementApp.Utilities.Converters
             image = null!;
             try
             {
-                var cacheKey = path;
+                string cacheKey;
                 string? absPath;
-                if (Uri.IsWellFormedUriString(path, UriKind.Absolute))
+                var isLocalFile = false;
+                if (Uri.TryCreate(path, UriKind.Absolute, out var absoluteUri))
                 {
-                    absPath = path;
+                    if (absoluteUri.IsFile)
+                    {
+                        absPath = absoluteUri.LocalPath;
+                        isLocalFile = true;
+                    }
+                    else
+                    {
+                        absPath = path;
+                    }
                 }
                 else
                 {
-                    if (_invalidPaths.TryGetValue(path, out _))
-                        return false;
-
                     absPath = Helpers.PathHelper.GetAbsolutePath(path, false);
+                    isLocalFile = true;
+                }
+
+                if (isLocalFile)
+                {
                     if (absPath == null || !File.Exists(absPath))
                     {
-                        CacheInvalidPath(path);
+                        if (!_invalidPaths.TryGetValue(path, out _))
+                            CacheInvalidPath(path);
                         return false;
                     }
 
-                    cacheKey = absPath;
+                    _invalidPaths.Remove(path);
+                    var file = new FileInfo(absPath);
+                    cacheKey = $"{file.FullName}|{file.LastWriteTimeUtc.Ticks}|{file.Length}";
+                }
+                else
+                {
+                    cacheKey = absPath!;
                 }
 
                 if (_imageCache.TryGetValue(cacheKey, out BitmapImage? cached) && cached != null)
@@ -149,9 +167,12 @@ namespace InventoryManagementApp.Utilities.Converters
                 loaded.CacheOption = BitmapCacheOption.OnLoad;
                 loaded.DecodePixelWidth = 256;
                 loaded.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
-                loaded.UriSource = new Uri(absPath, UriKind.Absolute);
+                loaded.UriSource = new Uri(absPath!, UriKind.Absolute);
                 loaded.EndInit();
                 loaded.Freeze();
+
+                if (_imageCache.Count >= MaxCacheEntries)
+                    _imageCache.Compact(0.1);
 
                 _imageCache.Set(cacheKey, loaded, new MemoryCacheEntryOptions
                 {

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -606,6 +606,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 await _itemService.UpdateItemAsync(updated, ct).ConfigureAwait(false);
+                await InvokeOnUiThreadAsync(() => ApplySuccessfulItemEdit(selected, updated)).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -616,6 +617,22 @@ namespace InventoryManagementApp.ViewModels
                 var refreshed = await RefreshItemsAfterMutationFailureAsync(updated.ItemID, ct).ConfigureAwait(false);
                 await _dialogService.ShowInfoAsync($"Failed to update {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {AppendItemMutationRefreshMessage(ex.Message, refreshed)}", "Error").ConfigureAwait(false);
             }
+        }
+
+        private void ApplySuccessfulItemEdit(ItemModel original, ItemModel updated)
+        {
+            var index = Items.IndexOf(original);
+            if (index < 0)
+                index = Items.ToList().FindIndex(item => item.ItemID == updated.ItemID);
+
+            if (index >= 0)
+                Items[index] = updated;
+
+            _pendingEdits.Remove(original);
+            _pendingEdits.Remove(updated);
+            OnPropertyChanged(nameof(PendingEdits));
+            SelectedItem = updated;
+            RefreshMissingImageCount();
         }
 
         private void ViewDetails()

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
@@ -4,13 +4,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{DynamicResource MainContentBackgroundBrush}">
     <Page.Resources>
-        <Style x:Key="ActivityStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinHeight" Value="78"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="230"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
+        <Style x:Key="ActivityStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
         <Style x:Key="ActivityDetailCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
@@ -21,7 +15,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Margin="0">
+    <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -29,28 +23,29 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderActivityLogsBrush}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.2*" MinWidth="260"/>
                     <ColumnDefinition Width="12"/>
                     <ColumnDefinition Width="1.8*" MinWidth="320"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center">
-                    <TextBlock Text="Activity Audit Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left">
+                    <TextBlock Text="Activity Logs" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Filter recent operational events, inspect the selected audit trail, and open the related workflow without losing row context."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                <WrapPanel Grid.Column="2" Style="{StaticResource PageHeaderStatsPanel}">
                     <Border Style="{StaticResource ActivityStatCard}">
                         <StackPanel>
                             <TextBlock Text="VISIBLE" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="{Binding FilteredLogCount, StringFormat={}{0} rows shown}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
@@ -60,7 +55,8 @@
                             <TextBlock Text="{Binding MatchedLogCount, StringFormat={}{0} rows matched}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
@@ -70,7 +66,8 @@
                             <TextBlock Text="{Binding OmittedLogCount, StringFormat={}{0} hidden from grid}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
@@ -80,7 +77,8 @@
                             <TextBlock Text="{Binding PrintStatusText}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
@@ -125,9 +123,6 @@
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
                     <TextBlock Text="Audit actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Open Related" Click="OpenRelatedPage_Click" IsEnabled="{Binding CanUseSelectedLogActions}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Open Detail" Click="OpenSelectedLog_Click" IsEnabled="{Binding CanUseSelectedLogActions}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedLog_Click" IsEnabled="{Binding CanUseSelectedLogActions}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Print Results" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintActivityRows}" Margin="0,0,4,4"/>
                         <TextBlock Text="{Binding ActivitySummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="6,1,0,4"/>
                     </WrapPanel>
@@ -350,20 +345,5 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="3"
-                Style="{StaticResource ToolbarCard}"
-                Margin="0,6,0,0"
-                Padding="8,5">
-            <DockPanel LastChildFill="True">
-                <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
-                    <TextBlock Text="{Binding FilteredLogCount, StringFormat='Visible: {0}'}" FontSize="11" Margin="0,0,12,0"/>
-                    <TextBlock Text="{Binding MatchedLogCount, StringFormat='Matched: {0}'}" FontSize="11" Margin="0,0,12,0"/>
-                    <TextBlock Text="{Binding OmittedLogCount, StringFormat='Hidden: {0}'}" FontSize="11" Margin="0,0,12,0"/>
-                    <TextBlock Text="{Binding TotalLogCount, StringFormat='Loaded: {0}'}" FontSize="11" Margin="0,0,12,0"/>
-                    <TextBlock Text="{Binding LastLoadedText, StringFormat='Last refresh: {0}'}" FontSize="11"/>
-                </WrapPanel>
-                <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
@@ -3,16 +3,10 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{DynamicResource MainContentBackgroundBrush}">
     <Page.Resources>
-        <Style x:Key="CalibrationMetricCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="235"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
+        <Style x:Key="CalibrationMetricCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
     </Page.Resources>
 
-    <Grid Margin="0">
+    <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -20,7 +14,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource ToolbarCard}" Padding="12,10">
+        <Border Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderCalibrationBrush}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.15*" MinWidth="0"/>
@@ -28,37 +22,37 @@
                     <ColumnDefinition Width="2.85*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
 
-                <StackPanel VerticalAlignment="Center">
-                    <TextBlock Text="Calibration Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left">
+                    <TextBlock Text="Calibration" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Track certificate readiness, overdue renewals, shelf-release status, and technician handoffs from one calibration register."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
 
-                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                <WrapPanel Grid.Column="2" Style="{StaticResource PageHeaderStatsPanel}">
                     <Border Style="{StaticResource CalibrationMetricCard}">
                         <StackPanel>
                             <TextBlock Text="REGISTER" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding CalibrationResultsSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding CalibrationResultsSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource CalibrationMetricCard}">
                         <StackPanel>
                             <TextBlock Text="DUE STATE" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding CalibrationBacklogSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding CalibrationBacklogSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource CalibrationMetricCard}">
                         <StackPanel>
                             <TextBlock Text="SELECTED" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedRecord.StatusDisplay, TargetNullValue='No certificate selected', FallbackValue='No certificate selected'}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding SelectedRecord.StatusDisplay, TargetNullValue='No certificate selected', FallbackValue='No certificate selected'}" FontSize="15" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource CalibrationMetricCard}">
                         <StackPanel>
                             <TextBlock Text="PRINT" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding CalibrationPrintStatus}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding CalibrationPrintStatus}" FontSize="15" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                 </WrapPanel>
@@ -75,11 +69,6 @@
                     <TextBlock Text="Certificate actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
                         <Button Style="{StaticResource PrimaryButton}" Content="Add Record" Command="{Binding AddCalibrationCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCalibrationDetailsCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCalibrationCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Command="{Binding CopySelectedCalibrationCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Record" Command="{Binding PrintSelectedCalibrationCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCalibrationCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
                 </DockPanel>
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
@@ -307,13 +296,6 @@
                                 </StackPanel>
                             </Border>
 
-                            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
-                                <StackPanel>
-                                    <TextBlock Text="Shelf release checklist" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
-                                    <TextBlock Text="{Binding SelectedCalibrationBenchChecklist}" TextWrapping="Wrap"/>
-                                </StackPanel>
-                            </Border>
-
                             <WrapPanel Margin="0,0,0,8">
                                 <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCalibrationDetailsCommand}" Margin="0,0,4,4"/>
                                 <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCalibrationCommand}" Margin="0,0,4,4"/>
@@ -333,17 +315,5 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
-            <DockPanel LastChildFill="True">
-                <WrapPanel DockPanel.Dock="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Copy Handoff" Command="{Binding CopySelectedCalibrationCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Due" Command="{Binding PrintCalibrationListCommand}" Margin="0,0,0,4"/>
-                </WrapPanel>
-                <StackPanel Margin="2,0,10,0">
-                    <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-                    <TextBlock Text="{Binding CalibrationPrintStatus}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
@@ -5,20 +5,8 @@
       Background="{DynamicResource MainContentBackgroundBrush}"
       PreviewKeyDown="Page_PreviewKeyDown">
     <Page.Resources>
-        <Style x:Key="CategoryStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="235"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
-        <Style x:Key="CategoryStatValueText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
-            <Setter Property="FontSize" Value="15"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="TextWrapping" Value="Wrap"/>
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-            <Setter Property="Margin" Value="0,3,0,0"/>
-        </Style>
+        <Style x:Key="CategoryStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
+        <Style x:Key="CategoryStatValueText" TargetType="TextBlock" BasedOn="{StaticResource PageHeaderStatValueText}"/>
         <Style x:Key="CategoryDetailCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
@@ -29,7 +17,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Margin="0">
+    <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -38,21 +26,21 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderCategoriesBrush}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.15*" MinWidth="0"/>
                     <ColumnDefinition Width="14"/>
                     <ColumnDefinition Width="1.65*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center" MinWidth="0">
-                    <TextBlock Text="Category Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" MinWidth="0">
+                    <TextBlock Text="Categories" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Shape the category language staff use for item setup, advisor search, printed directories, and clean handoffs between inventory areas."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                <WrapPanel Grid.Column="2" Style="{StaticResource PageHeaderStatsPanel}">
                     <Border Style="{StaticResource CategoryStatCard}">
                         <StackPanel>
                             <TextBlock Text="DIRECTORY" Style="{StaticResource LabelTextBlock}"/>
@@ -92,11 +80,6 @@
                     <WrapPanel>
                         <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding AddCommand}" Margin="0,0,4,4" ToolTip="Create and link a new category"/>
                         <Button Style="{StaticResource PrimaryButton}" Content="Save" Command="{Binding SaveCommand}" Margin="0,0,4,4" ToolTip="Save the selected category name"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Open" Click="OpenCategoryDetail_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopyCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintCategories_Click" IsEnabled="{Binding IsDirectoryPrintAvailable}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
                 </DockPanel>
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
@@ -278,13 +261,6 @@
 
                             <Border Style="{StaticResource CategoryDetailCard}">
                                 <StackPanel>
-                                    <TextBlock Text="Setup Checklist" Style="{StaticResource SectionHeader}"/>
-                                    <TextBlock Text="{Binding SelectedCategoryChecklist}" Style="{StaticResource CategoryDetailText}"/>
-                                </StackPanel>
-                            </Border>
-
-                            <Border Style="{StaticResource CategoryDetailCard}">
-                                <StackPanel>
                                     <TextBlock Text="Admin Handoff" Style="{StaticResource SectionHeader}"/>
                                     <TextBlock Text="{Binding SelectedCategoryHandoff}" Style="{StaticResource CategoryDetailText}"/>
                                 </StackPanel>
@@ -311,21 +287,6 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,6,0,0">
-            <DockPanel LastChildFill="True">
-                <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Open" Click="OpenCategoryDetail_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintCategories_Click" IsEnabled="{Binding IsDirectoryPrintAvailable}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Click="PrintSelectedCategory_Click" IsEnabled="{Binding IsSelectedCategoryActionAvailable}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Clear Filter" Command="{Binding ClearSearchCommand}" Margin="0,0,0,4"/>
-                </WrapPanel>
-                <StackPanel MinWidth="0">
-                    <TextBlock Text="{Binding SelectedCategorySummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="2,0,10,0"/>
-                    <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="2,2,10,0"/>
-                    <TextBlock Text="{Binding CategoryPrintSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="2,2,10,0"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
 
         <ProgressBar Grid.Row="4"
                      IsIndeterminate="True"

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml
@@ -5,82 +5,60 @@
       xmlns:pages="clr-namespace:InventoryManagementApp.Views.Pages"
       Background="{DynamicResource MainContentBackgroundBrush}">
     <Page.Resources>
-        <Style x:Key="CustomerStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinHeight" Value="74"/>
-            <Setter Property="MinWidth" Value="160"/>
-            <Setter Property="MaxWidth" Value="250"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
+        <Style x:Key="CustomerStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
         <Style x:Key="CustomerDetailText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="Margin" Value="0,2,0,0"/>
         </Style>
-        <Style x:Key="CustomerStatValueText" TargetType="TextBlock" BasedOn="{StaticResource HeadingTextBlock}">
-            <Setter Property="TextWrapping" Value="NoWrap"/>
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-            <Setter Property="MinHeight" Value="24"/>
-        </Style>
+        <Style x:Key="CustomerStatValueText" TargetType="TextBlock" BasedOn="{StaticResource PageHeaderStatValueText}"/>
     </Page.Resources>
 
     <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="14,12">
-            <DockPanel LastChildFill="False">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderCustomersBrush}">
+            <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,18,0" MinWidth="220" MaxWidth="460">
                     <TextBlock Text="Customers" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Find customer records, verify contact details, and prepare advisor handoffs before rentals or service follow-up." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                 </StackPanel>
-                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCustomerCommand}" IsEnabled="{Binding IsCustomerDirectoryActionAvailable}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Command="{Binding PrintSelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Directory" Command="{Binding PrintCustomerDirectoryCommand}" IsEnabled="{Binding IsCustomerDirectoryPrintAvailable}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,0,6"/>
+                <WrapPanel Style="{StaticResource PageHeaderStatsPanel}">
+                    <Border Style="{StaticResource CustomerStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="Visible Customers" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding CustomerDirectoryVisibleCount}" Style="{StaticResource CustomerStatValueText}"/>
+                            <TextBlock Text="{Binding CustomerVisibleWindowSummary}" Style="{StaticResource CustomerDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource CustomerStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="Matched Customers" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding CustomerDirectoryMatchCount}" Style="{StaticResource CustomerStatValueText}"/>
+                            <TextBlock Text="{Binding CustomerPrintSummary}" Style="{StaticResource CustomerDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource CustomerStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="Contact Path" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding CustomerContactSummary}" Style="{StaticResource CustomerStatValueText}"/>
+                            <TextBlock Text="Phone, mobile, and email context for the selected customer" Style="{StaticResource CustomerDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource CustomerStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="Selected Customer" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding SelectedCustomer.Company, TargetNullValue=No customer selected}" Style="{StaticResource CustomerStatValueText}"/>
+                            <TextBlock Text="{Binding CustomerOperationsSummary}" Style="{StaticResource CustomerDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                    </Border>
                 </WrapPanel>
             </DockPanel>
         </Border>
 
-        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
-            <Border Style="{StaticResource CustomerStatCard}">
-                <StackPanel>
-                    <TextBlock Text="Visible Customers" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding CustomerDirectoryVisibleCount}" Style="{StaticResource CustomerStatValueText}"/>
-                    <TextBlock Text="{Binding CustomerVisibleWindowSummary}" Style="{StaticResource CustomerDetailText}"/>
-                </StackPanel>
-            </Border>
-            <Border Style="{StaticResource CustomerStatCard}">
-                <StackPanel>
-                    <TextBlock Text="Matched Customers" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding CustomerDirectoryMatchCount}" Style="{StaticResource CustomerStatValueText}"/>
-                    <TextBlock Text="{Binding CustomerPrintSummary}" Style="{StaticResource CustomerDetailText}"/>
-                </StackPanel>
-            </Border>
-            <Border Style="{StaticResource CustomerStatCard}">
-                <StackPanel>
-                    <TextBlock Text="Contact Path" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding CustomerContactSummary}" Style="{StaticResource CustomerStatValueText}"/>
-                    <TextBlock Text="Phone, mobile, and email context for the selected customer" Style="{StaticResource CustomerDetailText}"/>
-                </StackPanel>
-            </Border>
-            <Border Style="{StaticResource CustomerStatCard}" Margin="0,0,0,8">
-                <StackPanel>
-                    <TextBlock Text="Selected Customer" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding SelectedCustomer.Company, TargetNullValue=No customer selected}" Style="{StaticResource CustomerStatValueText}"/>
-                    <TextBlock Text="{Binding CustomerOperationsSummary}" Style="{StaticResource CustomerDetailText}"/>
-                </StackPanel>
-            </Border>
-        </WrapPanel>
-
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1.65*" MinWidth="0"/>
                 <ColumnDefinition Width="6"/>
@@ -271,31 +249,11 @@
                                 <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintSelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,0,6"/>
                             </WrapPanel>
 
-                            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,4,0,0">
-                                <StackPanel>
-                                    <TextBlock Text="Desk Checklist" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
-                                    <TextBlock Text="Confirm the company, verify the best phone or email, copy or print the handoff, then move into the rental or service workflow with the right customer selected." TextWrapping="Wrap"/>
-                                </StackPanel>
-                            </Border>
                         </StackPanel>
                     </ScrollViewer>
-                    <Border Grid.Row="2" Style="{StaticResource DesktopSectionActionStrip}">
-                        <WrapPanel HorizontalAlignment="Right">
-                            <Button Style="{StaticResource PrimaryButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,6,6"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Sheet" Command="{Binding PrintSelectedCustomerCommand}" IsEnabled="{Binding IsSelectedCustomerActionAvailable}" Margin="0,0,0,6"/>
-                        </WrapPanel>
-                    </Border>
                 </Grid>
             </Border>
         </Grid>
 
-        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,6,0,0">
-            <DockPanel LastChildFill="True">
-                <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource GhostButton}" Content="Clear Search" Command="{Binding ClearCustomerSearchCommand}" IsEnabled="{Binding IsCustomerDirectoryActionAvailable}" Margin="0,0,0,6"/>
-                </WrapPanel>
-                <TextBlock Text="{Binding SelectedCustomerSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -6,49 +6,30 @@
       Background="{DynamicResource MainContentBackgroundBrush}"
       Focusable="True">
     <Page.Resources>
-        <Style x:Key="DashboardMetricCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="230"/>
-            <Setter Property="MinHeight" Value="72"/>
-            <Setter Property="Padding" Value="10,7"/>
-            <Setter Property="Margin" Value="0,0,6,6"/>
-        </Style>
-        <Style x:Key="DashboardMetricValueText" TargetType="TextBlock">
-            <Setter Property="FontSize" Value="15"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-        </Style>
+        <Style x:Key="DashboardMetricCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
+        <Style x:Key="DashboardMetricValueText" TargetType="TextBlock" BasedOn="{StaticResource PageHeaderStatValueText}"/>
     </Page.Resources>
 
-    <Grid x:Name="DashboardRoot" Margin="0">
+    <Grid x:Name="DashboardRoot" Margin="4">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="10,6" Margin="0,0,0,6">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderDashboardBrush}">
             <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Left" MinWidth="210" MaxWidth="320" Margin="0,0,14,0" VerticalAlignment="Center">
-                    <TextBlock Text="Dashboard Command Center" Style="{StaticResource PageTitleTextBlock}" TextTrimming="CharacterEllipsis"/>
-                    <TextBlock Text="Live workload, demand, and exception signals for the next counter action."
+                    <TextBlock Text="Dashboard" Style="{StaticResource PageTitleTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="Workload, demand, and exceptions requiring attention."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                MaxWidth="300"
                                Margin="0,1,0,0"/>
                 </StackPanel>
 
-                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="12,0,0,0">
-                    <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="New Item" Command="{Binding NewItemCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Open Items" Command="{Binding OpenItemsCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Open Rentals" Command="{Binding OpenRentalsCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Print Snapshot" Command="{Binding PrintDashboardSnapshotCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Import / Export" Command="{Binding OpenImportExportCommand}" Margin="0,0,0,4"/>
-                </WrapPanel>
-
+                <WrapPanel Style="{StaticResource PageHeaderStatsPanel}">
                 <ItemsControl ItemsSource="{Binding StatCards}" Margin="0,0,8,0" VerticalAlignment="Center">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
@@ -57,22 +38,41 @@
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border Style="{StaticResource DesktopSummaryCard}" MinWidth="92" MaxWidth="160" Margin="0,0,6,4" Padding="9,5">
+                            <Border Style="{StaticResource PageHeaderStatCard}">
                                 <StackPanel>
                                     <TextBlock Text="{Binding Value}"
-                                               FontSize="18"
-                                               FontWeight="Bold"
+                                               Style="{StaticResource PageHeaderStatValueText}"
                                                Foreground="{DynamicResource AccentBrush}"
-                                               TextTrimming="CharacterEllipsis"/>
+                                               />
                                     <TextBlock Text="{Binding Title}"
-                                               Style="{StaticResource CaptionTextBlock}"
-                                               TextWrapping="Wrap"
-                                               Margin="0,2,0,0"/>
+                                               Style="{StaticResource PageHeaderStatCaptionText}"/>
                                 </StackPanel>
                             </Border>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+                    <Border Style="{StaticResource DashboardMetricCard}">
+                        <StackPanel>
+                            <TextBlock Text="Checked out" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding CheckedOutItems.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource AccentBrush}"/>
+                            <TextBlock Text="Return or inspect before shift end." Style="{StaticResource PageHeaderStatCaptionText}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource DashboardMetricCard}">
+                        <StackPanel>
+                            <TextBlock Text="Items with issues" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding IncompleteItems.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource WarningBrush}"/>
+                            <TextBlock Text="Prioritize missing parts." Style="{StaticResource PageHeaderStatCaptionText}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource DashboardMetricCard}">
+                        <StackPanel>
+                            <TextBlock Text="Activity rows" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding RecentActivity.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource AccentBrush}"/>
+                            <TextBlock Text="Open latest audit rows." Style="{StaticResource PageHeaderStatCaptionText}"/>
+                        </StackPanel>
+                    </Border>
+                </WrapPanel>
             </DockPanel>
         </Border>
 
@@ -98,38 +98,7 @@
             </DockPanel>
         </Border>
 
-        <WrapPanel Grid.Row="2" Margin="0,0,0,6">
-            <Border Style="{StaticResource DashboardMetricCard}">
-                <StackPanel>
-                    <TextBlock Text="Checked out" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding CheckedOutItems.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource AccentBrush}"/>
-                    <TextBlock Text="Return or inspect before shift end." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-                </StackPanel>
-            </Border>
-            <Border Style="{StaticResource DashboardMetricCard}">
-                <StackPanel>
-                    <TextBlock Text="Active rentals" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding RentedItems.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource AccentBrush}"/>
-                    <TextBlock Text="Review due dates." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-                </StackPanel>
-            </Border>
-            <Border Style="{StaticResource DashboardMetricCard}">
-                <StackPanel>
-                    <TextBlock Text="Items with issues" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding IncompleteItems.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource WarningBrush}"/>
-                    <TextBlock Text="Prioritize missing parts." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-                </StackPanel>
-            </Border>
-            <Border Style="{StaticResource DashboardMetricCard}">
-                <StackPanel>
-                    <TextBlock Text="Activity rows" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding RecentActivity.Count}" Style="{StaticResource DashboardMetricValueText}" Foreground="{DynamicResource AccentBrush}"/>
-                    <TextBlock Text="Open latest audit rows." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-                </StackPanel>
-            </Border>
-        </WrapPanel>
-
-        <Grid Grid.Row="3">
+        <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1.65*" MinWidth="0"/>
                 <ColumnDefinition Width="6"/>
@@ -213,10 +182,12 @@
                                 <TextBlock Text="Away from shelf with holder context." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
                             <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
+                                <Button Style="{StaticResource PrimaryButton}" Content="New Item" Command="{Binding NewItemCommand}" Margin="0,0,4,4"/>
                                 <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCheckedOutItemCommand}" IsEnabled="{Binding HasSelectedCheckedOutItem}" Margin="0,0,4,4"/>
                                 <Button Style="{StaticResource GhostButton}" Content="Check In" Command="{Binding CheckInSelectedItemCommand}" IsEnabled="{Binding HasSelectedCheckedOutItem}" Margin="0,0,4,4"/>
                                 <Button Style="{StaticResource GhostButton}" Content="Print All" Command="{Binding PrintCheckedOutItemsCommand}" Margin="0,0,4,4"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Print Mine" Command="{Binding PrintMyCheckedOutItemsCommand}" Margin="0,0,0,4" ToolTip="Print only items checked out by the signed-in user."/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print Mine" Command="{Binding PrintMyCheckedOutItemsCommand}" Margin="0,0,4,4" ToolTip="Print only items checked out by the signed-in user."/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print Snapshot" Command="{Binding PrintDashboardSnapshotCommand}" Margin="0,0,0,4"/>
                             </WrapPanel>
                         </DockPanel>
                     </Border>
@@ -440,7 +411,7 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="4" Style="{StaticResource ToolbarCard}" Padding="6,3" Margin="0,6,0,0">
+        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Padding="6,3" Margin="0,6,0,0">
             <DockPanel LastChildFill="True">
                 <TextBlock Text="{Binding OperationsSummary}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,12,0" TextWrapping="Wrap"/>
                 <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Right" VerticalAlignment="Center" TextWrapping="Wrap"/>

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
@@ -5,20 +5,8 @@
       xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
       Background="{DynamicResource MainContentBackgroundBrush}">
     <Page.Resources>
-        <Style x:Key="DataOperationStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinHeight" Value="78"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="230"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
-        <Style x:Key="DataOperationStatValueText" TargetType="TextBlock">
-            <Setter Property="FontSize" Value="15"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="TextWrapping" Value="Wrap"/>
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-            <Setter Property="Margin" Value="0,3,0,0"/>
-        </Style>
+        <Style x:Key="DataOperationStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
+        <Style x:Key="DataOperationStatValueText" TargetType="TextBlock" BasedOn="{StaticResource PageHeaderStatValueText}"/>
         <Style x:Key="DataLaneCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
             <Setter Property="Margin" Value="0,0,8,8"/>
@@ -36,7 +24,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Margin="0">
+    <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -44,40 +32,40 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderImportExportBrush}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.15*" MinWidth="0"/>
                     <ColumnDefinition Width="10"/>
                     <ColumnDefinition Width="1.85*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center" MinWidth="220" MaxWidth="460">
-                    <TextBlock Text="Data Operations Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" MinWidth="220" MaxWidth="460">
+                    <TextBlock Text="Import / Export" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Coordinate item files, customer directories, image mapping, backups, and result review from one controlled data desk."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                <WrapPanel Grid.Column="2" Style="{StaticResource PageHeaderStatsPanel}">
                     <Border Style="{StaticResource DataOperationStatCard}">
                         <StackPanel>
                             <TextBlock Text="ITEM DATA" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource DataOperationStatValueText}"/>
-                            <TextBlock Text="CSV, JSON, XML" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="CSV, JSON, XML" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource DataOperationStatCard}">
                         <StackPanel>
                             <TextBlock Text="CUSTOMERS" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="Directory" Style="{StaticResource DataOperationStatValueText}"/>
-                            <TextBlock Text="Import and export" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Import and export" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource DataOperationStatCard}">
                         <StackPanel>
                             <TextBlock Text="PROTECTION" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="Full Backup" Style="{StaticResource DataOperationStatValueText}"/>
-                            <TextBlock Text="Database and assets" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Database and assets" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource DataOperationStatCard}">
@@ -87,35 +75,6 @@
                         </StackPanel>
                     </Border>
                 </WrapPanel>
-            </Grid>
-        </Border>
-
-        <Border Grid.Row="1" Style="{StaticResource ToolbarCard}" Padding="10,8" Margin="0,6,0,0">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <DockPanel LastChildFill="True">
-                    <TextBlock Text="Data actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                    <WrapPanel>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Import Items" Command="{Binding ImportItemsCommand}" MinWidth="118" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Export Items" Command="{Binding ExportItemsCommand}" MinWidth="118" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Import Customers" Command="{Binding ImportCustomersCommand}" MinWidth="132" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Export Customers" Command="{Binding ExportCustomersCommand}" MinWidth="132" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource DataActionButton}" Content="Create Full Backup" Command="{Binding BackupDatabaseCommand}"/>
-                        <Button Style="{StaticResource DataActionButton}" Content="Cancel Import" Command="{Binding CancelImportItemsCommand}" IsEnabled="{Binding ImportItemsCommand.IsRunning}"/>
-                    </WrapPanel>
-                </DockPanel>
-                <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
-                    <TextBlock Text="Result actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                    <WrapPanel>
-                        <Button Style="{StaticResource DataActionButton}" Content="Copy Selected" Click="CopySelectedLog_Click" IsEnabled="{Binding CanReviewSelectedLog}"/>
-                        <Button Style="{StaticResource DataActionButton}" Content="Print Log" Click="PrintLogs_Click" IsEnabled="{Binding CanPrintImportExportLogs}"/>
-                        <Button Style="{StaticResource DataActionButton}" Content="Clear Log" Command="{Binding ClearImportExportLogsCommand}"/>
-                        <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" VerticalAlignment="Center" Margin="6,1,0,4" MaxWidth="520"/>
-                    </WrapPanel>
-                </DockPanel>
             </Grid>
         </Border>
 
@@ -582,13 +541,5 @@
             </TabItem>
         </TabControl>
 
-        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,6,0,0" Padding="8,5">
-            <WrapPanel>
-                <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="680" Margin="0,0,10,4"/>
-                <TextBlock Text="{Binding DataOperationStatus}" FontSize="11" FontWeight="SemiBold" Margin="0,0,10,4" VerticalAlignment="Center"/>
-                <TextBlock Text="{Binding DataOperationSummary}" Style="{StaticResource CaptionTextBlock}" FontSize="11" VerticalAlignment="Center" TextWrapping="Wrap" MaxWidth="520" Margin="0,0,10,4"/>
-                <ProgressBar Width="120" Height="14" IsIndeterminate="True" Visibility="{Binding IsDataOperationBusy, Converter={StaticResource BoolToVis}}" Margin="0,0,0,4"/>
-            </WrapPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -61,20 +61,31 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderSearchBrush}">
             <DockPanel LastChildFill="True">
-                <WrapPanel DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <TextBlock Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
-                    <ComboBox Width="150" MinWidth="120" Margin="0,0,10,4" ItemsSource="{Binding Categories}" SelectedItem="{Binding SelectedCategory}"/>
-                </WrapPanel>
-                <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="10,0,0,0">
-                    <Button Content="Print Results" Click="PrintSearchResults_Click" Margin="0,0,4,4"/>
-                    <Button Content="Print Checked Out" Click="PrintCheckedOut_Click" Margin="0,0,4,4"/>
-                    <Button Content="Print Mine" Click="PrintMyCheckedOut_Click" Margin="0,0,0,4" ToolTip="Print only items checked out by the signed-in user."/>
-                </WrapPanel>
-                <WrapPanel VerticalAlignment="Center" MinWidth="0">
-                    <TextBlock Text="{Binding SearchResultsSummary}" Style="{StaticResource CaptionTextBlock}" Margin="0,0,12,4" TextTrimming="CharacterEllipsis"/>
-                    <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,4" TextTrimming="CharacterEllipsis"/>
+                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,16,0">
+                    <TextBlock Text="Search Tools" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock Text="Find an item, then open or check it out." Style="{StaticResource CaptionTextBlock}"/>
+                </StackPanel>
+                <WrapPanel Style="{StaticResource PageHeaderStatsPanel}" MinWidth="0">
+                    <Border Style="{StaticResource PageHeaderStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="BRAND" Style="{StaticResource LabelTextBlock}"/>
+                            <ComboBox Height="27" MinHeight="27" Margin="0,2,0,0" ItemsSource="{Binding Categories}" SelectedItem="{Binding SelectedCategory}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource PageHeaderStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="RESULTS" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding SearchResultsSummary}" Style="{StaticResource PageHeaderStatValueText}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource PageHeaderStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="CHECKED OUT" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource PageHeaderStatValueText}"/>
+                        </StackPanel>
+                    </Border>
                 </WrapPanel>
             </DockPanel>
         </Border>
@@ -93,16 +104,12 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0" BorderThickness="0,0,0,2">
-                        <DockPanel LastChildFill="True">
-                            <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="180" MaxWidth="420">
+                        <DockPanel LastChildFill="False">
+                            <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" HorizontalAlignment="Left" MinWidth="180" MaxWidth="520">
                                 <TextBlock Text="Search Results" Style="{StaticResource SectionHeader}" Margin="0"/>
                                 <TextBlock Text="Rows include photo, stock, holder, and location; double-click for full details." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                             </StackPanel>
-                            <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="10,0,0,0">
-                                <Button Content="Details" Command="{Binding ViewDetailsCommand}" Style="{StaticResource GhostButton}" Margin="0,0,4,4"/>
-                                <Button Content="Rent Out" Command="{Binding OpenRentalsCommand}" Style="{StaticResource GhostButton}" Margin="0,0,4,4"/>
-                                <Button Content="Check Out / In" Command="{Binding ToggleCheckOutCommand}" CommandParameter="{Binding SelectedItem}" Style="{StaticResource GhostButton}" Margin="0,0,0,4"/>
-                            </WrapPanel>
+                            <Button DockPanel.Dock="Right" Content="Print Results" Click="PrintSearchResults_Click" Style="{StaticResource GhostButton}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                         </DockPanel>
                     </Border>
                     <DataGrid x:Name="ResultsGrid"
@@ -211,6 +218,22 @@
                             </DataGridTemplateColumn>
                         </DataGrid.Columns>
                     </DataGrid>
+                    <Border Grid.Row="1" MaxWidth="380" MinHeight="126" Padding="18" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SearchResults.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <TextBlock Text="No search results yet" Style="{StaticResource SubheadingTextBlock}" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Use the Find bar above or choose a brand, then run a search to populate the item directory." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" TextAlignment="Center" MaxWidth="330" Margin="0,6,0,0"/>
+                        </StackPanel>
+                    </Border>
                 </Grid>
             </Border>
 
@@ -313,6 +336,22 @@
                                 </DataGridTemplateColumn>
                             </DataGrid.Columns>
                         </DataGrid>
+                        <Border Grid.Row="1" MaxWidth="330" MinHeight="112" Padding="16" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False">
+                            <Border.Style>
+                                <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding CheckedOutItems.Count}" Value="0">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <TextBlock Text="Nothing is checked out" Style="{StaticResource SubheadingTextBlock}" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Checked-out items will appear here with holder and return actions." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" TextAlignment="Center" MaxWidth="280" Margin="0,6,0,0"/>
+                            </StackPanel>
+                        </Border>
                     </Grid>
                 </Border>
 

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
@@ -3,23 +3,11 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{DynamicResource MainContentBackgroundBrush}">
     <Page.Resources>
-        <Style x:Key="KitStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="235"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
-        <Style x:Key="KitStatValueText" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-            <Setter Property="FontSize" Value="15"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="TextWrapping" Value="Wrap"/>
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-            <Setter Property="Margin" Value="0,3,0,0"/>
-        </Style>
+        <Style x:Key="KitStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
+        <Style x:Key="KitStatValueText" TargetType="TextBlock" BasedOn="{StaticResource PageHeaderStatValueText}"/>
     </Page.Resources>
 
-    <Grid Margin="0">
+    <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -27,19 +15,19 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource ToolbarCard}" Padding="12,10">
+        <Border Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderKitsBrush}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.15*" MinWidth="0"/>
                     <ColumnDefinition Width="12"/>
                     <ColumnDefinition Width="1.35*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center" MinWidth="220" MaxWidth="520">
-                    <TextBlock Text="Kit Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" MinWidth="220" MaxWidth="520">
+                    <TextBlock Text="Kits" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Build reusable item sets, maintain membership, confirm availability, and print kit handoffs from one operations surface."
                                Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                 </StackPanel>
-                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                <WrapPanel Grid.Column="2" Style="{StaticResource PageHeaderStatsPanel}">
                     <Border Style="{StaticResource KitStatCard}">
                         <StackPanel>
                             <TextBlock Text="DIRECTORY" Style="{StaticResource LabelTextBlock}"/>
@@ -78,13 +66,6 @@
                     <TextBlock Text="Kit actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
                         <Button Style="{StaticResource PrimaryButton}" Content="Add Kit" Command="{Binding AddKitCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenKitDetailsCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditKitCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Check Availability" Command="{Binding CheckAvailabilityCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopySelectedKitCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Kit" Command="{Binding PrintSelectedKitCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" IsEnabled="{Binding IsKitDirectoryPrintAvailable}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteKitCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
                 </DockPanel>
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
@@ -302,7 +283,6 @@
                             <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10"><StackPanel><TextBlock Text="Print output" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/><TextBlock Text="{Binding SelectedKitPrintSummary}" TextWrapping="Wrap"/></StackPanel></Border>
                             <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10"><StackPanel><TextBlock Text="Availability promise" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/><TextBlock Text="{Binding SelectedKitAvailabilitySummary}" TextWrapping="Wrap"/></StackPanel></Border>
                             <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10"><StackPanel><TextBlock Text="Selected item line" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/><TextBlock Text="{Binding SelectedKitItemSummary}" TextWrapping="Wrap"/></StackPanel></Border>
-                            <Border Style="{StaticResource DesktopNoteCard}"><StackPanel><TextBlock Text="Desk checklist" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/><TextBlock Text="Confirm active status, review required quantities, run availability, then print or copy the kit handoff." TextWrapping="Wrap"/></StackPanel></Border>
                         </StackPanel>
                     </ScrollViewer>
                     <Border Grid.Row="2" Style="{StaticResource DesktopPaneSubheader}" BorderThickness="0,1,0,0">
@@ -318,14 +298,5 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
-            <DockPanel LastChildFill="True">
-                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" IsEnabled="{Binding IsKitDirectoryPrintAvailable}" Margin="0,0,0,4"/>
-                </WrapPanel>
-                <TextBlock Text="{Binding SelectedKitSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml
@@ -3,13 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{DynamicResource MainContentBackgroundBrush}">
     <Page.Resources>
-        <Style x:Key="MaintenanceStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinHeight" Value="78"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="235"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
+        <Style x:Key="MaintenanceStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
         <Style x:Key="MaintenanceDetailCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
@@ -20,7 +14,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Margin="0">
+    <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -28,7 +22,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource ToolbarCard}" Padding="12,10">
+        <Border Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderMaintenanceBrush}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.15*" MinWidth="0"/>
@@ -36,37 +30,37 @@
                     <ColumnDefinition Width="2*" MinWidth="320"/>
                 </Grid.ColumnDefinitions>
 
-                <StackPanel VerticalAlignment="Center" MinWidth="0">
-                    <TextBlock Text="Maintenance Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" MinWidth="0">
+                    <TextBlock Text="Maintenance" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Prioritize overdue service, stage upcoming work, and keep technician handoffs ready from one dense operations surface."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
 
-                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                <WrapPanel Grid.Column="2" Style="{StaticResource PageHeaderStatsPanel}">
                     <Border Style="{StaticResource MaintenanceStatCard}">
                         <StackPanel>
                             <TextBlock Text="SCHEDULE" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding MaintenanceResultsSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding MaintenanceResultsSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource MaintenanceStatCard}">
                         <StackPanel>
                             <TextBlock Text="BACKLOG" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding MaintenanceBacklogSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding MaintenanceBacklogSummary}" FontSize="15" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource MaintenanceStatCard}">
                         <StackPanel>
                             <TextBlock Text="SELECTED" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedRecord.StatusDisplay, TargetNullValue='No work selected', FallbackValue='No work selected'}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding SelectedRecord.StatusDisplay, TargetNullValue='No work selected', FallbackValue='No work selected'}" FontSize="15" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource MaintenanceStatCard}">
                         <StackPanel>
                             <TextBlock Text="PRINT" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding MaintenancePrintStatus}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                            <TextBlock Text="{Binding MaintenancePrintStatus}" FontSize="15" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
                 </WrapPanel>
@@ -83,12 +77,6 @@
                     <TextBlock Text="Work order actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
                         <Button Style="{StaticResource PrimaryButton}" Content="Add Work" Command="{Binding AddMaintenanceCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenMaintenanceDetailsCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditMaintenanceCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Complete" Command="{Binding CompleteMaintenanceCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Command="{Binding CopySelectedMaintenanceCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Record" Command="{Binding PrintSelectedMaintenanceCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteMaintenanceCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
                 </DockPanel>
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
@@ -304,13 +292,6 @@
                                 </StackPanel>
                             </Border>
 
-                            <Border Style="{StaticResource MaintenanceDetailCard}" Margin="0,0,0,10">
-                                <StackPanel>
-                                    <TextBlock Text="Bench checklist" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
-                                    <TextBlock Text="{Binding SelectedMaintenanceBenchChecklist}" TextWrapping="Wrap"/>
-                                </StackPanel>
-                            </Border>
-
                             <WrapPanel Margin="0,0,0,8">
                                 <Button Style="{StaticResource PrimaryButton}" Content="Complete" Command="{Binding CompleteMaintenanceCommand}" Margin="0,0,4,4"/>
                                 <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditMaintenanceCommand}" Margin="0,0,4,4"/>
@@ -331,17 +312,5 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
-            <DockPanel LastChildFill="True">
-                <WrapPanel DockPanel.Dock="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Complete" Command="{Binding CompleteMaintenanceCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Schedule" Command="{Binding PrintMaintenanceListCommand}" Margin="0,0,0,4"/>
-                </WrapPanel>
-                <StackPanel Margin="2,0,10,0">
-                    <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-                    <TextBlock Text="{Binding MaintenancePrintStatus}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -7,17 +7,8 @@
       xmlns:pages="clr-namespace:InventoryManagementApp.Views.Pages"
       Background="{DynamicResource MainContentBackgroundBrush}">
     <Page.Resources>
-        <Style x:Key="DirectoryStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="10,6"/>
-            <Setter Property="MinHeight" Value="54"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="230"/>
-            <Setter Property="Margin" Value="0,0,6,6"/>
-        </Style>
-        <Style x:Key="DirectoryStatValueText" TargetType="TextBlock" BasedOn="{StaticResource StatisticValueTextBlock}">
-            <Setter Property="TextWrapping" Value="Wrap"/>
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-        </Style>
+        <Style x:Key="DirectoryStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
+        <Style x:Key="DirectoryStatValueText" TargetType="TextBlock" BasedOn="{StaticResource PageHeaderStatValueText}"/>
         <Style x:Key="DirectoryDetailText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="Margin" Value="0,2,0,0"/>
@@ -81,74 +72,63 @@
     <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="8,5" Margin="0,0,0,5">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderManageItemsBrush}">
             <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="220" MaxWidth="460">
                     <TextBlock Text="Manage Items" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Maintain the item directory, review current availability, and save inline stock/location edits before staff use live records." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
-                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="12,0,0,0">
-                    <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="New" Command="{Binding NewItemCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="Mobile Capture" Command="{Binding OpenMobileCaptureCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="Edit" Command="{Binding EditItemCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Details" Command="{Binding ViewDetailsCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource LoadingAwareGhostButton}" Content="History" Command="{Binding OpenRentalHistoryCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Delete" Command="{Binding DeleteSelectedItemCommand}" CommandParameter="{Binding SelectedItem}" Margin="0,0,4,4"/>
-                </WrapPanel>
-            </DockPanel>
-        </Border>
-
-        <WrapPanel Grid.Row="1" Margin="0,0,0,5">
+                <WrapPanel Style="{StaticResource PageHeaderStatsPanel}" Margin="12,0,0,0">
             <Border Style="{StaticResource DirectoryStatCard}">
                 <StackPanel>
                     <TextBlock Text="Loaded Rows" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding Items.Count}" Style="{StaticResource DirectoryStatValueText}"/>
-                    <TextBlock Text="Virtualized directory rows currently in memory" Style="{StaticResource DirectoryDetailText}"/>
+                    <TextBlock Text="Virtualized directory rows currently in memory" Style="{StaticResource DirectoryDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource DirectoryStatCard}">
                 <StackPanel>
                     <TextBlock Text="Pending Edits" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding PendingEdits.Count}" Style="{StaticResource DirectoryStatValueText}"/>
-                    <TextBlock Text="Inline quantity, price, or location changes awaiting save" Style="{StaticResource DirectoryDetailText}"/>
+                    <TextBlock Text="Inline quantity, price, or location changes awaiting save" Style="{StaticResource DirectoryDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource DirectoryStatCard}">
                 <StackPanel>
                     <TextBlock Text="Missing Images" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding MissingImageCount}" Style="{StaticResource DirectoryStatValueText}"/>
-                    <TextBlock Text="Loaded rows still using the default item photo" Style="{StaticResource DirectoryDetailText}"/>
+                    <TextBlock Text="Loaded rows still using the default item photo" Style="{StaticResource DirectoryDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource DirectoryStatCard}">
                 <StackPanel>
                     <TextBlock Text="Page Size" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding PageSize}" Style="{StaticResource DirectoryStatValueText}"/>
-                    <TextBlock Text="Rows requested per directory load" Style="{StaticResource DirectoryDetailText}"/>
+                    <TextBlock Text="Rows requested per directory load" Style="{StaticResource DirectoryDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource DirectoryStatCard}">
                 <StackPanel>
                     <TextBlock Text="Directory Status" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Style="{StaticResource DirectoryStatusValueText}"/>
-                    <TextBlock Style="{StaticResource DirectoryStatusDetailText}"/>
+                    <TextBlock Style="{StaticResource DirectoryStatusDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource DirectoryStatCard}">
                 <StackPanel>
                     <TextBlock Text="Selected Item" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding SelectedItem.Name, TargetNullValue=No item selected}" Style="{StaticResource DirectoryStatValueText}"/>
-                    <TextBlock Text="{Binding SelectedItem.AvailabilityDetail, TargetNullValue='Select a row to review availability and next actions.'}" Style="{StaticResource DirectoryDetailText}"/>
+                    <TextBlock Text="{Binding SelectedItem.AvailabilityDetail, TargetNullValue='Select a row to review availability and next actions.'}" Style="{StaticResource DirectoryDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                 </StackPanel>
             </Border>
-        </WrapPanel>
+                </WrapPanel>
+            </DockPanel>
+        </Border>
 
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1.7*" MinWidth="0"/>
                 <ColumnDefinition Width="6"/>
@@ -193,6 +173,8 @@
                                 <TextBox Width="56" MinWidth="48" IsEnabled="{Binding IsDirectoryBusy, Converter={StaticResource InverseBooleanConverter}}" Text="{Binding PageSize, UpdateSourceTrigger=LostFocus}"/>
                             </WrapPanel>
                             <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="12,0,0,0">
+                                <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="New" Command="{Binding NewItemCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Mobile Capture" Command="{Binding OpenMobileCaptureCommand}" Margin="0,0,4,4"/>
                                 <Button Style="{StaticResource LoadingAwarePrimaryButton}" Content="Save Changes" Command="{Binding CommitChangesCommand}" Margin="0,0,4,4"/>
                                 <Button Style="{StaticResource LoadingAwareGhostButton}" Content="Details" Command="{Binding ViewDetailsCommand}" Margin="0,0,4,4"/>
                             </WrapPanel>
@@ -395,27 +377,11 @@
                                 </StackPanel>
                             </Border>
 
-                            <Border Style="{StaticResource DesktopSummaryCard}">
-                                <StackPanel>
-                                    <TextBlock Text="Directory checklist" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
-                                    <TextBlock Text="1. Filter or sort to the right record. 2. Confirm the selected item context. 3. Save pending inline edits before leaving the page." TextWrapping="Wrap"/>
-                                </StackPanel>
-                            </Border>
                         </StackPanel>
                     </ScrollViewer>
                 </DockPanel>
             </Border>
         </Grid>
 
-        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Padding="6,3" Margin="0,5,0,0">
-            <WrapPanel>
-                <TextBlock Text="{Binding Items.Count, StringFormat='Loaded rows: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <TextBlock Text="{Binding PageSize, StringFormat='Page size: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <TextBlock Text="{Binding PendingEdits.Count, StringFormat='Pending inline edits: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <TextBlock Text="{Binding MissingImageCount, StringFormat='Missing images in loaded rows: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <TextBlock Text="{Binding SelectedSortOption.DisplayName, StringFormat='Sort: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <TextBlock Text="{Binding Items.HasMoreItems, StringFormat='More rows available: {0}'}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
-            </WrapPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -5,17 +5,8 @@
       Background="{DynamicResource MainContentBackgroundBrush}"
       Focusable="True">
     <Page.Resources>
-        <Style x:Key="RentalStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="8,4"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="235"/>
-            <Setter Property="MinHeight" Value="48"/>
-            <Setter Property="Margin" Value="0,0,8,6"/>
-        </Style>
-        <Style x:Key="RentalStatValueText" TargetType="TextBlock" BasedOn="{StaticResource HeadingTextBlock}">
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-            <Setter Property="TextWrapping" Value="NoWrap"/>
-        </Style>
+        <Style x:Key="RentalStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
+        <Style x:Key="RentalStatValueText" TargetType="TextBlock" BasedOn="{StaticResource PageHeaderStatValueText}"/>
         <Style x:Key="RentalDetailText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="Margin" Value="0,2,0,0"/>
@@ -97,63 +88,51 @@
     <Grid x:Name="RootLayout" Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition x:Name="RentalStatsRow" Height="Auto"/>
             <RowDefinition x:Name="RentalMainRow" Height="1.55*"/>
             <RowDefinition x:Name="RentalSplitterRow" Height="6"/>
             <RowDefinition x:Name="RequestQueueRow" Height="1.25*"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
-            <DockPanel LastChildFill="False">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderRentalsBrush}">
+            <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" MinWidth="220" MaxWidth="520">
                     <TextBlock Text="Rentals" Style="{StaticResource PageTitleTextBlock}"/>
                     <TextBlock Text="Run active checkouts, returns, customer documents, and follow-up requests from one rental desk." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
-                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="12,0,0,0">
-                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Details" Command="{Binding OpenRentalDetailsCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource RentalBusyPrimaryButton}" Content="Request" Command="{Binding PlaceRequestCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="Pick Slip" Command="{Binding PrintPickingSlipCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="Invoice" Command="{Binding PrintInvoiceCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource RentalBusyGhostButton}" Content="Delete" Command="{Binding DeleteRentalCommand}" Margin="0,0,0,6"/>
-                </WrapPanel>
-            </DockPanel>
-        </Border>
-
-        <WrapPanel x:Name="RentalStatsStrip" Grid.Row="1" Margin="0,0,0,6">
+                <WrapPanel x:Name="RentalStatsStrip" Style="{StaticResource PageHeaderStatsPanel}" Margin="12,0,0,0">
             <Border Style="{StaticResource RentalStatCard}">
                 <StackPanel>
                     <TextBlock Text="Filtered Rentals" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding Rentals.Count}" Style="{StaticResource RentalStatValueText}"/>
-                    <TextBlock Text="{Binding SearchSummary}" Style="{StaticResource RentalDetailText}" ToolTip="{Binding SearchSummary}"/>
+                    <TextBlock Text="{Binding SearchSummary}" Style="{StaticResource RentalDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" ToolTip="{Binding SearchSummary}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource RentalStatCard}">
                 <StackPanel>
                     <TextBlock Text="Checked Out" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding ActiveRentals.Count}" Style="{StaticResource RentalStatValueText}"/>
-                    <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource RentalDetailText}" ToolTip="{Binding CheckedOutSummary}"/>
+                    <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource RentalDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" ToolTip="{Binding CheckedOutSummary}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource RentalStatCard}">
                 <StackPanel>
                     <TextBlock Text="Open Requests" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding PendingRequests.Count}" Style="{StaticResource RentalStatValueText}"/>
-                    <TextBlock Text="{Binding RequestSummary}" Style="{StaticResource RentalDetailText}" ToolTip="{Binding RequestSummary}"/>
+                    <TextBlock Text="{Binding RequestSummary}" Style="{StaticResource RentalDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" ToolTip="{Binding RequestSummary}"/>
                 </StackPanel>
             </Border>
             <Border Style="{StaticResource RentalStatCard}">
                 <StackPanel>
                     <TextBlock Text="Selected Rental" Style="{StaticResource LabelTextBlock}"/>
                     <TextBlock Text="{Binding SelectedRental.ItemNumber, TargetNullValue=No rental selected}" Style="{StaticResource RentalStatValueText}"/>
-                    <TextBlock Text="{Binding SelectedRental.CustomerName, StringFormat='Customer: {0}', TargetNullValue='Select a row to review customer, timing, and document actions.'}" Style="{StaticResource RentalDetailText}"/>
+                    <TextBlock Text="{Binding SelectedRental.CustomerName, StringFormat='Customer: {0}', TargetNullValue='Select a row to review customer, timing, and document actions.'}" Style="{StaticResource RentalDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                 </StackPanel>
             </Border>
-        </WrapPanel>
+                </WrapPanel>
+            </DockPanel>
+        </Border>
 
-        <Grid Grid.Row="2" Margin="0,0,0,0">
+        <Grid Grid.Row="1" Margin="0,0,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1.65*" MinWidth="0"/>
                 <ColumnDefinition Width="6"/>
@@ -357,9 +336,9 @@
             </Border>
         </Grid>
 
-        <GridSplitter Grid.Row="3" Height="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+        <GridSplitter Grid.Row="2" Height="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0" MinWidth="0">
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0" MinWidth="0">
             <Grid MinWidth="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -532,6 +511,6 @@
             </Grid>
         </Border>
 
-        <ProgressBar Grid.Row="0" Grid.RowSpan="5" IsIndeterminate="True" Height="4" VerticalAlignment="Top" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}"/>
+        <ProgressBar Grid.Row="0" Grid.RowSpan="4" IsIndeterminate="True" Height="4" VerticalAlignment="Top" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}"/>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -111,7 +111,6 @@ namespace InventoryManagementApp.Views.Pages
 
             _isCompactHeight = compactHeight;
             RentalStatsStrip.Visibility = compactHeight ? Visibility.Collapsed : Visibility.Visible;
-            RentalStatsRow.Height = compactHeight ? new GridLength(0) : GridLength.Auto;
             RentalMainRow.Height = compactHeight ? new GridLength(1.6, GridUnitType.Star) : new GridLength(1.55, GridUnitType.Star);
             RentalSplitterRow.Height = compactHeight ? new GridLength(6) : new GridLength(6);
             RequestQueueRow.Height = compactHeight ? new GridLength(1.15, GridUnitType.Star) : new GridLength(1.25, GridUnitType.Star);

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml
@@ -4,13 +4,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{DynamicResource MainContentBackgroundBrush}">
     <Page.Resources>
-        <Style x:Key="ReportsStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinHeight" Value="78"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="240"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
+        <Style x:Key="ReportsStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
         <Style x:Key="ReportsDetailCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
@@ -21,7 +15,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Margin="0">
+    <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -29,28 +23,29 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderReportsBrush}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.15*" MinWidth="0"/>
                     <ColumnDefinition Width="12"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center" MinWidth="0">
-                    <TextBlock Text="Reports Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" MinWidth="0">
+                    <TextBlock Text="Reports" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Run operational reports, inspect the highest-priority rows, then jump to the exact source page for follow-up."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                <WrapPanel Grid.Column="2" Style="{StaticResource PageHeaderStatsPanel}">
                     <Border Style="{StaticResource ReportsStatCard}">
                         <StackPanel>
                             <TextBlock Text="REPORT" Style="{StaticResource LabelTextBlock}"/>
                             <TextBlock Text="{Binding SelectedReport, TargetNullValue=Select report, FallbackValue=Select report}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
@@ -60,7 +55,8 @@
                             <TextBlock Text="{Binding ReportLineWindowSummary}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
@@ -70,7 +66,8 @@
                             <TextBlock Text="{Binding SelectedLineDestination}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
@@ -80,7 +77,8 @@
                             <TextBlock Text="{Binding LastRunText}"
                                        FontSize="15"
                                        FontWeight="SemiBold"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
                                        Margin="0,3,0,0"/>
                         </StackPanel>
                     </Border>
@@ -105,7 +103,6 @@
                                   ToolTip="Choose the report to run"
                                   Margin="0,0,6,4"/>
                         <Button Style="{StaticResource PrimaryButton}" Content="Run Report" Command="{Binding RunReportCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Open Source Page" Click="OpenSourcePage_Click" IsEnabled="{Binding CanUseReportRows}" Margin="0,0,4,4"/>
                         <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearReportCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
                 </DockPanel>
@@ -113,7 +110,6 @@
                     <TextBlock Text="Output actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
                         <Button Style="{StaticResource PrimaryButton}" Content="Print Report" Click="PrintReport_Click" IsEnabled="{Binding CanPrintCurrentReport}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedRow_Click" IsEnabled="{Binding CanUseReportRows}" Margin="0,0,4,4"/>
                         <TextBlock Text="{Binding ReportStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="6,1,0,4"/>
                     </WrapPanel>
                 </DockPanel>
@@ -320,18 +316,5 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="3"
-                Style="{StaticResource ToolbarCard}"
-                Margin="0,6,0,0"
-                Padding="8,5">
-            <DockPanel LastChildFill="True">
-                <ProgressBar Width="140"
-                             Height="14"
-                             DockPanel.Dock="Right"
-                             IsIndeterminate="True"
-                             Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-                <TextBlock Text="{Binding ReportStatus}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml
@@ -4,21 +4,8 @@
       Background="{DynamicResource MainContentBackgroundBrush}"
       Focusable="True">
     <Page.Resources>
-        <Style x:Key="ReservationStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinWidth" Value="150"/>
-            <Setter Property="MaxWidth" Value="235"/>
-            <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
-        <Style x:Key="ReservationStatValueText" TargetType="TextBlock">
-            <Setter Property="FontSize" Value="15"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="TextWrapping" Value="Wrap"/>
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-            <Setter Property="MaxHeight" Value="36"/>
-            <Setter Property="Margin" Value="0,3,0,0"/>
-        </Style>
+        <Style x:Key="ReservationStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
+        <Style x:Key="ReservationStatValueText" TargetType="TextBlock" BasedOn="{StaticResource PageHeaderStatValueText}"/>
         <Style x:Key="ReservationDetailCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
             <Setter Property="Padding" Value="12"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
@@ -29,7 +16,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Margin="0">
+    <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -37,21 +24,21 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderReservationsBrush}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.15*" MinWidth="0"/>
                     <ColumnDefinition Width="8"/>
                     <ColumnDefinition Width="1.85*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center" MinWidth="0">
-                    <TextBlock Text="Reservations Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" MinWidth="0">
+                    <TextBlock Text="Reservations" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Stage customer holds, confirm availability, prepare shelf pickup, and move ready reservations into rentals from one operations surface."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                <WrapPanel Grid.Column="2" Style="{StaticResource PageHeaderStatsPanel}">
                     <Border Style="{StaticResource ReservationStatCard}">
                         <StackPanel>
                             <TextBlock Text="DIRECTORY" Style="{StaticResource LabelTextBlock}"/>
@@ -96,14 +83,6 @@
                     <TextBlock Text="Hold actions" Style="{StaticResource LabelTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <WrapPanel>
                         <Button Style="{StaticResource PrimaryButton}" Content="Add Hold" Command="{Binding AddReservationCommand}" Margin="0,0,4,4" ToolTip="Create a new hold"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmReservationCommand}" Margin="0,0,4,4" ToolTip="Confirm the selected pending hold"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Fulfill" Command="{Binding FulfillReservationCommand}" Margin="0,0,4,4" ToolTip="Complete the selected confirmed hold with a rental ID"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Details" Command="{Binding OpenReservationDetailsCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Edit" Command="{Binding EditReservationCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Cancel" Command="{Binding CancelReservationCommand}" Margin="0,0,4,4"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Command="{Binding CopyReservationHandoffCommand}" Margin="0,0,4,4" ToolTip="Copy selected hold handoff"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Handoff" Command="{Binding PrintReservationHandoffCommand}" Margin="0,0,4,4" ToolTip="Print selected hold handoff"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteReservationCommand}" Margin="0,0,4,4"/>
                     </WrapPanel>
                 </DockPanel>
                 <DockPanel Grid.Row="1" LastChildFill="True" Margin="0,4,0,0">
@@ -347,13 +326,6 @@
 
                             <Border Style="{StaticResource ReservationDetailCard}">
                                 <StackPanel>
-                                    <TextBlock Text="Shelf Checklist" Style="{StaticResource LabelTextBlock}"/>
-                                    <TextBlock Text="{Binding SelectedReservationShelfChecklist}" TextWrapping="Wrap" Margin="0,3,0,0"/>
-                                </StackPanel>
-                            </Border>
-
-                            <Border Style="{StaticResource ReservationDetailCard}">
-                                <StackPanel>
                                     <TextBlock Text="Handoff Text" Style="{StaticResource LabelTextBlock}"/>
                                     <TextBlock Text="{Binding SelectedReservationDetail}" TextWrapping="Wrap" Margin="0,3,0,0"/>
                                 </StackPanel>
@@ -378,18 +350,5 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0" Padding="10,7">
-            <DockPanel LastChildFill="True">
-                <WrapPanel DockPanel.Dock="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add Hold" Command="{Binding AddReservationCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print List" Command="{Binding PrintReservationDirectoryCommand}" Margin="0,0,0,4"/>
-                </WrapPanel>
-                <StackPanel Margin="2,0,10,0">
-                    <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                    <TextBlock Text="{Binding ReservationVisibleWindowSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                    <TextBlock Text="{Binding ReservationPrintStatus}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml
@@ -5,13 +5,7 @@
       Background="{DynamicResource MainContentBackgroundBrush}">
 
     <Page.Resources>
-        <Style x:Key="SettingsStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinWidth" Value="160"/>
-            <Setter Property="MaxWidth" Value="260"/>
-            <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
+        <Style x:Key="SettingsStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
         <Style x:Key="SettingsActionButton" TargetType="Button" BasedOn="{StaticResource GhostButton}">
             <Setter Property="MinWidth" Value="112"/>
             <Setter Property="Margin" Value="0,0,4,4"/>
@@ -28,54 +22,54 @@
         </Style>
     </Page.Resources>
 
-    <Grid Margin="0">
+    <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="12,10">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderSettingsBrush}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.15*" MinWidth="0"/>
                     <ColumnDefinition Width="8"/>
                     <ColumnDefinition Width="1.85*" MinWidth="0"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center" MinWidth="0">
-                    <TextBlock Text="Admin Settings Workbench" FontSize="22" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" MinWidth="0">
+                    <TextBlock Text="Settings" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Control database access, workstation defaults, field visibility, brand identity, reminders, and recovery destinations from one stable admin desk."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,3,0,0"/>
                 </StackPanel>
-                <WrapPanel Grid.Column="2" HorizontalAlignment="Right">
+                <WrapPanel Grid.Column="2" Style="{StaticResource PageHeaderStatsPanel}">
                     <Border Style="{StaticResource SettingsStatCard}">
                         <StackPanel>
                             <TextBlock Text="DATABASE" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding ConnectionString}" FontWeight="SemiBold" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="34" Margin="0,3,0,0"/>
-                            <TextBlock Text="Test before switching" Style="{StaticResource CaptionTextBlock}"/>
+                            <TextBlock Text="{Binding ConnectionString}" Style="{StaticResource PageHeaderStatValueText}"/>
+                            <TextBlock Text="Test before switching" Style="{StaticResource PageHeaderStatCaptionText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource SettingsStatCard}">
                         <StackPanel>
                             <TextBlock Text="IDENTITY" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding ApplicationName}" FontWeight="SemiBold" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="34" Margin="0,3,0,0"/>
-                            <TextBlock Text="Theme, labels, logo" Style="{StaticResource CaptionTextBlock}"/>
+                            <TextBlock Text="{Binding ApplicationName}" Style="{StaticResource PageHeaderStatValueText}"/>
+                            <TextBlock Text="Theme, labels, logo" Style="{StaticResource PageHeaderStatCaptionText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource SettingsStatCard}">
                         <StackPanel>
                             <TextBlock Text="REMINDERS" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding SelectedEmailProvider}" FontWeight="SemiBold" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="34" Margin="0,3,0,0"/>
-                            <TextBlock Text="Email and SMS" Style="{StaticResource CaptionTextBlock}"/>
+                            <TextBlock Text="{Binding SelectedEmailProvider}" Style="{StaticResource PageHeaderStatValueText}"/>
+                            <TextBlock Text="Email and SMS" Style="{StaticResource PageHeaderStatCaptionText}"/>
                         </StackPanel>
                     </Border>
                     <Border Style="{StaticResource SettingsStatCard}">
                         <StackPanel>
                             <TextBlock Text="RECOVERY" Style="{StaticResource LabelTextBlock}"/>
-                            <TextBlock Text="{Binding BackupDirectory}" FontWeight="SemiBold" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="34" Margin="0,3,0,0"/>
-                            <TextBlock Text="Export destination" Style="{StaticResource CaptionTextBlock}"/>
+                            <TextBlock Text="{Binding BackupDirectory}" Style="{StaticResource PageHeaderStatValueText}"/>
+                            <TextBlock Text="Export destination" Style="{StaticResource PageHeaderStatCaptionText}"/>
                         </StackPanel>
                     </Border>
                 </WrapPanel>
@@ -86,19 +80,6 @@
             <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="01 Service Status">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
-                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
-                            <DockPanel LastChildFill="True">
-                                <WrapPanel DockPanel.Dock="Left" VerticalAlignment="Center">
-                                    <TextBlock Text="Admin Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,4"/>
-                                    <Button Style="{StaticResource SettingsPrimaryActionButton}" Content="Test DB" Command="{Binding TestDbCommand}"/>
-                                    <Button Style="{StaticResource SettingsPrimaryActionButton}" Content="Test Email" Command="{Binding TestEmailCommand}"/>
-                                    <Button Style="{StaticResource SettingsPrimaryActionButton}" Content="Save Email" Command="{Binding SaveEmailSettingsCommand}"/>
-                                    <Button Style="{StaticResource SettingsPrimaryActionButton}" Content="Save Messaging" Command="{Binding SaveMessagingSettingsCommand}"/>
-                                    <Button Style="{StaticResource SettingsPrimaryActionButton}" Content="Save Backup" Command="{Binding SaveBackupSettingsCommand}"/>
-                                </WrapPanel>
-                                <TextBlock Text="Current configuration snapshot" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                            </DockPanel>
-                        </Border>
                         <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
                             <Grid Margin="0,8,0,0">
                                 <Grid.ColumnDefinitions>
@@ -760,11 +741,5 @@
             </TabItem>
         </TabControl>
 
-        <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,6,0,0" Padding="8,5">
-            <DockPanel LastChildFill="True">
-                <TextBlock DockPanel.Dock="Right" Text="Settings desk ready" FontSize="11" Margin="10,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
-                <TextBlock Text="Admin settings: database, defaults, item display, email, branding, messaging, and backups stay aligned from this workbench." Style="{StaticResource CaptionTextBlock}" FontSize="11" TextWrapping="Wrap" VerticalAlignment="Center"/>
-            </DockPanel>
-        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -6,36 +6,24 @@
       xmlns:pages="clr-namespace:InventoryManagementApp.Views.Pages"
       Background="{DynamicResource MainContentBackgroundBrush}">
     <Page.Resources>
-        <Style x:Key="UserStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
-            <Setter Property="Padding" Value="12,10"/>
-            <Setter Property="MinHeight" Value="76"/>
-            <Setter Property="MinWidth" Value="160"/>
-            <Setter Property="MaxWidth" Value="250"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
+        <Style x:Key="UserStatCard" TargetType="Border" BasedOn="{StaticResource PageHeaderStatCard}"/>
         <Style x:Key="UserDetailText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="Margin" Value="0,2,0,0"/>
         </Style>
-        <Style x:Key="UserStatValueText" TargetType="TextBlock" BasedOn="{StaticResource HeadingTextBlock}">
-            <Setter Property="TextWrapping" Value="NoWrap"/>
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-            <Setter Property="MinHeight" Value="24"/>
-        </Style>
+        <Style x:Key="UserStatValueText" TargetType="TextBlock" BasedOn="{StaticResource PageHeaderStatValueText}"/>
     </Page.Resources>
 
     <Grid Margin="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="14,12">
-            <DockPanel LastChildFill="False">
+        <Border Grid.Row="0" Style="{StaticResource PageHeaderBand}" Background="{DynamicResource PageHeaderUsersBrush}">
+            <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,18,0" MinWidth="220" MaxWidth="460">
-                    <TextBlock Text="Users Workbench" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock Text="Users" Style="{StaticResource PageTitleTextBlock}" TextWrapping="Wrap"/>
                     <TextBlock Text="Manage account access, password recovery, profile photos, and audit-ready user directory output from one admin desk."
                                Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
@@ -46,49 +34,40 @@
                                TextWrapping="Wrap"
                                Margin="0,4,0,0"/>
                 </StackPanel>
-                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add User" Command="{Binding AddUserCommand}" IsEnabled="{Binding CanUseUserActions}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit Access" Command="{Binding EditUserCommand}" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Reset Password" Click="ResetSelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Upload Photo" Command="{Binding UploadUserPhotoCommand}" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedUser_Click" IsEnabled="{Binding CanUseSelectedUserActions}" Margin="0,0,6,6"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Click="PrintUsers_Click" IsEnabled="{Binding CanPrintUsers}" Margin="0,0,0,6"/>
+                <WrapPanel Style="{StaticResource PageHeaderStatsPanel}">
+                    <Border Style="{StaticResource UserStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="Visible Users" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding VisibleUserCount}" Style="{StaticResource UserStatValueText}"/>
+                            <TextBlock Text="{Binding UserWindowStatusText}" Style="{StaticResource UserDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource UserStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="Directory Filter" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding UserFilterStatusText}" Style="{StaticResource UserStatValueText}"/>
+                            <TextBlock Text="Search by ID, user, role, contact, lockout, or access summary before printing" Style="{StaticResource UserDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource UserStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="Selected Access" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding SelectedAccessStatusText}" Style="{StaticResource UserStatValueText}"/>
+                            <TextBlock Text="Review allowed app areas before editing permissions" Style="{StaticResource UserDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource UserStatCard}">
+                        <StackPanel>
+                            <TextBlock Text="Security State" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="{Binding SelectedSecurityStatusText}" Style="{StaticResource UserStatValueText}"/>
+                            <TextBlock Text="Password reset, lockout, and active-status context" Style="{StaticResource UserDetailText}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                    </Border>
                 </WrapPanel>
             </DockPanel>
         </Border>
 
-        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
-            <Border Style="{StaticResource UserStatCard}">
-                <StackPanel>
-                    <TextBlock Text="Visible Users" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding VisibleUserCount}" Style="{StaticResource UserStatValueText}"/>
-                    <TextBlock Text="{Binding UserWindowStatusText}" Style="{StaticResource UserDetailText}"/>
-                </StackPanel>
-            </Border>
-            <Border Style="{StaticResource UserStatCard}">
-                <StackPanel>
-                    <TextBlock Text="Directory Filter" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding UserFilterStatusText}" Style="{StaticResource UserStatValueText}"/>
-                    <TextBlock Text="Search by ID, user, role, contact, lockout, or access summary before printing" Style="{StaticResource UserDetailText}"/>
-                </StackPanel>
-            </Border>
-            <Border Style="{StaticResource UserStatCard}">
-                <StackPanel>
-                    <TextBlock Text="Selected Access" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding SelectedAccessStatusText}" Style="{StaticResource UserStatValueText}"/>
-                    <TextBlock Text="Review allowed app areas before editing permissions" Style="{StaticResource UserDetailText}"/>
-                </StackPanel>
-            </Border>
-            <Border Style="{StaticResource UserStatCard}" Margin="0,0,0,8">
-                <StackPanel>
-                    <TextBlock Text="Security State" Style="{StaticResource LabelTextBlock}"/>
-                    <TextBlock Text="{Binding SelectedSecurityStatusText}" Style="{StaticResource UserStatValueText}"/>
-                    <TextBlock Text="Password reset, lockout, and active-status context" Style="{StaticResource UserDetailText}"/>
-                </StackPanel>
-            </Border>
-        </WrapPanel>
-
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1.65*" MinWidth="0"/>
                 <ColumnDefinition Width="6"/>
@@ -342,13 +321,6 @@
                                 </StackPanel>
                             </Border>
 
-                            <Border Style="{StaticResource DesktopInsetCard}" Background="{DynamicResource TextBoxBackgroundBrush}">
-                                <StackPanel>
-                                    <TextBlock Text="Admin Next Step" Style="{StaticResource SectionHeader}"/>
-                                    <TextBlock Text="Reset the password when the user is blocked at login, edit access when a role changes, upload a current photo for quick visual confirmation, or print the filtered directory for an audit packet."
-                                               TextWrapping="Wrap"/>
-                                </StackPanel>
-                            </Border>
                         </StackPanel>
                     </ScrollViewer>
 
@@ -364,22 +336,5 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="3"
-                Background="{DynamicResource SurfaceAltBrush}"
-                BorderBrush="{DynamicResource BorderBrushAlt}"
-                BorderThickness="1,0,1,1"
-                Padding="8,4">
-            <DockPanel>
-                <TextBlock DockPanel.Dock="Left"
-                           Text="{Binding UserDirectoryStatusText}"
-                           FontSize="11"
-                           VerticalAlignment="Center"/>
-                <TextBlock DockPanel.Dock="Right"
-                           Text="{Binding UserWindowStatusText}"
-                           Style="{StaticResource CaptionTextBlock}"
-                           VerticalAlignment="Center"
-                           TextWrapping="Wrap"/>
-            </DockPanel>
-        </Border>
     </Grid>
 </Page>

--- a/scripts/run-app-qa-screenshots.ps1
+++ b/scripts/run-app-qa-screenshots.ps1
@@ -269,7 +269,6 @@ if ($Capture.Count -gt 0) {
     }
     $expectedFolders = @($expectedScreenshotFiles | ForEach-Object { ($_ -split '\\')[0] } | Select-Object -Unique)
     $ExpectedScreenshotCount = $expectedScreenshotFiles.Count
-    $SkipFullScreen = $true
 }
 if ($ExpectedScreenshotCount -lt $expectedScreenshotFiles.Count) {
     $ExpectedScreenshotCount = $expectedScreenshotFiles.Count


### PR DESCRIPTION
## Summary

- standardize all main pages on fixed SD Light page-owned header bands and right-aligned summary cards
- move header actions into their relevant content toolbars and improve Search Tools empty states
- refresh edited item images immediately and invalidate stale same-path bitmap cache entries
- ignore generated named QA runs and support fullscreen output for targeted screenshot captures
- update responsive/XAML contracts and add header consistency and image refresh regression coverage

## Why

Page transitions used inconsistent header heights, alignment, card sizing, and action placement. Item image edits were persisted but could continue displaying a cached or stale in-memory image until restart.

## Validation

- `dotnet restore InventoryManagementApp.sln`
- `dotnet build InventoryManagementApp.sln --no-restore`
- `dotnet test InventoryManagementApp.sln --no-build` — 1,462 passed, 5 skipped
- `./scripts/check-banned-words.sh`
- SD Light QA pass — 76 standard 1920x1080 captures and 76 fullscreen captures

## Notes

- Existing NuGet pruning and analyzer warnings remain unchanged.
- Generated QA images are intentionally not committed.
